### PR TITLE
Support text translations in survey, using i18next

### DIFF
--- a/example/demo_survey/locales/en/survey.json
+++ b/example/demo_survey/locales/en/survey.json
@@ -1,80 +1,91 @@
 {
-  "homepage": {
-    "introduction": "<p class=\"center _dark-green _strong\" style=\"color: #2B7F79;\">We are seeking your participation in a study on people's travel behavior in the Montreal area. This study aims to better understand the trips of people living in the Greater Montreal Area.</p><p class=\"center _oblique\"><a href=\"http://www.artm.quebec/origin-destination-survey/\">More about this survey</p>",
-    "pageTwoIntroduction": "<p class=\"center _strong\" style=\"color: #2B7F79;\">You already completed the first part. The second part will focus on the travel behavior of your household's members.</p><p class=\"center _oblique\">To sign in, please use the same email and password that you provided when you did the first part, or use the same Google or Facebook account.</p>",
-    "start":"Start"
-  },
-  "postregistration": {
-    "introduction":"Thank you for your participation!",
-    "login": "Your access code",
-    "password": "Your password",
-    "start":"Start",
-    "info": "You will need this information if you want to reconnect to your interview or if you want to use another computer to access it."
-  },
-  "person": {
-    "deleteThisGroupedObject": "Delete this person",
-    "addGroupedObject": "Add a person",
-    "dayScheduleFor": "Day schedule for",
-    "yourDaySchedule": "Your day schedule"
-  },
-  "auth": {
-    "UsernameOrEmail": "Email address",
-    "missingUsernameOrEmail": "Please provide your email address",
-    "authenticationFailed": "Your email address or password was not found or is invalid",
-    "pleaseChooseAUsernameOrEnterYourEmail": "To participate, please provide your email address",
-    "pleaseChooseAUsernameOrEnterYourEmailAndAPassword": "To register, please enter your email address, choose a password and confirm it, or use your Google or Facebook account.",
-    "usernameOrEmailAlreadyExists": "Your email address is already registered. PLease use your existing account.",
-    "WhyLoginInfo": "Because of the survey length, we propose that you connect with an email, or Google or Facebook account, so that you can come back later to finish the survey. You may choose to continue without an account, but you will not be able to finish the survey if your session expires.",
-    "PasswordlessHeader": "",
-    "UseAnonymousLogin": "Continue without connecting"
-  },
-  "visitedPlace": {
-    "deleteThisGroupedObject": "Delete this location",
-    "addGroupedObject": "Add the next location",
-    "activities": {
-      "home": "Home",
-      "workUsual": "Work at usual location",
-      "workNotUsual": "Work",
-      "schoolUsual": "School, studies at usual location",
-      "schoolNotUsual": "School, studies",
-      "schoolNotStudent": "School, studies",
-      "service": "Service",
-      "medical": "Health",
-      "workOnTheRoad": "On the road",
-      "workOnTheRoadFromHome": "On the road",
-      "workOnTheRoadFromUsualWork": "On the road",
-      "worship": "Place of worship",
-      "leisure": "Leisure",
-      "shopping": "Shopping",
-      "restaurant": "Restaurant, bar, coffee shop",
-      "dropSomeone": "Drop or accompany someone",
-      "fetchSomeone": "Pick someone up",
-      "visiting": "Visiting friends or family",
-      "secondaryHome": "Secondary home or cottage",
-      "other": "Other"
+    "homepage": {
+        "introduction": "<p class=\"center _dark-green _strong\" style=\"color: #2B7F79;\">We are seeking your participation in a study on people's travel behavior in the Montreal area. This study aims to better understand the trips of people living in the Greater Montreal Area.</p><p class=\"center _oblique\"><a href=\"http://www.artm.quebec/origin-destination-survey/\">More about this survey</p>",
+        "pageTwoIntroduction": "<p class=\"center _strong\" style=\"color: #2B7F79;\">You already completed the first part. The second part will focus on the travel behavior of your household's members.</p><p class=\"center _oblique\">To sign in, please use the same email and password that you provided when you did the first part, or use the same Google or Facebook account.</p>",
+        "start": "Start"
     },
-    "editVisitedPlace": "Edit",
-    "deleteVisitedPlace": "Delete",
-    "saveVisitedPlace": "Save this location",
-    "insertVisitedPlace": "Insert a location here",
-    "editVisitedPlaces": "Edit, insert or delete location a location",
-    "addVisitedPlace": "Add the next location",
-    "cancelEditVisitedPlaces": "Cancel",
-    "resetVisitedPlaces": "Reset visited places and trips for this person"
-  },
-  "trip": {
-    "trip": "Trip",
-    "editTrip": "Edit",
-    "saveTrip": "Save this trip",
-    "editTrips": "Edit trips",
-    "cancelEditTrips": "Cancel",
-    "modes": {
-      "carDriver": "Car driver",
-      "carPassenger": "Car passenger"
+    "postregistration": {
+        "introduction": "Thank you for your participation!",
+        "login": "Your access code",
+        "password": "Your password",
+        "start": "Start",
+        "info": "You will need this information if you want to reconnect to your interview or if you want to use another computer to access it."
+    },
+    "person": {
+        "deleteThisGroupedObject": "Delete this person",
+        "addGroupedObject": "Add a person",
+        "dayScheduleFor": "Day schedule for",
+        "yourDaySchedule": "Your day schedule"
+    },
+    "auth": {
+        "UsernameOrEmail": "Email address",
+        "missingUsernameOrEmail": "Please provide your email address",
+        "authenticationFailed": "Your email address or password was not found or is invalid",
+        "pleaseChooseAUsernameOrEnterYourEmail": "To participate, please provide your email address",
+        "pleaseChooseAUsernameOrEnterYourEmailAndAPassword": "To register, please enter your email address, choose a password and confirm it, or use your Google or Facebook account.",
+        "usernameOrEmailAlreadyExists": "Your email address is already registered. PLease use your existing account.",
+        "WhyLoginInfo": "Because of the survey length, we propose that you connect with an email, or Google or Facebook account, so that you can come back later to finish the survey. You may choose to continue without an account, but you will not be able to finish the survey if your session expires.",
+        "PasswordlessHeader": "",
+        "UseAnonymousLogin": "Continue without connecting"
+    },
+    "visitedPlace": {
+        "deleteThisGroupedObject": "Delete this location",
+        "addGroupedObject": "Add the next location",
+        "activities": {
+            "home": "Home",
+            "workUsual": "Work at usual location",
+            "workNotUsual": "Work",
+            "schoolUsual": "School, studies at usual location",
+            "schoolNotUsual": "School, studies",
+            "schoolNotStudent": "School, studies",
+            "service": "Service",
+            "medical": "Health",
+            "workOnTheRoad": "On the road",
+            "workOnTheRoadFromHome": "On the road",
+            "workOnTheRoadFromUsualWork": "On the road",
+            "worship": "Place of worship",
+            "leisure": "Leisure",
+            "shopping": "Shopping",
+            "restaurant": "Restaurant, bar, coffee shop",
+            "dropSomeone": "Drop or accompany someone",
+            "fetchSomeone": "Pick someone up",
+            "visiting": "Visiting friends or family",
+            "secondaryHome": "Secondary home or cottage",
+            "other": "Other"
+        },
+        "editVisitedPlace": "Edit",
+        "deleteVisitedPlace": "Delete",
+        "saveVisitedPlace": "Save this location",
+        "insertVisitedPlace": "Insert a location here",
+        "editVisitedPlaces": "Edit, insert or delete location a location",
+        "addVisitedPlace": "Add the next location",
+        "cancelEditVisitedPlaces": "Cancel",
+        "resetVisitedPlaces": "Reset visited places and trips for this person"
+    },
+    "trip": {
+        "trip": "Trip",
+        "editTrip": "Edit",
+        "saveTrip": "Save this trip",
+        "editTrips": "Edit trips",
+        "cancelEditTrips": "Cancel",
+        "modes": {
+            "carDriver": "Car driver",
+            "carPassenger": "Car passenger"
+        }
+    },
+    "mode": {
+        "deleteThisGroupedObject": "Delete this mode of transport",
+        "addGroupedObject": "Add a mode of transport"
+    },
+    "AccessCode": "Please enter the access code written in the letter or the email you received<br /><span class=\"_pale _oblique\">Leave blank if no access code was received</span>",
+    "Age": "Age<span class=\\\"_pale _oblique\\\">Enter 0 for babies less than 1 years old</span>",
+    "Age_one": "Age",
+    "validation": {
+        "AgeRequired": "Age is required."
+    },
+    "Female": "Female",
+    "gender": {
+        "Custom": "{{nickname}} identifies themselves as",
+        "Custom_one": "I identify myself as"
     }
-  },
-  "mode": {
-    "deleteThisGroupedObject": "Delete this mode of transport",
-    "addGroupedObject": "Add a mode of transport"
-  }
 }

--- a/example/demo_survey/locales/fr/survey.json
+++ b/example/demo_survey/locales/fr/survey.json
@@ -1,80 +1,91 @@
 {
-  "homepage": {
-    "introduction": "<p class=\"center _strong\" style=\"color: #2B7F79;\">Nous sollicitons votre participation à une étude sur la mobilité des personnes de la région de Montréal. Cette étude vise à mieux connaître les déplacements des personnes habitant sur le territoire de la grande région de Montréal.</p><p class=\"center _oblique\"><a href=\"http://www.artm.quebec/eod/\">En savoir davantage sur cette étude</a></p>",
-    "pageTwoIntroduction": "<p class=\"center _strong\" style=\"color: #2B7F79;\">Vous avez déjà complété la première partie. La deuxième partie concerne les déplacements des membres de votre ménage.</p><p class=\"center _oblique\">Pour vous connecter, utilisez l'adresse courriel et le mot de passe que vous avez indiqués pour accéder à la première partie ou utilisez le même compte Google ou Facebook.</p>",
-    "start":"Débuter"
-  },
-  "postregistration": {
-    "introduction":"Merci pour votre participation!",
-    "login": "Votre code d'acces",
-    "password": "Votre mot de passe",
-    "start":"Débuter",
-    "info": "Vous aurez besoin de ces informations si vous désirez vous reconnecter à votre entrevue ou si vous désirez y accéder à partir d’un autre ordinateur."
-  },
-  "person": {
-    "deleteThisGroupedObject": "Supprimer cette personne",
-    "addGroupedObject": "Ajouter une personne",
-    "dayScheduleFor": "Horaire de la journée de",
-    "yourDaySchedule": "Votre horaire de la journée"
-  },
-  "auth": {
-    "UsernameOrEmail": "Courriel",
-    "missingUsernameOrEmail": "Veuillez indiquer votre courriel",
-    "authenticationFailed": "Votre courriel ou votre mot de passe est introuvable ou invalide",
-    "pleaseChooseAUsernameOrEnterYourEmail": "Pour participer, veuillez entrer votre courriel",
-    "pleaseChooseAUsernameOrEnterYourEmailAndAPassword": "Pour vous enregistrer, entrez votre courriel, puis choisissez un mot de passe et confirmez-le, ou utilisez votre compte Google ou Facebook.",
-    "usernameOrEmailAlreadyExists": "Votre courriel est déjà enregistré, veuillez utiliser votre compte déjà créé.",
-    "WhyLoginInfo": "En raison de la durée de l'enquête, nous vous proposons de vous connecter avec une adresse courriel, ou un compte Facebook ou Google, pour pouvoir la poursuivre plus tard. Enfin, il est tout à fait possible de continuer sans compte, mais vous ne pourrez revenir dans votre questionnaire si votre session expire.",
-    "PasswordlessHeader": "",
-    "UseAnonymousLogin": "Continuer sans se connecter"
-  },
-  "visitedPlace": {
-    "deleteThisGroupedObject": "Supprimer ce lieu",
-    "addGroupedObject": "Ajouter le prochain lieu",
-    "activities": {
-      "home": "Domicile",
-      "workUsual": "Travail au lieu habituel",
-      "workNotUsual": "Travail",
-      "schoolUsual": "École, études au lieu habituel",
-      "schoolNotUsual": "École, études",
-      "schoolNotStudent": "École, études",
-      "service": "Service",
-      "medical": "Santé",
-      "shopping": "Magasinage",
-      "workOnTheRoad": "Sur la route",
-      "workOnTheRoadFromHome": "Sur la route",
-      "workOnTheRoadFromUsualWork": "Sur la route",
-      "worship": "Lieu de culte",
-      "leisure": "Loisirs",
-      "restaurant": "Restaurant, bar, café",
-      "dropSomeone": "Reconduire ou accompagner quelqu'un",
-      "fetchSomeone": "Aller chercher quelqu'un",
-      "visiting": "Visite d'amis ou famille",
-      "secondaryHome": "Résidence secondaire ou chalet",
-      "other": "Autre"
+    "homepage": {
+        "introduction": "<p class=\"center _strong\" style=\"color: #2B7F79;\">Nous sollicitons votre participation à une étude sur la mobilité des personnes de la région de Montréal. Cette étude vise à mieux connaître les déplacements des personnes habitant sur le territoire de la grande région de Montréal.</p><p class=\"center _oblique\"><a href=\"http://www.artm.quebec/eod/\">En savoir davantage sur cette étude</a></p>",
+        "pageTwoIntroduction": "<p class=\"center _strong\" style=\"color: #2B7F79;\">Vous avez déjà complété la première partie. La deuxième partie concerne les déplacements des membres de votre ménage.</p><p class=\"center _oblique\">Pour vous connecter, utilisez l'adresse courriel et le mot de passe que vous avez indiqués pour accéder à la première partie ou utilisez le même compte Google ou Facebook.</p>",
+        "start": "Débuter"
     },
-    "editVisitedPlace": "Modifier",
-    "deleteVisitedPlace": "Supprimer",
-    "saveVisitedPlace": "Sauvegarder ce lieu",
-    "insertVisitedPlace": "Insérer un lieu ici",
-    "editVisitedPlaces": "Modifier, insérer ou supprimer un lieu",
-    "addVisitedPlace": "Ajouter le prochain lieu",
-    "cancelEditVisitedPlaces": "Annuler",
-    "resetVisitedPlaces": "Réinitialiser les lieux visités et les déplacements de cette personne"
-  },
-  "trip": {
-    "trip": "Déplacement",
-    "editTrip": "Modifier",
-    "saveTrip": "Sauvegarder ce déplacement",
-    "editTrips": "Modifier un déplacement",
-    "cancelEditTrips": "Annuler",
-    "modes": {
-      "carDriver": "Auto conducteur",
-      "carPassenger": "Auto passager"
+    "postregistration": {
+        "introduction": "Merci pour votre participation!",
+        "login": "Votre code d'acces",
+        "password": "Votre mot de passe",
+        "start": "Débuter",
+        "info": "Vous aurez besoin de ces informations si vous désirez vous reconnecter à votre entrevue ou si vous désirez y accéder à partir d’un autre ordinateur."
+    },
+    "person": {
+        "deleteThisGroupedObject": "Supprimer cette personne",
+        "addGroupedObject": "Ajouter une personne",
+        "dayScheduleFor": "Horaire de la journée de",
+        "yourDaySchedule": "Votre horaire de la journée"
+    },
+    "auth": {
+        "UsernameOrEmail": "Courriel",
+        "missingUsernameOrEmail": "Veuillez indiquer votre courriel",
+        "authenticationFailed": "Votre courriel ou votre mot de passe est introuvable ou invalide",
+        "pleaseChooseAUsernameOrEnterYourEmail": "Pour participer, veuillez entrer votre courriel",
+        "pleaseChooseAUsernameOrEnterYourEmailAndAPassword": "Pour vous enregistrer, entrez votre courriel, puis choisissez un mot de passe et confirmez-le, ou utilisez votre compte Google ou Facebook.",
+        "usernameOrEmailAlreadyExists": "Votre courriel est déjà enregistré, veuillez utiliser votre compte déjà créé.",
+        "WhyLoginInfo": "En raison de la durée de l'enquête, nous vous proposons de vous connecter avec une adresse courriel, ou un compte Facebook ou Google, pour pouvoir la poursuivre plus tard. Enfin, il est tout à fait possible de continuer sans compte, mais vous ne pourrez revenir dans votre questionnaire si votre session expire.",
+        "PasswordlessHeader": "",
+        "UseAnonymousLogin": "Continuer sans se connecter"
+    },
+    "visitedPlace": {
+        "deleteThisGroupedObject": "Supprimer ce lieu",
+        "addGroupedObject": "Ajouter le prochain lieu",
+        "activities": {
+            "home": "Domicile",
+            "workUsual": "Travail au lieu habituel",
+            "workNotUsual": "Travail",
+            "schoolUsual": "École, études au lieu habituel",
+            "schoolNotUsual": "École, études",
+            "schoolNotStudent": "École, études",
+            "service": "Service",
+            "medical": "Santé",
+            "shopping": "Magasinage",
+            "workOnTheRoad": "Sur la route",
+            "workOnTheRoadFromHome": "Sur la route",
+            "workOnTheRoadFromUsualWork": "Sur la route",
+            "worship": "Lieu de culte",
+            "leisure": "Loisirs",
+            "restaurant": "Restaurant, bar, café",
+            "dropSomeone": "Reconduire ou accompagner quelqu'un",
+            "fetchSomeone": "Aller chercher quelqu'un",
+            "visiting": "Visite d'amis ou famille",
+            "secondaryHome": "Résidence secondaire ou chalet",
+            "other": "Autre"
+        },
+        "editVisitedPlace": "Modifier",
+        "deleteVisitedPlace": "Supprimer",
+        "saveVisitedPlace": "Sauvegarder ce lieu",
+        "insertVisitedPlace": "Insérer un lieu ici",
+        "editVisitedPlaces": "Modifier, insérer ou supprimer un lieu",
+        "addVisitedPlace": "Ajouter le prochain lieu",
+        "cancelEditVisitedPlaces": "Annuler",
+        "resetVisitedPlaces": "Réinitialiser les lieux visités et les déplacements de cette personne"
+    },
+    "trip": {
+        "trip": "Déplacement",
+        "editTrip": "Modifier",
+        "saveTrip": "Sauvegarder ce déplacement",
+        "editTrips": "Modifier un déplacement",
+        "cancelEditTrips": "Annuler",
+        "modes": {
+            "carDriver": "Auto conducteur",
+            "carPassenger": "Auto passager"
+        }
+    },
+    "mode": {
+        "deleteThisGroupedObject": "Supprimer ce mode de transport",
+        "addGroupedObject": "Ajouter un mode de transport"
+    },
+    "AccessCode": "Veuillez indiquer le code d'accès inscrit dans la lettre ou le courriel que vous avez reçu<br /><span class=\"_pale _oblique\">Laissez vide si aucun code d'accès reçu</span>",
+    "Age": "Âge<br /><span class=\"_pale _oblique\">Inscrire 0 pour les bébés de moins de 1 an</span>",
+    "Age_one": "Âge",
+    "validation": {
+        "AgeRequired": "L'âge est requis."
+    },
+    "Female": "Femme",
+    "gender": {
+        "Custom": "{{nickname}} s'identifie comme",
+        "Custom_one": "Je m'identifie comme"
     }
-  },
-  "mode": {
-    "deleteThisGroupedObject": "Supprimer ce mode de transport",
-    "addGroupedObject": "Ajouter un mode de transport"
-  }
 }

--- a/example/demo_survey/src/survey/widgets/home.tsx
+++ b/example/demo_survey/src/survey/widgets/home.tsx
@@ -6,6 +6,7 @@
  */
 import moment from 'moment-business-days';
 import { booleanPointInPolygon as turfBooleanPointInPolygon } from '@turf/turf';
+import { TFunction } from 'i18next';
 
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import config from 'chaire-lib-common/lib/config/shared/project.config';
@@ -57,10 +58,7 @@ export const accessCode: SurveyWidgetConfig = {
   inputType: "string",
   datatype: "string",
   containsHtml: true,
-  label: {
-    fr: `Veuillez indiquer le code d'accès inscrit dans la lettre ou le courriel que vous avez reçu<br /><span class="_pale _oblique">Laissez vide si aucun code d'accès reçu</span>`,
-    en: `Please enter the access code written in the letter or the email you received<br /><span class="_pale _oblique">Leave blank if no access code was received</span>`
-  }
+  label: (t: TFunction) => t('survey:AccessCode')
 }
 
 export const householdSize: SurveyWidgetConfig = {

--- a/example/demo_survey/src/survey/widgets/householdMembers.tsx
+++ b/example/demo_survey/src/survey/widgets/householdMembers.tsx
@@ -12,6 +12,7 @@ import { faFemale } from '@fortawesome/free-solid-svg-icons/faFemale';
 import { faChild } from '@fortawesome/free-solid-svg-icons/faChild';
 import { faPortrait } from '@fortawesome/free-solid-svg-icons/faPortrait';
 import { booleanPointInPolygon as turfBooleanPointInPolygon } from '@turf/turf';
+import { TFunction } from 'i18next';
 
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import * as surveyHelperNew from 'evolution-common/lib/utils/helpers';
@@ -42,24 +43,15 @@ export const personAge = {
   datatype: "integer",
   twoColumns: true,
   containsHtml: true,
-  label: {
-    fr: function(interview) {
-      const householdSize = helper.countPersons(interview);
-      return `Âge${householdSize !== 1 ? `<br /><span class="_pale _oblique">Inscrire 0 pour les bébés de moins de 1 an</span>` : ''}`;
-    },
-    en: function(interview) {
-      const householdSize = helper.countPersons(interview);
-      return `Age${householdSize !== 1 ? `<br /><span class=\"_pale _oblique\">Enter 0 for babies less than 1 years old</span>` : ''}`;
-    }
+  label: (t: TFunction, interview) => {
+    const householdSize = helper.countPersons(interview);
+    return t('survey:Age', { count: householdSize });
   },
   validations: function(value, customValue, interview, path, customPath) {
     return [
       {
         validation: _isBlank(value),
-        errorMessage: {
-          fr: `L'âge est requis.`,
-          en: `Age is required.`
-        }
+        errorMessage: (t: TFunction) => t('survey:validation:AgeRequired')
       },
       {
         validation: (isNaN(Number(value)) || !Number.isInteger(Number(value))),
@@ -136,10 +128,7 @@ export const personGender = {
     {
       value: 'female',
       internalId: 2,
-      label: {
-        fr: "Femme",
-        en: "Female"
-      }
+      label: (t: TFunction) => t('survey:Female')
     },
     {
       value: 'male',
@@ -152,17 +141,10 @@ export const personGender = {
     {
       value: 'custom',
       internalId: 3,
-      label: {
-        fr: function(interview, path) {
-          const householdSize = helper.countPersons(interview);
-          const nickname      = surveyHelperNew.getResponse(interview, path, "Cette personne", '../nickname');
-          return householdSize === 1 ? `Je m'identifie comme` : `${nickname} s'identifie comme`;
-        },
-        en: function(interview, path) {
-          const householdSize = helper.countPersons(interview);
-          const nickname = surveyHelperNew.getResponse(interview, path, "This person", '../nickname');
-          return householdSize === 1 ? `I identify myself as` : `${nickname} identifies themselves as`;
-        }
+      label: (t:TFunction, interview, path) => {
+        const householdSize = helper.countPersons(interview);
+        const nickname      = surveyHelperNew.getResponse(interview, path, "Cette personne", '../nickname');
+        return t('survey:gender:Custom', { count: householdSize, nickname });
       }
     }
   ],

--- a/packages/evolution-common/package.json
+++ b/packages/evolution-common/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.32",
     "chaire-lib-common": "^0.2.2",
+    "i18next": "^22.4.15",
     "lodash.clonedeep": "^4.5.0",
     "lodash.get": "^4.4.2",
     "lodash.isequal": "^4.5.0",

--- a/packages/evolution-common/src/services/widgets/WidgetConfig.ts
+++ b/packages/evolution-common/src/services/widgets/WidgetConfig.ts
@@ -350,8 +350,10 @@ export type WidgetConfig<CustomSurvey, CustomHousehold, CustomHome, CustomPerson
           action: (section: any, sections: any[], saveCallback?: () => void) => void;
           // FIXME: Type the saveCallback. There is a `this` bound to the function, with props.interview. See if we can pass the interview as parameter instead, and/or anything else.
           saveCallback?: () => void;
-          // FIXME Type the confirm popup
-          confirmPopup?: any;
+          confirmPopup?: {
+              title?: I18nData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
+              content: I18nData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
+          };
           size?: 'small' | 'medium' | 'large';
           conditional?: ParsingFunction<
               boolean | [boolean] | [boolean, unknown],
@@ -370,5 +372,6 @@ export type WidgetConfig<CustomSurvey, CustomHousehold, CustomHome, CustomPerson
               CustomHome,
               CustomPerson
           >;
+          title: I18nData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
           // TODO Further type this
       };

--- a/packages/evolution-common/src/services/widgets/WidgetConfig.ts
+++ b/packages/evolution-common/src/services/widgets/WidgetConfig.ts
@@ -8,7 +8,7 @@
 
 import { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { UserInterviewAttributes, InterviewResponsePath, InterviewResponses } from '../interviews/interview';
-import { ParsingFunction } from '../../utils/helpers';
+import { ParsingFunction, I18nData } from '../../utils/helpers';
 import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
 
 /**
@@ -29,11 +29,7 @@ export type ValidationFunction<CustomSurvey, CustomHousehold, CustomHome, Custom
     path: string,
     customPath?: string,
     user?: CliUser
-) => { validation: boolean; errorMessage: LangData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson> }[];
-
-export type LangData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson> = {
-    [lang: string]: string | ParsingFunction<string, CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
-};
+) => { validation: boolean; errorMessage: I18nData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson> }[];
 
 export type InputStringType<CustomSurvey, CustomHousehold, CustomHome, CustomPerson> = {
     inputType: 'string';
@@ -54,7 +50,7 @@ export type InputTextType<CustomSurvey, CustomHousehold, CustomHome, CustomPerso
 
 // TODO This type is used by select, checkbox, radio, buttons etc. See if we can leverage functionality. Now every widget uses a subset of the properties (some may not need some of them, some could use them)
 type BaseChoiceType<CustomSurvey, CustomHousehold, CustomHome, CustomPerson> = {
-    label: string | { [lang: string]: string };
+    label: I18nData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
     hidden?: boolean;
     icon?: IconProp;
     iconPath?: string;
@@ -88,7 +84,7 @@ export type RadioChoiceType<CustomSurvey, CustomHousehold, CustomHome, CustomPer
 
 export type GroupedChoiceType<CustomSurvey, CustomHousehold, CustomHome, CustomPerson> = {
     groupShortname: string;
-    groupLabel: string | { [lang: string]: string };
+    groupLabel: I18nData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
     choices: ChoiceType<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>[];
 };
 
@@ -119,7 +115,7 @@ export type InputCheckboxType<CustomSurvey, CustomHousehold, CustomHome, CustomP
     addCustom?: boolean;
     columns?: number;
     sameLine?: boolean;
-    customLabel?: string | LangData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
+    customLabel?: I18nData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
     datatype?: 'string' | 'integer' | 'float' | 'text';
 };
 
@@ -141,7 +137,7 @@ export type InputRadioType<CustomSurvey, CustomHousehold, CustomHome, CustomPers
     addCustom?: boolean;
     columns?: number;
     sameLine?: boolean;
-    customLabel?: string | LangData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
+    customLabel?: I18nData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
     customChoice?: string;
     datatype?: 'string' | 'integer' | 'float' | 'text' | 'boolean';
 };
@@ -230,14 +226,14 @@ export type InputRangeType<CustomSurvey, CustomHousehold, CustomHome, CustomPers
     maxValue?: number;
     minValue?: number;
     formatLabel?: (value: number, lang: string) => string;
-    labels?: (string | LangData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>)[];
+    labels?: I18nData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>[];
     trackClassName?: string;
 };
 
 export type InputDatePickerType<CustomSurvey, CustomHousehold, CustomHome, CustomPerson> = {
     inputType: 'datePicker';
     showTimeSelect?: boolean;
-    placeholderText?: string | LangData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
+    placeholderText?: I18nData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
     maxDate?: Date | ParsingFunction<Date, CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
     minDate?: Date | ParsingFunction<Date, CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
     locale?: { [languageCode: string]: string };
@@ -246,8 +242,8 @@ export type InputDatePickerType<CustomSurvey, CustomHousehold, CustomHome, Custo
 type InputMapType<CustomSurvey, CustomHousehold, CustomHome, CustomPerson> = {
     defaultCenter: { lat: number; lon: number };
     geocodingQueryString?: ParsingFunction<string | undefined, CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
-    refreshGeocodingLabel?: LangData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
-    afterRefreshButtonText?: LangData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
+    refreshGeocodingLabel?: I18nData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
+    afterRefreshButtonText?: I18nData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
     icon?: {
         url: string | ParsingFunction<string, CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
     };
@@ -287,10 +283,10 @@ export type WidgetConfig<CustomSurvey, CustomHousehold, CustomHome, CustomPerson
           twoColumns?: boolean;
           path: InterviewResponsePath<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
           containsHtml?: boolean;
-          label: LangData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
+          label: I18nData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
           helpPopup?: {
-              title: LangData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
-              content: LangData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
+              title: I18nData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
+              content: I18nData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
           };
           validations?: ValidationFunction<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
           conditional?: ParsingFunction<
@@ -318,7 +314,7 @@ export type WidgetConfig<CustomSurvey, CustomHousehold, CustomHome, CustomPerson
           type: 'text';
           align?: 'center' | 'left' | 'right';
           containsHtml?: boolean;
-          text: LangData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
+          text: I18nData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
           classes?: string;
           conditional?: ParsingFunction<
               boolean | [boolean] | [boolean, unknown],
@@ -345,7 +341,7 @@ export type WidgetConfig<CustomSurvey, CustomHousehold, CustomHome, CustomPerson
           // FIXME What is this path used for? Document and/or type further
           path: string;
           color?: string;
-          label: LangData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
+          label: I18nData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
           hideWhenRefreshing?: boolean;
           icon?: IconProp;
           iconPath?: string;

--- a/packages/evolution-common/src/utils/helpers.ts
+++ b/packages/evolution-common/src/utils/helpers.ts
@@ -6,6 +6,7 @@
  */
 import _get from 'lodash.get';
 import _set from 'lodash.set';
+import { i18n, TFunction } from 'i18next';
 
 import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
 import * as LE from 'chaire-lib-common/lib/utils/LodashExtensions';
@@ -16,6 +17,36 @@ export type ParsingFunction<T, CustomSurvey, CustomHousehold, CustomHome, Custom
     path: string,
     user?: CliUser
 ) => T;
+
+export type LangData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson> = {
+    [lang: string]: string | ParsingFunction<string, CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
+};
+
+export type TranslatableStringFunction<CustomSurvey, CustomHousehold, CustomHome, CustomPerson> = (
+    t: TFunction,
+    interview: UserInterviewAttributes<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>,
+    path: string,
+    user?: CliUser
+) => string;
+
+export type I18nData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson> =
+    | string
+    | LangData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>
+    | TranslatableStringFunction<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
+
+export const translateString = <CustomSurvey, CustomHousehold, CustomHome, CustomPerson>(
+    i18nData: I18nData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson> | undefined,
+    i18nObj: i18n,
+    interview: UserInterviewAttributes<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>,
+    path: string,
+    user?: CliUser
+): string | undefined => {
+    return typeof i18nData === 'function'
+        ? i18nData(i18nObj.t, interview, path, user)
+        : typeof i18nData === 'object'
+            ? parseString(i18nData[i18nObj.language], interview, path, user)
+            : i18nData;
+};
 
 /**
  * Verify if the value is a function. If so, call it with the other parameters,

--- a/packages/evolution-frontend/src/actions/utils/Validation.ts
+++ b/packages/evolution-frontend/src/actions/utils/Validation.ts
@@ -1,5 +1,6 @@
 import { UserInterviewAttributes } from 'evolution-common/lib/services/interviews/interview';
-import { ValidationFunction, LangData } from 'evolution-common/lib/services/widgets';
+import { ValidationFunction } from 'evolution-common/lib/services/widgets';
+import { I18nData } from 'evolution-common/lib/utils/helpers';
 
 /**
  * Check the validations for a specific value
@@ -19,7 +20,7 @@ export const checkValidations = <CustomSurvey, CustomHousehold, CustomHome, Cust
     interview: UserInterviewAttributes<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>,
     path: string,
     customPath?: string
-): [boolean, LangData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson> | undefined] => {
+): [boolean, I18nData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson> | undefined] => {
     if (typeof validations === 'function') {
         try {
             const validationsGroup = validations(value, customValue, interview, path, customPath);

--- a/packages/evolution-frontend/src/components/inputs/InputButton.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputButton.tsx
@@ -59,11 +59,7 @@ const InputButtonOption = <CustomSurvey, CustomHousehold, CustomHome, CustomPers
                 id={props.id}
             >
                 {props.choice.icon && <FontAwesomeIcon icon={props.choice.icon} className="faIconLeft" />}
-                {surveyHelper.parseString(
-                    props.choice.label[props.i18n.language] || props.choice.label,
-                    props.interview,
-                    props.path
-                )}
+                {surveyHelper.translateString(props.choice.label, props.i18n, props.interview, props.path, props.user)}
             </button>
         </div>
     );

--- a/packages/evolution-frontend/src/components/inputs/InputCheckbox.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputCheckbox.tsx
@@ -42,6 +42,7 @@ interface InputCheckboxChoiceProps<CustomSurvey, CustomHousehold, CustomHome, Cu
     interview: UserInterviewAttributes<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
     // TODO There's also a path in widgetConfig, but this one comes from the props of the question. See if it's always the same and use the one from widgetConfig if necessary
     path: string;
+    user: CliUser;
     checked: boolean;
     iconSize: string;
     onCheckboxInputChange: React.ChangeEventHandler;
@@ -62,10 +63,12 @@ const InputCheckboxChoice = <CustomSurvey, CustomHousehold, CustomHome, CustomPe
         props.choice.value !== null && props.choice.value !== undefined
             ? props.choice.value.toString()
             : props.choice.value;
-    const strLabel = surveyHelper.parseString(
-        props.choice.label[props.i18n.language] || props.choice.label,
+    const strLabel = surveyHelper.translateString(
+        props.choice.label,
+        props.i18n,
         props.interview,
-        props.path
+        props.path,
+        props.user
     );
     const inputCheckboxRef: React.RefObject<HTMLInputElement> = React.createRef();
     const iconPath = props.choice.iconPath
@@ -236,6 +239,7 @@ export class InputCheckbox<CustomSurvey, CustomHousehold, CustomHome, CustomPers
                     key={`${this.props.id}__${choice.value}__key`}
                     interview={this.props.interview}
                     path={this.props.path}
+                    user={this.props.user}
                     checked={valueSet.has(choice.value)}
                     iconSize={iconSize}
                     onCheckboxClick={this.onCheckboxClick}
@@ -249,10 +253,9 @@ export class InputCheckbox<CustomSurvey, CustomHousehold, CustomHome, CustomPers
         const columnedChoiceInputs = this.getColumnedChoices(choiceInputs);
 
         const strCustomLabel = this.props.widgetConfig.customLabel
-            ? surveyHelper.parseString(
-                this.props.widgetConfig.customLabel[this.props.i18n.language] ||
-                      (this.props.widgetConfig.customLabel as string) ||
-                      '',
+            ? surveyHelper.translateString(
+                this.props.widgetConfig.customLabel,
+                this.props.i18n,
                 this.props.interview,
                 this.props.path
             )

--- a/packages/evolution-frontend/src/components/inputs/InputDatePicker.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputDatePicker.tsx
@@ -63,9 +63,14 @@ export const InputDatePicker = <CustomSurvey, CustomHousehold, CustomHome, Custo
                         : undefined
                 }
                 placeholderText={
-                    props.widgetConfig.placeholderText && props.widgetConfig.placeholderText[props.i18n.language]
-                        ? props.widgetConfig.placeholderText[props.i18n.language]
-                        : props.t('ClickToSelectDate')
+                    props.widgetConfig.placeholderText
+                        ? surveyHelper.translateString(
+                            props.widgetConfig.placeholderText,
+                            props.i18n,
+                            props.interview,
+                            props.path
+                        )
+                        : props.t('main:ClickToSelectDate')
                 }
                 selected={props.value !== undefined ? new Date(props.value) : undefined}
                 onChange={(date) => props.onValueChange({ target: { value: date } })}

--- a/packages/evolution-frontend/src/components/inputs/InputMapFindPlace.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputMapFindPlace.tsx
@@ -312,8 +312,9 @@ export class InputMapPoint<CustomSurvey, CustomHousehold, CustomHome, CustomPers
             : undefined;
 
         const afterRefreshButtonText = this.props.widgetConfig.afterRefreshButtonText
-            ? surveyHelper.parseString(
-                this.props.widgetConfig.afterRefreshButtonText[this.props.i18n.language],
+            ? surveyHelper.translateString(
+                this.props.widgetConfig.afterRefreshButtonText,
+                this.props.i18n,
                 this.props.interview,
                 this.props.path,
                 this.props.user
@@ -341,8 +342,9 @@ export class InputMapPoint<CustomSurvey, CustomHousehold, CustomHome, CustomPers
                         ref={this.geocodeButtonRef}
                     >
                         <FontAwesomeIcon icon={faMapMarkerAlt} className="faIconLeft" />
-                        {surveyHelper.parseString(
-                            this.props.widgetConfig.refreshGeocodingLabel[this.props.i18n.language],
+                        {surveyHelper.translateString(
+                            this.props.widgetConfig.refreshGeocodingLabel,
+                            this.props.i18n,
                             this.props.interview,
                             this.props.path,
                             this.props.user

--- a/packages/evolution-frontend/src/components/inputs/InputMapPoint.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputMapPoint.tsx
@@ -163,8 +163,9 @@ export class InputMapPoint<CustomSurvey, CustomHousehold, CustomHome, CustomPers
                         ref={this.geocodeButtonRef}
                     >
                         <FontAwesomeIcon icon={faMapMarkerAlt} className="faIconLeft" />
-                        {surveyHelper.parseString(
-                            this.props.widgetConfig.refreshGeocodingLabel[this.props.i18n.language],
+                        {surveyHelper.translateString(
+                            this.props.widgetConfig.refreshGeocodingLabel,
+                            this.props.i18n,
                             this.props.interview,
                             this.props.path,
                             this.props.user

--- a/packages/evolution-frontend/src/components/inputs/InputMultiselect.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputMultiselect.tsx
@@ -122,8 +122,9 @@ export class InputMultiselect<CustomSurvey, CustomHousehold, CustomHome, CustomP
                 );
             })
             .map((choice) => {
-                const label = surveyHelper.parseString(
-                    choice.label[this.props.i18n.language] || choice.label,
+                const label = surveyHelper.translateString(
+                    choice.label,
+                    this.props.i18n,
                     this.props.interview,
                     this.props.path,
                     this.props.user
@@ -161,8 +162,9 @@ export class InputMultiselect<CustomSurvey, CustomHousehold, CustomHome, CustomP
                         tabIndex={-1}
                     >
                         {shortcut.icon && <FontAwesomeIcon icon={shortcut.icon} className="faIconLeft" />}
-                        {surveyHelper.parseString(
-                            shortcut.label[this.props.i18n.language] || shortcut.label,
+                        {surveyHelper.translateString(
+                            shortcut.label,
+                            this.props.i18n,
                             this.props.interview,
                             this.props.path,
                             this.props.user

--- a/packages/evolution-frontend/src/components/inputs/InputRadio.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputRadio.tsx
@@ -45,6 +45,7 @@ interface InputRadioChoiceProps<CustomSurvey, CustomHousehold, CustomHome, Custo
     interview: UserInterviewAttributes<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
     // TODO There's also a path in widgetConfig, but this one comes from the props of the question. See if it's always the same and use the one from widgetConfig if necessary
     path: string;
+    user: CliUser;
     checked: boolean;
     iconSize: string;
     children?: React.ReactNode;
@@ -66,10 +67,12 @@ const InputRadioChoice = <CustomSurvey, CustomHousehold, CustomHome, CustomPerso
         props.choice.value !== null && props.choice.value !== undefined
             ? props.choice.value.toString()
             : props.choice.value;
-    const strLabel = surveyHelper.parseString(
-        props.choice.label[props.i18n.language] || props.choice.label,
+    const strLabel = surveyHelper.translateString(
+        props.choice.label,
+        props.i18n,
         props.interview,
-        props.path
+        props.path,
+        props.user
     );
     const inputRadioRef: React.RefObject<HTMLInputElement> = React.createRef();
     const iconPath = props.choice.iconPath
@@ -254,6 +257,7 @@ export class InputRadio<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>
                     key={`${this.props.id}__${choice.value}__key`}
                     interview={this.props.interview}
                     path={this.props.path}
+                    user={this.props.user}
                     checked={choice.value === this.props.value}
                     iconSize={iconSize}
                     onRadioClick={this.onRadioClick}

--- a/packages/evolution-frontend/src/components/inputs/InputRange.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputRange.tsx
@@ -38,12 +38,7 @@ export const InputRange = <CustomSurvey, CustomHousehold, CustomHome, CustomPers
     const labels = props.widgetConfig.labels;
     const labelItems = labels
         ? labels.map((label, idx) => {
-            const labelStr = surveyHelper.parseString(
-                label[props.i18n.language] || label,
-                props.interview,
-                props.path,
-                props.user
-            );
+            const labelStr = surveyHelper.translateString(label, props.i18n, props.interview, props.path, props.user);
             return (
                 <p
                     key={`inputRange_${props.id}_label_${idx}`}

--- a/packages/evolution-frontend/src/components/inputs/InputSelect.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputSelect.tsx
@@ -49,12 +49,7 @@ const InputSelectOption = <CustomSurvey, CustomHousehold, CustomHome, CustomPers
             value={props.choice.value}
             className={'input-select-option'}
         >
-            {surveyHelper.parseString(
-                props.choice.label[props.i18n.language] || props.choice.label,
-                props.interview,
-                props.path,
-                props.user
-            )}
+            {surveyHelper.translateString(props.choice.label, props.i18n, props.interview, props.path, props.user)}
         </option>
     );
 };

--- a/packages/evolution-frontend/src/components/inputs/__tests__/InputButton.test.tsx
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/InputButton.test.tsx
@@ -10,6 +10,7 @@ import { render, fireEvent } from '@testing-library/react';
 
 import { interviewAttributes } from './interviewData.test';
 import InputButton from '../InputButton';
+import i18next from 'i18next';
 
 const userAttributes = {
     id: 1,
@@ -24,6 +25,7 @@ const userAttributes = {
 
 describe('InputButton with normal options', () => {
     const conditionalFct = jest.fn().mockReturnValue(true);
+    const translationFct = jest.fn().mockReturnValue('Translated string');
     const choices = [
         {
             value: 'val1',
@@ -47,6 +49,12 @@ describe('InputButton with normal options', () => {
             value: 'conditionalVal',
             label: { en: 'english conditional', fr: 'conditionnelle' },
             conditional: conditionalFct
+        },
+        {
+            value: 'val3',
+            label: translationFct,
+            hidden: false,
+            color: 'green'
         }
     ];
 
@@ -82,6 +90,7 @@ describe('InputButton with normal options', () => {
         expect(wrapper).toMatchSnapshot();
         expect(conditionalFct).toHaveBeenCalledTimes(1);
         expect(conditionalFct).toHaveBeenCalledWith(interviewAttributes, 'foo.test', userAttributes);
+        expect(translationFct).toHaveBeenCalledWith(i18next.t, interviewAttributes, 'foo.test', userAttributes);
         
     });
 

--- a/packages/evolution-frontend/src/components/inputs/__tests__/InputCheckbox.test.tsx
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/InputCheckbox.test.tsx
@@ -8,12 +8,11 @@ import React from 'react';
 import TestRenderer from 'react-test-renderer';
 import { faCrow } from '@fortawesome/free-solid-svg-icons/faCrow';
 
-import { UserInterviewAttributes } from 'evolution-common/lib/services/interviews/interview';
-
 import { shuffle } from 'chaire-lib-common/lib/utils/RandomUtils';
 import { interviewAttributes } from './interviewData.test';
 
 import InputCheckbox from '../InputCheckbox';
+import i18next from 'i18next';
 
 jest.mock('chaire-lib-common/lib/utils/RandomUtils', () => ({
     shuffle: jest.fn()
@@ -35,6 +34,7 @@ const userAttributes = {
 describe('Render InputCheckbox with various parameter combinations, all parameters', () => {
 
     const conditionalFct = jest.fn().mockReturnValue(true);
+    const translationFct = jest.fn().mockReturnValue('Translated string');
     const choices = [
         {
             value: 'val1',
@@ -56,6 +56,12 @@ describe('Render InputCheckbox with various parameter combinations, all paramete
             value: 'conditionalVal',
             label: { en: 'english conditional', fr: 'conditionnelle' },
             conditional: conditionalFct
+        },
+        {
+            value: 'val3',
+            label: translationFct,
+            hidden: false,
+            color: 'green'
         }
     ];
 
@@ -100,6 +106,7 @@ describe('Render InputCheckbox with various parameter combinations, all paramete
         expect(wrapper).toMatchSnapshot();
         expect(conditionalFct).toHaveBeenCalledTimes(1);
         expect(conditionalFct).toHaveBeenCalledWith(interviewAttributes, 'foo.test', userAttributes);
+        expect(translationFct).toHaveBeenCalledWith(i18next.t, interviewAttributes, 'foo.test', userAttributes);
     });
 
     test('Conditional value hidden, same line', () => {

--- a/packages/evolution-frontend/src/components/inputs/__tests__/InputMultiselect.test.tsx
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/InputMultiselect.test.tsx
@@ -9,6 +9,7 @@ import TestRenderer from 'react-test-renderer';
 
 import { interviewAttributes } from './interviewData.test';
 import InputMultiselect from '../InputMultiselect';
+import i18next from 'i18next';
 
 const userAttributes = {
     id: 1,
@@ -24,6 +25,7 @@ const userAttributes = {
 describe('Render InputMultiselect with various options', () => {
 
     const conditionalFct = jest.fn().mockReturnValue(true);
+    const translationFct = jest.fn().mockReturnValue('Translated string');
     const choices = [
         {
             value: 'val1',
@@ -45,6 +47,12 @@ describe('Render InputMultiselect with various options', () => {
             value: 'conditionalVal',
             label: { en: 'english conditional', fr: 'conditionnelle' },
             conditional: conditionalFct
+        },
+        {
+            value: 'val3',
+            label: translationFct,
+            hidden: false,
+            color: 'green'
         }
     ];
 
@@ -78,9 +86,11 @@ describe('Render InputMultiselect with various options', () => {
         expect(wrapper).toMatchSnapshot();
         expect(conditionalFct).toHaveBeenCalledTimes(1);
         expect(conditionalFct).toHaveBeenCalledWith(interviewAttributes, 'foo.test', userAttributes);
+        expect(translationFct).toHaveBeenCalledWith(i18next.t, interviewAttributes, 'foo.test', userAttributes);
     });
     
     test('With shortcuts', () => {
+        const shortcutTranslateFct = jest.fn().mockReturnValue('Translated shortcut');
         const configWithShortcuts = Object.assign({}, widgetConfig, { 
             shortcuts: [
                 {
@@ -91,6 +101,11 @@ describe('Render InputMultiselect with various options', () => {
                 {
                     value: 'conditionalVal',
                     label: { en: 'english conditional', fr: 'conditionnelle' },
+                    color: 'red'
+                },
+                {
+                    value: 'val3',
+                    label: shortcutTranslateFct,
                     color: 'red'
                 },
             ]
@@ -109,6 +124,7 @@ describe('Render InputMultiselect with various options', () => {
             />
         );
         expect(wrapper).toMatchSnapshot();
+        expect(shortcutTranslateFct).toHaveBeenCalledWith(i18next.t, interviewAttributes, 'foo.test', userAttributes);
     });
 
     test('With all parameters', () => {

--- a/packages/evolution-frontend/src/components/inputs/__tests__/InputRadio.test.tsx
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/InputRadio.test.tsx
@@ -13,6 +13,7 @@ import { interviewAttributes } from './interviewData.test';
 import { shuffle } from 'chaire-lib-common/lib/utils/RandomUtils';
 
 import InputRadio from '../InputRadio';
+import i18next from 'i18next';
 
 jest.mock('chaire-lib-common/lib/utils/RandomUtils', () => ({
     shuffle: jest.fn()
@@ -34,6 +35,7 @@ const userAttributes = {
 describe('Render InputRadio with various parameter combinations, all parameters', () => {
 
     const conditionalFct = jest.fn().mockReturnValue(true);
+    const translationFct = jest.fn().mockReturnValue('Translated string');
     const choices = [
         {
             value: 'val1',
@@ -55,6 +57,12 @@ describe('Render InputRadio with various parameter combinations, all parameters'
             value: 'conditionalVal',
             label: { en: 'english conditional', fr: 'conditionnelle' },
             conditional: conditionalFct
+        },
+        {
+            value: 'val3',
+            label: translationFct,
+            hidden: false,
+            color: 'green'
         }
     ];
 
@@ -99,6 +107,7 @@ describe('Render InputRadio with various parameter combinations, all parameters'
         expect(wrapper).toMatchSnapshot();
         expect(conditionalFct).toHaveBeenCalledTimes(1);
         expect(conditionalFct).toHaveBeenCalledWith(interviewAttributes, 'foo.test', userAttributes);
+        expect(translationFct).toHaveBeenCalledWith(i18next.t, interviewAttributes, 'foo.test', userAttributes);
     });
 
     test('Conditional value hidden, same line', () => {

--- a/packages/evolution-frontend/src/components/inputs/__tests__/InputSelect.test.tsx
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/InputSelect.test.tsx
@@ -9,6 +9,7 @@ import TestRenderer from 'react-test-renderer';
 
 import { interviewAttributes } from './interviewData.test';
 import InputSelect from '../InputSelect';
+import i18next from 'i18next';
 
 const userAttributes = {
     id: 1,
@@ -24,6 +25,7 @@ const userAttributes = {
 test('Render InputSelect with normal option type', () => {
 
     const conditionalFct = jest.fn().mockReturnValue(true);
+    const translationFct = jest.fn().mockReturnValue('Translated string');
     const choices = [
         {
             value: 'val1',
@@ -45,6 +47,12 @@ test('Render InputSelect with normal option type', () => {
             value: 'conditionalVal',
             label: { en: 'english conditional', fr: 'conditionnelle' },
             conditional: conditionalFct
+        },
+        {
+            value: 'val3',
+            label: translationFct,
+            hidden: false,
+            color: 'green'
         }
     ];
 
@@ -77,6 +85,7 @@ test('Render InputSelect with normal option type', () => {
     expect(wrapper).toMatchSnapshot();
     expect(conditionalFct).toHaveBeenCalledTimes(1);
     expect(conditionalFct).toHaveBeenCalledWith(interviewAttributes, 'foo.test', userAttributes);
+    expect(translationFct).toHaveBeenCalledWith(i18next.t, interviewAttributes, 'foo.test', userAttributes);
     
 });
 

--- a/packages/evolution-frontend/src/components/inputs/__tests__/__snapshots__/InputButton.test.tsx.snap
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/__snapshots__/InputButton.test.tsx.snap
@@ -40,6 +40,18 @@ exports[`InputButton with normal options Render InputButton with normal option t
       english conditional
     </button>
   </div>
+  <div
+    className="survey-question__input-button-input-container"
+  >
+    <button
+      className="survey-section__button button green large"
+      id="test__input-button__val3"
+      onClick={[Function]}
+      type="button"
+    >
+      Translated string
+    </button>
+  </div>
 </div>
 `;
 

--- a/packages/evolution-frontend/src/components/inputs/__tests__/__snapshots__/InputCheckbox.test.tsx.snap
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/__snapshots__/InputCheckbox.test.tsx.snap
@@ -155,6 +155,33 @@ exports[`Render InputCheckbox with various parameter combinations, all parameter
       </label>
     </div>
   </div>
+  <div
+    className="survey-question__input-checkbox-input-container"
+    onClick={[Function]}
+  >
+    <div
+      className="label-input-container"
+    >
+      <input
+        checked={false}
+        className="input-checkbox"
+        id="test_val3__input-checkbox__val3"
+        name="test_val3"
+        onChange={[Function]}
+        onClick={[Function]}
+        type="checkbox"
+        value="val3"
+      />
+      <label
+        htmlFor="test_val3__input-checkbox__val3"
+        onClick={[Function]}
+      >
+        <span>
+          Translated string
+        </span>
+      </label>
+    </div>
+  </div>
 </div>
 `;
 
@@ -282,6 +309,33 @@ exports[`Render InputCheckbox with various parameter combinations, all parameter
         >
           <span>
             english conditional
+          </span>
+        </label>
+      </div>
+    </div>
+    <div
+      className="survey-question__input-checkbox-input-container"
+      onClick={[Function]}
+    >
+      <div
+        className="label-input-container"
+      >
+        <input
+          checked={false}
+          className="input-checkbox"
+          id="test_val3__input-checkbox__val3"
+          name="test_val3"
+          onChange={[Function]}
+          onClick={[Function]}
+          type="checkbox"
+          value="val3"
+        />
+        <label
+          htmlFor="test_val3__input-checkbox__val3"
+          onClick={[Function]}
+        >
+          <span>
+            Translated string
           </span>
         </label>
       </div>
@@ -519,10 +573,6 @@ exports[`Render InputCheckbox with various parameter combinations, all parameter
         </label>
       </div>
     </div>
-  </div>
-  <div
-    className="survey-question__input-checkbox-group-column"
-  >
     <div
       className="survey-question__input-checkbox-input-container"
       onClick={[Function]}
@@ -546,6 +596,37 @@ exports[`Render InputCheckbox with various parameter combinations, all parameter
         >
           <span>
             english conditional
+          </span>
+        </label>
+      </div>
+    </div>
+  </div>
+  <div
+    className="survey-question__input-checkbox-group-column"
+  >
+    <div
+      className="survey-question__input-checkbox-input-container"
+      onClick={[Function]}
+    >
+      <div
+        className="label-input-container"
+      >
+        <input
+          checked={false}
+          className="input-checkbox"
+          id="test_val3__input-checkbox__val3"
+          name="test_val3"
+          onChange={[Function]}
+          onClick={[Function]}
+          type="checkbox"
+          value="val3"
+        />
+        <label
+          htmlFor="test_val3__input-checkbox__val3"
+          onClick={[Function]}
+        >
+          <span>
+            Translated string
           </span>
         </label>
       </div>

--- a/packages/evolution-frontend/src/components/inputs/__tests__/__snapshots__/InputDatePicker.test.tsx.snap
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/__snapshots__/InputDatePicker.test.tsx.snap
@@ -83,7 +83,7 @@ exports[`Should correctly render InputDatePicker with various parameters Test ti
         onClick={[Function]}
         onFocus={[Function]}
         onKeyDown={[Function]}
-        placeholder="ClickToSelectDate"
+        placeholder="click"
         readOnly={false}
         type="text"
         value=""

--- a/packages/evolution-frontend/src/components/inputs/__tests__/__snapshots__/InputMultiselect.test.tsx.snap
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/__snapshots__/InputMultiselect.test.tsx.snap
@@ -623,5 +623,13 @@ exports[`Render InputMultiselect with various options With shortcuts 1`] = `
   >
     english conditional
   </button>
+  <button
+    className="button shortcut-button red"
+    onClick={[Function]}
+    tabIndex={-1}
+    type="button"
+  >
+    Translated shortcut
+  </button>
 </div>
 `;

--- a/packages/evolution-frontend/src/components/inputs/__tests__/__snapshots__/InputRadio.test.tsx.snap
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/__snapshots__/InputRadio.test.tsx.snap
@@ -155,6 +155,33 @@ exports[`Render InputRadio with various parameter combinations, all parameters C
       </label>
     </div>
   </div>
+  <div
+    className="survey-question__input-radio-input-container"
+    onClick={[Function]}
+  >
+    <div
+      className="label-input-container"
+    >
+      <input
+        checked={false}
+        className="input-radio"
+        id="test_val3__input-radio__val3"
+        name="test_val3"
+        onChange={[Function]}
+        onClick={[Function]}
+        type="radio"
+        value="val3"
+      />
+      <label
+        htmlFor="test_val3__input-radio__val3"
+        onClick={[Function]}
+      >
+        <span>
+          Translated string
+        </span>
+      </label>
+    </div>
+  </div>
 </div>
 `;
 
@@ -282,6 +309,33 @@ exports[`Render InputRadio with various parameter combinations, all parameters I
         >
           <span>
             english conditional
+          </span>
+        </label>
+      </div>
+    </div>
+    <div
+      className="survey-question__input-radio-input-container"
+      onClick={[Function]}
+    >
+      <div
+        className="label-input-container"
+      >
+        <input
+          checked={false}
+          className="input-radio"
+          id="test_val3__input-radio__val3"
+          name="test_val3"
+          onChange={[Function]}
+          onClick={[Function]}
+          type="radio"
+          value="val3"
+        />
+        <label
+          htmlFor="test_val3__input-radio__val3"
+          onClick={[Function]}
+        >
+          <span>
+            Translated string
           </span>
         </label>
       </div>
@@ -531,10 +585,6 @@ exports[`Render InputRadio with various parameter combinations, all parameters W
         value=""
       />
     </div>
-  </div>
-  <div
-    className="survey-question__input-radio-group-column"
-  >
     <div
       className="survey-question__input-radio-input-container"
       onClick={[Function]}
@@ -558,6 +608,37 @@ exports[`Render InputRadio with various parameter combinations, all parameters W
         >
           <span>
             english conditional
+          </span>
+        </label>
+      </div>
+    </div>
+  </div>
+  <div
+    className="survey-question__input-radio-group-column"
+  >
+    <div
+      className="survey-question__input-radio-input-container"
+      onClick={[Function]}
+    >
+      <div
+        className="label-input-container"
+      >
+        <input
+          checked={false}
+          className="input-radio"
+          id="test_val3__input-radio__val3"
+          name="test_val3"
+          onChange={[Function]}
+          onClick={[Function]}
+          type="radio"
+          value="val3"
+        />
+        <label
+          htmlFor="test_val3__input-radio__val3"
+          onClick={[Function]}
+        >
+          <span>
+            Translated string
           </span>
         </label>
       </div>

--- a/packages/evolution-frontend/src/components/inputs/__tests__/__snapshots__/InputSelect.test.tsx.snap
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/__snapshots__/InputSelect.test.tsx.snap
@@ -96,6 +96,12 @@ exports[`Render InputSelect with normal option type 1`] = `
     >
       english conditional
     </option>
+    <option
+      className="input-select-option"
+      value="val3"
+    >
+      Translated string
+    </option>
     <optgroup
       label=""
     />

--- a/packages/evolution-frontend/src/services/interviews/interview.ts
+++ b/packages/evolution-frontend/src/services/interviews/interview.ts
@@ -1,5 +1,6 @@
 import { UserInterviewAttributes } from 'evolution-common/lib/services/interviews/interview';
-import { WidgetConfig, LangData } from 'evolution-common/lib/services/widgets';
+import { WidgetConfig } from 'evolution-common/lib/services/widgets';
+import { I18nData } from 'evolution-common/lib/utils/helpers';
 
 export type WidgetStatus<CustomSurvey, CustomHousehold, CustomHome, CustomPerson> = {
     path: string;
@@ -13,7 +14,7 @@ export type WidgetStatus<CustomSurvey, CustomHousehold, CustomHome, CustomPerson
     isValid: boolean;
     isResponded: boolean;
     isCustomResponded: boolean;
-    errorMessage?: LangData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
+    errorMessage?: I18nData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
     groupedObjectId?: string;
     value: unknown;
     customValue?: unknown;

--- a/packages/evolution-legacy/src/components/survey/Button.js
+++ b/packages/evolution-legacy/src/components/survey/Button.js
@@ -98,20 +98,19 @@ export class Button extends React.Component {
           onMouseUp = {this.onMouseUp}
         >
           {widgetConfig.icon && <FontAwesomeIcon icon={widgetConfig.icon} className="faIconLeft" />}
-          {surveyHelper.parseString((this.props.label || widgetConfig.label[this.props.i18n.language] || widgetConfig.label), this.props.interview, this.props.path)}
+          {surveyHelper.translateString(this.props.label || widgetConfig.label, this.props.i18n, this.props.interview, this.props.path)}
         </button>
         { /* confirmPopup below: */ }
         {    widgetConfig.confirmPopup 
           && widgetConfig.confirmPopup.shortname 
           && this.props.confirmModalOpenedShortname === widgetConfig.confirmPopup.shortname
           && widgetConfig.confirmPopup.content
-          && widgetConfig.confirmPopup.content[this.props.i18n.language]
           && (<div>
               <ConfirmModal
                 isOpen                      = {true}
                 closeModal                  = {this.props.closeConfirmModal}
-                text                        = {surveyHelper.parseString(widgetConfig.confirmPopup.content[this.props.i18n.language] || widgetConfig.confirmPopup.content, this.props.interview, this.props.path)}
-                title                       = {widgetConfig.confirmPopup.title && widgetConfig.confirmPopup.title[this.props.i18n.language] ? surveyHelper.parseString(widgetConfig.confirmPopup.title[this.props.i18n.language] || widgetConfig.confirmPopup.title, this.props.interview, this.props.path) : null}
+                text                        = {surveyHelper.translateString(widgetConfig.confirmPopup.content, this.props.i18n, this.props.interview, this.props.path)}
+                title                       = {widgetConfig.confirmPopup.title ? surveyHelper.translateString(widgetConfig.confirmPopup.title, this.props.i18n, this.props.interview, this.props.path) : null}
                 cancelAction                = {widgetConfig.confirmPopup.cancelAction}
                 showCancelButton            = {widgetConfig.confirmPopup.showCancelButton !== false}
                 showConfirmButton           = {widgetConfig.confirmPopup.showConfirmButton !== false}

--- a/packages/evolution-legacy/src/components/survey/InfoMap.js
+++ b/packages/evolution-legacy/src/components/survey/InfoMap.js
@@ -90,7 +90,7 @@ export class InfoMap extends React.Component {
     }
 
     this.bounds            = new this.props.google.maps.LatLngBounds();
-    const title            = surveyHelper.parseString(this.props.widgetConfig.title[this.props.i18n.language] || this.props.widgetConfig.title, this.props.interview, this.props.path, this.props.user);
+    const title            = surveyHelper.translateString(this.props.widgetConfig.title, this.props.i18n, this.props.interview, this.props.path, this.props.user);
     const geojsons         = this.props.widgetConfig.geojsons(this.props.interview, this.props.path, this.props.activeUuid);
     const gMarkers         = [];
     const gPolylines       = [];

--- a/packages/evolution-legacy/src/components/survey/Question.js
+++ b/packages/evolution-legacy/src/components/survey/Question.js
@@ -206,9 +206,9 @@ export class Question extends React.Component {
       inputType = this.props.widgetConfig.inputType;
     }
     const InputComponent   = this.getInputComponent(inputType);
-    const label            = surveyHelper.parseString(widgetConfig.label[i18n.language] || widgetConfig.label, this.props.interview, this.props.path, this.props.user);
+    const label            = surveyHelper.translateString(widgetConfig.label, this.props.i18n, this.props.interview, this.props.path, this.props.user);
     const twoColumns       = typeof widgetConfig.twoColumns === 'function' ? widgetConfig.twoColumns(this.props.interview, this.props.path) : widgetConfig.twoColumns;
-    const showErrorMessage = widgetStatus.isResponded === true && widgetStatus.isValid === false && !disabled && widgetStatus.errorMessage && widgetStatus.errorMessage[i18n.language] ? true : false;
+    const showErrorMessage = widgetStatus.isResponded === true && widgetStatus.isValid === false && !disabled && widgetStatus.errorMessage ? true : false;
     const content = (
       <div 
         style={{position: 'relative'}}
@@ -225,19 +225,17 @@ export class Question extends React.Component {
               <Markdown className="label" source={label} />
             }
           </label>
-          { showErrorMessage === true && <p className="apptr__form-error-message">{widgetConfig.containsHtml ? <span dangerouslySetInnerHTML={{__html: widgetStatus.errorMessage[i18n.language]}}/> : widgetStatus.errorMessage[i18n.language] }</p>}
+          { showErrorMessage === true && <p className="apptr__form-error-message">{widgetConfig.containsHtml ? <span dangerouslySetInnerHTML={{__html: surveyHelper.translateString(widgetStatus.errorMessage, this.props.i18n, this.props.interview, this.props.path)}}/> : surveyHelper.translateString(widgetStatus.errorMessage, this.props.i18n, this.props.interview, this.props.path) }</p>}
           { /* helpPopup below: */ }
           {    widgetConfig.helpPopup 
             && widgetConfig.helpPopup.title 
-            && widgetConfig.helpPopup.content 
-            && widgetConfig.helpPopup.title[i18n.language] 
-            && widgetConfig.helpPopup.content[i18n.language]
+            && widgetConfig.helpPopup.content
             && (<div>
                 {this.state.helperModalIsOpen && <SimpleModal
                   isOpen       = {true}
                   closeModal   = {this.closeHelperModal}
-                  text         = {surveyHelper.parseString(widgetConfig.helpPopup.content[i18n.language] || widgetConfig.helpPopup.content, this.props.interview, this.props.path, this.props.user)}
-                  title        = {surveyHelper.parseString(widgetConfig.helpPopup.title[i18n.language] || widgetConfig.helpPopup.title, this.props.interview, this.props.path, this.props.user)}
+                  text         = {surveyHelper.translateString(widgetConfig.helpPopup.content, this.props.i18n, this.props.interview, this.props.path, this.props.user)}
+                  title        = {surveyHelper.translateString(widgetConfig.helpPopup.title, this.props.i18n, this.props.interview, this.props.path, this.props.user)}
                   containsHtml = {widgetConfig.helpPopup.containsHtml}
                   action       = {widgetConfig.action}
                 />}
@@ -248,7 +246,7 @@ export class Question extends React.Component {
                   tabIndex  = {-1}
                 >
                   <FontAwesomeIcon icon={faQuestionCircle} className="faIconLeft" />
-                  {surveyHelper.parseString(widgetConfig.helpPopup.title[i18n.language] || widgetConfig.helpPopup.title, this.props.interview, this.props.path, this.props.user)}
+                  {surveyHelper.translateString(widgetConfig.helpPopup.title, this.props.i18n, this.props.interview, this.props.path, this.props.user)}
                 </button>
               </div>)
             }

--- a/packages/evolution-legacy/src/components/survey/Text.js
+++ b/packages/evolution-legacy/src/components/survey/Text.js
@@ -18,7 +18,7 @@ export const Text = ({widgetConfig, widgetStatus, i18n, interview, path, user}) 
     return null;
   }
 
-  const content = surveyHelper.parseString(widgetConfig.text[i18n.language] || widgetConfig.text, interview, path, user);
+  const content = surveyHelper.translateString(widgetConfig.text, i18n, interview, path, user);
   if (_isBlank(content))
   {
     return null;


### PR DESCRIPTION
This adds the translatable string function type to any survey string requiring i18n.

Now, all translation can call the `translationString` function in the `helpers.ts` file. It actually simplifies the usage of those strings, as it is now not necessary to check previous existence of the language, and prevents the current heterogeneity of those string usages. This single function takes care of everything.

Add some examples of usage of translatable string function in the demo_survey application