### PR TITLE
Add a new 'size' property to change the size of icons on map widgets

### DIFF
--- a/example/demo_survey/src/survey/widgets/home.tsx
+++ b/example/demo_survey/src/survey/widgets/home.tsx
@@ -492,7 +492,8 @@ export const homeGeography = {
         </span></p>`
   },
   icon: {
-    url: `/dist/images/activities_icons/home_marker.svg`
+    url: `/dist/images/activities_icons/home_marker.svg`,
+    size: [80, 80]
   },
   defaultCenter: config.mapDefaultCenter,
   refreshGeocodingLabel: {

--- a/example/demo_survey/src/survey/widgets/visitedPlaces.tsx
+++ b/example/demo_survey/src/survey/widgets/visitedPlaces.tsx
@@ -827,10 +827,12 @@ export const visitedPlaceGeography = {
       }
   },
   icon: {
-    url: (interview, path) => (`/dist/images/activities_icons/${surveyHelperNew.getResponse(interview, path, null, '../activity')}_marker.svg`)
+    url: (interview, path) => (`/dist/images/activities_icons/${surveyHelperNew.getResponse(interview, path, null, '../activity')}_marker.svg`),
+    size: [80, 80]
   },
   placesIcon: {
-    url: (interview, path) => (`/dist/images/activities_icons/default_marker.svg`)
+    url: (interview, path) => (`/dist/images/activities_icons/default_marker.svg`),
+    size: [80, 80]
   },
   defaultCenter: function (interview, path) {
     const person = helper.getPerson(interview);

--- a/packages/evolution-common/src/services/widgets/WidgetConfig.ts
+++ b/packages/evolution-common/src/services/widgets/WidgetConfig.ts
@@ -247,7 +247,8 @@ type InputMapType<CustomSurvey, CustomHousehold, CustomHome, CustomPerson> = {
     refreshGeocodingLabel?: I18nData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
     afterRefreshButtonText?: I18nData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
     icon?: {
-        url: string | ParsingFunction<string, CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
+        url: string | ParsingFunction<string, CustomSurvey, CustomHousehold, CustomHome, CustomPerson>,
+        size?: [number, number];
     };
     containsHtml?: boolean;
     maxZoom?: number;
@@ -273,7 +274,8 @@ export type InputMapFindPlaceType<CustomSurvey, CustomHousehold, CustomHome, Cus
 > & {
     inputType: 'mapFindPlace';
     placesIcon?: {
-        url: string | ParsingFunction<string, CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
+        url: string | ParsingFunction<string, CustomSurvey, CustomHousehold, CustomHome, CustomPerson>,
+        size?: [number, number];
     };
     showPhoto?: boolean;
     autoConfirmIfSingleResult?: boolean;

--- a/packages/evolution-frontend/src/components/inputs/InputMapFindPlace.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputMapFindPlace.tsx
@@ -17,7 +17,7 @@ import projectConfig from 'chaire-lib-common/lib/config/shared/project.config';
 import { InputMapFindPlaceType } from 'evolution-common/lib/services/widgets';
 import * as surveyHelper from 'evolution-common/lib/utils/helpers';
 import { WithTranslation, withTranslation } from 'react-i18next';
-import { FeatureGeocodedProperties, MarkerData, PlaceGeocodedProperties } from './maps/InputMapTypes';
+import { FeatureGeocodedProperties, MarkerData, defaultIconSize, PlaceGeocodedProperties } from './maps/InputMapTypes';
 import InputSelect from './InputSelect';
 import { CommonInputProps } from './CommonInputProps';
 
@@ -263,6 +263,8 @@ export class InputMapFindPlace<CustomSurvey, CustomHousehold, CustomHome, Custom
             ) || '/dist/images/default_marker.svg'
             : '/dist/images/default_marker.svg';
 
+        const placesIconSize = this.props.widgetConfig.placesIcon && this.props.widgetConfig.placesIcon.size ? this.props.widgetConfig.placesIcon.size : defaultIconSize;
+
         const iconUrl = this.props.widgetConfig.icon
             ? surveyHelper.parseString(
                 this.props.widgetConfig.icon.url,
@@ -271,6 +273,8 @@ export class InputMapFindPlace<CustomSurvey, CustomHousehold, CustomHome, Custom
                 this.props.user
             ) || '/dist/images/default_marker.svg'
             : '/dist/images/default_marker.svg';
+
+        const iconSize = this.props.widgetConfig.icon && this.props.widgetConfig.icon.size ? this.props.widgetConfig.icon.size : defaultIconSize;
 
         const placeMenuChoices = places.map((place) => {
             const placeData = place.properties.placeData as any;
@@ -287,7 +291,7 @@ export class InputMapFindPlace<CustomSurvey, CustomHousehold, CustomHome, Custom
             places.forEach((feature) =>
                 markers.push({
                     position: feature,
-                    icon: { url: feature === this.state.selectedPlace ? this.selectedIconUrl : placesIconUrl },
+                    icon: { url: feature === this.state.selectedPlace ? this.selectedIconUrl : placesIconUrl, size: placesIconSize },
                     draggable: this.state.selectedPlace ? true : false,
                     onClick: () => this.setState({ selectedPlace: feature })
                 })
@@ -295,7 +299,7 @@ export class InputMapFindPlace<CustomSurvey, CustomHousehold, CustomHome, Custom
         } else if (this.props.value) {
             markers.push({
                 position: this.props.value,
-                icon: { url: iconUrl },
+                icon: { url: iconUrl, size: iconSize},
                 draggable: true
             });
         }

--- a/packages/evolution-frontend/src/components/inputs/InputMapPoint.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputMapPoint.tsx
@@ -50,6 +50,7 @@ export class InputMapPoint<CustomSurvey, CustomHousehold, CustomHome, CustomPers
 > {
     private geocodeButtonRef: React.RefObject<HTMLButtonElement> = React.createRef();
     private iconUrl: string;
+    private iconSize: [number, number];
 
     constructor(props: InputMapPointProps<CustomSurvey, CustomHousehold, CustomHome, CustomPerson> & WithTranslation) {
         super(props);
@@ -69,6 +70,8 @@ export class InputMapPoint<CustomSurvey, CustomHousehold, CustomHome, CustomPers
             ) || '/dist/images/default_marker.svg'
             : '/dist/images/default_marker.svg';
 
+        this.iconSize = this.props.widgetConfig.icon && this.props.widgetConfig.icon.size ? this.props.widgetConfig.icon.size : [40, 40];
+
         this.state = {
             defaultCenter,
             currentBounds: undefined,
@@ -76,7 +79,7 @@ export class InputMapPoint<CustomSurvey, CustomHousehold, CustomHome, CustomPers
                 ? [
                     {
                         position: this.props.value,
-                        icon: { url: this.iconUrl },
+                        icon: { url: this.iconUrl, size: this.iconSize },
                         draggable: true
                     }
                 ]
@@ -94,7 +97,7 @@ export class InputMapPoint<CustomSurvey, CustomHousehold, CustomHome, CustomPers
                 ? [
                     {
                         position: feature,
-                        icon: { url: this.iconUrl },
+                        icon: { url: this.iconUrl, size: this.iconSize },
                         draggable: true
                     }
                 ]

--- a/packages/evolution-frontend/src/components/inputs/__tests__/InputMapFindPlace.test.tsx
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/InputMapFindPlace.test.tsx
@@ -71,12 +71,14 @@ describe('Render InputMapPoint with various parameters', () => {
                 en: `Refresh map`
             },
             icon: {
-                url: 'path/to/icon'
+                url: 'path/to/icon',
+                size: [80, 80] as [number, number]
             },
             maxZoom: 18,
             defaultZoom: 15,
             placesIcon: {
-                url: 'path/to/icon'
+                url: 'path/to/icon',
+                size: [85, 85] as [number, number]
             },
             updateDefaultValueWhenResponded: true
         }, baseWidgetConfig);
@@ -109,12 +111,12 @@ describe('Test geocoding requests', () => {
             en: `Geocode`
         },
         icon: {
-            url: 'path/to/icon'
+            url: 'path/to/icon',
         },
         maxZoom: 18,
         defaultZoom: 15,
         placesIcon: {
-            url: 'path/to/icon'
+            url: 'path/to/icon',
         },
         size: 'medium',
         updateDefaultValueWhenResponded: true

--- a/packages/evolution-frontend/src/components/inputs/__tests__/InputMapPoint.test.tsx
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/InputMapPoint.test.tsx
@@ -70,7 +70,8 @@ describe('Render InputMapPoint with various parameters', () => {
                 en: `Refresh map`
             },
             icon: {
-                url: 'path/to/icon'
+                url: 'path/to/icon',
+                size: [20, 20] as [number, number]
             },
             maxZoom: 18,
             defaultZoom: 15
@@ -104,12 +105,14 @@ describe('Test geocoding requests', () => {
             en: `Geocode`
         },
         icon: {
-            url: 'path/to/icon'
+            url: 'path/to/icon',
+            size: [20, 20] as [number, number]
         },
         maxZoom: 18,
         defaultZoom: 15,
         placesIcon: {
-            url: 'path/to/icon'
+            url: 'path/to/icon',
+            size: [60, 60] as [number, number]
         },
         updateDefaultValueWhenResponded: true
     }, baseWidgetConfig);

--- a/packages/evolution-frontend/src/components/inputs/maps/InputMapTypes.tsx
+++ b/packages/evolution-frontend/src/components/inputs/maps/InputMapTypes.tsx
@@ -18,10 +18,12 @@ export type PlaceGeocodedProperties = FeatureGeocodedProperties & {
 
 export interface MarkerData {
     position: GeoJSON.Feature<GeoJSON.Point>;
-    icon: { url: string };
+    icon: { url: string, size: [number, number] };
     draggable: boolean;
     readonly onClick?: () => void;
 }
+
+export const defaultIconSize: [number, number] = [40, 40];
 
 export type geocodeSingleFct = (
     addressQueryString: string,

--- a/packages/evolution-frontend/src/components/inputs/maps/google/InputMapGoogle.tsx
+++ b/packages/evolution-frontend/src/components/inputs/maps/google/InputMapGoogle.tsx
@@ -192,8 +192,8 @@ const InputMapGoogle: React.FunctionComponent<InputGoogleMapPointProps> = (props
                     draggable={markerData.draggable}
                     icon={{
                         url: markerData.icon.url,
-                        size: new google.maps.Size(40, 40),
-                        scaledSize: new google.maps.Size(40, 40)
+                        size: new google.maps.Size(markerData.icon.size[0], markerData.icon.size[1]),
+                        scaledSize: new google.maps.Size(markerData.icon.size[0], markerData.icon.size[1])
                     }}
                     onClick={markerData.onClick}
                 />


### PR DESCRIPTION
This adds the necessary functionality to fix issue https://github.com/chairemobilite/od_mtl_2023/issues/401.

Tests currently fail... not quite sure why.