### PR TITLE
Extract a function to get the URL path for a section

### DIFF
--- a/example/demo_survey/src/survey/templates/SegmentsSection.tsx
+++ b/example/demo_survey/src/survey/templates/SegmentsSection.tsx
@@ -30,6 +30,7 @@ import GroupedObject   from 'evolution-legacy/lib/components/survey/GroupedObjec
 import * as surveyHelper from 'evolution-common/lib/utils/helpers';
 import LoadingPage     from 'evolution-legacy/lib/components/shared/LoadingPage';
 import helper          from '../helper';
+import { getPathForSection } from 'evolution-frontend/lib/services/url';
 
 //const ResponsiveEllipsis = responsiveHOC()(HTMLEllipsis);
 
@@ -97,9 +98,9 @@ export class SegmentsSection extends React.Component<any, any> {
     }
     const history = createBrowserHistory();
 
-    if (history.location.pathname !== '/survey/' + this.props.shortname && !history.location.pathname.startsWith('/admin') && !history.location.pathname.startsWith('/admin/survey'))
-    {
-      history.push('/survey/' + this.props.shortname);
+    const path = getPathForSection(history.location.pathname, this.props.shortname);
+    if (path) {
+        history.push(path);
     }
     
     surveyHelper.devLog('%c rendering section ' + this.props.shortname, 'background: rgba(0,0,255,0.1);')

--- a/example/demo_survey/src/survey/templates/VisitedPlacesSection.tsx
+++ b/example/demo_survey/src/survey/templates/VisitedPlacesSection.tsx
@@ -39,6 +39,7 @@ import * as surveyHelper from 'evolution-common/lib/utils/helpers';
 import helper          from '../helper';
 import ConfirmModal    from 'evolution-legacy/lib/components/survey/modal/ConfirmModal';
 import LoadingPage     from 'evolution-legacy/lib/components/shared/LoadingPage';
+import { getPathForSection } from 'evolution-frontend/lib/services/url';
 
 export class VisitedPlacesSection extends React.Component<any, any> {
 
@@ -129,9 +130,9 @@ export class VisitedPlacesSection extends React.Component<any, any> {
     }
     const history = createBrowserHistory();
 
-    if (history.location.pathname !== '/survey/' + this.props.shortname && !history.location.pathname.startsWith('/admin') && !history.location.pathname.startsWith('/admin/survey'))
-    {
-      history.push('/survey/' + this.props.shortname);
+    const path = getPathForSection(history.location.pathname, this.props.shortname);
+    if (path) {
+        history.push(path);
     }
 
     surveyHelper.devLog('%c rendering section ' + this.props.shortname, 'background: rgba(0,0,255,0.1);')

--- a/packages/evolution-common/src/services/widgets/WidgetConfig.ts
+++ b/packages/evolution-common/src/services/widgets/WidgetConfig.ts
@@ -247,7 +247,7 @@ type InputMapType<CustomSurvey, CustomHousehold, CustomHome, CustomPerson> = {
     refreshGeocodingLabel?: I18nData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
     afterRefreshButtonText?: I18nData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
     icon?: {
-        url: string | ParsingFunction<string, CustomSurvey, CustomHousehold, CustomHome, CustomPerson>,
+        url: string | ParsingFunction<string, CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
         size?: [number, number];
     };
     containsHtml?: boolean;
@@ -274,7 +274,7 @@ export type InputMapFindPlaceType<CustomSurvey, CustomHousehold, CustomHome, Cus
 > & {
     inputType: 'mapFindPlace';
     placesIcon?: {
-        url: string | ParsingFunction<string, CustomSurvey, CustomHousehold, CustomHome, CustomPerson>,
+        url: string | ParsingFunction<string, CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
         size?: [number, number];
     };
     maxGeocodingResultsBounds?: ParsingFunction<

--- a/packages/evolution-frontend/src/components/inputs/InputMapFindPlace.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputMapFindPlace.tsx
@@ -273,7 +273,10 @@ export class InputMapFindPlace<CustomSurvey, CustomHousehold, CustomHome, Custom
             ) || '/dist/images/default_marker.svg'
             : '/dist/images/default_marker.svg';
 
-        const placesIconSize = this.props.widgetConfig.placesIcon && this.props.widgetConfig.placesIcon.size ? this.props.widgetConfig.placesIcon.size : defaultIconSize;
+        const placesIconSize =
+            this.props.widgetConfig.placesIcon && this.props.widgetConfig.placesIcon.size
+                ? this.props.widgetConfig.placesIcon.size
+                : defaultIconSize;
 
         const iconUrl = this.props.widgetConfig.icon
             ? surveyHelper.parseString(
@@ -284,7 +287,10 @@ export class InputMapFindPlace<CustomSurvey, CustomHousehold, CustomHome, Custom
             ) || '/dist/images/default_marker.svg'
             : '/dist/images/default_marker.svg';
 
-        const iconSize = this.props.widgetConfig.icon && this.props.widgetConfig.icon.size ? this.props.widgetConfig.icon.size : defaultIconSize;
+        const iconSize =
+            this.props.widgetConfig.icon && this.props.widgetConfig.icon.size
+                ? this.props.widgetConfig.icon.size
+                : defaultIconSize;
 
         const placeMenuChoices = places.map((place) => {
             const placeData = place.properties.placeData as any;
@@ -301,7 +307,10 @@ export class InputMapFindPlace<CustomSurvey, CustomHousehold, CustomHome, Custom
             places.forEach((feature) =>
                 markers.push({
                     position: feature,
-                    icon: { url: feature === this.state.selectedPlace ? this.selectedIconUrl : placesIconUrl, size: placesIconSize },
+                    icon: {
+                        url: feature === this.state.selectedPlace ? this.selectedIconUrl : placesIconUrl,
+                        size: placesIconSize
+                    },
                     draggable: this.state.selectedPlace ? true : false,
                     onClick: () => this.onMarkerSelect(feature)
                 })
@@ -311,7 +320,7 @@ export class InputMapFindPlace<CustomSurvey, CustomHousehold, CustomHome, Custom
         if (this.props.value) {
             markers.push({
                 position: this.props.value,
-                icon: { url: iconUrl, size: iconSize},
+                icon: { url: iconUrl, size: iconSize },
                 draggable: true
             });
         }

--- a/packages/evolution-frontend/src/components/inputs/InputMapPoint.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputMapPoint.tsx
@@ -70,7 +70,10 @@ export class InputMapPoint<CustomSurvey, CustomHousehold, CustomHome, CustomPers
             ) || '/dist/images/default_marker.svg'
             : '/dist/images/default_marker.svg';
 
-        this.iconSize = this.props.widgetConfig.icon && this.props.widgetConfig.icon.size ? this.props.widgetConfig.icon.size : [40, 40];
+        this.iconSize =
+            this.props.widgetConfig.icon && this.props.widgetConfig.icon.size
+                ? this.props.widgetConfig.icon.size
+                : [40, 40];
 
         this.state = {
             defaultCenter,

--- a/packages/evolution-frontend/src/components/inputs/maps/InputMapTypes.tsx
+++ b/packages/evolution-frontend/src/components/inputs/maps/InputMapTypes.tsx
@@ -18,7 +18,7 @@ export type PlaceGeocodedProperties = FeatureGeocodedProperties & {
 
 export interface MarkerData {
     position: GeoJSON.Feature<GeoJSON.Point>;
-    icon: { url: string, size: [number, number] };
+    icon: { url: string; size: [number, number] };
     draggable: boolean;
     readonly onClick?: () => void;
 }

--- a/packages/evolution-frontend/src/services/__tests__/url.test.ts
+++ b/packages/evolution-frontend/src/services/__tests__/url.test.ts
@@ -1,0 +1,15 @@
+import each from 'jest-each';
+import { getPathForSection } from '../url';
+
+each([
+    [ 'survey/home', 'survey/newSection' ],
+    [ '/survey/home', '/survey/newSection' ],
+    [ '/edit/uuid/survey/home', '/edit/uuid/survey/newSection' ],
+    [ 'edit/uuid/survey/home', 'edit/uuid/survey/newSection' ],
+    [ 'survey/newSection', false ],
+    [ '/survey/newSection', false ],
+    [ '/admin/survey/uuid', false ],
+    [ 'edit/uuid/survey/newSection', false ],
+]).test('Get path for section: %s', async(currentPath, expected) => {
+    expect(getPathForSection(currentPath, 'newSection')).toEqual(expected);
+});

--- a/packages/evolution-frontend/src/services/url.ts
+++ b/packages/evolution-frontend/src/services/url.ts
@@ -1,0 +1,32 @@
+/**
+ * Get the path in the URL for a given section
+ * @param currentPath The current location path of the page
+ * @param section The requested section
+ * @returns The updated path for the section, or `false` if the path is already correct
+ */
+export const getPathForSection = (currentPath: string, section: string) => {
+    // TODO: This was copy-pasted from the Section component, which was correct,
+    // so other components can re-use, but given how it works now, why does the
+    // admin require a special treatment?
+    if (
+        !currentPath.startsWith('/admin') &&
+        !currentPath.startsWith('/admin/survey') &&
+        !currentPath.endsWith(`/${section}`)
+    ) {
+        // Change the last part of the path to be the current section
+        // TODO Originally, admin routes did not need this. Can they be included in this code path?
+        const pathParts = currentPath.split('/');
+        // Ignore if it corresponds to the 'survey' path, which would be the first, preceded or not by /
+        // TODO Too custom! there must be a better way
+        if (
+            (!currentPath.startsWith('/') && pathParts.length > 1) ||
+            (currentPath.startsWith('/') && pathParts.length > 2)
+        ) {
+            pathParts.splice(pathParts.length - 1, 1, section);
+        } else {
+            pathParts.push(section);
+        }
+        return pathParts.join('/');
+    }
+    return false;
+};

--- a/packages/evolution-legacy/src/components/survey/Section.js
+++ b/packages/evolution-legacy/src/components/survey/Section.js
@@ -20,6 +20,7 @@ import Button           from './Button';
 import Question         from 'evolution-frontend/lib/components/survey/Question';
 import Group            from './Group';
 import LoadingPage      from '../shared/LoadingPage';
+import { getPathForSection } from 'evolution-frontend/lib/services/url';
 
 export class Section extends React.Component {
 
@@ -135,19 +136,9 @@ export class Section extends React.Component {
     }
     const history = createBrowserHistory();
 
-    if (!history.location.pathname.startsWith('/admin') && !history.location.pathname.startsWith('/admin/survey') && !history.location.pathname.endsWith(`/${this.props.shortname}`))
-    {
-        // Change the last part of the path to be the current section
-        // TODO Originally, admin routes did not need this. Can they be included in this code path?
-        const pathParts = history.location.pathname.split('/');
-        // Ignore if it corresponds to the 'survey' path, which would be the first, preceded or not by /
-        // TODO Too custom! there must be a better way
-        if ((!history.location.pathname.startsWith('/') && pathParts.length > 1) || (history.location.pathname.startsWith('/') && pathParts.length > 2)) {
-            pathParts.splice(pathParts.length - 1, 1, this.props.shortname);
-        } else {
-            pathParts.push(this.props.shortname);
-        }
-        history.push(pathParts.join('/'));
+    const path = getPathForSection(history.location.pathname, this.props.shortname);
+    if (path) {
+        history.push(path);
     }
 
     const widgetsComponentByShortname = {};


### PR DESCRIPTION
This is required to fix the URL for interviewers where the `edit/<uuid>` is removed from the URL, preventing the possibility to refresh the page