### PR TITLE
inputSelect: Add line separator for groups without label

### DIFF
--- a/example/demo_survey/src/survey/sections.ts
+++ b/example/demo_survey/src/survey/sections.ts
@@ -27,7 +27,7 @@ const homeWidgets = [
   'homeRegion',
   'homeCountry',
   'homePostalCode',
-  //'homeDwellingType',
+  'homeDwellingType',
   'homeGeography'
 ];
 

--- a/example/demo_survey/src/survey/widgets/segments.tsx
+++ b/example/demo_survey/src/survey/widgets/segments.tsx
@@ -2646,77 +2646,88 @@ export const segmentParkingPaymentType = {
   },
   choices: [
     {
-      value: "parkingMeter",
-      internalId: 1,
-      label: {
-        fr: "Oui (parcomètre)",
-        en: "Yes (parking meter)"
-      }
-    },
-    {
-      value: "residentialPermit",
-      internalId: 1,
-      label: {
-        fr: "Oui (vignette de stationnement résidentiel)",
-        en: "Yes (residential permit)"
-      }
-    },
-    {
-      value: "parkingPass",
-      internalId: 1,
-      label: {
-        fr: "Oui (passe ou permis de stationnement)",
-        en: "Yes (parking pass or permit)"
-      }
-    },
-    {
-      value: "free",
-      internalId: 2,
-      label: {
-        fr: "Non (gratuit)",
-        en: "No (free parking)"
-      }
-    },
-    {
-      value: "paidByEmployer",
-      internalId: 3,
-      label: {
-        fr: "Non (payé par l'employeur)",
-        en: "No (paid by employer)"
-      },
-      conditional: function(interview, path) {
-        const person = helper.getPerson(interview);
-        const trip: any = surveyHelperNew.getResponse(interview, path, null, '../../');
-        const visitedPlaces = person.visitedPlaces;
-        const destination = trip && trip._destinationVisitedPlaceUuid && visitedPlaces[trip._destinationVisitedPlaceUuid] ? visitedPlaces[trip._destinationVisitedPlaceUuid] : null;
-        const destinationActivity = destination ? destination.activity : null;
-        return ['workUsual', 'workNotUsual', 'workOnTheRoad', 'workOnTheRoadFromUsualWork'].indexOf(destinationActivity) > -1;
-      }
-    },
-    {
-      value: "didNotPark",
-      internalId: 5,
-      label: {
-        fr: "Le véhicule n'a pas été stationné",
-        en: "The vehicle was not parked"
-      }
-    },
-    {
-      value: "dontKnow",
-      internalId: 4,
-      label: {
-        fr: "Je ne sais pas",
-        en: "I don't know"
-      }
-    },
-    {
-      value: "nonApplicable",
-      internalId: 5,
-      label: {
-        fr: "Non applicable",
-        en: "N/A"
-      },
-      conditional: false
+        groupLabel: '',
+        groupShortname: 'paid',
+        choices: [
+            {
+                value: "parkingMeter",
+                internalId: 1,
+                label: {
+                  fr: "Oui (parcomètre)",
+                  en: "Yes (parking meter)"
+                }
+            },
+            {
+                value: "residentialPermit",
+                internalId: 1,
+                label: {
+                    fr: "Oui (vignette de stationnement résidentiel)",
+                    en: "Yes (residential permit)"
+                }
+            },
+            {
+                value: "parkingPass",
+                internalId: 1,
+                label: {
+                    fr: "Oui (passe ou permis de stationnement)",
+                    en: "Yes (parking pass or permit)"
+                }
+            },
+        ]
+    }, {
+        groupLabel: '',
+        groupShortname: 'freeOthers',
+        choices: [
+            {
+                value: "free",
+                internalId: 2,
+                label: {
+                  fr: "Non (gratuit)",
+                  en: "No (free parking)"
+                }
+            },
+            {
+                value: "paidByEmployer",
+                internalId: 3,
+                label: {
+                  fr: "Non (payé par l'employeur)",
+                  en: "No (paid by employer)"
+                },
+                conditional: function(interview, path) {
+                  const person = helper.getPerson(interview);
+                  const trip: any = surveyHelperNew.getResponse(interview, path, null, '../../');
+                  const visitedPlaces = person.visitedPlaces;
+                  const destination = trip && trip._destinationVisitedPlaceUuid && visitedPlaces[trip._destinationVisitedPlaceUuid] ? visitedPlaces[trip._destinationVisitedPlaceUuid] : null;
+                  const destinationActivity = destination ? destination.activity : null;
+                  return ['workUsual', 'workNotUsual', 'workOnTheRoad', 'workOnTheRoadFromUsualWork'].indexOf(destinationActivity) > -1;
+                }
+            },
+            {
+                value: "didNotPark",
+                internalId: 5,
+                label: {
+                  fr: "Le véhicule n'a pas été stationné",
+                  en: "The vehicle was not parked"
+                }
+            },
+            {
+                value: "dontKnow",
+                internalId: 4,
+                label: {
+                  fr: "Je ne sais pas",
+                  en: "I don't know"
+                }
+            },
+            {
+                value: "nonApplicable",
+                internalId: 5,
+                label: {
+                  fr: "Non applicable",
+                  en: "N/A"
+                },
+                conditional: false
+            }
+        ]
     }
   ],
   conditional: function(interview, path) {

--- a/packages/evolution-frontend/src/components/inputs/InputSelect.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputSelect.tsx
@@ -78,11 +78,20 @@ export const InputSelect = <CustomSurvey, CustomHousehold, CustomHome, CustomPer
                 />
             ));
 
-            return (
-                <optgroup
-                    key={`input-select-group-container__${choice.groupShortname}`}
-                    label={choice.groupLabel[props.i18n.language] || choice.groupLabel}
-                >
+            const groupLabel = surveyHelper.translateString(
+                choice.groupLabel,
+                props.i18n,
+                props.interview,
+                props.path,
+                props.user
+            );
+            return _isBlank(groupLabel) ? (
+                <React.Fragment>
+                    <option disabled>_________</option>
+                    {groupSelectOptions}
+                </React.Fragment>
+            ) : (
+                <optgroup key={`input-select-group-container__${choice.groupShortname}`} label={groupLabel}>
                     {groupSelectOptions}
                 </optgroup>
             );

--- a/packages/evolution-frontend/src/components/inputs/__tests__/InputSelect.test.tsx
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/InputSelect.test.tsx
@@ -165,3 +165,77 @@ test('Render InputSelect with choice function and grouped choice type', () => {
     expect(choiceFct).toHaveBeenCalledWith(interviewAttributes, 'foo.test', userAttributes);
     
 });
+
+test('Render InputSelect with grouped choice type without labels', () => {
+
+    const choices = [
+        {
+            value: 'val1',
+            label: { en: 'english value', fr: 'valeur française' },
+            hidden: false,
+            icon: 'creative-commons' as const
+        },
+        {
+            groupName: 'select group',
+            groupShortname: 'sel',
+            groupLabel: '',
+            choices: [
+                {
+                    value: 'val2',
+                    label: 'Unilingual label',
+                    iconPath: 'img/test.png'
+                },
+                {
+                    value: 'hiddenVal',
+                    label: { en: 'english hidden', fr: 'cachée' },
+                    hidden: true
+                },
+            ]
+        },
+        {
+            groupName: 'select group',
+            groupShortname: 'sel',
+            groupLabel: '',
+            choices: [
+                {
+                    value: 'val2',
+                    label: 'Unilingual label',
+                    iconPath: 'img/test.png'
+                },
+                {
+                    value: 'val3',
+                    label: { en: 'english val3', fr: 'val3 français' }
+                },
+            ]
+        }
+    ];
+
+    const widgetConfig = {
+        type: 'question' as const,
+        twoColumns: true,
+        path: 'test.foo',
+        inputType: 'select' as const,
+        choices,
+        containsHtml: true,
+        size: 'medium',
+        label: {
+            fr: `Texte en français`,
+            en: `English text`
+        }
+    };
+
+    const wrapper = TestRenderer.create(
+        <InputSelect
+            id={'test'}
+            onValueChange={() => { /* nothing to do */}}
+            widgetConfig={widgetConfig}
+            value='value'
+            inputRef={React.createRef()}
+            interview={interviewAttributes}
+            user={userAttributes}
+            path='foo.test'
+        />
+    );
+    expect(wrapper).toMatchSnapshot();
+
+});

--- a/packages/evolution-frontend/src/components/inputs/__tests__/__snapshots__/InputSelect.test.tsx.snap
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/__snapshots__/InputSelect.test.tsx.snap
@@ -57,6 +57,65 @@ exports[`Render InputSelect with choice function and grouped choice type 1`] = `
 </div>
 `;
 
+exports[`Render InputSelect with grouped choice type without labels 1`] = `
+<div
+  className="survey-question__input-select-container"
+>
+  <select
+    id="test"
+    onChange={[Function]}
+    style={
+      Object {
+        "maxWidth": "100%",
+        "overflow": "hidden",
+        "textOverflow": "ellipsis",
+        "whiteSpace": "nowrap",
+      }
+    }
+    value="value"
+  >
+    <option
+      className="input-select-option"
+      value=""
+    />
+    <option
+      className="input-select-option"
+      value="val1"
+    >
+      english value
+    </option>
+    <option
+      disabled={true}
+    >
+      _________
+    </option>
+    <option
+      className="input-select-option"
+      value="val2"
+    >
+      Unilingual label
+    </option>
+    <option
+      disabled={true}
+    >
+      _________
+    </option>
+    <option
+      className="input-select-option"
+      value="val2"
+    >
+      Unilingual label
+    </option>
+    <option
+      className="input-select-option"
+      value="val3"
+    >
+      english val3
+    </option>
+  </select>
+</div>
+`;
+
 exports[`Render InputSelect with normal option type 1`] = `
 <div
   className="survey-question__input-select-container"


### PR DESCRIPTION
Fixes #130

Select choices can be separated in groups with group labels. If the label is set to an empty string, instead of adding an indented optgroup with an empty label, add a disabled horizontal line option to separate the group from the rest.

Inpired from this stackoverflow answer: https://stackoverflow.com/questions/899148/html-select-option-separator

Update the car driver's parking question to split in group with empty label. And re-activate the dwelling type question, for an example with groups with labels.