### PR TITLE
logging: use a logging middleware to log user accesses to interviews

### DIFF
--- a/packages/evolution-backend/src/api/interviews.routes.ts
+++ b/packages/evolution-backend/src/api/interviews.routes.ts
@@ -41,9 +41,6 @@ router.post('/createNew', async (req, res) => {
         while ((await participantAuthModel.find({ username: userName })) !== undefined) {
             userName = `${req.body.createUser}_${suffixCount++}`;
         }
-        if (req.user && (req.user as any).id) {
-            initialResponses['_editingUsers'] = [(req.user as any).id];
-        }
         const participant = await participantAuthModel.createAndSave({ username: userName });
         const interview = await Interviews.createInterviewForUser(participant.attributes.id, initialResponses);
 

--- a/packages/evolution-backend/src/api/survey.user.routes.ts
+++ b/packages/evolution-backend/src/api/survey.user.routes.ts
@@ -110,6 +110,7 @@ export default (authorizationMiddleware): Router => {
 
                 const interview = await Interviews.getInterviewByUuid(content.interviewId);
                 if (interview) {
+                    // TODO Log a different way
                     if (req.user && (req.user as any).id !== interview.participant_id) {
                         const userId = (req.user as any).id;
                         const editingUsers = interview.responses._editingUsers || [];

--- a/packages/evolution-backend/src/api/survey.user.routes.ts
+++ b/packages/evolution-backend/src/api/survey.user.routes.ts
@@ -113,15 +113,6 @@ export default (authorizationMiddleware, loggingMiddleware: InterviewLoggingMidd
 
                 const interview = await Interviews.getInterviewByUuid(content.interviewId);
                 if (interview) {
-                    // TODO Log a different way
-                    if (req.user && (req.user as any).id !== interview.participant_id) {
-                        const userId = (req.user as any).id;
-                        const editingUsers = interview.responses._editingUsers || [];
-                        if (!editingUsers.includes(userId)) {
-                            editingUsers.push(userId);
-                            interview.responses._editingUsers = editingUsers;
-                        }
-                    }
                     interview.responses._ip = ip;
                     interview.responses._updatedAt = timestamp;
                     const retInterview = await updateInterview(interview, {

--- a/packages/evolution-backend/src/api/survey.user.routes.ts
+++ b/packages/evolution-backend/src/api/survey.user.routes.ts
@@ -16,8 +16,9 @@ import Interviews from '../services/interviews/interviews';
 import { addRolesToInterview, updateInterview } from '../services/interviews/interview';
 import { UserInterviewAttributes } from 'evolution-common/lib/services/interviews/interview';
 import serverConfig from '../config/projectConfig';
+import { InterviewLoggingMiddlewares } from '../services/logging/queryLoggingMiddleware';
 
-export default (authorizationMiddleware): Router => {
+export default (authorizationMiddleware, loggingMiddleware: InterviewLoggingMiddlewares): Router => {
     const router = express.Router();
 
     router.use(isLoggedIn);
@@ -78,6 +79,7 @@ export default (authorizationMiddleware): Router => {
     router.get(
         '/survey/activeInterview/:interviewId',
         authorizationMiddleware(['update', 'read']),
+        loggingMiddleware.openingInterview(false),
         async (req: Request, res: Response) => {
             try {
                 activateInterview(req, res, (req) => Interviews.getInterviewByUuid(req.params.interviewId));
@@ -91,6 +93,7 @@ export default (authorizationMiddleware): Router => {
     router.post(
         '/survey/updateInterview/',
         authorizationMiddleware(['update', 'read']),
+        loggingMiddleware.updatingInterview(false),
         async (req: Request, res: Response) => {
             try {
                 const ip = (req as any).clientIp;

--- a/packages/evolution-backend/src/models/__tests__/interviews.db.test.ts
+++ b/packages/evolution-backend/src/models/__tests__/interviews.db.test.ts
@@ -64,8 +64,7 @@ const localUserInterviewAttributes = {
     is_completed: undefined,
     responses: {
         accessCode: '11111',
-        booleanField: true,
-        _editingUsers: [localUser.id]
+        booleanField: true
     },
     validations: {},
     logs: [],
@@ -101,8 +100,7 @@ const googleUserInterviewAttributes = {
             someField: 'somewhere',
             otherField: 'Third stop on the right',
             arrayField: ['foo', 'bar']
-        },
-        _editingUsers: [localUser.id, localUser2.id]
+        }
     },
     validations: {},
     logs: [],
@@ -679,58 +677,6 @@ describe(`stream interviews query`, () => {
             expect(i).toBe(nbInterviews);
             done();
         });
-    });
-
-});
-
-describe(`Stat editing users`, () => {
-
-    test('Stat all users', async () => {
-        const statUsers = await dbQueries.statEditingUsers({});
-        expect(statUsers.length).toEqual(2);
-        statUsers.forEach((statUser) => {
-            switch(statUser.email) {
-                case localUser.email: 
-                    expect(statUser.count).toEqual('2');
-                    break;
-                case localUser2.email:
-                    expect(statUser.count).toEqual('1');
-                    break;
-                default:
-                    throw `Unexpected user email ${statUser.email}`;
-            }
-        })
-    });
-
-    test('Stat for specific permission', async () => {
-        const statUsers = await dbQueries.statEditingUsers({ permissions: [permission2]});
-        expect(statUsers.length).toEqual(1);
-        statUsers.forEach((statUser) => {
-            switch(statUser.email) {
-                case localUser2.email:
-                    expect(statUser.count).toEqual('1');
-                    break;
-                default:
-                    throw `Unexpected user email ${statUser.email}`;
-            }
-        })
-    });
-
-    test('Stat for multiple permission', async () => {
-        const statUsers = await dbQueries.statEditingUsers({ permissions: [permission2, permission1]});
-        expect(statUsers.length).toEqual(2);
-        statUsers.forEach((statUser) => {
-            switch(statUser.email) {
-                case localUser.email: 
-                    expect(statUser.count).toEqual('2');
-                    break;
-                case localUser2.email:
-                    expect(statUser.count).toEqual('1');
-                    break;
-                default:
-                    throw `Unexpected user email ${statUser.email}`;
-            }
-        })
     });
 
 });

--- a/packages/evolution-backend/src/models/__tests__/interviews.db.test.ts
+++ b/packages/evolution-backend/src/models/__tests__/interviews.db.test.ts
@@ -258,19 +258,26 @@ describe(`find by response`, () => {
 
 });
 
-describe('Get interview by interview uuid', () => {
+describe('Get interview and ID by interview uuid', () => {
     test('Valid interview', async () => {
         const interview = await dbQueries.getInterviewByUuid(localUserInterviewAttributes.uuid);
         expect(interview).toEqual(expect.objectContaining(_removeBlankFields({ ...localUserInterviewAttributes })));
+        const interviewId = await dbQueries.getInterviewIdByUuid(localUserInterviewAttributes.uuid);
+        expect(interviewId).toEqual((interview as any).id);
     });
 
     test('Invalid interview', async () => {
         const interview = await dbQueries.getInterviewByUuid(uuidV4());
         expect(interview).toBeUndefined();
+        const interviewId = await dbQueries.getInterviewIdByUuid(uuidV4());
+        expect(interviewId).toBeUndefined()
     });
 
     test('Not a valid uuid', async () => {
         await expect(dbQueries.getInterviewByUuid('not a valid uuid'))
+            .rejects
+            .toThrowError();
+        await expect(dbQueries.getInterviewIdByUuid('not a valid uuid'))
             .rejects
             .toThrowError();
     })

--- a/packages/evolution-backend/src/models/__tests__/interviewsAccesses.db.test.ts
+++ b/packages/evolution-backend/src/models/__tests__/interviewsAccesses.db.test.ts
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import knex from 'chaire-lib-backend/lib/config/shared/db.config';
+import { v4 as uuidV4 } from 'uuid';
+import { create, truncate } from 'chaire-lib-backend/lib/models/db/default.db.queries';
+
+import dbQueries from '../interviewsAccesses.db.queries';
+import interviewsDbQueries from '../interviews.db.queries';
+
+const localParticipant = {
+    id: 1,
+    email: 'test@transition.city',
+    is_valid: true
+};
+
+const localUser = {
+    ...localParticipant,
+    uuid: uuidV4(),
+}
+
+const anotherUser = {
+    id: 2,
+    email: 'test2@transition.city',
+    is_valid: true,
+    uuid: uuidV4(),
+}
+
+const localUserInterviewAttributes = {
+    uuid: uuidV4(),
+    participant_id: localParticipant.id,
+    is_valid: false,
+    is_active: true,
+    is_completed: undefined,
+    responses: {
+        accessCode: '11111',
+        booleanField: true,
+    },
+    validations: {},
+    logs: [],
+    audits: { errorOne: 3, errorThree: 1 }
+};
+
+beforeAll(async () => {
+    jest.setTimeout(10000);
+    await truncate(knex, 'sv_interviews_accesses');
+    await truncate(knex, 'sv_interviews');
+    await truncate(knex, 'sv_participants');
+    await create(knex, 'sv_participants', undefined, localParticipant as any);
+    await truncate(knex, 'users');
+    await create(knex, 'users', undefined, localUser as any);
+    await create(knex, 'users', undefined, anotherUser as any);
+    await interviewsDbQueries.create(localUserInterviewAttributes);
+});
+
+afterAll(async() => {
+    await truncate(knex, 'sv_interviews_accesses');
+    await truncate(knex, 'sv_interviews');
+    await truncate(knex, 'users');
+    await truncate(knex, 'sv_participants');
+});
+
+const assertAccessCounts = async (cnt: number) => {
+    const data = await dbQueries.collection();
+    expect(data.length).toEqual(cnt);
+}
+
+describe('userOpenedInterview', () => {
+
+    test('User opened existing interview for the first time', async() => {
+        expect(await dbQueries.userOpenedInterview({ interviewUuid: localUserInterviewAttributes.uuid, userId: localUser.id })).toEqual(true);
+        await assertAccessCounts(1);
+    });
+
+    test('User opened existing interview once more', async() => {
+        expect(await dbQueries.userOpenedInterview({ interviewUuid: localUserInterviewAttributes.uuid, userId: localUser.id })).toEqual(false);
+        await assertAccessCounts(1);
+    });
+
+    test('Interview does not exist', async() => {
+        let exception: any = undefined;
+        try {
+            await dbQueries.userOpenedInterview({ interviewUuid: uuidV4(), userId: localUser.id })
+        } catch (error) {
+            exception = error;
+        }
+        expect(exception).toBeDefined();
+        expect((exception as any).message).toEqual(expect.stringContaining("cannot log the user opening the interview (knex error: The requested interview does not exist:"))
+        await assertAccessCounts(1);
+    });
+
+    test('User does not exist', async() => {
+        let exception: any = undefined;
+        try {
+            await dbQueries.userOpenedInterview({ interviewUuid:localUserInterviewAttributes.uuid, userId: localUser.id - 1 })
+        } catch (error) {
+            exception = error;
+        }
+        expect(exception).toBeDefined();
+        expect((exception as any).message).toEqual(expect.stringContaining('violates foreign key constraint "sv_interviews_accesses_user_id_foreign")'))
+        await assertAccessCounts(1);
+    });
+
+    test('Second user opened existing interview', async() => {
+        expect(await dbQueries.userOpenedInterview({ interviewUuid: localUserInterviewAttributes.uuid, userId: anotherUser.id, validationMode: false })).toEqual(true);
+        await assertAccessCounts(2);
+    });
+
+    test('Second user opened existing interview, for validation', async() => {
+        expect(await dbQueries.userOpenedInterview({ interviewUuid: localUserInterviewAttributes.uuid, userId: anotherUser.id, validationMode: true })).toEqual(true);
+        await assertAccessCounts(3);
+    });
+
+});
+
+describe('userUpdatedInterview', () => {
+
+    const assertUpdateCounts = async (userId: number, validationMode: boolean, updateCnt: number) => {
+        const data = await dbQueries.collection();
+        console.log(data, userId, validationMode);
+        const record = data.find(access => access.user_id === userId && access.for_validation === validationMode)
+        expect(record).toBeDefined();
+        expect(record?.update_count).toEqual(updateCnt);
+    }
+
+    test('User updated interview in edit mode', async() => {
+        expect(await dbQueries.userUpdatedInterview({ interviewUuid: localUserInterviewAttributes.uuid, userId: anotherUser.id })).toEqual(true);
+        await assertAccessCounts(3);
+        await assertUpdateCounts(anotherUser.id, false, 1);
+    });
+
+    test('User updated interview in edit mode, again', async() => {
+        expect(await dbQueries.userUpdatedInterview({ interviewUuid: localUserInterviewAttributes.uuid, userId: anotherUser.id, validationMode: false })).toEqual(true);
+        await assertAccessCounts(3);
+        await assertUpdateCounts(anotherUser.id, false, 2);
+    });
+
+    test('User updated interview in validation mode', async() => {
+        expect(await dbQueries.userUpdatedInterview({ interviewUuid: localUserInterviewAttributes.uuid, userId: anotherUser.id, validationMode: true })).toEqual(true);
+        await assertAccessCounts(3);
+        await assertUpdateCounts(anotherUser.id, true, 1);
+    });
+
+    test('User updated interview in validation mode, again', async() => {
+        expect(await dbQueries.userUpdatedInterview({ interviewUuid: localUserInterviewAttributes.uuid, userId: anotherUser.id, validationMode: true })).toEqual(true);
+        await assertAccessCounts(3);
+        await assertUpdateCounts(anotherUser.id, true, 2);
+    });
+
+    test('New user updated interview in validation mode', async() => {
+        expect(await dbQueries.userUpdatedInterview({ interviewUuid: localUserInterviewAttributes.uuid, userId: localUser.id, validationMode: true })).toEqual(true);
+        await assertAccessCounts(4);
+        await assertUpdateCounts(localUser.id, true, 1);
+    });
+
+    test('New user updated interview in validation mode, again', async() => {
+        expect(await dbQueries.userUpdatedInterview({ interviewUuid: localUserInterviewAttributes.uuid, userId: localUser.id, validationMode: true })).toEqual(true);
+        await assertAccessCounts(4);
+        await assertUpdateCounts(localUser.id, true, 2);
+    });
+
+    test('Interview does not exist', async() => {
+        let exception: any = undefined;
+        try {
+            await dbQueries.userUpdatedInterview({ interviewUuid: uuidV4(), userId: localUser.id })
+        } catch (error) {
+            exception = error;
+        }
+        expect(exception).toBeDefined();
+        expect((exception as any).message).toEqual(expect.stringContaining("cannot log the user updating an interview (knex error: The requested interview does not exist:"))
+        
+    });
+
+    test('User does not exist', async() => {
+        let exception: any = undefined;
+        try {
+            await dbQueries.userUpdatedInterview({ interviewUuid:localUserInterviewAttributes.uuid, userId: localUser.id - 1 })
+        } catch (error) {
+            exception = error;
+        }
+        expect(exception).toBeDefined();
+        expect((exception as any).message).toEqual(expect.stringContaining('violates foreign key constraint "sv_interviews_accesses_user_id_foreign")'))
+    });
+
+});

--- a/packages/evolution-backend/src/models/interviews.db.queries.ts
+++ b/packages/evolution-backend/src/models/interviews.db.queries.ts
@@ -551,43 +551,6 @@ const getInterviewsStream = function (params: {
     return interviewsQuery.stream();
 };
 
-// TODO Add filters by date?
-const statEditingUsers = async (params: { permissions?: string[] }): Promise<{ email: string; count: number }[]> => {
-    try {
-        const innerQuery = knex
-            .select('id', knex.raw('json_array_elements(responses->\'_editingUsers\')::text::int as user_id'))
-            .from(tableName)
-            .whereRaw('responses->\'_editingUsers\' is not null')
-            .groupBy('id')
-            .as('i');
-        const statQuery = knex
-            .select('email')
-            .from(innerQuery)
-            .leftJoin('users', 'users.id', 'i.user_id')
-            .count()
-            .groupBy('email');
-
-        if (params.permissions) {
-            params.permissions.forEach((permission, index) => {
-                const wherePermission = `(users.permissions->>'${permission}')::boolean = true`;
-                if (index === 0) {
-                    statQuery.whereRaw(wherePermission);
-                } else {
-                    statQuery.orWhereRaw(wherePermission);
-                }
-            });
-        }
-
-        return (await statQuery) as { email: string; count: number }[];
-    } catch (error) {
-        throw new TrError(
-            `Cannot stat the editing users for interviews (knex error: ${error})`,
-            'DBQCR0007',
-            'DatabaseCannotStatEditingUsersBecauseDatabaseError'
-        );
-    }
-};
-
 export default {
     findByResponse,
     getInterviewByUuid,
@@ -597,6 +560,5 @@ export default {
     update,
     getList,
     getValidationErrors,
-    getInterviewsStream,
-    statEditingUsers
+    getInterviewsStream
 };

--- a/packages/evolution-backend/src/models/interviews.db.queries.ts
+++ b/packages/evolution-backend/src/models/interviews.db.queries.ts
@@ -110,6 +110,21 @@ const getInterviewByUuid = async <CustomSurvey, CustomHousehold, CustomHome, Cus
     }
 };
 
+const getInterviewIdByUuid = async <CustomSurvey, CustomHousehold, CustomHome, CustomPerson>(
+    interviewUuid: string
+): Promise<number | undefined> => {
+    try {
+        const interviews = await knex.select('id').from(tableName).where('uuid', interviewUuid);
+        return interviews.length === 1 ? interviews[0].id : undefined;
+    } catch (error) {
+        console.error(error);
+        throw new TrError(
+            `cannot find interview id by uuid because of a database error (knex error: ${error})`,
+            'TITQGC0022'
+        );
+    }
+};
+
 const getUserInterview = async <CustomSurvey, CustomHousehold, CustomHome, CustomPerson>(
     participantId: number
 ): Promise<UserInterviewAttributes<CustomSurvey, CustomHousehold, CustomHome, CustomPerson> | undefined> => {
@@ -576,6 +591,7 @@ const statEditingUsers = async (params: { permissions?: string[] }): Promise<{ e
 export default {
     findByResponse,
     getInterviewByUuid,
+    getInterviewIdByUuid,
     getUserInterview,
     create,
     update,

--- a/packages/evolution-backend/src/models/interviewsAccesses.db.queries.ts
+++ b/packages/evolution-backend/src/models/interviewsAccesses.db.queries.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import knex from 'chaire-lib-backend/lib/config/shared/db.config';
+import TrError from 'chaire-lib-common/lib/utils/TrError';
+import { UserInterviewAccesses } from '../services/logging/loggingTypes';
+
+import interviewsDbQueries from './interviews.db.queries';
+
+const tableName = 'sv_interviews_accesses';
+
+const getInterviewId = async (interviewUuid: string): Promise<number> => {
+    const interviewId = await interviewsDbQueries.getInterviewIdByUuid(interviewUuid);
+    if (interviewId === undefined) {
+        throw `The requested interview does not exist: ${interviewUuid}`;
+    }
+    return interviewId;
+};
+
+const getRecord = async (options: { interviewId: number; userId: number; validationMode?: boolean }) => {
+    const record = await knex
+        .select(`${tableName}.*`)
+        .from(tableName)
+        .where('interview_id', options.interviewId)
+        .andWhere('user_id', options.userId)
+        .andWhere('for_validation', options.validationMode === true);
+    return record.length !== 1 ? undefined : record[0];
+};
+
+const userOpenedInterview = async (options: {
+    interviewUuid: string;
+    userId: number;
+    validationMode?: boolean;
+}): Promise<boolean> => {
+    try {
+        const interviewId = await getInterviewId(options.interviewUuid);
+        const userRecord = await getRecord({
+            interviewId,
+            userId: options.userId,
+            validationMode: options.validationMode
+        });
+        if (userRecord !== undefined) {
+            // There already a record, return
+            return false;
+        }
+        await knex(tableName).insert({
+            interview_id: interviewId,
+            user_id: options.userId,
+            for_validation: options.validationMode === true
+        });
+        return true;
+    } catch (error) {
+        console.error(error);
+        throw new TrError(`cannot log the user opening the interview (knex error: ${error})`, 'TIUAQGC0001');
+    }
+};
+
+const userUpdatedInterview = async (options: {
+    interviewUuid: string;
+    userId: number;
+    validationMode?: boolean;
+}): Promise<boolean> => {
+    try {
+        const interviewId = await getInterviewId(options.interviewUuid);
+        const userRecord = await getRecord({
+            interviewId,
+            userId: options.userId,
+            validationMode: options.validationMode
+        });
+        if (userRecord !== undefined) {
+            // There already a record, update the edit counts
+            await knex(tableName)
+                .update({
+                    update_count: userRecord.update_count + 1
+                })
+                .where('interview_id', interviewId)
+                .andWhere('user_id', options.userId)
+                .andWhere('for_validation', options.validationMode === true);
+        } else {
+            // Insert a new record, the opening time will be the current timestamp
+            await knex(tableName).insert({
+                interview_id: interviewId,
+                user_id: options.userId,
+                for_validation: options.validationMode === true,
+                update_count: 1
+            });
+        }
+        return true;
+    } catch (error) {
+        console.error(error);
+        throw new TrError(`cannot log the user updating an interview (knex error: ${error})`, 'TIUAQGC0002');
+    }
+};
+
+const collection = async (): Promise<UserInterviewAccesses[]> => {
+    try {
+        return await knex.select(`${tableName}.*`).from(tableName);
+    } catch (error) {
+        console.error(error);
+        throw new TrError(`cannot fetch user interview accesses (knex error: ${error})`, 'TIUAQGC0003');
+    }
+};
+
+export default {
+    userOpenedInterview,
+    userUpdatedInterview,
+    collection
+};

--- a/packages/evolution-backend/src/models/migrations/20230627151700_createUserLoggingTbl.ts
+++ b/packages/evolution-backend/src/models/migrations/20230627151700_createUserLoggingTbl.ts
@@ -1,0 +1,22 @@
+import { Knex } from 'knex';
+import { onUpdateTrigger } from '../../config/knexfile';
+
+const tableName = 'sv_interviews_accesses';
+
+export async function up(knex: Knex): Promise<unknown> {
+    await knex.schema.createTable(tableName, (table: Knex.TableBuilder) => {
+        table.integer('interview_id').notNullable();
+        table.foreign('interview_id').references('sv_interviews.id').onDelete('CASCADE');
+        table.integer('user_id').notNullable();
+        table.foreign('user_id').references('users.id').onDelete('CASCADE');
+        table.boolean('for_validation').notNullable().defaultTo(false);
+        table.integer('update_count').notNullable().defaultTo(0);
+        table.timestamps(true, true);
+        table.primary(['interview_id', 'user_id', 'for_validation']);
+    });
+    return knex.raw(onUpdateTrigger(tableName));
+}
+
+export async function down(knex: Knex): Promise<unknown> {
+    return knex.schema.dropTable(tableName);
+}

--- a/packages/evolution-backend/src/services/interviews/__tests__/interviews.test.ts
+++ b/packages/evolution-backend/src/services/interviews/__tests__/interviews.test.ts
@@ -9,6 +9,7 @@ import { v4 as uuidV4 } from 'uuid';
 import Interviews from '../interviews';
 import { InterviewAttributes } from 'evolution-common/lib/services/interviews/interview';
 import interviewsQueries from '../../../models/interviews.db.queries';
+import interviewsAccessesQueries from '../../../models/interviewsAccesses.db.queries';
 import { registerAccessCodeValidationFunction } from '../../accessCode';
 import { updateInterview } from '../interview';
 
@@ -18,12 +19,15 @@ jest.mock('../../../models/interviews.db.queries', () => ({
     create: jest.fn(),
     getUserInterview: jest.fn(),
     getList: jest.fn(),
-    getValidationErrors: jest.fn(),
+    getValidationErrors: jest.fn()
+}));
+
+jest.mock('../../../models/interviewsAccesses.db.queries', () => ({
     statEditingUsers: jest.fn()
 }));
 const mockDbCreate = interviewsQueries.create as jest.MockedFunction<typeof interviewsQueries.create>;
 const mockDbGetByUuid = interviewsQueries.getInterviewByUuid as jest.MockedFunction<typeof interviewsQueries.getInterviewByUuid>;
-const mockStatEditingUsers = interviewsQueries.statEditingUsers as jest.MockedFunction<typeof interviewsQueries.statEditingUsers>;
+const mockStatEditingUsers = interviewsAccessesQueries.statEditingUsers as jest.MockedFunction<typeof interviewsAccessesQueries.statEditingUsers>;
 
 jest.mock('../interview', () => ({
     updateInterview: jest.fn()
@@ -489,8 +493,8 @@ describe('Stat editing users', () => {
 
     test('Test with correct answer', async () => {
         const userStats = [
-            { email: 'foo@bar.com', count: 10 },
-            { email: 'a@b.c', count: 2 }
+            { email: 'foo@bar.com', interview_id: 12, user_id: 3, for_validation: false, update_count: 10, created_at: '2023-06-28', updated_at: '2023-06-28' },
+            { email: 'a@b.c', interview_id: 12, user_id: 3, for_validation: false, update_count: 2, created_at: '2023-06-28', updated_at: '2023-06-28' }
         ]
         mockStatEditingUsers.mockResolvedValueOnce(userStats);
         const stats = await Interviews.statEditingUsers();
@@ -500,8 +504,8 @@ describe('Stat editing users', () => {
 
     test('Test with permissions', async () => {
         const userStats = [
-            { email: 'foo@bar.com', count: 10 },
-            { email: 'a@b.c', count: 2 }
+            { email: 'foo@bar.com', interview_id: 12, user_id: 3, for_validation: false, update_count: 10, created_at: '2023-06-28', updated_at: '2023-06-28' },
+            { email: 'a@b.c', interview_id: 12, user_id: 3, for_validation: false, update_count: 2, created_at: '2023-06-28', updated_at: '2023-06-28' }
         ]
         mockStatEditingUsers.mockResolvedValueOnce(userStats);
         const stats = await Interviews.statEditingUsers({ permissions: [ 'role1', 'role2' ] });

--- a/packages/evolution-backend/src/services/interviews/interviews.ts
+++ b/packages/evolution-backend/src/services/interviews/interviews.ts
@@ -11,11 +11,13 @@ import { mapResponsesToValidatedData } from './interviewUtils';
 import { validateAccessCode } from '../accessCode';
 import { validate as validateUuid } from 'uuid';
 import interviewsDbQueries, { InterviewSearchAttributes, OperatorSigns } from '../../models/interviews.db.queries';
+import interviewsAccessesDbQueries from '../../models/interviewsAccesses.db.queries';
 import {
     InterviewAttributes,
     InterviewListAttributes,
     UserInterviewAttributes
 } from 'evolution-common/lib/services/interviews/interview';
+import { UserInterviewAccesses } from '../logging/loggingTypes';
 
 const getFiltersForDb = (
     filter: { is_valid?: 'valid' | 'invalid' | 'notInvalid' | 'notValidated' | 'all' } & {
@@ -259,7 +261,7 @@ export default class Interviews {
 
     static statEditingUsers = async (
         params: { permissions?: string[] } = {}
-    ): Promise<{ email: string; count: number }[]> => {
-        return await interviewsDbQueries.statEditingUsers(params);
+    ): Promise<(UserInterviewAccesses & { email: string })[]> => {
+        return await interviewsAccessesDbQueries.statEditingUsers(params);
     };
 }

--- a/packages/evolution-backend/src/services/logging/__tests__/queryLoggingMiddleware.test.ts
+++ b/packages/evolution-backend/src/services/logging/__tests__/queryLoggingMiddleware.test.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { NextFunction, Request, Response } from 'express';
+import { v4 as uuidV4 } from 'uuid'
+import { logUserAccessesMiddleware, defaultMiddlewares } from '../queryLoggingMiddleware';
+import each from 'jest-each';
+import interviewsAccessesDbQueries from '../../../models/interviewsAccesses.db.queries';
+
+jest.mock('../../../models/interviewsAccesses.db.queries', () => ({
+    userOpenedInterview: jest.fn(),
+    userUpdatedInterview: jest.fn(),
+}));
+const mockUserOpenedQuery = interviewsAccessesDbQueries.userOpenedInterview as jest.MockedFunction<typeof interviewsAccessesDbQueries.userOpenedInterview>;
+const mockUserUpdatedQuery = interviewsAccessesDbQueries.userUpdatedInterview as jest.MockedFunction<typeof interviewsAccessesDbQueries.userUpdatedInterview>;
+
+let mockRequest: Partial<Request>;
+let mockResponse: Partial<Response>;
+let nextFunction: NextFunction = jest.fn();
+let mockUser = { id: 3, username: 'notAdmin' };
+
+const interviewId = uuidV4();
+
+beforeEach(() => {
+    mockRequest = {};
+    mockResponse = {
+        json: jest.fn(),
+        status: jest.fn().mockReturnThis()
+    };
+    (nextFunction as any).mockClear();
+    mockUserOpenedQuery.mockClear();
+    mockUserUpdatedQuery.mockClear();
+});
+
+each([
+    ['Interview uuid in params', mockUser, { interviewUuid: interviewId }, true],
+    ['Interview id in params', mockUser, { interviewUuid: interviewId }, true],
+    ['No interview ID', mockUser, {  }, false],
+    ['No user, should not happen, but not cause exception either', undefined, { interviewUuid: interviewId }, false],
+]).describe('log opening the interview: %s', (_title, user, reqParams, expectedCalled) => {
+
+    test('log user access: edit mode', async () => {
+        mockRequest.user = user;
+        const request = { ...mockRequest, params: reqParams };
+        logUserAccessesMiddleware.openingInterview(false)(request as Request, mockResponse as Response, nextFunction);
+        if (expectedCalled) {
+            expect(mockUserOpenedQuery).toHaveBeenCalledTimes(1);
+            expect(mockUserOpenedQuery).toHaveBeenCalledWith({ interviewUuid: interviewId, userId: user.id, validationMode: false });
+        } else {
+            expect(mockUserOpenedQuery).not.toHaveBeenCalled();
+        }
+        expect(nextFunction).toHaveBeenCalled();
+    });
+
+    test('log user access: validation mode', async () => {
+        mockRequest.user = user;
+        const request = { ...mockRequest, params: reqParams };
+        logUserAccessesMiddleware.openingInterview(true)(request as Request, mockResponse as Response, nextFunction);
+        if (expectedCalled) {
+            expect(mockUserOpenedQuery).toHaveBeenCalledTimes(1);
+            expect(mockUserOpenedQuery).toHaveBeenCalledWith({ interviewUuid: interviewId, userId: user.id, validationMode: true });
+        } else {
+            expect(mockUserOpenedQuery).not.toHaveBeenCalled();
+        }
+        expect(nextFunction).toHaveBeenCalled();
+    });
+
+    test('default no log: edit mode', async () => {
+        mockRequest.user = user;
+        const request = { ...mockRequest, params: reqParams };
+        defaultMiddlewares.openingInterview(false)(request as Request, mockResponse as Response, nextFunction);
+        expect(nextFunction).toHaveBeenCalled();
+    });
+
+    test('default no log: validation mode', async () => {
+        mockRequest.user = user;
+        const request = { ...mockRequest, params: reqParams };
+        defaultMiddlewares.openingInterview(true)(request as Request, mockResponse as Response, nextFunction);
+        expect(nextFunction).toHaveBeenCalled();
+    });
+});
+
+each([
+    ['Interview uuid in params', mockUser, { interviewUuid: interviewId }, {}, true],
+    ['Interview id in body', mockUser, {}, { interviewId: interviewId }, true],
+    ['No interview ID', mockUser, {}, {}, false],
+    ['No user, should not happen, but not cause exception either', undefined, { interviewUuid: interviewId }, {}, false],
+]).describe('log updating the interview: %s', (_title, user, reqParams, body, expectedCalled) => {
+
+    test('edit mode', async () => {
+        mockRequest.user = user;
+        const request = { ...mockRequest, params: reqParams, body: body };
+        logUserAccessesMiddleware.updatingInterview(false)(request as Request, mockResponse as Response, nextFunction);
+        if (expectedCalled) {
+            expect(mockUserUpdatedQuery).toHaveBeenCalledTimes(1);
+            expect(mockUserUpdatedQuery).toHaveBeenCalledWith({ interviewUuid: interviewId, userId: user.id, validationMode: false });
+        } else {
+            expect(mockUserUpdatedQuery).not.toHaveBeenCalled();
+        }
+        expect(nextFunction).toHaveBeenCalled();
+    });
+
+    test('validation mode', async () => {
+        mockRequest.user = user;
+        const request = { ...mockRequest, params: reqParams, body: body };
+        logUserAccessesMiddleware.updatingInterview(true)(request as Request, mockResponse as Response, nextFunction);
+        if (expectedCalled) {
+            expect(mockUserUpdatedQuery).toHaveBeenCalledTimes(1);
+            expect(mockUserUpdatedQuery).toHaveBeenCalledWith({ interviewUuid: interviewId, userId: user.id, validationMode: true });
+        } else {
+            expect(mockUserUpdatedQuery).not.toHaveBeenCalled();
+        }
+        expect(nextFunction).toHaveBeenCalled();
+    });
+
+    test('default no log: edit mode', async () => {
+        mockRequest.user = user;
+        const request = { ...mockRequest, params: reqParams, body: body };
+        defaultMiddlewares.updatingInterview(false)(request as Request, mockResponse as Response, nextFunction);
+        expect(nextFunction).toHaveBeenCalled();
+    });
+
+    test('default no log: validation mode', async () => {
+        mockRequest.user = user;
+        const request = { ...mockRequest, params: reqParams, body: body };
+        defaultMiddlewares.updatingInterview(true)(request as Request, mockResponse as Response, nextFunction);
+        expect(nextFunction).toHaveBeenCalled();
+    });
+});

--- a/packages/evolution-backend/src/services/logging/loggingTypes.ts
+++ b/packages/evolution-backend/src/services/logging/loggingTypes.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+export type UserInterviewAccesses = {
+    interview_id: number;
+    user_id: number;
+    for_validation: boolean;
+    update_count: number;
+    created_at: string;
+    updated_at: string;
+};

--- a/packages/evolution-backend/src/services/logging/queryLoggingMiddleware.ts
+++ b/packages/evolution-backend/src/services/logging/queryLoggingMiddleware.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { UserAttributes } from 'chaire-lib-backend/lib/services/users/user';
+import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
+import { NextFunction, Request, Response } from 'express';
+import interviewsAccessesDbQueries from '../../models/interviewsAccesses.db.queries';
+
+export type InterviewLoggingMiddlewares = {
+    openingInterview: (validationMode: boolean) => (req: Request, res: Response, next: NextFunction) => void;
+    updatingInterview: (validationMode: boolean) => (req: Request, res: Response, next: NextFunction) => void;
+};
+
+const openingInterview = (validationMode: boolean) => (req: Request, _res: Response, next: NextFunction) => {
+    // Log a user opening the interview
+    const interviewUuid = req.params.interviewUuid || req.params.interviewId;
+    const user = req.user as UserAttributes;
+    if (!_isBlank(interviewUuid) && !_isBlank(user)) {
+        // We don't need to wait for this to complete, failures are not dramatic, but we may want to do something about it?
+        // TODO do not require to cast user, see https://github.com/chairemobilite/transition/issues/676 for chaire-lib function to do this
+        interviewsAccessesDbQueries.userOpenedInterview({ interviewUuid, userId: user.id, validationMode });
+    }
+    next();
+};
+
+const updatingInterview = (validationMode: boolean) => (req: Request, _res: Response, next: NextFunction) => {
+    // Log a user updating an interview
+    const interviewUuid = req.params.interviewUuid || req.body.interviewId;
+    const user = req.user as UserAttributes;
+    if (!_isBlank(interviewUuid) && !_isBlank(user)) {
+        // We don't need to wait for this to complete, failures are not dramatic, but we may want to do something about it?
+        // TODO do not require to cast user, see https://github.com/chairemobilite/transition/issues/676 for chaire-lib function to do this
+        interviewsAccessesDbQueries.userUpdatedInterview({ interviewUuid, userId: user.id, validationMode });
+    }
+    next();
+};
+
+export const defaultMiddlewares: InterviewLoggingMiddlewares = {
+    openingInterview: () => (_req: Request, _res: Response, next: NextFunction) => next(),
+    updatingInterview: () => (_req: Request, _res: Response, next: NextFunction) => next()
+};
+
+export const logUserAccessesMiddleware: InterviewLoggingMiddlewares = {
+    openingInterview,
+    updatingInterview
+};

--- a/packages/evolution-common/src/services/interviews/interview.ts
+++ b/packages/evolution-common/src/services/interviews/interview.ts
@@ -87,9 +87,6 @@ export type InterviewResponses<CustomSurvey, CustomHousehold, CustomHome, Custom
     _language?: string;
     _isCompleted?: boolean;
 
-    // Array of user_id of users who edited this interview, excluding the user himself
-    // FIXME Remove from here (see https://github.com/chairemobilite/transition-legacy/issues/1987)
-    _editingUsers?: number[];
     _sections?: {
         [sectionName: string]: SectionStatus & {
             [subSection: string]: SectionStatus;

--- a/packages/evolution-legacy/src/apps/admin/server/routes.js
+++ b/packages/evolution-legacy/src/apps/admin/server/routes.js
@@ -8,9 +8,10 @@ import router from 'evolution-backend/lib/api/interviews.routes';
 import getSurveyRouter from 'evolution-backend/lib/api/survey.user.routes';
 import validationSurveyRouter from 'evolution-backend/lib/api/survey.validation.routes';
 import userIsAuthorized from 'evolution-backend/lib/services/auth/userAuthorization';
+import { logUserAccessesMiddleware } from 'evolution-backend/lib/services/logging/queryLoggingMiddleware';
 
 module.exports = function(app) {
-    const userSurveyRouter = getSurveyRouter(userIsAuthorized);
+    const userSurveyRouter = getSurveyRouter(userIsAuthorized, logUserAccessesMiddleware);
     app.use('/api/interviews/', router);
     app.use('/api', userSurveyRouter);
     app.use('/api', validationSurveyRouter);

--- a/packages/evolution-legacy/src/apps/participant/server/routes.js
+++ b/packages/evolution-legacy/src/apps/participant/server/routes.js
@@ -6,8 +6,9 @@
  */
 import getSurveyRouter from 'evolution-backend/lib/api/survey.user.routes';
 import participantIsAuthorized from 'evolution-backend/lib/services/auth/participantAuthorization';
+import { defaultMiddlewares } from 'evolution-backend/lib/services/logging/queryLoggingMiddleware';
 
 module.exports = function(app) {
-    const userSurveyRouter = getSurveyRouter(participantIsAuthorized);
+    const userSurveyRouter = getSurveyRouter(participantIsAuthorized, defaultMiddlewares);
     app.use('/api', userSurveyRouter);
 };


### PR DESCRIPTION
Fixes #43 

Add a database table, which tracks users who access a given interview, counting the number of edits done in the interview, with start and update timestamps

The express routes to open and update the interview use an additional middleware, which saves the user access to the interview. In the admin application, the middleware saves the data to the table described above. In the participant applicaiton, it does nothing.

The previous _editingUsers field in the responses is dropped and the statEditingUsers function is updated accordingly.