### PR TITLE
homepage: add a consent checkbox to agree to usage of data

### DIFF
--- a/example/demo_survey/locales/en/survey.json
+++ b/example/demo_survey/locales/en/survey.json
@@ -1,8 +1,9 @@
 {
     "homepage": {
-        "introduction": "<p class=\"center _dark-green _strong\" style=\"color: #2B7F79;\">We are seeking your participation in a study on people's travel behavior in the Montreal area. This study aims to better understand the trips of people living in the Greater Montreal Area.</p><p class=\"center _oblique\"><a href=\"http://www.artm.quebec/origin-destination-survey/\">More about this survey</p>",
-        "pageTwoIntroduction": "<p class=\"center _strong\" style=\"color: #2B7F79;\">You already completed the first part. The second part will focus on the travel behavior of your household's members.</p><p class=\"center _oblique\">To sign in, please use the same email and password that you provided when you did the first part, or use the same Google or Facebook account.</p>",
-        "start": "Start"
+        "introduction": "<p class=\"_dark-green _strong\" style=\"color: #2B7F79;\">We are seeking your participation in a study on people's travel behavior in the Montreal area. This study aims to better understand the trips of people living in the Greater Montreal Area.</p><p class=\"_oblique\"><a href=\"http://www.artm.quebec/origin-destination-survey/\">More about this survey</p>",
+        "pageTwoIntroduction": "<p class=\"_strong\" style=\"color: #2B7F79;\">You already completed the first part. The second part will focus on the travel behavior of your household's members.</p><p class=\"center _oblique\">To sign in, please use the same email and password that you provided when you did the first part, or use the same Google or Facebook account.</p>",
+        "start": "Start",
+        "AgreementText": "I consent to the usage of my data for research purposes"
     },
     "footer": "<p class=\"center\" style=\"font-size: 85%; margin-bottom: 2rem; padding-top: 2rem;\">Powered by <a href=\"https://github.com/chairemobilite/evolution\" target=\"_blank\">Evolution</a></p>",
     "postregistration": {

--- a/example/demo_survey/locales/fr/survey.json
+++ b/example/demo_survey/locales/fr/survey.json
@@ -1,8 +1,9 @@
 {
     "homepage": {
-        "introduction": "<p class=\"center _strong\" style=\"color: #2B7F79;\">Nous sollicitons votre participation à une étude sur la mobilité des personnes de la région de Montréal. Cette étude vise à mieux connaître les déplacements des personnes habitant sur le territoire de la grande région de Montréal.</p><p class=\"center _oblique\"><a href=\"http://www.artm.quebec/eod/\">En savoir davantage sur cette étude</a></p>",
-        "pageTwoIntroduction": "<p class=\"center _strong\" style=\"color: #2B7F79;\">Vous avez déjà complété la première partie. La deuxième partie concerne les déplacements des membres de votre ménage.</p><p class=\"center _oblique\">Pour vous connecter, utilisez l'adresse courriel et le mot de passe que vous avez indiqués pour accéder à la première partie ou utilisez le même compte Google ou Facebook.</p>",
-        "start": "Débuter"
+        "introduction": "<p class=\"_strong\" style=\"color: #2B7F79;\">Nous sollicitons votre participation à une étude sur la mobilité des personnes de la région de Montréal. Cette étude vise à mieux connaître les déplacements des personnes habitant sur le territoire de la grande région de Montréal.</p><p class=\"_oblique\"><a href=\"http://www.artm.quebec/eod/\">En savoir davantage sur cette étude</a></p>",
+        "pageTwoIntroduction": "<p class=\"_strong\" style=\"color: #2B7F79;\">Vous avez déjà complété la première partie. La deuxième partie concerne les déplacements des membres de votre ménage.</p><p class=\"center _oblique\">Pour vous connecter, utilisez l'adresse courriel et le mot de passe que vous avez indiqués pour accéder à la première partie ou utilisez le même compte Google ou Facebook.</p>",
+        "start": "Débuter",
+        "AgreementText": "Je consens à l'usage des mes données à des fins de recherche"
     },
     "footer": "<p class=\"center\" style=\"font-size: 85%; margin-bottom: 2rem; padding-top: 2rem;\">Propulsé par <a href=\"https://github.com/chairemobilite/evolution\" target=\"_blank\">Evolution</a></p>",
     "postregistration": {

--- a/locales/en/main.json
+++ b/locales/en/main.json
@@ -30,5 +30,7 @@
   "validatorLvl1": "Basic validator",
   "validatorLvl2": "Super validator",
   "ClickToSelectDate": "Click to select a date",
-  "footer": ""
+  "footer": "",
+  "AgreementText": "",
+  "ErrorNotAgreed": "You must accept usage of your date to continue to the survey"
 }

--- a/locales/fr/main.json
+++ b/locales/fr/main.json
@@ -30,5 +30,7 @@
   "validatorLvl1": "Valideur de base",
   "validatorLvl2": "Super-valideur",
   "ClickToSelectDate": "Cliquer pour sélectionner une date",
-  "footer": ""
+  "footer": "",
+  "AgreementText": "",
+  "ErrorNotAgreed": "Vous devez accepter l'utilisation de vos données pour continuer vers l'enquête"
 }

--- a/packages/evolution-frontend/src/components/pageParts/ConsentAndStartForm.tsx
+++ b/packages/evolution-frontend/src/components/pageParts/ConsentAndStartForm.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import React from 'react';
+
+import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
+import { WithTranslation, withTranslation } from 'react-i18next';
+import config from 'chaire-lib-common/lib/config/shared/project.config';
+import FormErrors from 'chaire-lib-frontend/lib/components/pageParts/FormErrors';
+
+export type ConsentAndStartFormProps = {
+    afterClicked: () => void;
+};
+
+type AgreementCheckboxProps = {
+    text: string;
+    onChange: (isChecked: boolean) => void;
+};
+
+const AgreementCheckbox = (props: AgreementCheckboxProps) => {
+    const [checked, setChecked] = React.useState(false);
+    const [updateKey, setUpdateKey] = React.useState(0);
+    const onChange = (_e) => {
+        const newChecked = !checked;
+        setChecked(newChecked);
+        props.onChange(newChecked);
+    };
+
+    return (
+        <React.Fragment>
+            <input
+                type="checkbox"
+                id="surveyConsent"
+                key={`surveyConsentIdx${updateKey}`}
+                className={'_input-checkbox'}
+                value="agree"
+                checked={checked}
+                onChange={onChange}
+            />
+            <label
+                htmlFor="surveyConsent"
+                onClick={() => {
+                    onChange;
+                    setUpdateKey(updateKey + 1);
+                }}
+            >
+                <span>{props.text}</span>
+            </label>
+        </React.Fragment>
+    );
+};
+
+const ConsentAndStartForm = (props: ConsentAndStartFormProps & WithTranslation) => {
+    const [agreed, setAgreed] = React.useState(false);
+    const [showError, setShowError] = React.useState(false);
+    const color = config.startButtonColor ? config.startButtonColor : 'green';
+    const agreementText = props.t(['survey:homepage:AgreementText', 'main:AgreementText']);
+    console.log('agreement text', agreementText);
+    React.useEffect(() => {
+        if (_isBlank(agreementText)) {
+            setAgreed(true);
+        }
+    }, [agreementText]);
+    const onButtonClicked = () => {
+        if (!agreed) {
+            setShowError(true);
+        } else {
+            props.afterClicked();
+        }
+    };
+    const onAgreementChange = (hasAgreed) => {
+        setShowError(false);
+        setAgreed(hasAgreed);
+    };
+    return (
+        <div className="survey-section__button-agreement">
+            {!_isBlank(agreementText) && <AgreementCheckbox text={agreementText} onChange={onAgreementChange} />}
+            {showError && (
+                <FormErrors
+                    errors={[props.t(['survey:homepage:ErrorNotAgreed', 'main:ErrorNotAgreed'])]}
+                    errorType="Error"
+                />
+            )}
+            <div className="center">
+                <button
+                    type="button"
+                    className={`survey-section__button button ${color} large`}
+                    onClick={onButtonClicked}
+                >
+                    {props.t(['survey:homepage:start', 'auth:Start'])}
+                </button>
+            </div>
+        </div>
+    );
+};
+
+export default withTranslation()(ConsentAndStartForm);

--- a/packages/evolution-frontend/src/components/pageParts/__tests__/ConsentAndStartForm.test.tsx
+++ b/packages/evolution-frontend/src/components/pageParts/__tests__/ConsentAndStartForm.test.tsx
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import React from 'react';
+import TestRenderer from 'react-test-renderer';
+import { mount } from 'enzyme';
+
+import ConsentAndStartForm from '../ConsentAndStartForm';
+
+// Mock the react-i18next to control the translated string (see )
+let translatedString = '';
+jest.mock('react-i18next', () => ({
+    // this mock makes sure any components using the translate HoC receive the t function as a prop
+    withTranslation: () => Component => {
+      Component.defaultProps = { ...Component.defaultProps, t: (str: string | string[]) => typeof str === 'string' ? str : str.findIndex(s => s.includes('AgreementText')) !== -1 ? translatedString : str[0] };
+      return Component;
+    },
+}));
+
+
+describe('Render ConsentAndStartForm', () => {
+
+    test('Without consent checkbox', () => {
+        translatedString = '';
+        const wrapper = TestRenderer.create(
+            <ConsentAndStartForm
+                afterClicked={jest.fn()}
+            />
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('With consent checkbox', () => {
+        translatedString = 'I agree';
+        const wrapper = TestRenderer.create(
+            <ConsentAndStartForm
+                afterClicked={jest.fn()}
+            />
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+    
+});
+
+
+describe('Button click', () => {
+
+    test('Without consent', () => {
+        const afterClick = jest.fn();
+        translatedString = '';
+        const consentAndStartForm = mount( <ConsentAndStartForm
+            afterClicked={afterClick}
+        />);
+    
+        // Click on button and make sure it accepts the change
+        const formButton = consentAndStartForm.find(`.survey-section__button`).at(0);
+        formButton.simulate('click');
+
+        // Check that the callback has been called
+        expect(afterClick).toHaveBeenCalled();
+    });
+
+    test('With consent, not checked', () => {
+        const afterClick = jest.fn();
+        translatedString = 'I agree';
+        const consentAndStartForm = mount( <ConsentAndStartForm
+            afterClicked={afterClick}
+        />);
+    
+        // Click on button, it should not agree
+        const formButton = consentAndStartForm.find(`.survey-section__button`).at(0);
+        formButton.simulate('click');
+        
+
+        // Make sure the callback was not called and the error message appears
+        expect(afterClick).not.toHaveBeenCalled();
+        consentAndStartForm.update();
+        const errors = consentAndStartForm.find(`.apptr__form-errors-container`).at(0);
+        expect(errors.length).toEqual(1);
+    });
+
+    test('With consent, checked', () => {
+        const afterClick = jest.fn();
+        translatedString = 'I agree';
+        const consentAndStartForm = mount( <ConsentAndStartForm
+            afterClicked={afterClick}
+        />);
+    
+        // Check the checkbox
+        const consentCheckbox = consentAndStartForm.find(`#surveyConsent`).at(0);
+        consentCheckbox.simulate('change');
+        consentAndStartForm.update();
+
+        // Click on button and make sure it accepts the change
+        const formButton = consentAndStartForm.find(`.survey-section__button`).at(0);
+
+        // Check the period and validate the choices
+        formButton.simulate('click');
+        expect(afterClick).toHaveBeenCalled();
+    });
+
+});

--- a/packages/evolution-frontend/src/components/pageParts/__tests__/__snapshots__/ConsentAndStartForm.test.tsx.snap
+++ b/packages/evolution-frontend/src/components/pageParts/__tests__/__snapshots__/ConsentAndStartForm.test.tsx.snap
@@ -1,0 +1,53 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Render ConsentAndStartForm With consent checkbox 1`] = `
+<div
+  className="survey-section__button-agreement"
+>
+  <input
+    checked={false}
+    className="_input-checkbox"
+    id="surveyConsent"
+    onChange={[Function]}
+    type="checkbox"
+    value="agree"
+  />
+  <label
+    htmlFor="surveyConsent"
+    onClick={[Function]}
+  >
+    <span>
+      I agree
+    </span>
+  </label>
+  <div
+    className="center"
+  >
+    <button
+      className="survey-section__button button green large"
+      onClick={[Function]}
+      type="button"
+    >
+      survey:homepage:start
+    </button>
+  </div>
+</div>
+`;
+
+exports[`Render ConsentAndStartForm Without consent checkbox 1`] = `
+<div
+  className="survey-section__button-agreement"
+>
+  <div
+    className="center"
+  >
+    <button
+      className="survey-section__button button green large"
+      onClick={[Function]}
+      type="button"
+    >
+      survey:homepage:start
+    </button>
+  </div>
+</div>
+`;

--- a/packages/evolution-legacy/src/components/survey/HomePage.js
+++ b/packages/evolution-legacy/src/components/survey/HomePage.js
@@ -12,7 +12,7 @@ import {v4 as uuidv4}      from 'uuid'
 
 import { startRegister } from '../../actions/shared/auth';
 import config            from 'chaire-lib-common/lib/config/shared/project.config';
-import Button            from './Button';
+import ConsentAndStartForm from 'evolution-frontend/lib/components/pageParts/ConsentAndStartForm';
 import { InterviewContext } from 'evolution-frontend/lib/contexts/InterviewContext';
 
 class HomePage extends React.Component { 
@@ -28,107 +28,6 @@ class HomePage extends React.Component {
       this.props.history.push(goToPage === '' || goToPage === '/' ? '/survey' : goToPage);
     }
 
-    this.widgetStatus = {
-      isVisible: true
-    };
-
-    this.widgetConfig = {
-      color: config.startButtonColor ? config.startButtonColor : 'green',
-      action: function(section, sections, saveCallback) {
-
-        if (config.loginFromUrl)
-        {
-
-          const params = new URLSearchParams(this.props.location.search);
-          this.setState(() => ({ error: null }));
-          const generatePassword = (Math.floor((Math.random() * 800000)) + 100000).toString();
-          
-          if ( params.get(config.loginFromUrlMapping.usernameOrEmail) ){ //verify thaht there is a username in the url
-            let username = params.get(config.loginFromUrlMapping.usernameOrEmail)
-            for (let property in config.loginFromUrlMapping) {
-              if (params.get(config.loginFromUrlMapping[property])){
-                {property === 'usernameOrEmail'? null : username += '_?'+property+'_'+params.get(config.loginFromUrlMapping[property])}
-              }
-            } 
-
-            if (!username) { //if no name --> go to register
-              this.props.history.push('/register');
-            } else { //if already login and same username --> go to survey otherwise log the user
-              
-              fetch('/verifyAuthentication', { credentials: 'include' }).then((response) => {
-                if (response.status === 200) {
-                  response.json().then((body) => {
-                    if (body.status === 'Login successful!' && body.user.username && body.user.username === username) {
-                      this.props.history.push('/survey');
-                    } else { // case when user is not register or the username from url and the fetch are not the same
-                      this.props.startRegister(
-                        {
-                          usernameOrEmail  : username,
-                          generatedPassword: generatePassword,
-                          password         : config.loginFromUrlMapping.password ? params.get(config.loginFromUrlMapping.password) : generatePassword
-                        },
-                        this.props.history
-                      );
-                    }
-                  });
-                } else { // case when response status is not 200
-                  if (config.allowRegistration !== false)
-                  {
-                    this.props.startRegister(
-                      {
-                        usernameOrEmail  : username,
-                        generatedPassword: generatePassword,
-                        password         : config.loginFromUrlMapping.password ? params.get(config.loginFromUrlMapping.password) : generatePassword
-                      },
-                      this.props.history
-                    );
-                  }
-                  else
-                  {
-                    this.props.history.push('/login');
-                  } 
-                }
-              });
-            }
-          } else { // if no username in the url go to register
-            if (config.allowRegistration !== false)
-            {
-              this.props.history.push('/register');
-            }
-            else
-            {
-              this.props.history.push('/login');
-            }
-          }
-        } 
-        else if (config.loginWithoutUsername) 
-        {
-
-          if (config.allowRegistration !== false)
-          {
-            this.setState(() => ({ error: null }));
-            const generatePassword = (Math.floor((Math.random() * 800000)) + 100000).toString();
-            const username = uuidv4();
-            this.props.startRegister(
-              {
-                usernameOrEmail  : username,
-                generatedPassword: generatePassword,
-                password         : generatePassword
-              },
-              this.props.history
-            );
-          }
-          else
-          {
-            this.props.history.push('/login');
-          }
-        }
-        else
-        {
-          config.isPartTwo === true || config.allowRegistration === false ? this.props.history.push('/login') : this.props.history.push('/register');
-        }  
-      }.bind(this)
-    };
   }
 
   componentDidMount() {
@@ -140,6 +39,100 @@ class HomePage extends React.Component {
         }
     }
     
+  }
+
+  afterClick = () => {
+    if (config.loginFromUrl)
+    {
+
+      const params = new URLSearchParams(this.props.location.search);
+      this.setState(() => ({ error: null }));
+      const generatePassword = (Math.floor((Math.random() * 800000)) + 100000).toString();
+      
+      if ( params.get(config.loginFromUrlMapping.usernameOrEmail) ){ //verify thaht there is a username in the url
+        let username = params.get(config.loginFromUrlMapping.usernameOrEmail)
+        for (let property in config.loginFromUrlMapping) {
+          if (params.get(config.loginFromUrlMapping[property])){
+            {property === 'usernameOrEmail'? null : username += '_?'+property+'_'+params.get(config.loginFromUrlMapping[property])}
+          }
+        } 
+
+        if (!username) { //if no name --> go to register
+          this.props.history.push('/register');
+        } else { //if already login and same username --> go to survey otherwise log the user
+          
+          fetch('/verifyAuthentication', { credentials: 'include' }).then((response) => {
+            if (response.status === 200) {
+              response.json().then((body) => {
+                if (body.status === 'Login successful!' && body.user.username && body.user.username === username) {
+                  this.props.history.push('/survey');
+                } else { // case when user is not register or the username from url and the fetch are not the same
+                  this.props.startRegister(
+                    {
+                      usernameOrEmail  : username,
+                      generatedPassword: generatePassword,
+                      password         : config.loginFromUrlMapping.password ? params.get(config.loginFromUrlMapping.password) : generatePassword
+                    },
+                    this.props.history
+                  );
+                }
+              });
+            } else { // case when response status is not 200
+              if (config.allowRegistration !== false)
+              {
+                this.props.startRegister(
+                  {
+                    usernameOrEmail  : username,
+                    generatedPassword: generatePassword,
+                    password         : config.loginFromUrlMapping.password ? params.get(config.loginFromUrlMapping.password) : generatePassword
+                  },
+                  this.props.history
+                );
+              }
+              else
+              {
+                this.props.history.push('/login');
+              } 
+            }
+          });
+        }
+      } else { // if no username in the url go to register
+        if (config.allowRegistration !== false)
+        {
+          this.props.history.push('/register');
+        }
+        else
+        {
+          this.props.history.push('/login');
+        }
+      }
+    } 
+    else if (config.loginWithoutUsername) 
+    {
+
+      if (config.allowRegistration !== false)
+      {
+        this.setState(() => ({ error: null }));
+        const generatePassword = (Math.floor((Math.random() * 800000)) + 100000).toString();
+        const username = uuidv4();
+        this.props.startRegister(
+          {
+            usernameOrEmail  : username,
+            generatedPassword: generatePassword,
+            password         : generatePassword
+          },
+          this.props.history
+        );
+      }
+      else
+      {
+        this.props.history.push('/login');
+      }
+    }
+    else
+    {
+      config.isPartTwo === true || config.allowRegistration === false ? this.props.history.push('/login') : this.props.history.push('/register');
+    }  
   }
 
   render(){
@@ -157,10 +150,8 @@ class HomePage extends React.Component {
             >
               {!config.introLogoAfterStartButton && config.logoPaths && <div className="main-logo center"><img src={config.logoPaths[this.props.i18n.language]} style={{width: '100%'}} alt="Logo" /></div>}
               {config.isPartTwo === true ? <div dangerouslySetInnerHTML={{__html: this.props.t(`survey:homepage:pageTwoIntroduction`)}} /> : <div dangerouslySetInnerHTML={{__html: this.props.t(`survey:homepage:introduction`)}} /> }
-              {config.hideStartButtonOnHomePage !== true && <Button
-                widgetConfig = {this.widgetConfig}
-                widgetStatus = {this.widgetStatus}
-                label        = {config.costumHomePageButtonLabel ? this.props.t(`survey:homepage:start`) : this.props.t(`auth:Start`)}
+              {config.hideStartButtonOnHomePage !== true && <ConsentAndStartForm
+                afterClicked = {this.afterClick}
               />}
               {config.introLogoAfterStartButton && config.logoPaths && <div className="main-logo center"><img src={config.logoPaths[this.props.i18n.language]} style={{width: '100%'}} alt="Logo" /></div>}
               {config.introductionTwoParagraph && <div dangerouslySetInnerHTML={{__html: this.props.t(`survey:homepage:introductionParagraphTwo`)}} />}


### PR DESCRIPTION
Fixes #128

Create a new widget with a consent checkbox and the start button.

By default, the main:AgreementText in evolution is empty, so there won't be a checkbox. If the `survey:homepage:AgreementText` translation is defined in a project, it will be displayed next to a checkbox. This checkbox must be checkbox for the button to go to the main login page.

If the checkbox is not checked, the `survey:homepage:ErrorNotAgreed` text is displayed. It falls back to a default error message indicating to check the box.