### PR TITLE
Allow rounding lat lon coordinates in InputMapFindPlace

### DIFF
--- a/packages/evolution-common/src/services/widgets/WidgetConfig.ts
+++ b/packages/evolution-common/src/services/widgets/WidgetConfig.ts
@@ -284,6 +284,7 @@ export type InputMapFindPlaceType<CustomSurvey, CustomHousehold, CustomHome, Cus
         CustomHome,
         CustomPerson
     >;
+    coordinatesPrecision?: number; // number of decimals to keep for latitute longitude coordinates.
     showPhoto?: boolean;
     autoConfirmIfSingleResult?: boolean;
     updateDefaultValueWhenResponded?: boolean;

--- a/packages/evolution-frontend/src/components/inputs/InputMapFindPlace.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputMapFindPlace.tsx
@@ -127,6 +127,12 @@ export class InputMapFindPlace<CustomSurvey, CustomHousehold, CustomHome, Custom
     }
 
     onValueChange = (feature?: GeoJSON.Feature<GeoJSON.Point, FeatureGeocodedProperties>) => {
+        if (feature) {
+            feature.geometry.coordinates = feature.geometry.coordinates.map((coordinate) => {
+                return Number(coordinate.toFixed(this.props.widgetConfig.coordinatesPrecision ?? 5));
+            });
+        }
+
         this.props.onValueChange({ target: { value: feature } });
         this.setState({
             selectedPlace: undefined,

--- a/packages/evolution-frontend/src/components/inputs/__tests__/InputMapFindPlace.test.tsx
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/InputMapFindPlace.test.tsx
@@ -76,6 +76,7 @@ describe('Render InputMapPoint with various parameters', () => {
             },
             maxZoom: 18,
             defaultZoom: 15,
+            coordinatesPrecision: 6,
             placesIcon: {
                 url: 'path/to/icon',
                 size: [85, 85] as [number, number]


### PR DESCRIPTION
By default, coordinates are rounded to 5 decimal places. At worst, this is a +/- 1 meter precision loss. https://en.wikipedia.org/wiki/Decimal_degrees#Precision