### PR TITLE
Add sorting and display options to a question's answers.

### DIFF
--- a/packages/evolution-common/src/services/widgets/WidgetConfig.ts
+++ b/packages/evolution-common/src/services/widgets/WidgetConfig.ts
@@ -117,7 +117,6 @@ export type InputCheckboxType<CustomSurvey, CustomHousehold, CustomHome, CustomP
     sameLine?: boolean;
     customLabel?: I18nData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
     datatype?: 'string' | 'integer' | 'float' | 'text';
-    alignChoices?: boolean;
     columns?: number;
     rows?: number;
     alignment?: 'vertical' | 'horizontal' | 'auto';
@@ -144,7 +143,6 @@ export type InputRadioType<CustomSurvey, CustomHousehold, CustomHome, CustomPers
     customLabel?: I18nData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
     customChoice?: string;
     datatype?: 'string' | 'integer' | 'float' | 'text' | 'boolean';
-    alignChoices?: boolean;
     columns?: number;
     rows?: number;
     alignment?: 'vertical' | 'horizontal' | 'auto';

--- a/packages/evolution-common/src/services/widgets/WidgetConfig.ts
+++ b/packages/evolution-common/src/services/widgets/WidgetConfig.ts
@@ -121,7 +121,6 @@ export type InputCheckboxType<CustomSurvey, CustomHousehold, CustomHome, CustomP
     columns?: number;
     rows?: number;
     alignment?: 'vertical' | 'horizontal' | 'auto';
-    customAlignment?: boolean;
     customAlignmentLengths?: number[];
 };
 
@@ -149,7 +148,6 @@ export type InputRadioType<CustomSurvey, CustomHousehold, CustomHome, CustomPers
     columns?: number;
     rows?: number;
     alignment?: 'vertical' | 'horizontal' | 'auto';
-    customAlignment?: boolean;
     customAlignmentLengths?: number[];
 };
 

--- a/packages/evolution-common/src/services/widgets/WidgetConfig.ts
+++ b/packages/evolution-common/src/services/widgets/WidgetConfig.ts
@@ -114,10 +114,15 @@ export type InputCheckboxType<CustomSurvey, CustomHousehold, CustomHome, CustomP
     seed?: number;
     shuffle?: boolean;
     addCustom?: boolean;
-    columns?: number;
     sameLine?: boolean;
     customLabel?: I18nData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
     datatype?: 'string' | 'integer' | 'float' | 'text';
+    alignChoices?: boolean;
+    columns?: number;
+    rows?: number;
+    alignment?: 'vertical' | 'horizontal' | 'auto';
+    customAlignment?: boolean;
+    customAlignmentLengths?: [number];
 };
 
 export type InputRadioType<CustomSurvey, CustomHousehold, CustomHome, CustomPerson> = {
@@ -136,11 +141,16 @@ export type InputRadioType<CustomSurvey, CustomHousehold, CustomHome, CustomPers
     seed?: number;
     shuffle?: boolean;
     addCustom?: boolean;
-    columns?: number;
     sameLine?: boolean;
     customLabel?: I18nData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
     customChoice?: string;
     datatype?: 'string' | 'integer' | 'float' | 'text' | 'boolean';
+    alignChoices?: boolean;
+    columns?: number;
+    rows?: number;
+    alignment?: 'vertical' | 'horizontal' | 'auto';
+    customAlignment?: boolean;
+    customAlignmentLengths?: number[];
 };
 
 // TODO Could select widget have a custom 'other' field? Like checkbox and radios

--- a/packages/evolution-common/src/services/widgets/WidgetConfig.ts
+++ b/packages/evolution-common/src/services/widgets/WidgetConfig.ts
@@ -122,7 +122,7 @@ export type InputCheckboxType<CustomSurvey, CustomHousehold, CustomHome, CustomP
     rows?: number;
     alignment?: 'vertical' | 'horizontal' | 'auto';
     customAlignment?: boolean;
-    customAlignmentLengths?: [number];
+    customAlignmentLengths?: number[];
 };
 
 export type InputRadioType<CustomSurvey, CustomHousehold, CustomHome, CustomPerson> = {

--- a/packages/evolution-frontend/src/components/inputs/InputCheckbox.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputCheckbox.tsx
@@ -16,6 +16,7 @@ import { InputCheckboxType, ChoiceType } from 'evolution-common/lib/services/wid
 import { UserInterviewAttributes } from 'evolution-common/lib/services/interviews/interview';
 import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
 import { CommonInputProps } from './CommonInputProps';
+import { _sortByParameters } from './InputChoiceSorting';
 
 export type InputCheckboxProps<CustomSurvey, CustomHousehold, CustomHome, CustomPerson> = CommonInputProps<
     CustomSurvey,
@@ -182,13 +183,12 @@ export class InputCheckbox<CustomSurvey, CustomHousehold, CustomHome, CustomPers
         e.stopPropagation();
         this.props.onValueChange({ target: { value: this.props.value } }, e.target.value);
     };
-
+    
     private getColumnedChoices = (choiceInputs: JSX.Element[]): JSX.Element[] => {
         if (this.props.widgetConfig.columns === undefined || this.props.widgetConfig.columns <= 0) {
             return choiceInputs;
         }
-        // Chunkify the input choices in columns
-        const widgetsByColumn = _chunkify(choiceInputs, this.props.widgetConfig.columns, true);
+        const widgetsByColumn = _sortByParameters(choiceInputs, this.props.widgetConfig.alignment, this.props.widgetConfig.columns, this.props.widgetConfig.rows, this.props.widgetConfig.customAlignment, this.props.widgetConfig.customAlignmentLengths);
         const columnedChoiceInputs: JSX.Element[] = [];
         for (let i = 0, count = widgetsByColumn.length; i < count; i++) {
             const columnWidgets = widgetsByColumn[i];
@@ -198,6 +198,7 @@ export class InputCheckbox<CustomSurvey, CustomHousehold, CustomHome, CustomPers
                 </div>
             );
         }
+
         return columnedChoiceInputs;
     };
 
@@ -263,9 +264,8 @@ export class InputCheckbox<CustomSurvey, CustomHousehold, CustomHome, CustomPers
 
         return (
             <div
-                className={`survey-question__input-checkbox-group-container${
-                    this.props.widgetConfig.sameLine === false ? ' no-wrap' : ''
-                }`}
+                className={`survey-question__input-checkbox-group-container${this.props.widgetConfig.sameLine === false ? ' no-wrap' : ''
+                    }`}
             >
                 {columnedChoiceInputs}
                 {this.props.customId && (

--- a/packages/evolution-frontend/src/components/inputs/InputCheckbox.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputCheckbox.tsx
@@ -187,6 +187,8 @@ export class InputCheckbox<CustomSurvey, CustomHousehold, CustomHome, CustomPers
     private getColumnedChoices = (choiceInputs: JSX.Element[]): JSX.Element[] => {
         if (this.props.widgetConfig.columns === undefined || this.props.widgetConfig.columns <= 0) {
             return choiceInputs;
+        } else if (!this.props.widgetConfig.alignment) {
+            return choiceInputs;
         }
         const widgetsByColumn = _sortByParameters(choiceInputs, this.props.widgetConfig.alignment, this.props.widgetConfig.columns, this.props.widgetConfig.rows, this.props.widgetConfig.customAlignment, this.props.widgetConfig.customAlignmentLengths);
         const columnedChoiceInputs: JSX.Element[] = [];

--- a/packages/evolution-frontend/src/components/inputs/InputCheckbox.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputCheckbox.tsx
@@ -189,7 +189,7 @@ export class InputCheckbox<CustomSurvey, CustomHousehold, CustomHome, CustomPers
         } else if (!this.props.widgetConfig.alignment) {
             return choiceInputs;
         }
-        const widgetsByColumn = _sortByParameters(choiceInputs, this.props.widgetConfig.alignment, this.props.widgetConfig.columns, this.props.widgetConfig.rows, this.props.widgetConfig.customAlignment, this.props.widgetConfig.customAlignmentLengths);
+        const widgetsByColumn = _sortByParameters(choiceInputs, this.props.widgetConfig.alignment, this.props.widgetConfig.columns, this.props.widgetConfig.rows, this.props.widgetConfig.customAlignmentLengths);
         const columnedChoiceInputs: JSX.Element[] = [];
         for (let i = 0, count = widgetsByColumn.length; i < count; i++) {
             const columnWidgets = widgetsByColumn[i];

--- a/packages/evolution-frontend/src/components/inputs/InputCheckbox.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputCheckbox.tsx
@@ -184,7 +184,7 @@ export class InputCheckbox<CustomSurvey, CustomHousehold, CustomHome, CustomPers
     };
 
     private getColumnedChoices = (choiceInputs: JSX.Element[]): JSX.Element[] => {
-        if ((this.props.widgetConfig.alignChoices === undefined || !this.props.widgetConfig.alignChoices)) {
+        if ((this.props.widgetConfig.alignment === undefined && this.props.widgetConfig.columns === undefined && this.props.widgetConfig.rows === undefined && (!this.props.widgetConfig.customAlignmentLengths || this.props.widgetConfig.customAlignmentLengths === undefined))) {
             return choiceInputs;
         }
         const widgetsByColumn = sortByParameters(choiceInputs, this.props.widgetConfig.alignment, this.props.widgetConfig.columns, this.props.widgetConfig.rows, this.props.widgetConfig.customAlignmentLengths);

--- a/packages/evolution-frontend/src/components/inputs/InputCheckbox.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputCheckbox.tsx
@@ -10,7 +10,6 @@ import { WithTranslation, withTranslation } from 'react-i18next';
 import { shuffle } from 'chaire-lib-common/lib/utils/RandomUtils';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
-import { _chunkify } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import * as surveyHelper from 'evolution-common/lib/utils/helpers';
 import { InputCheckboxType, ChoiceType } from 'evolution-common/lib/services/widgets';
 import { UserInterviewAttributes } from 'evolution-common/lib/services/interviews/interview';

--- a/packages/evolution-frontend/src/components/inputs/InputCheckbox.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputCheckbox.tsx
@@ -15,7 +15,7 @@ import { InputCheckboxType, ChoiceType } from 'evolution-common/lib/services/wid
 import { UserInterviewAttributes } from 'evolution-common/lib/services/interviews/interview';
 import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
 import { CommonInputProps } from './CommonInputProps';
-import { _sortByParameters } from './InputChoiceSorting';
+import { sortByParameters } from './InputChoiceSorting';
 
 export type InputCheckboxProps<CustomSurvey, CustomHousehold, CustomHome, CustomPerson> = CommonInputProps<
     CustomSurvey,
@@ -182,14 +182,12 @@ export class InputCheckbox<CustomSurvey, CustomHousehold, CustomHome, CustomPers
         e.stopPropagation();
         this.props.onValueChange({ target: { value: this.props.value } }, e.target.value);
     };
-    
+
     private getColumnedChoices = (choiceInputs: JSX.Element[]): JSX.Element[] => {
-        if (this.props.widgetConfig.columns === undefined || this.props.widgetConfig.columns <= 0) {
-            return choiceInputs;
-        } else if (!this.props.widgetConfig.alignment) {
+        if ((this.props.widgetConfig.alignChoices === undefined || !this.props.widgetConfig.alignChoices)) {
             return choiceInputs;
         }
-        const widgetsByColumn = _sortByParameters(choiceInputs, this.props.widgetConfig.alignment, this.props.widgetConfig.columns, this.props.widgetConfig.rows, this.props.widgetConfig.customAlignmentLengths);
+        const widgetsByColumn = sortByParameters(choiceInputs, this.props.widgetConfig.alignment, this.props.widgetConfig.columns, this.props.widgetConfig.rows, this.props.widgetConfig.customAlignmentLengths);
         const columnedChoiceInputs: JSX.Element[] = [];
         for (let i = 0, count = widgetsByColumn.length; i < count; i++) {
             const columnWidgets = widgetsByColumn[i];

--- a/packages/evolution-frontend/src/components/inputs/InputChoiceSorting.ts
+++ b/packages/evolution-frontend/src/components/inputs/InputChoiceSorting.ts
@@ -1,13 +1,7 @@
-const verticalByColumns = function (arr: any[], columns: number) {
-    const len = arr.length;
-    const out: any[] = [];
-    let index = 0;
-    while (index + columns < len) {
-        out.push(arr.slice(index, index += columns));
-    }
-    out.push(arr.slice(index));
+import { _chunkify } from 'chaire-lib-common/lib/utils/LodashExtensions';
 
-    return out;
+const verticalByColumns = function (arr: any[], columns: number) {
+    return _chunkify(arr, columns);
 }
 export { verticalByColumns };
 

--- a/packages/evolution-frontend/src/components/inputs/InputChoiceSorting.ts
+++ b/packages/evolution-frontend/src/components/inputs/InputChoiceSorting.ts
@@ -131,7 +131,7 @@ const customVertical = function<Value>(arr: Value[], custom: number[]): Value[][
     let index = 0;
     let columnIndex = 0;
     while (index + custom[columnIndex] < len) {
-        out.push(arr.slice(index, index += custom[columnIndex]))
+        out.push(arr.slice(index, index += custom[columnIndex]));
         columnIndex++;
     }
     out.push(arr.slice(index));

--- a/packages/evolution-frontend/src/components/inputs/InputChoiceSorting.ts
+++ b/packages/evolution-frontend/src/components/inputs/InputChoiceSorting.ts
@@ -5,8 +5,6 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 
-import { Type } from "typescript";
-
 /**
  * Sort the array to be displayed to the target number of columns in vertical fashion.
  * @param arr - Array to be sorted.
@@ -17,7 +15,7 @@ import { Type } from "typescript";
  * // Prints [[0,1,2],[3,4,5]]
  * console.log(verticalByColumns([0,1,2,3,4,5], 2));
  */
-const verticalByColumns = function<Type>(arr: Type[], columns: number): Type[][] {
+const verticalByColumns = function<T>(arr: T[], columns: number): T[][] {
     const len = arr.length;
     const out: any[] = [];
     let index = 0;
@@ -43,7 +41,7 @@ const verticalByColumns = function<Type>(arr: Type[], columns: number): Type[][]
  * // Prints [[0,1],[2,3],[4,5]]
  * console.log(verticalByRows([0,1,2,3,4,5], 2));
  */
-const verticalByRows = function<Type>(arr: Type[], rows: number): Type[][] {
+const verticalByRows = function<T>(arr: T[], rows: number): T[][] {
     const len = arr.length;
     const out: any[] = [];
     let index = 0;
@@ -65,7 +63,7 @@ const verticalByRows = function<Type>(arr: Type[], rows: number): Type[][] {
  * // Prints [[0,2,4],[1,3,5]]
  * console.log(horizontalByColumns([0,1,2,3,4,5], 2));
  */
-const horizontalByColumns = function<Type>(arr: Type[], columns: number ): Type[][] {
+const horizontalByColumns = function<T>(arr: T[], columns: number ): T[][] {
     const len = arr.length;
     const out: any[] = [];
     let index = 0;
@@ -96,7 +94,7 @@ const horizontalByColumns = function<Type>(arr: Type[], columns: number ): Type[
  * // Prints [[0,3],[1,4],[2,5]]
  * console.log(horizontalByRows([0,1,2,3,4,5], 2));
  */
-const horizontalByRows = function<Type>(arr: Type[], rows: number): Type[][] {
+const horizontalByRows = function<T>(arr: T[], rows: number): T[][] {
     const len = arr.length;
     const out: any[] = [];
     let index = 0;
@@ -127,7 +125,7 @@ const horizontalByRows = function<Type>(arr: Type[], rows: number): Type[][] {
  * // Prints [[0,1,2],[3,4],[5]]
  * console.log(customVertical([0,1,2,3,4,5], [3,2,1]));
  */
-const customVertical = function<Type>(arr: Type[], custom: number[]): Type[][] {
+const customVertical = function<T>(arr: T[], custom: number[]): T[][] {
     const len = arr.length;
     const out: any[] = [];
     let index = 0;
@@ -151,7 +149,7 @@ const customVertical = function<Type>(arr: Type[], custom: number[]): Type[][] {
  * // Prints [[0,3,5],[1,4],[2]]
  * console.log(customHorizontal([0,1,2,3,4,5], [3,2,1]));
  */
-const customHorizontal = function<Type>(arr: Type[], custom: number[]): Type[][] {
+const customHorizontal = function<T>(arr: T[], custom: number[]): T[][] {
     console.log(custom);
 
     const len = arr.length;
@@ -198,7 +196,7 @@ const customHorizontal = function<Type>(arr: Type[], custom: number[]): Type[][]
    * @param customAlignmentLengths - Specify the lengths of each row or column individually, if alignement is horizontal, the first specified row must be the longuest.
    * @returns A 2 dimension array containing the input array sorted into columns for display or the original array in case of invalid parameters.
    */
-const sortByParameters = function<Type>(arr: Type[], alignment?: 'vertical' | 'horizontal' | 'auto', columns?: number, rows?: number, customAlignmentLengths?: number[]): Type[] | Type[][] {
+const sortByParameters = function<T>(arr: T[], alignment?: 'vertical' | 'horizontal' | 'auto', columns?: number, rows?: number, customAlignmentLengths?: number[]): T[] | T[][] {
     if (customAlignmentLengths && customAlignmentLengths.length > 0) {
         switch (alignment) {
             case 'vertical':

--- a/packages/evolution-frontend/src/components/inputs/InputChoiceSorting.ts
+++ b/packages/evolution-frontend/src/components/inputs/InputChoiceSorting.ts
@@ -22,14 +22,14 @@ const verticalByColumns = function<Value>(arr: Value[], columns: number): Value[
     let columnIndex = 0;
     let countPerColumn = Math.ceil(len / columns);
     while (index + countPerColumn < len) {
-        out.push(arr.slice(index, (index += countPerColumn)))
+        out.push(arr.slice(index, (index += countPerColumn)));
         columnIndex++;
         countPerColumn = Math.ceil((len - index) / (columns - columnIndex));
     }
-    out.push(arr.slice(index))
+    out.push(arr.slice(index));
 
     return out;
-}
+};
 
 /**
  * Sort the array to be displayed to the target number of rows in vertical fashion.
@@ -46,12 +46,12 @@ const verticalByRows = function<Value>(arr: Value[], rows: number): Value[][] {
     const out: any[] = [];
     let index = 0;
     while (index + rows < len) {
-        out.push(arr.slice(index, (index += rows)))
+        out.push(arr.slice(index, (index += rows)));
     }
-    out.push(arr.slice(index))
+    out.push(arr.slice(index));
 
     return out;
-}
+};
 
 /**
  * Sort the array to be displayed to the target number of columns in horizontal fashion
@@ -82,7 +82,7 @@ const horizontalByColumns = function<Value>(arr: Value[], columns: number ): Val
     }
 
     return out;
-}
+};
 
 /**
  * Sort the array to be displayed to the target number of rows in horizontal fashion.
@@ -113,7 +113,7 @@ const horizontalByRows = function<Value>(arr: Value[], rows: number): Value[][] 
     }
 
     return out;
-}
+};
 
 /**
  * Sort the array to be displayed in columns by the custom array information.
@@ -137,7 +137,7 @@ const customVertical = function<Value>(arr: Value[], custom: number[]): Value[][
     out.push(arr.slice(index));
 
     return out;
-}
+};
 
 /**
  * Sort the array to be displayed in rows by the custom array information.
@@ -181,7 +181,7 @@ const customHorizontal = function<Value>(arr: Value[], custom: number[]): Value[
     }
 
     return out;
-}
+};
 
 /**
    * Sorts the array based on the specified parameters.
@@ -234,5 +234,6 @@ const sortByParameters = function<Value>(arr: Value[], alignment?: 'vertical' | 
                 return verticalByColumns(arr, 2);
             }
     }
-}
+};
+
 export { sortByParameters };

--- a/packages/evolution-frontend/src/components/inputs/InputChoiceSorting.ts
+++ b/packages/evolution-frontend/src/components/inputs/InputChoiceSorting.ts
@@ -15,7 +15,7 @@
  * // Prints [[0,1,2],[3,4,5]]
  * console.log(verticalByColumns([0,1,2,3,4,5], 2));
  */
-const verticalByColumns = function<T>(arr: T[], columns: number): T[][] {
+const verticalByColumns = function<Value>(arr: Value[], columns: number): Value[][] {
     const len = arr.length;
     const out: any[] = [];
     let index = 0;
@@ -41,7 +41,7 @@ const verticalByColumns = function<T>(arr: T[], columns: number): T[][] {
  * // Prints [[0,1],[2,3],[4,5]]
  * console.log(verticalByRows([0,1,2,3,4,5], 2));
  */
-const verticalByRows = function<T>(arr: T[], rows: number): T[][] {
+const verticalByRows = function<Value>(arr: Value[], rows: number): Value[][] {
     const len = arr.length;
     const out: any[] = [];
     let index = 0;
@@ -63,7 +63,7 @@ const verticalByRows = function<T>(arr: T[], rows: number): T[][] {
  * // Prints [[0,2,4],[1,3,5]]
  * console.log(horizontalByColumns([0,1,2,3,4,5], 2));
  */
-const horizontalByColumns = function<T>(arr: T[], columns: number ): T[][] {
+const horizontalByColumns = function<Value>(arr: Value[], columns: number ): Value[][] {
     const len = arr.length;
     const out: any[] = [];
     let index = 0;
@@ -94,7 +94,7 @@ const horizontalByColumns = function<T>(arr: T[], columns: number ): T[][] {
  * // Prints [[0,3],[1,4],[2,5]]
  * console.log(horizontalByRows([0,1,2,3,4,5], 2));
  */
-const horizontalByRows = function<T>(arr: T[], rows: number): T[][] {
+const horizontalByRows = function<Value>(arr: Value[], rows: number): Value[][] {
     const len = arr.length;
     const out: any[] = [];
     let index = 0;
@@ -125,7 +125,7 @@ const horizontalByRows = function<T>(arr: T[], rows: number): T[][] {
  * // Prints [[0,1,2],[3,4],[5]]
  * console.log(customVertical([0,1,2,3,4,5], [3,2,1]));
  */
-const customVertical = function<T>(arr: T[], custom: number[]): T[][] {
+const customVertical = function<Value>(arr: Value[], custom: number[]): Value[][] {
     const len = arr.length;
     const out: any[] = [];
     let index = 0;
@@ -149,7 +149,7 @@ const customVertical = function<T>(arr: T[], custom: number[]): T[][] {
  * // Prints [[0,3,5],[1,4],[2]]
  * console.log(customHorizontal([0,1,2,3,4,5], [3,2,1]));
  */
-const customHorizontal = function<T>(arr: T[], custom: number[]): T[][] {
+const customHorizontal = function<Value>(arr: Value[], custom: number[]): Value[][] {
     console.log(custom);
 
     const len = arr.length;
@@ -196,7 +196,7 @@ const customHorizontal = function<T>(arr: T[], custom: number[]): T[][] {
    * @param customAlignmentLengths - Specify the lengths of each row or column individually, if alignement is horizontal, the first specified row must be the longuest.
    * @returns A 2 dimension array containing the input array sorted into columns for display or the original array in case of invalid parameters.
    */
-const sortByParameters = function<T>(arr: T[], alignment?: 'vertical' | 'horizontal' | 'auto', columns?: number, rows?: number, customAlignmentLengths?: number[]): T[] | T[][] {
+const sortByParameters = function<Value>(arr: Value[], alignment?: 'vertical' | 'horizontal' | 'auto', columns?: number, rows?: number, customAlignmentLengths?: number[]): Value[][] {
     if (customAlignmentLengths && customAlignmentLengths.length > 0) {
         switch (alignment) {
             case 'vertical':
@@ -234,7 +234,5 @@ const sortByParameters = function<T>(arr: T[], alignment?: 'vertical' | 'horizon
                 return verticalByColumns(arr, 2);
             }
     }
-
-    return arr;
 }
 export { sortByParameters };

--- a/packages/evolution-frontend/src/components/inputs/InputChoiceSorting.ts
+++ b/packages/evolution-frontend/src/components/inputs/InputChoiceSorting.ts
@@ -1,7 +1,25 @@
-const verticalByColumns = function (arr: any[], columns: number) {
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+/**
+ * Sort the array to be displayed to the target number of columns in vertical fashion.
+ * @param arr - Array to be sorted.
+ * @param columns - Target number of columns.
+ * @returns A 2 dimension array containing the data as columns to be displayed.
+ *
+ * @example
+ * // Prints [[0,1,2],[3,4,5]]
+ * console.log(verticalByColumns([0,1,2,3,4,5], 2));
+ */
+const verticalByColumns = function (arr: any[], columns: number): any[][] {
     const len = arr.length;
     const out: any[] = [];
-    let index = 0, countPerColumn = Math.ceil(len / columns), columnIndex = 0;
+    let index = 0;
+    let columnIndex = 0;
+    let countPerColumn = Math.ceil(len / columns);
     while (index + countPerColumn < len) {
         out.push(arr.slice(index, (index += countPerColumn)))
         columnIndex++;
@@ -11,9 +29,18 @@ const verticalByColumns = function (arr: any[], columns: number) {
 
     return out;
 }
-export { verticalByColumns };
 
-const verticalByRows = function (arr: any[], rows: number) {
+/**
+ * Sort the array to be displayed to the target number of rows in vertical fashion.
+ * @param arr - Array to be sorted
+ * @param rows - Target number of rows.
+ * @returns A 2 dimension array containing the data as columns to be displayed.
+ *
+ * @example
+ * // Prints [[0,1],[2,3],[4,5]]
+ * console.log(verticalByRows([0,1,2,3,4,5], 2));
+ */
+const verticalByRows = function (arr: any[], rows: number): any[][] {
     const len = arr.length;
     const out: any[] = [];
     let index = 0;
@@ -23,13 +50,23 @@ const verticalByRows = function (arr: any[], rows: number) {
     out.push(arr.slice(index))
 
     return out;
-};
-export { verticalByRows };
+}
 
-const horizontalByColumns = function (arr: any[], columns: number ) {
+/**
+ * Sort the array to be displayed to the target number of columns in horizontal fashion
+ * @param arr - Array to be sorted.
+ * @param columns - Target number of columns.
+ * @returns A 2 dimension array containing the data as columns to be displayed.
+ *
+ * @example
+ * // Prints [[0,2,4],[1,3,5]]
+ * console.log(horizontalByColumns([0,1,2,3,4,5], 2));
+ */
+const horizontalByColumns = function (arr: any[], columns: number ): any[][] {
     const len = arr.length;
     const out: any[] = [];
-    let index = 0, columnIndex = 0;
+    let index = 0;
+    let columnIndex = 0;
     let newColumn: any[] = [];
     while(index < len)
     {
@@ -45,12 +82,23 @@ const horizontalByColumns = function (arr: any[], columns: number ) {
 
     return out;
 }
-export { horizontalByColumns };
 
-const horizontalByRows = function (arr: any[], rows: number) {
+/**
+ * Sort the array to be displayed to the target number of rows in horizontal fashion.
+ * @param arr - Array to be sorted.
+ * @param rows - Target number of rows.
+ * @returns A 2 dimension array containing the data as columns to be displayed.
+ *
+ * @example
+ * // Prints [[0,3],[1,4],[2,5]]
+ * console.log(horizontalByRows([0,1,2,3,4,5], 2));
+ */
+const horizontalByRows = function (arr: any[], rows: number): any[][] {
     const len = arr.length;
     const out: any[] = [];
-    let index = 0, columnIndex = 0, columns = Math.ceil(arr.length / rows);
+    let index = 0;
+    let columnIndex = 0;
+    const columns = Math.ceil(arr.length / rows);
     let newColumn: any[] = [];
     while (index < len) {
         newColumn.push(arr[index]);
@@ -65,12 +113,22 @@ const horizontalByRows = function (arr: any[], rows: number) {
 
     return out;
 }
-export { horizontalByRows };
 
-const customVertical = function (arr: any[], custom: number[]) {
+/**
+ * Sort the array to be displayed in columns by the custom array information.
+ * @param arr - Array to be sorted.
+ * @param custom - Array containing the dedired length of each column.
+ * @returns A 2 dimension array containing the data as columns to be displayed.
+ *
+ * @example
+ * // Prints [[0,1,2],[3,4],[5]]
+ * console.log(customVertical([0,1,2,3,4,5], [3,2,1]));
+ */
+const customVertical = function (arr: any[], custom: number[]): any[][] {
     const len = arr.length;
     const out: any[] = [];
-    let index = 0, columnIndex = 0;
+    let index = 0;
+    let columnIndex = 0;
     while (index + custom[columnIndex] < len) {
         out.push(arr.slice(index, index += custom[columnIndex]))
         columnIndex++;
@@ -79,12 +137,25 @@ const customVertical = function (arr: any[], custom: number[]) {
 
     return out;
 }
-export { customVertical }
 
-const customHorizontal = function (arr: any[], custom: number[]) {
-    const len = arr.length, customLen = custom.length;
+/**
+ * Sort the array to be displayed in rows by the custom array information.
+ * @param arr - Array to be sorted.
+ * @param custom - Array containing the desired legnths of each row.
+ * @returns A 2 dimension array containing the data as columns to be displayed.
+ *
+ * @example
+ * // Prints [[0,3,5],[1,4],[2]]
+ * console.log(customHorizontal([0,1,2,3,4,5], [3,2,1]));
+ */
+const customHorizontal = function (arr: any[], custom: number[]): any[][] {
+    console.log(custom);
+    
+    const len = arr.length;
     const out: any[] = [];
-    let index = 0, columnIndex = 0, rowIndex = 0;
+    let index = 0;
+    let columnIndex = 0;
+    let rowIndex = 0;
     let newColumn: any[] = [];
     while (index < len && columnIndex < custom[0]) {
         if (columnIndex >= custom[rowIndex]) {
@@ -97,8 +168,9 @@ const customHorizontal = function (arr: any[], custom: number[]) {
         }
         newColumn.push(arr[index]);
         index += custom[rowIndex];
+        console.log(custom[rowIndex]);
         rowIndex++;
-        if(index >= len) {
+        if(index >= len || rowIndex >= custom[columnIndex]) {
             columnIndex++;
             rowIndex = 0;
             index = columnIndex;
@@ -109,46 +181,50 @@ const customHorizontal = function (arr: any[], custom: number[]) {
 
     return out;
 }
-export { customHorizontal };
 
-const _sortByParameters = function (arr: any[], alignment: 'vertical' | 'horizontal' | 'auto', columns?: number, rows?: number, customAlignmentLengths?: number[]) {
+/**
+   * Sorts the array based on the specified parameters.
+   *
+   * @remarks
+   * The return array will always contain the data sorted in columns.
+   *
+   * @param arr - Array to be sorted.
+   * @param alignement - In wich way should the array be sorted? Top to bottom or left to right.
+   * @param colums - Target amount of columns, if columns and rows are specified, columns is used.
+   * @param rows - target amount of rows, if columns and rows are specified, columns is used.
+   * @param customAlignmentLengths - Specify the lengths of each row or column individually, if alignement is horizontal, the first specified row must be the longuest.
+   * @returns A 2 dimension array containing the input array sorted into columns for display or the original array in case of invalid parameters.
+   */
+const sortByParameters = function (arr: any[], alignment?: 'vertical' | 'horizontal' | 'auto', columns?: number, rows?: number, customAlignmentLengths?: number[]): any[] | any[][] {
     if (customAlignmentLengths && customAlignmentLengths.length > 0) {
         switch (alignment) {
             case 'vertical':
-                arr = customVertical(arr, customAlignmentLengths);
-                break;
+                return customVertical(arr, customAlignmentLengths);
             case 'horizontal':
-                arr = customHorizontal(arr, customAlignmentLengths);
-                break;
+                return customHorizontal(arr, customAlignmentLengths);
             default:
                 break;
         }
     } else if (columns && columns > 0) {
         switch (alignment) {
             case 'vertical':
-                arr = verticalByColumns(arr, columns);
-                break;
+                return verticalByColumns(arr, columns);
             case 'horizontal':
-                arr = horizontalByColumns(arr, columns);
-                break;
+                return horizontalByColumns(arr, columns);
             default:
-                verticalByColumns(arr, columns);
-                break;
+                return verticalByColumns(arr, columns);
             }
     } else if (rows && rows > 0) {
         switch (alignment) {
             case 'vertical':
-                arr = verticalByRows(arr, rows);
-                break;
+                return verticalByRows(arr, rows);
             case 'horizontal':
-                arr = horizontalByRows(arr, rows);
-                break;
+                return horizontalByRows(arr, rows);
             default:
-                verticalByRows(arr, rows);
-                break;
+                return verticalByRows(arr, rows);
             }
     }
 
     return arr;
 }
-export { _sortByParameters };
+export { sortByParameters };

--- a/packages/evolution-frontend/src/components/inputs/InputChoiceSorting.ts
+++ b/packages/evolution-frontend/src/components/inputs/InputChoiceSorting.ts
@@ -1,0 +1,154 @@
+const verticalByColumns = function (arr: any[], columns: number) {
+    const len = arr.length;
+    const out: any[] = [];
+    let index = 0;
+    while (index + columns < len) {
+        out.push(arr.slice(index, index += columns));
+    }
+    out.push(arr.slice(index));
+
+    return out;
+}
+export { verticalByColumns };
+
+const verticalByRows = function (arr: any[], rows: number) {
+    const len = arr.length;
+    const out: any[] = [];
+    let index = 0;
+    while (index + rows < len) {
+        out.push(arr.slice(index, (index += rows)))
+    }
+    out.push(arr.slice(index))
+
+    return out;
+};
+export { verticalByRows };
+
+const horizontalByColumns = function (arr: any[], columns: number ) {
+    const len = arr.length;
+    const out: any[] = [];
+    let index = 0, columnIndex = 0;
+    let newColumn: any[] = [];
+    while(index < len)
+    {
+        newColumn.push(arr[index]);
+        index += columns;
+        if(index >= len && columnIndex < columns) {
+            columnIndex++;
+            index = columnIndex;
+            out.push(newColumn);
+            newColumn = [];
+        }
+    }
+
+    return out;
+}
+export { horizontalByColumns };
+
+const horizontalByRows = function (arr: any[], rows: number) {
+    const len = arr.length;
+    const out: any[] = [];
+    let index = 0, columnIndex = 0, columns = Math.ceil(arr.length / rows);
+    let newColumn: any[] = [];
+    while (index < len) {
+        newColumn.push(arr[index]);
+        index += columns;
+        if(index >= len && columnIndex < columns) {
+            columnIndex++;
+            index = columnIndex;
+            out.push(newColumn);
+            newColumn = [];
+        }
+    }
+
+    return out;
+}
+export { horizontalByRows };
+
+const customVertical = function (arr: any[], custom: number[]) {
+    const len = arr.length;
+    const out: any[] = [];
+    let index = 0, columnIndex = 0;
+    while (index + custom[columnIndex] < len) {
+        out.push(arr.slice(index, index += custom[columnIndex]))
+        columnIndex++;
+    }
+    out.push(arr.slice(index));
+
+    return out;
+}
+export { customVertical }
+
+const customHorizontal = function (arr: any[], custom: number[]) {
+    const len = arr.length, customLen = custom.length;
+    const out: any[] = [];
+    let index = 0, columnIndex = 0, rowIndex = 0;
+    let newColumn: any[] = [];
+    while (index < len && columnIndex < custom[0]) {
+        if (columnIndex >= custom[rowIndex]) {
+            columnIndex++;
+            rowIndex = 0;
+            index = columnIndex;
+            out.push(newColumn);
+            newColumn = [];
+            continue;
+        }
+        newColumn.push(arr[index]);
+        index += custom[rowIndex];
+        rowIndex++;
+        if(index >= len) {
+            columnIndex++;
+            rowIndex = 0;
+            index = columnIndex;
+            out.push(newColumn);
+            newColumn = [];
+        }
+    }
+
+    return out;
+}
+export { customHorizontal };
+
+const _sortByParameters = function (arr: any[], alignment, columns, rows, customAlignment, customAlignmentLengths?: number[]) {
+    if (customAlignment) {
+        if (customAlignmentLengths && customAlignmentLengths.length > 0) {
+            switch (alignment) {
+                case 'vertical':
+                    arr = customVertical(arr, customAlignmentLengths);
+                    break;
+                case 'horizontal':
+                    arr = customHorizontal(arr, customAlignmentLengths);
+                    break;
+                default:
+                    break;
+            }
+        }
+    } else if ((columns ?? 0) > 0) {
+        switch (alignment) {
+            case 'vertical':
+                arr = verticalByColumns(arr, columns);
+                break;
+            case 'horizontal':
+                arr = horizontalByColumns(arr, columns);
+                break;
+            default:
+                verticalByColumns(arr, columns);
+                break;
+            }
+    } else if ((rows ?? 0 ) > 0) {
+        switch (alignment) {
+            case 'vertical':
+                arr = verticalByRows(arr, rows);
+                break;
+            case 'horizontal':
+                arr = horizontalByRows(arr, rows);
+                break;
+            default:
+                verticalByRows(arr, rows);
+                break;
+            }
+    }
+
+    return arr;
+}
+export { _sortByParameters };

--- a/packages/evolution-frontend/src/components/inputs/InputChoiceSorting.ts
+++ b/packages/evolution-frontend/src/components/inputs/InputChoiceSorting.ts
@@ -5,7 +5,7 @@ const verticalByColumns = function (arr: any[], columns: number) {
     while (index + countPerColumn < len) {
         out.push(arr.slice(index, (index += countPerColumn)))
         columnIndex++;
-        countPerColumn = Math.ceil((index + 1) / (columns - columnIndex));
+        countPerColumn = Math.ceil((len - index) / (columns - columnIndex));
     }
     out.push(arr.slice(index))
 

--- a/packages/evolution-frontend/src/components/inputs/InputChoiceSorting.ts
+++ b/packages/evolution-frontend/src/components/inputs/InputChoiceSorting.ts
@@ -4,6 +4,9 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
+
+import { Type } from "typescript";
+
 /**
  * Sort the array to be displayed to the target number of columns in vertical fashion.
  * @param arr - Array to be sorted.
@@ -14,7 +17,7 @@
  * // Prints [[0,1,2],[3,4,5]]
  * console.log(verticalByColumns([0,1,2,3,4,5], 2));
  */
-const verticalByColumns = function (arr: any[], columns: number): any[][] {
+const verticalByColumns = function<Type>(arr: Type[], columns: number): Type[][] {
     const len = arr.length;
     const out: any[] = [];
     let index = 0;
@@ -40,7 +43,7 @@ const verticalByColumns = function (arr: any[], columns: number): any[][] {
  * // Prints [[0,1],[2,3],[4,5]]
  * console.log(verticalByRows([0,1,2,3,4,5], 2));
  */
-const verticalByRows = function (arr: any[], rows: number): any[][] {
+const verticalByRows = function<Type>(arr: Type[], rows: number): Type[][] {
     const len = arr.length;
     const out: any[] = [];
     let index = 0;
@@ -62,7 +65,7 @@ const verticalByRows = function (arr: any[], rows: number): any[][] {
  * // Prints [[0,2,4],[1,3,5]]
  * console.log(horizontalByColumns([0,1,2,3,4,5], 2));
  */
-const horizontalByColumns = function (arr: any[], columns: number ): any[][] {
+const horizontalByColumns = function<Type>(arr: Type[], columns: number ): Type[][] {
     const len = arr.length;
     const out: any[] = [];
     let index = 0;
@@ -93,7 +96,7 @@ const horizontalByColumns = function (arr: any[], columns: number ): any[][] {
  * // Prints [[0,3],[1,4],[2,5]]
  * console.log(horizontalByRows([0,1,2,3,4,5], 2));
  */
-const horizontalByRows = function (arr: any[], rows: number): any[][] {
+const horizontalByRows = function<Type>(arr: Type[], rows: number): Type[][] {
     const len = arr.length;
     const out: any[] = [];
     let index = 0;
@@ -124,7 +127,7 @@ const horizontalByRows = function (arr: any[], rows: number): any[][] {
  * // Prints [[0,1,2],[3,4],[5]]
  * console.log(customVertical([0,1,2,3,4,5], [3,2,1]));
  */
-const customVertical = function (arr: any[], custom: number[]): any[][] {
+const customVertical = function<Type>(arr: Type[], custom: number[]): Type[][] {
     const len = arr.length;
     const out: any[] = [];
     let index = 0;
@@ -148,9 +151,9 @@ const customVertical = function (arr: any[], custom: number[]): any[][] {
  * // Prints [[0,3,5],[1,4],[2]]
  * console.log(customHorizontal([0,1,2,3,4,5], [3,2,1]));
  */
-const customHorizontal = function (arr: any[], custom: number[]): any[][] {
+const customHorizontal = function<Type>(arr: Type[], custom: number[]): Type[][] {
     console.log(custom);
-    
+
     const len = arr.length;
     const out: any[] = [];
     let index = 0;
@@ -195,7 +198,7 @@ const customHorizontal = function (arr: any[], custom: number[]): any[][] {
    * @param customAlignmentLengths - Specify the lengths of each row or column individually, if alignement is horizontal, the first specified row must be the longuest.
    * @returns A 2 dimension array containing the input array sorted into columns for display or the original array in case of invalid parameters.
    */
-const sortByParameters = function (arr: any[], alignment?: 'vertical' | 'horizontal' | 'auto', columns?: number, rows?: number, customAlignmentLengths?: number[]): any[] | any[][] {
+const sortByParameters = function<Type>(arr: Type[], alignment?: 'vertical' | 'horizontal' | 'auto', columns?: number, rows?: number, customAlignmentLengths?: number[]): Type[] | Type[][] {
     if (customAlignmentLengths && customAlignmentLengths.length > 0) {
         switch (alignment) {
             case 'vertical':
@@ -203,7 +206,7 @@ const sortByParameters = function (arr: any[], alignment?: 'vertical' | 'horizon
             case 'horizontal':
                 return customHorizontal(arr, customAlignmentLengths);
             default:
-                break;
+                return customVertical(arr, customAlignmentLengths);
         }
     } else if (columns && columns > 0) {
         switch (alignment) {
@@ -222,6 +225,15 @@ const sortByParameters = function (arr: any[], alignment?: 'vertical' | 'horizon
                 return horizontalByRows(arr, rows);
             default:
                 return verticalByRows(arr, rows);
+            }
+    } else {
+        switch(alignment) {
+            case 'vertical':
+                return verticalByColumns(arr, 2);
+            case 'horizontal':
+                return horizontalByRows(arr, 2);
+            default:
+                return verticalByColumns(arr, 2);
             }
     }
 

--- a/packages/evolution-frontend/src/components/inputs/InputChoiceSorting.ts
+++ b/packages/evolution-frontend/src/components/inputs/InputChoiceSorting.ts
@@ -1,7 +1,15 @@
-import { _chunkify } from 'chaire-lib-common/lib/utils/LodashExtensions';
-
 const verticalByColumns = function (arr: any[], columns: number) {
-    return _chunkify(arr, columns);
+    const len = arr.length;
+    const out: any[] = [];
+    let index = 0, countPerColumn = Math.ceil(len / columns), columnIndex = 0;
+    while (index + countPerColumn < len) {
+        out.push(arr.slice(index, (index += countPerColumn)))
+        columnIndex++;
+        countPerColumn = Math.ceil((index + 1) / (columns - columnIndex));
+    }
+    out.push(arr.slice(index))
+
+    return out;
 }
 export { verticalByColumns };
 
@@ -103,7 +111,7 @@ const customHorizontal = function (arr: any[], custom: number[]) {
 }
 export { customHorizontal };
 
-const _sortByParameters = function (arr: any[], alignment, columns, rows, customAlignment, customAlignmentLengths?: number[]) {
+const _sortByParameters = function (arr: any[], alignment: 'vertical' | 'horizontal' | 'auto', columns?: number, rows?: number, customAlignment?: boolean, customAlignmentLengths?: number[]) {
     if (customAlignment) {
         if (customAlignmentLengths && customAlignmentLengths.length > 0) {
             switch (alignment) {
@@ -117,7 +125,7 @@ const _sortByParameters = function (arr: any[], alignment, columns, rows, custom
                     break;
             }
         }
-    } else if ((columns ?? 0) > 0) {
+    } else if (columns && columns > 0) {
         switch (alignment) {
             case 'vertical':
                 arr = verticalByColumns(arr, columns);
@@ -129,7 +137,7 @@ const _sortByParameters = function (arr: any[], alignment, columns, rows, custom
                 verticalByColumns(arr, columns);
                 break;
             }
-    } else if ((rows ?? 0 ) > 0) {
+    } else if (rows && rows > 0) {
         switch (alignment) {
             case 'vertical':
                 arr = verticalByRows(arr, rows);

--- a/packages/evolution-frontend/src/components/inputs/InputChoiceSorting.ts
+++ b/packages/evolution-frontend/src/components/inputs/InputChoiceSorting.ts
@@ -111,19 +111,17 @@ const customHorizontal = function (arr: any[], custom: number[]) {
 }
 export { customHorizontal };
 
-const _sortByParameters = function (arr: any[], alignment: 'vertical' | 'horizontal' | 'auto', columns?: number, rows?: number, customAlignment?: boolean, customAlignmentLengths?: number[]) {
-    if (customAlignment) {
-        if (customAlignmentLengths && customAlignmentLengths.length > 0) {
-            switch (alignment) {
-                case 'vertical':
-                    arr = customVertical(arr, customAlignmentLengths);
-                    break;
-                case 'horizontal':
-                    arr = customHorizontal(arr, customAlignmentLengths);
-                    break;
-                default:
-                    break;
-            }
+const _sortByParameters = function (arr: any[], alignment: 'vertical' | 'horizontal' | 'auto', columns?: number, rows?: number, customAlignmentLengths?: number[]) {
+    if (customAlignmentLengths && customAlignmentLengths.length > 0) {
+        switch (alignment) {
+            case 'vertical':
+                arr = customVertical(arr, customAlignmentLengths);
+                break;
+            case 'horizontal':
+                arr = customHorizontal(arr, customAlignmentLengths);
+                break;
+            default:
+                break;
         }
     } else if (columns && columns > 0) {
         switch (alignment) {

--- a/packages/evolution-frontend/src/components/inputs/InputRadio.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputRadio.tsx
@@ -16,6 +16,7 @@ import { InputRadioType, RadioChoiceType } from 'evolution-common/lib/services/w
 import { UserInterviewAttributes } from 'evolution-common/lib/services/interviews/interview';
 import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
 import { CommonInputProps } from './CommonInputProps';
+import { _sortByParameters } from './InputChoiceSorting';
 
 export type InputRadioProps<CustomSurvey, CustomHousehold, CustomHome, CustomPerson> = CommonInputProps<
     CustomSurvey,
@@ -206,11 +207,10 @@ export class InputRadio<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>
     };
 
     private getColumnedChoices = (choiceInputs: JSX.Element[]): JSX.Element[] => {
-        if (this.props.widgetConfig.columns === undefined || this.props.widgetConfig.columns <= 0) {
+        if ((this.props.widgetConfig.alignChoices === undefined || !this.props.widgetConfig.alignChoices)) {
             return choiceInputs;
         }
-        // Chunkify the input choices in columns
-        const widgetsByColumn = _chunkify(choiceInputs, this.props.widgetConfig.columns, true);
+        const widgetsByColumn = _sortByParameters(choiceInputs, this.props.widgetConfig.alignment, this.props.widgetConfig.columns, this.props.widgetConfig.rows, this.props.widgetConfig.customAlignment, this.props.widgetConfig.customAlignmentLengths);
         const columnedChoiceInputs: JSX.Element[] = [];
         for (let i = 0, count = widgetsByColumn.length; i < count; i++) {
             const columnWidgets = widgetsByColumn[i];
@@ -285,10 +285,8 @@ export class InputRadio<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>
                     )}
                 </InputRadioChoiceT>
             ));
-
         // separate by columns if needed:
         const columnedChoiceInputs = this.getColumnedChoices(choiceInputs);
-
         return (
             <div
                 className={`survey-question__input-radio-group-container${

--- a/packages/evolution-frontend/src/components/inputs/InputRadio.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputRadio.tsx
@@ -209,6 +209,8 @@ export class InputRadio<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>
     private getColumnedChoices = (choiceInputs: JSX.Element[]): JSX.Element[] => {
         if ((this.props.widgetConfig.alignChoices === undefined || !this.props.widgetConfig.alignChoices)) {
             return choiceInputs;
+        } else if (!this.props.widgetConfig.alignment) {
+            return choiceInputs;
         }
         const widgetsByColumn = _sortByParameters(choiceInputs, this.props.widgetConfig.alignment, this.props.widgetConfig.columns, this.props.widgetConfig.rows, this.props.widgetConfig.customAlignment, this.props.widgetConfig.customAlignmentLengths);
         const columnedChoiceInputs: JSX.Element[] = [];

--- a/packages/evolution-frontend/src/components/inputs/InputRadio.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputRadio.tsx
@@ -211,7 +211,7 @@ export class InputRadio<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>
         } else if (!this.props.widgetConfig.alignment) {
             return choiceInputs;
         }
-        const widgetsByColumn = _sortByParameters(choiceInputs, this.props.widgetConfig.alignment, this.props.widgetConfig.columns, this.props.widgetConfig.rows, this.props.widgetConfig.customAlignment, this.props.widgetConfig.customAlignmentLengths);
+        const widgetsByColumn = _sortByParameters(choiceInputs, this.props.widgetConfig.alignment, this.props.widgetConfig.columns, this.props.widgetConfig.rows, this.props.widgetConfig.customAlignmentLengths);
         const columnedChoiceInputs: JSX.Element[] = [];
         for (let i = 0, count = widgetsByColumn.length; i < count; i++) {
             const columnWidgets = widgetsByColumn[i];

--- a/packages/evolution-frontend/src/components/inputs/InputRadio.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputRadio.tsx
@@ -10,7 +10,6 @@ import { WithTranslation, withTranslation } from 'react-i18next';
 import { shuffle } from 'chaire-lib-common/lib/utils/RandomUtils';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
-import { _chunkify } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import * as surveyHelper from 'evolution-common/lib/utils/helpers';
 import { InputRadioType, RadioChoiceType } from 'evolution-common/lib/services/widgets';
 import { UserInterviewAttributes } from 'evolution-common/lib/services/interviews/interview';

--- a/packages/evolution-frontend/src/components/inputs/InputRadio.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputRadio.tsx
@@ -15,7 +15,7 @@ import { InputRadioType, RadioChoiceType } from 'evolution-common/lib/services/w
 import { UserInterviewAttributes } from 'evolution-common/lib/services/interviews/interview';
 import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
 import { CommonInputProps } from './CommonInputProps';
-import { _sortByParameters } from './InputChoiceSorting';
+import { sortByParameters } from './InputChoiceSorting';
 
 export type InputRadioProps<CustomSurvey, CustomHousehold, CustomHome, CustomPerson> = CommonInputProps<
     CustomSurvey,
@@ -208,10 +208,8 @@ export class InputRadio<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>
     private getColumnedChoices = (choiceInputs: JSX.Element[]): JSX.Element[] => {
         if ((this.props.widgetConfig.alignChoices === undefined || !this.props.widgetConfig.alignChoices)) {
             return choiceInputs;
-        } else if (!this.props.widgetConfig.alignment) {
-            return choiceInputs;
         }
-        const widgetsByColumn = _sortByParameters(choiceInputs, this.props.widgetConfig.alignment, this.props.widgetConfig.columns, this.props.widgetConfig.rows, this.props.widgetConfig.customAlignmentLengths);
+        const widgetsByColumn = sortByParameters(choiceInputs, this.props.widgetConfig.alignment, this.props.widgetConfig.columns, this.props.widgetConfig.rows, this.props.widgetConfig.customAlignmentLengths);
         const columnedChoiceInputs: JSX.Element[] = [];
         for (let i = 0, count = widgetsByColumn.length; i < count; i++) {
             const columnWidgets = widgetsByColumn[i];

--- a/packages/evolution-frontend/src/components/inputs/InputRadio.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputRadio.tsx
@@ -206,7 +206,7 @@ export class InputRadio<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>
     };
 
     private getColumnedChoices = (choiceInputs: JSX.Element[]): JSX.Element[] => {
-        if ((this.props.widgetConfig.alignChoices === undefined || !this.props.widgetConfig.alignChoices)) {
+        if ((this.props.widgetConfig.alignment === undefined && this.props.widgetConfig.columns === undefined && this.props.widgetConfig.rows === undefined && (!this.props.widgetConfig.customAlignmentLengths || this.props.widgetConfig.customAlignmentLengths === undefined))) {
             return choiceInputs;
         }
         const widgetsByColumn = sortByParameters(choiceInputs, this.props.widgetConfig.alignment, this.props.widgetConfig.columns, this.props.widgetConfig.rows, this.props.widgetConfig.customAlignmentLengths);

--- a/packages/evolution-frontend/src/components/inputs/__tests__/InputChoiceSorting.test.ts
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/InputChoiceSorting.test.ts
@@ -4,9 +4,7 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import exp from 'constants';
 import {sortByParameters} from '../InputChoiceSorting';
-import { ro } from 'date-fns/locale';
 
 const array = [0,1,2,3,4,5,6,7,8,9];
 

--- a/packages/evolution-frontend/src/components/inputs/__tests__/InputChoiceSorting.test.ts
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/InputChoiceSorting.test.ts
@@ -1,0 +1,68 @@
+import * as inputChoiceSorting from '../InputChoiceSorting';
+
+const array = [0,1,2,3,4,5,6,7,8,9];
+
+describe('Sort array in vertical fashion ', () =>{
+    test('by columns.', () => {
+        const columnCount = 3;
+        const result = inputChoiceSorting.verticalByColumns(array, columnCount);
+
+        expect(result).toEqual([[0,1,2,3],[4,5,6],[7,8,9]]);
+    });
+
+    test('by rows.', () => {
+        const rowCount = 4;
+        const result = inputChoiceSorting.verticalByRows(array, rowCount);
+
+        expect(result).toEqual([[0,1,2,3],[4,5,6,7],[8,9]]);
+    });
+});
+
+describe('Sort array in horizontal fashion', () =>{
+    test('by columns.', () => {
+        const columnCount = 3;
+        const result = inputChoiceSorting.horizontalByColumns(array, columnCount);
+
+        expect(result).toEqual([[0,3,6,9],[1,4,7],[2,5,8]])
+    });
+    test('by rows.', () => {
+        const rowCount = 5
+        const result = inputChoiceSorting.horizontalByRows(array, rowCount);
+
+        expect(result).toEqual([[0,2,4,6,8], [1,3,5,7,9]]);
+    });
+});
+
+describe('Sort array by parameters ', () => {
+    test('with valid parameters.', () => {
+        const columns = 2;
+        let rows: number | undefined;
+        const alignment = "vertical";
+        const result = inputChoiceSorting._sortByParameters(array, alignment, columns, rows);
+
+        expect(result).toEqual([[0,1,2,3,4],[5,6,7,8,9]]);
+    });
+    test('with invalid parameters.', () => {
+        const columns = -1;
+        const alignment = "vertical";
+        const result = inputChoiceSorting._sortByParameters(array, alignment, columns);
+
+        expect(result).toEqual([0,1,2,3,4,5,6,7,8,9]);
+    });
+    test('with custom vertical parameters.', () => {
+        const alignment = "vertical";
+        const customAlignment = true;
+        const customAlignmentLengths = [4,4,2];
+        const result = inputChoiceSorting._sortByParameters(array, alignment, undefined, undefined, customAlignment, customAlignmentLengths)
+
+        expect(result).toEqual([[0,1,2,3],[4,5,6,7],[8,9]]);
+    });
+    test('with custom horizontal parameters.', () => {
+        const alignment = "horizontal";
+        const customAlignment = true;
+        const customAlignmentLengths = [4,4,2];
+        const result = inputChoiceSorting._sortByParameters(array, alignment, undefined, undefined, customAlignment, customAlignmentLengths)
+
+        expect(result).toEqual([[0,4,8],[1,5,9],[2,6],[3,7]]);
+    });
+});

--- a/packages/evolution-frontend/src/components/inputs/__tests__/InputChoiceSorting.test.ts
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/InputChoiceSorting.test.ts
@@ -4,7 +4,9 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
+import exp from 'constants';
 import {sortByParameters} from '../InputChoiceSorting';
+import { ro } from 'date-fns/locale';
 
 const array = [0,1,2,3,4,5,6,7,8,9];
 
@@ -31,7 +33,7 @@ describe('Sort array in vertical fashion ', () =>{
     test('Vertical By no columns & no rows', () => {
         const result = sortByParameters(array, alignment);
 
-        expect(result).toEqual([0,1,2,3,4,5,6,7,8,9]);
+        expect(result).toEqual([[0,1,2,3,4],[5,6,7,8,9]]);
     });
 });
 
@@ -58,7 +60,33 @@ describe('Sort array in horizontal fashion', () =>{
     test('horizontal By no columns & no rows', () => {
         const result = sortByParameters(array, alignment);
 
-        expect(result).toEqual([0,1,2,3,4,5,6,7,8,9]);
+        expect(result).toEqual([[0,5],[1,6],[2,7],[3,8],[4,9]]);
+    });
+});
+
+describe('Sort array with no alignement', () => {
+    const columns = 2;
+    const rows = 2;
+
+    test('with  columns', () => {
+        const result = sortByParameters(array, undefined, columns);
+
+        expect(result).toEqual([[0,1,2,3,4],[5,6,7,8,9]]);
+    });
+    test('with rows', () => {
+        const result = sortByParameters(array, undefined, undefined, rows);
+
+        expect(result).toEqual([[0,1],[2,3],[4,5],[6,7],[8,9]]);
+    });
+    test('with columns & rows', () => {
+        const result = sortByParameters(array, undefined, columns, rows);
+
+        expect(result).toEqual([[0,1,2,3,4],[5,6,7,8,9]]);
+    });
+    test('with no columns & no rows', () => {
+        const result = sortByParameters(array);
+
+        expect(result).toEqual([[0,1,2,3,4],[5,6,7,8,9]]);
     });
 });
 
@@ -75,7 +103,7 @@ describe('Sort array by parameters', () => {
     test('with invalid parameters.', () => {
         const result = sortByParameters(array, alignment, undefined, rows, undefined);
 
-        expect(result).toEqual([0,1,2,3,4,5,6,7,8,9]);
+        expect(result).toEqual([[0,1,2,3,4],[5,6,7,8,9]]);
     });
     test('with valid columns but invalid rows', () => {
         const result = sortByParameters(array, alignment, columns, rows, undefined);

--- a/packages/evolution-frontend/src/components/inputs/__tests__/InputChoiceSorting.test.ts
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/InputChoiceSorting.test.ts
@@ -1,66 +1,131 @@
-import * as inputChoiceSorting from '../InputChoiceSorting';
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import {sortByParameters} from '../InputChoiceSorting';
 
 const array = [0,1,2,3,4,5,6,7,8,9];
 
 describe('Sort array in vertical fashion ', () =>{
-    test('by columns.', () => {
-        const columnCount = 3;
-        const result = inputChoiceSorting.verticalByColumns(array, columnCount);
+    const columns = 3;
+    const rows = 3;
+    const alignment = 'vertical';
+
+    test('Vertical By columns', () => {
+        const result = sortByParameters(array, alignment, columns);
 
         expect(result).toEqual([[0,1,2,3],[4,5,6],[7,8,9]]);
     });
+    test('Vertical By rows', () => {
+        const result = sortByParameters(array, alignment, undefined, rows);
 
-    test('by rows.', () => {
-        const rowCount = 4;
-        const result = inputChoiceSorting.verticalByRows(array, rowCount);
+        expect(result).toEqual([[0,1,2],[3,4,5],[6,7,8],[9]]);
+    });
+    test('Vertical By columns & rows', () => {
+        const result = sortByParameters(array, alignment, columns, rows);
 
-        expect(result).toEqual([[0,1,2,3],[4,5,6,7],[8,9]]);
+        expect(result).toEqual([[0,1,2,3],[4,5,6],[7,8,9]]);
+    });
+    test('Vertical By no columns & no rows', () => {
+        const result = sortByParameters(array, alignment);
+
+        expect(result).toEqual([0,1,2,3,4,5,6,7,8,9]);
     });
 });
 
 describe('Sort array in horizontal fashion', () =>{
-    test('by columns.', () => {
-        const columnCount = 3;
-        const result = inputChoiceSorting.horizontalByColumns(array, columnCount);
+    const columns = 3;
+    const rows = 3;
+    const alignment = 'horizontal';
 
-        expect(result).toEqual([[0,3,6,9],[1,4,7],[2,5,8]])
+    test('horizontal By columns', () => {
+        const result = sortByParameters(array, alignment, columns);
+
+        expect(result).toEqual([[0,3,6,9],[1,4,7],[2,5,8]]);
     });
-    test('by rows.', () => {
-        const rowCount = 5
-        const result = inputChoiceSorting.horizontalByRows(array, rowCount);
+    test('horizontal By rows', () => {
+        const result = sortByParameters(array, alignment, undefined, rows);
 
-        expect(result).toEqual([[0,2,4,6,8], [1,3,5,7,9]]);
+        expect(result).toEqual([[0,4,8],[1,5,9],[2,6],[3,7]]);
+    });
+    test('horizontal By columns & rows', () => {
+        const result = sortByParameters(array, alignment, columns, rows);
+
+        expect(result).toEqual([[0,3,6,9],[1,4,7],[2,5,8]]);
+    });
+    test('horizontal By no columns & no rows', () => {
+        const result = sortByParameters(array, alignment);
+
+        expect(result).toEqual([0,1,2,3,4,5,6,7,8,9]);
     });
 });
 
-describe('Sort array by parameters ', () => {
+describe('Sort array by parameters', () => {
+    const columns = 2;
+    const rows = -1;
+    const alignment = 'vertical';
+
     test('with valid parameters.', () => {
-        const columns = 2;
-        let rows: number | undefined;
-        const alignment = "vertical";
-        const result = inputChoiceSorting._sortByParameters(array, alignment, columns, rows);
+        const result = sortByParameters(array, alignment, columns, undefined, undefined);
 
         expect(result).toEqual([[0,1,2,3,4],[5,6,7,8,9]]);
     });
     test('with invalid parameters.', () => {
-        const columns = -1;
-        const alignment = "vertical";
-        const result = inputChoiceSorting._sortByParameters(array, alignment, columns);
+        const result = sortByParameters(array, alignment, undefined, rows, undefined);
 
         expect(result).toEqual([0,1,2,3,4,5,6,7,8,9]);
     });
-    test('with custom vertical parameters.', () => {
-        const alignment = "vertical";
-        const customAlignmentLengths = [4,4,2];
-        const result = inputChoiceSorting._sortByParameters(array, alignment, undefined, undefined, customAlignmentLengths)
+    test('with valid columns but invalid rows', () => {
+        const result = sortByParameters(array, alignment, columns, rows, undefined);
+
+        expect(result).toEqual([[0,1,2,3,4],[5,6,7,8,9]]);
+    })
+});
+
+describe('Sort array by custom parameters', () => {
+    const sameAmount = [4,4,2];
+    const moreParameters = [6,6,4];
+    const lessParameters = [2,2];
+    const invalidHorizontalParameters = [3,5,2];
+    const vertical = 'vertical';
+    const horizontal = 'horizontal';
+
+    test('Vertical with same amount of choices and parameters.', () => {
+        const result = sortByParameters(array, vertical, undefined, undefined, sameAmount)
 
         expect(result).toEqual([[0,1,2,3],[4,5,6,7],[8,9]]);
     });
-    test('with custom horizontal parameters.', () => {
-        const alignment = "horizontal";
-        const customAlignmentLengths = [4,4,2];
-        const result = inputChoiceSorting._sortByParameters(array, alignment, undefined, undefined, customAlignmentLengths)
+    test('Vertical with less parameters than choices.', () => {
+        const result = sortByParameters(array, vertical, undefined, undefined, lessParameters)
+
+        expect(result).toEqual([[0,1],[2,3],[4,5,6,7,8,9]]);
+    });
+    test('Vertical with more parameters than choices.', () => {
+        const result = sortByParameters(array, vertical, undefined, undefined, moreParameters)
+
+        expect(result).toEqual([[0,1,2,3,4,5],[6,7,8,9]]);
+    });
+
+    test('Horizontal with same amount of choices and parameters.', () => {
+        const result = sortByParameters(array, horizontal, undefined, undefined, sameAmount)
 
         expect(result).toEqual([[0,4,8],[1,5,9],[2,6],[3,7]]);
+    });
+    test('Horizontal with less parameters than choices.', () => {
+        const result = sortByParameters(array, horizontal, undefined, undefined, lessParameters)
+
+        expect(result).toEqual([[0,2],[1,3]]);
+    });
+    test('Horizontal with more parameters than choices.', () => {
+        const result = sortByParameters(array, horizontal, undefined, undefined, moreParameters)
+
+        expect(result).toEqual([[0,6],[1,7],[2,8],[3,9],[4],[5]]);
+    });
+    test('Horizontal with invalid parameters', () => {
+        const result = sortByParameters(array, horizontal, undefined, undefined, invalidHorizontalParameters);
+
+        expect(result).toEqual([[0,3,8],[1,4,9],[2,5]]);
     });
 });

--- a/packages/evolution-frontend/src/components/inputs/__tests__/InputChoiceSorting.test.ts
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/InputChoiceSorting.test.ts
@@ -51,17 +51,15 @@ describe('Sort array by parameters ', () => {
     });
     test('with custom vertical parameters.', () => {
         const alignment = "vertical";
-        const customAlignment = true;
         const customAlignmentLengths = [4,4,2];
-        const result = inputChoiceSorting._sortByParameters(array, alignment, undefined, undefined, customAlignment, customAlignmentLengths)
+        const result = inputChoiceSorting._sortByParameters(array, alignment, undefined, undefined, customAlignmentLengths)
 
         expect(result).toEqual([[0,1,2,3],[4,5,6,7],[8,9]]);
     });
     test('with custom horizontal parameters.', () => {
         const alignment = "horizontal";
-        const customAlignment = true;
         const customAlignmentLengths = [4,4,2];
-        const result = inputChoiceSorting._sortByParameters(array, alignment, undefined, undefined, customAlignment, customAlignmentLengths)
+        const result = inputChoiceSorting._sortByParameters(array, alignment, undefined, undefined, customAlignmentLengths)
 
         expect(result).toEqual([[0,4,8],[1,5,9],[2,6],[3,7]]);
     });


### PR DESCRIPTION
With the use of the new parameters, radio and checkbox type questions can have their answers aligned by column and row and have their answers ordered vertically or horizantally. Use 'alignChoices' to have the options aligned, 'columns' to target a number of columns , 'rows' to target a number of rows, 'alignment' to specify in wich direction to order the choices, 'customAlignmentLengths' to specify the length of each row or column. When using custom lengths in horizontal alignment, the first row must be the longuest.