### PR TITLE
multiselect: Make sure shortcut options are available

### DIFF
--- a/packages/evolution-frontend/src/components/inputs/InputMultiselect.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputMultiselect.tsx
@@ -150,6 +150,10 @@ export class InputMultiselect<CustomSurvey, CustomHousehold, CustomHome, CustomP
             hasShortcuts = true;
             for (let i = 0, count = this.props.widgetConfig.shortcuts.length; i < count; i++) {
                 const shortcut = this.props.widgetConfig.shortcuts[i];
+                // Make sure the corresponding option is available, otherwise don't add the shortcut
+                if (selectOptions.findIndex((visiblechoice) => visiblechoice.value === shortcut.value) === -1) {
+                    continue;
+                }
                 shortcutButtons.push(
                     <button
                         key={'shortcut' + i}

--- a/packages/evolution-frontend/src/components/inputs/__tests__/InputMultiselect.test.tsx
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/InputMultiselect.test.tsx
@@ -127,6 +127,8 @@ describe('Render InputMultiselect with various options', () => {
     });
 
     test('With all parameters', () => {
+        // One of the shortcuts is not a present choice
+        conditionalFct.mockReturnValueOnce(false);
         const configWithShortcuts = Object.assign({}, widgetConfig, { 
             shortcuts: [
                 {

--- a/packages/evolution-frontend/src/components/inputs/__tests__/__snapshots__/InputMultiselect.test.tsx.snap
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/__snapshots__/InputMultiselect.test.tsx.snap
@@ -446,14 +446,6 @@ exports[`Render InputMultiselect with various options With all parameters 1`] = 
   >
     Unilingual label
   </button>
-  <button
-    className="button shortcut-button red"
-    onClick={[Function]}
-    tabIndex={-1}
-    type="button"
-  >
-    english conditional
-  </button>
 </div>
 `;
 


### PR DESCRIPTION
Fixes #150

Do not add a shortcut button for an option that is not available in the choices.