### PR TITLE
Visited places cards: only round bottom corners

### DIFF
--- a/packages/evolution-legacy/src/styles/survey/_survey.scss
+++ b/packages/evolution-legacy/src/styles/survey/_survey.scss
@@ -96,7 +96,7 @@
   .survey-group-object {
     background-color: rgba(255,255,255,0.4);
     border: 1px solid rgba(255,255,255,0.7);
-    border-radius: 1rem;
+    border-radius: 0 0 1rem 1rem;
     padding: 1rem;
     margin-bottom: 2rem;
   }


### PR DESCRIPTION
Keeping the top corners square gives a better look.