### PR TITLE
Remove 'Loading...' label for button, instead just disable the button

### DIFF
--- a/packages/evolution-legacy/src/components/survey/Button.js
+++ b/packages/evolution-legacy/src/components/survey/Button.js
@@ -11,7 +11,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { withSurveyContext } from 'evolution-frontend/lib/components/hoc/WithSurveyContextHoc';
 import ConfirmModal         from './modal/ConfirmModal';
 import * as surveyHelper    from 'evolution-common/lib/utils/helpers';
-import InputLoading         from 'evolution-frontend/lib/components/inputs/InputLoading';
 
 export class Button extends React.Component {
   constructor(props) {
@@ -79,23 +78,23 @@ export class Button extends React.Component {
     {
       return null;
     }
-    
-    if(widgetConfig.hideWhenRefreshing && this.props.loadingState > 0)
-    {
-      return <InputLoading t={this.props.t} />;
-    }
+
     let saveCallback = this.props.saveCallback || this.props.widgetConfig.saveCallback;
     if (typeof saveCallback === 'function')
     {
       saveCallback = saveCallback.bind(this);
-    }    
+    }
+
+    const isLoading = widgetConfig.hideWhenRefreshing && this.props.loadingState > 0;
+    const buttonColor = (widgetConfig.color || 'green');
     return (
       <div className={widgetConfig.align || 'center'}>
         <button
           type      = "button"
-          className = {`survey-section__button button ${widgetConfig.color || 'green'} ${widgetConfig.size || 'large'}`}
+          className = {`survey-section__button button ${buttonColor} ${widgetConfig.size || 'large'} ${isLoading ? 'disabled' : ''}`}
           onMouseDown = {this.onMouseDown}
           onMouseUp = {this.onMouseUp}
+          disabled={{isLoading}}
         >
           {widgetConfig.icon && <FontAwesomeIcon icon={widgetConfig.icon} className="faIconLeft" />}
           {surveyHelper.translateString(this.props.label || widgetConfig.label, this.props.i18n, this.props.interview, this.props.path)}


### PR DESCRIPTION
Ideally this should be done in InputButton, but some surveys still use the Button.js class from evolution-legacy.

When a survey was loading, this button used to be changed to a label (ex: "Loading..."). However, since this label was smaller than the button, the content below would be moved slightly which would be quite annoying.

Now, instead of replacing the button with a label, we simply disable it so it is not clickable anymore. Since the height does not change, the flickering problem is solved.

Ideally, the property would be renamed disabledWhenRefreshing, but since this class will eventually be replaced by InputButton, I am keeping it as-is to avoid breaking changes.