### PR TITLE
Disable the ability to click on POIs on the Google Map

### DIFF
--- a/packages/evolution-frontend/src/components/inputs/maps/google/InputMapGoogle.tsx
+++ b/packages/evolution-frontend/src/components/inputs/maps/google/InputMapGoogle.tsx
@@ -202,6 +202,7 @@ const InputMapGoogle: React.FunctionComponent<InputGoogleMapPointProps> = (props
             onClick={(e) => onPositionChange(e, 'mapClicked')}
             onZoomChanged={onZoomChange}
             onBoundsChanged={onBoundsChanged}
+            clickableIcons={false}
         >
             {props.markers.map((markerData, index) => (
                 <Marker


### PR DESCRIPTION
You can still see them, but you can't get the popup anymore. You can still click to move the marker there. Fixes #158