### PR TITLE
Change map language from config.js

### DIFF
--- a/packages/evolution-frontend/src/components/inputs/maps/google/InputMapGoogle.tsx
+++ b/packages/evolution-frontend/src/components/inputs/maps/google/InputMapGoogle.tsx
@@ -61,6 +61,7 @@ const callWithBounds = (
 const InputMapGoogle: React.FunctionComponent<InputGoogleMapPointProps> = (props: InputGoogleMapPointProps) => {
     const { isLoaded } = useJsApiLoader({
         region: projectConfig.region,
+        language: projectConfig.defaultLocale,
         ...googleConfig
     });
 


### PR DESCRIPTION
Ideally we would just get the value from the i18n system to allow changing the language when the map is loaded. Unfortunately, @react-google-maps does not allow changing the map language once the map is loaded. See https://github.com/chairemobilite/evolution/pull/114#issuecomment-1568529296 for a discussion

So, for now, we will at least allow seting the map language from the config file. If a survey is done mostly in, for example Québec, then we can set the language to french in the config file.