### PR TITLE
Drop node 16 support

### DIFF
--- a/.github/workflows/evolution.yml
+++ b/.github/workflows/evolution.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x, 20.x]
     env:
       PROJECT_CONFIG: ${{ github.workspace }}/example/demo_survey/config.js
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build Node app
-FROM node:16-bullseye
+FROM node:18-bullseye
 WORKDIR /app
 
 # TODO split package.json copy and yarn install to have some intermediary images

--- a/example/demo_survey/package.json
+++ b/example/demo_survey/package.json
@@ -1,6 +1,6 @@
 {
     "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
     },
     "name": "demo_survey",
     "version": "1.0.0",
@@ -9,10 +9,10 @@
     "private": true,
     "repository": "github.com/chairemobilite/evolution",
     "scripts": {
-        "build:dev": "cross-env NODE_OPTIONS=--max_old_space_size=4096 webpack --watch --progress --colors --env development --mode development",
-        "build:prod": "cross-env NODE_OPTIONS=--max_old_space_size=4096 webpack -p --progress --colors --env production --mode production",
-        "build:admin:dev": "cross-env NODE_OPTIONS=--max_old_space_size=4096 webpack --config webpack.admin.config.js --watch --progress --colors --env development --mode development",
-        "build:admin:prod": "cross-env NODE_OPTIONS=--max_old_space_size=4096 webpack --config webpack.admin.config.js -p --progress --colors --env production --mode production",
+        "build:dev": "cross-env NODE_OPTIONS=\"--max_old_space_size=4096 --openssl-legacy-provider\" webpack --watch --progress --colors --env development --mode development",
+        "build:prod": "cross-env NODE_OPTIONS=\"--max_old_space_size=4096 --openssl-legacy-provider\" webpack -p --progress --colors --env production --mode production",
+        "build:admin:dev": "cross-env NODE_OPTIONS=\"--max_old_space_size=4096 --openssl-legacy-provider\" webpack --config webpack.admin.config.js --watch --progress --colors --env development --mode development",
+        "build:admin:prod": "cross-env NODE_OPTIONS=\"--max_old_space_size=4096 --openssl-legacy-provider\" webpack --config webpack.admin.config.js -p --progress --colors --env production --mode production",
         "build:test": "cross-env NODE_ENV=test webpack -p --env test --mode development --watch --progress --colors",
         "clean": "rimraf lib/",
         "cleanModules": "rimraf node_modules/",

--- a/packages/evolution-backend/package.json
+++ b/packages/evolution-backend/package.json
@@ -1,6 +1,6 @@
 {
     "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
     },
     "name": "evolution-backend",
     "version": "0.2.2",

--- a/packages/evolution-common/package.json
+++ b/packages/evolution-common/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "name": "evolution-common",
   "version": "0.2.2",

--- a/packages/evolution-frontend/package.json
+++ b/packages/evolution-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "name": "evolution-frontend",
   "version": "0.2.2",

--- a/packages/evolution-legacy/package.json
+++ b/packages/evolution-legacy/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "name": "evolution-legacy",
   "version": "0.2.2",


### PR DESCRIPTION
Fixes #165

All packages now require node 18+

Add the --openssl-legacy-provider flag to yarn build scripts to support current webpack.