### PR TITLE
Add an evolution-interviewer node module for interviewer support

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
         "packages/evolution-backend",
         "packages/evolution-frontend",
         "packages/evolution-legacy",
+        "packages/evolution-interviewer",
         "example/demo_survey"
     ],
     "scripts": {
@@ -17,7 +18,7 @@
         "migrate": "yarn workspace chaire-lib-backend run migrate && yarn workspace evolution-backend run migrate",
         "migrate-test": "PROJECT_CONFIG=${PWD}/transition/tests/config_test.js yarn workspace chaire-lib-backend run migrate-test && PROJECT_CONFIG=${PWD}/transition/tests/config_test.js yarn workspace evolution-backend run migrate-test",
         "clean": "yarn workspaces run clean",
-        "cleanModules": "yarn workspace evolution-common run cleanModules && yarn workspace evolution-backend run cleanModules && yarn workspace evolution-frontend run cleanModules && yarn workspace evolution-legacy run cleanModules && yarn workspace demo_survey run cleanModules && rimraf node_modules",
+        "cleanModules": "yarn workspace evolution-common run cleanModules && yarn workspace evolution-backend run cleanModules && yarn workspace evolution-frontend run cleanModules && yarn workspace evolution-legacy run cleanModules && yarn workspace evolution-interviewer run cleanModules && yarn workspace demo_survey run cleanModules && rimraf node_modules",
         "compile": "yarn workspaces run compile",
         "compile:dev": "yarn wsrun compile:dev",
         "create-user": "yarn workspace chaire-lib-backend run create-user",
@@ -29,11 +30,11 @@
         "start:admin": "yarn workspace demo_survey run start:admin",
         "start:debug": "yarn workspace demo_survey run start:debug",
         "start:tracing": "yarn workspace demo_survey run start:tracing",
-        "test": "yarn workspace evolution-common run test && yarn workspace evolution-backend run test && yarn workspace evolution-frontend run test && yarn workspace evolution-legacy run test",
-        "test:unit": "yarn workspace evolution-common run test:unit && yarn workspace evolution-backend run test:unit && yarn workspace evolution-frontend run test:unit && yarn workspace evolution-legacy run test:unit",
-        "test:sequential": "yarn workspace evolution-common run test:sequential && yarn workspace evolution-backend run test:sequential && yarn workspace evolution-frontend run test:sequential",
-        "lint": "yarn workspace evolution-common run lint && yarn workspace evolution-backend run lint && yarn workspace evolution-frontend run lint",
-        "format": "yarn workspace evolution-common run format && yarn workspace evolution-backend run format && yarn workspace evolution-frontend run format",
+        "test": "yarn workspace evolution-common run test && yarn workspace evolution-backend run test && yarn workspace evolution-frontend run test && yarn workspace evolution-legacy run test && yarn workspace evolution-interviewer run test",
+        "test:unit": "yarn workspace evolution-common run test:unit && yarn workspace evolution-backend run test:unit && yarn workspace evolution-frontend run test:unit && yarn workspace evolution-legacy run test:unit && yarn workspace evolution-interviewer run test:unit",
+        "test:sequential": "yarn workspace evolution-common run test:sequential && yarn workspace evolution-backend run test:sequential && yarn workspace evolution-frontend run test:sequential && yarn workspace evolution-interviewer run test:sequential",
+        "lint": "yarn workspace evolution-common run lint && yarn workspace evolution-backend run lint && yarn workspace evolution-frontend run lint && yarn workspace evolution-interviewer run lint",
+        "format": "yarn workspace evolution-common run format && yarn workspace evolution-backend run format && yarn workspace evolution-frontend run format && yarn workspace evolution-interviewer run format",
         "list-tasks": "yarn workspace evolution-legacy run list-tasks",
         "generate-migration": "knex migrate:make",
         "reset-submodules": "rimraf transition/ && git submodule init && git submodule update"

--- a/packages/evolution-interviewer/.eslintignore
+++ b/packages/evolution-interviewer/.eslintignore
@@ -1,0 +1,3 @@
+lib/
+node_modules/
+**/__tests__

--- a/packages/evolution-interviewer/.eslintrc.json
+++ b/packages/evolution-interviewer/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../configs/base.eslintrc.json"
+}

--- a/packages/evolution-interviewer/.prettierignore
+++ b/packages/evolution-interviewer/.prettierignore
@@ -1,0 +1,2 @@
+lib/
+node_modules/

--- a/packages/evolution-interviewer/.prettierrc.js
+++ b/packages/evolution-interviewer/.prettierrc.js
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2022, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+module.exports = {
+  ...require('../../configs/base.prettierrc')
+}

--- a/packages/evolution-interviewer/jest.config.js
+++ b/packages/evolution-interviewer/jest.config.js
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+/* eslint-disable node/no-unpublished-require */
+const baseConfig = require('../../tests/jest.config.base');
+
+module.exports = {
+    ...baseConfig,
+    'testPathIgnorePatterns': ['(/__tests__/.*(db\\.test)\\.(jsx?|tsx?))$'],
+};
+

--- a/packages/evolution-interviewer/jest.sequential.config.js
+++ b/packages/evolution-interviewer/jest.sequential.config.js
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2022, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+/* eslint-disable node/no-unpublished-require */
+const baseConfig = require('../../tests/jest.config.base');
+
+// Ignore db.queries.test files
+module.exports = {
+    ...baseConfig,
+    'testRegex': '(/__tests__/.*(db\\.test)\\.(jsx?|tsx?))$'
+};

--- a/packages/evolution-interviewer/package.json
+++ b/packages/evolution-interviewer/package.json
@@ -1,0 +1,59 @@
+{
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "name": "evolution-interviewer",
+    "version": "0.2.2",
+    "description": "Interviewer module for for Evolution platform",
+    "repository": "github.com/chairemobilite/evolution",
+    "license": "MIT",
+    "scripts": {
+        "clean": "rimraf lib/",
+        "cleanModules": "rimraf node_modules/",
+        "compile": "tsc",
+        "compile:dev": "tsc -w",
+        "migrate": "knex migrate:latest --knexfile lib/config/knexfile.js",
+        "migrate:rollback": "knex migrate:down --knexfile lib/config/knexfile.js",
+        "migrate-test": "cross-env NODE_ENV=test knex migrate:latest --knexfile lib/config/knexfile.js",
+        "test": "cross-env NODE_ENV=test jest --config=jest.config.js",
+        "test:unit": "cross-env NODE_ENV=test jest --config=jest.config.js",
+        "test:sequential": "echo 'cross-env NODE_ENV=test jest --config=jest.sequential.config.js --runInBand'",
+        "test:ui": "echo 'no tests to run for this workspace'",
+        "lint": "eslint .",
+        "format": "prettier-eslint $PWD/'src/**/*.{ts,tsx}' --write"
+    },
+    "dependencies": {
+        "@casl/ability": "^5.4.3",
+        "chaire-lib-backend": "^0.2.2",
+        "chaire-lib-common": "^0.2.2",
+        "chaire-lib-frontend": "^0.2.2",
+        "evolution-backend": "^0.2.2",
+        "evolution-common": "^0.2.2",
+        "evolution-frontend": "^0.2.2",
+        "express": "^4.17.1",
+        "i18next": "^22.4.15",
+        "knex": "^2.4.2",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.set": "^4.3.2",
+        "lodash.unset": "^4.5.2",
+        "moment": "^2.29.4",
+        "typescript": "^4.9.4",
+        "uuid": "^8.3.2"
+    },
+    "devDependencies": {
+        "@types/jest": "^26.0.3",
+        "@types/jest-each": "^24.3.0",
+        "@types/node": "^17.0.38",
+        "@typescript-eslint/eslint-plugin": "^5.45.1",
+        "@typescript-eslint/parser": "^5.45.1",
+        "cross-env": "^7.0.2",
+        "eslint": "^8.29.0",
+        "eslint-plugin-node": "^11.1.0",
+        "jest": "^27.3.1",
+        "jest-each": "^27.3.1",
+        "jest-fetch-mock": "^3.0.3",
+        "mock-knex": "^0.4.10",
+        "prettier-eslint-cli": "^7.1.0",
+        "ts-jest": "^27.0.7"
+    }
+}

--- a/packages/evolution-interviewer/src/client/config/i18nextExtra.config.ts
+++ b/packages/evolution-interviewer/src/client/config/i18nextExtra.config.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+/** This file adds functions to get additional contexts for i18next translate
+ * function. This context comes from the interviewMode preference, which can be
+ * either an interviewer or participant mode */
+import Preferences from 'chaire-lib-common/lib/config/Preferences';
+import i18n from 'chaire-lib-frontend/lib/config/i18n.config';
+
+const getContextParticipant = (context?: string) => context;
+const getContextInterviewer = (context?: string) => (context === undefined ? 'cati' : `cati_${context}`);
+
+export const setCurrentI18nFunction = (mode: 'participant' | 'interviewer') =>
+    (currentContextFct = mode === 'interviewer' ? getContextInterviewer : getContextParticipant);
+
+let currentContextFct =
+    Preferences.get('interviewMode', 'participant') === 'interviewer' ? getContextInterviewer : getContextParticipant;
+Preferences.addChangeListener((updatedPrefs) => {
+    if (updatedPrefs.interviewMode !== undefined) {
+        setCurrentI18nFunction(updatedPrefs.interviewMode);
+        // force a reload of the translations
+        i18n.changeLanguage(i18n.language);
+    }
+});
+
+export const getI18nContext = (context?: string) => currentContextFct(context);

--- a/packages/evolution-interviewer/src/client/services/interviewers/interviewerSupport.ts
+++ b/packages/evolution-interviewer/src/client/services/interviewers/interviewerSupport.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { TFunction } from 'i18next';
+
+import Preferences from 'chaire-lib-common/lib/config/Preferences';
+import { ApplicationConfiguration } from 'chaire-lib-frontend/lib/config/application.config';
+import { EvolutionApplicationConfiguration } from 'evolution-frontend/lib/config/application.config';
+
+const interviewerModeMenuItem = {
+    getText: (t: TFunction) =>
+        Preferences.get('interviewMode', 'participant') === 'interviewer'
+            ? t('survey:ParticipantMode')
+            : t('survey:InterviewerMode'),
+    action: () => {
+        const currentMode = Preferences.get('interviewMode', 'participant');
+        const newMode = currentMode === 'participant' ? 'interviewer' : 'participant';
+        Preferences.update({ interviewMode: newMode });
+    }
+};
+
+const addInterviewerOptions = <CustomSurvey, CustomHousehold, CustomHome, CustomPerson>(
+    config: ApplicationConfiguration<
+        EvolutionApplicationConfiguration<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>
+    >
+) => {
+    const menuItems = config.userMenuItems || [];
+    menuItems.push(interviewerModeMenuItem);
+    config.userMenuItems = menuItems;
+    // TODO Add specific monitoring for interviewers
+};
+
+export default addInterviewerOptions;

--- a/packages/evolution-interviewer/src/server/services/auth/__tests__/roleDefinition.test.ts
+++ b/packages/evolution-interviewer/src/server/services/auth/__tests__/roleDefinition.test.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2022, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import _cloneDeep from 'lodash.clonedeep';
+import { subject } from '@casl/ability';
+
+import { InterviewsSubject, InterviewSubject } from 'evolution-backend/lib/services/auth/roleDefinition';
+import defineUserRoles, { INTERVIEWER_ROLE, INTERVIEWER_SUPERVISOR_ROLE, InterviewersSubject } from '../roleDefinition';
+import defineAbilitiesFor from 'chaire-lib-backend/lib/services/auth/userPermissions';
+import each from 'jest-each';
+
+defineUserRoles();
+
+const interview = {
+    id: 1,
+    uuid: 'arbitrary',
+    participant_id: 1,
+    is_active: true
+}
+
+describe('Interviewer role', () => {
+    const user = {
+        id: 1,
+        uuid: 'arbitrary user',
+        is_admin: false,
+        permissions: { [INTERVIEWER_ROLE]: true }
+    };
+
+    each([
+        ['can read other', 'read', true],
+        ['can update other', 'update', true],
+        ['cannot delete other', 'delete', false],
+        ['can create other', 'create', true],
+        ['cannot validate other', 'validate', false],
+        ['cannot confirm other', 'confirm', false],
+    ]).test('%s', (_title, permission, expectedResult) => {
+        const permissions = defineAbilitiesFor(user);
+        expect(permissions.can(permission, subject(InterviewSubject, interview))).toEqual(expectedResult);
+    });
+
+    test('Interviews list', () => {
+        const permissions = defineAbilitiesFor(user);
+        expect(permissions.can('create', InterviewsSubject)).toBeFalsy();
+        expect(permissions.can('read', InterviewsSubject)).toBeTruthy();
+        expect(permissions.can('update', InterviewsSubject)).toBeTruthy();
+        expect(permissions.can('validate', InterviewsSubject)).toBeFalsy();
+        expect(permissions.can('confirm', InterviewsSubject)).toBeFalsy();
+        expect(permissions.can('delete', InterviewsSubject)).toBeFalsy();
+    });
+
+    test('Interviewers', () => {
+        const permissions = defineAbilitiesFor(user);
+        expect(permissions.can('manage', InterviewersSubject)).toBeFalsy();
+    });
+});
+
+describe('Interviewer supervisor role', () => {
+    const user = {
+        id: 1,
+        uuid: 'arbitrary user',
+        is_admin: false,
+        permissions: { [INTERVIEWER_ROLE]: false, [INTERVIEWER_SUPERVISOR_ROLE]: true }
+    };
+
+    each([
+        ['can read other', 'read', true],
+        ['can update other', 'update', true],
+        ['cannot delete other', 'delete', false],
+        ['can create other', 'create', true],
+        ['cannot validate other', 'validate', false],
+        ['cannot confirm other', 'confirm', false],
+    ]).test('%s', (_title, permission, expectedResult) => {
+        const permissions = defineAbilitiesFor(user);
+        expect(permissions.can(permission, subject(InterviewSubject, interview))).toEqual(expectedResult);
+    });
+
+    test('Interviews list', () => {
+        const permissions = defineAbilitiesFor(user);
+        expect(permissions.can('create', InterviewsSubject)).toBeFalsy();
+        expect(permissions.can('read', InterviewsSubject)).toBeTruthy();
+        expect(permissions.can('update', InterviewsSubject)).toBeTruthy();
+        expect(permissions.can('validate', InterviewsSubject)).toBeFalsy();
+        expect(permissions.can('confirm', InterviewsSubject)).toBeFalsy();
+        expect(permissions.can('delete', InterviewsSubject)).toBeFalsy();
+    });
+
+    test('Interviewers', () => {
+        const permissions = defineAbilitiesFor(user);
+        expect(permissions.can('manage', InterviewersSubject)).toBeTruthy();
+    });
+});

--- a/packages/evolution-interviewer/src/server/services/auth/roleDefinition.ts
+++ b/packages/evolution-interviewer/src/server/services/auth/roleDefinition.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { addRole, addRoleHomePage } from 'chaire-lib-backend/lib/services/auth/userPermissions';
+import { InterviewsSubject, InterviewSubject } from 'evolution-backend/lib/services/auth/roleDefinition';
+
+export const INTERVIEWER_ROLE = 'interviewer';
+export const INTERVIEWER_SUPERVISOR_ROLE = 'interviewerSup';
+
+export const InterviewersSubject = 'Interviewers';
+
+export default () => {
+    // Add an interviewer role
+    addRole(INTERVIEWER_ROLE, ({ can }, _user) => {
+        // Required permissions to list interviews by access code and create new interviews from access code
+        can(['read', 'update'], InterviewsSubject);
+        // Required permissions to read and edit any user's interview
+        can(['read', 'update'], InterviewSubject);
+        can(['create'], InterviewSubject);
+    });
+    addRoleHomePage(INTERVIEWER_ROLE, '/interviews');
+
+    // Add an interviewer supervisor role
+    addRole(INTERVIEWER_SUPERVISOR_ROLE, ({ can }, _user) => {
+        // Required permissions to list interviews by access code and create new interviews from access code
+        can(['read', 'update'], InterviewsSubject);
+        // Required permissions to read and edit any user's interview
+        can(['read', 'update'], InterviewSubject);
+        can(['create'], InterviewSubject);
+        can(['manage'], InterviewersSubject);
+    });
+};

--- a/packages/evolution-interviewer/tsconfig.json
+++ b/packages/evolution-interviewer/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "extends": "../../configs/base.tsconfig.json",
+    "compilerOptions": {
+        "outDir": "lib",
+        "rootDir": "src",
+        "isolatedModules": false, // Should be removed to inherit the true eventually
+        "noImplicitAny": false, // Should be removed to inherit the true eventually
+    },
+    "exclude": [
+        "node_modules",
+        "**/__tests__",
+        "**/*.test.ts"
+    ],
+    "include": [
+        "src/**/*.ts"
+    ]
+}


### PR DESCRIPTION
Fixes #175

This interviewer module adds roles for interviewers, which are users allowed to read or update any interviews and interviewer supervisor, which have the same permissions as interviewers, but also manage interviewers.

This module also adds support for an interviewer mode in the interview, which can be used to change labels for this mode, or by widgets.

To use, the server admin application needs to call the `roleDefinition` default function to add the roles.

The frontend admin application needs to import the `interviewerSupport` file and add the interviewer options to the application configuration.