### PR TITLE
interviewer: use partial configuration as arguments

### DIFF
--- a/locales/en/main.json
+++ b/locales/en/main.json
@@ -33,5 +33,7 @@
   "ClickToSelectDate": "Click to select a date",
   "footer": "",
   "AgreementText": "",
-  "ErrorNotAgreed": "You must accept usage of your date to continue to the survey"
+  "ErrorNotAgreed": "You must accept usage of your date to continue to the survey",
+  "InterviewerMode": "Interviewer mode",
+  "ParticipantMode": "Participant mode"
 }

--- a/locales/fr/main.json
+++ b/locales/fr/main.json
@@ -33,5 +33,7 @@
   "ClickToSelectDate": "Cliquer pour sélectionner une date",
   "footer": "",
   "AgreementText": "",
-  "ErrorNotAgreed": "Vous devez accepter l'utilisation de vos données pour continuer vers l'enquête"
+  "ErrorNotAgreed": "Vous devez accepter l'utilisation de vos données pour continuer vers l'enquête",
+  "InterviewerMode": "Mode intervieweur",
+  "ParticipantMode": "Mode participant"
 }

--- a/packages/evolution-interviewer/src/client/services/interviewers/interviewerSupport.ts
+++ b/packages/evolution-interviewer/src/client/services/interviewers/interviewerSupport.ts
@@ -13,8 +13,8 @@ import { EvolutionApplicationConfiguration } from 'evolution-frontend/lib/config
 const interviewerModeMenuItem = {
     getText: (t: TFunction) =>
         Preferences.get('interviewMode', 'participant') === 'interviewer'
-            ? t('survey:ParticipantMode')
-            : t('survey:InterviewerMode'),
+            ? t(['survey:ParticipantMode', 'main:ParticipantMode'])
+            : t(['survey:InterviewerMode', 'main:InterviewerMode']),
     action: () => {
         const currentMode = Preferences.get('interviewMode', 'participant');
         const newMode = currentMode === 'participant' ? 'interviewer' : 'participant';
@@ -23,14 +23,19 @@ const interviewerModeMenuItem = {
 };
 
 const addInterviewerOptions = <CustomSurvey, CustomHousehold, CustomHome, CustomPerson>(
-    config: ApplicationConfiguration<
-        EvolutionApplicationConfiguration<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>
+    config: Partial<
+        ApplicationConfiguration<
+            EvolutionApplicationConfiguration<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>
+        >
     >
-) => {
+): Partial<
+    ApplicationConfiguration<EvolutionApplicationConfiguration<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>>
+> => {
     const menuItems = config.userMenuItems || [];
     menuItems.push(interviewerModeMenuItem);
     config.userMenuItems = menuItems;
     // TODO Add specific monitoring for interviewers
+    return config;
 };
 
 export default addInterviewerOptions;


### PR DESCRIPTION
Also, return the modified config instead of simply modifying in place. Add a default text for interviewer/participant modes in the evolution locales.