### PR TITLE
interview list: auto create new interviews and prefill answers from query

### DIFF
--- a/example/demo_survey/src/admin/app-admin.tsx
+++ b/example/demo_survey/src/admin/app-admin.tsx
@@ -11,6 +11,7 @@ import parsers from './parsers'
 setApplicationConfiguration<SurveyAppConfig>({
     sections: surveySections,
     widgets: widgetsConfig,
+    allowedUrlFields: ['source', 'household.carNumber'],
     // TODO See if the demo is wrong or the admin validation types
     getAdminValidations: () => validations as any,
     projectHelpers,

--- a/example/demo_survey/src/app-survey.tsx
+++ b/example/demo_survey/src/app-survey.tsx
@@ -10,6 +10,7 @@ setApplicationConfiguration<SurveyAppConfig>({
     sections: surveySections,
     widgets: widgetsConfig,
     projectHelpers,
+    allowedUrlFields: ['source', 'household.carNumber']
 });
 
 runClientApp();

--- a/packages/evolution-frontend/package.json
+++ b/packages/evolution-frontend/package.json
@@ -39,6 +39,7 @@
     "history": "^4.9.0",
     "i18next": "^22.4.15",
     "lodash.clonedeep": "^4.5.0",
+    "lodash.get": "^4.4.2",
     "lodash.isequal": "^4.5.0",
     "lodash.set": "^4.3.2",
     "lodash.sortby": "^4.7.0",

--- a/packages/evolution-frontend/src/components/pageParts/interviews/InterviewSearchList.tsx
+++ b/packages/evolution-frontend/src/components/pageParts/interviews/InterviewSearchList.tsx
@@ -14,6 +14,7 @@ import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 
 type InterviewSearchListProps = {
     autoCreateIfNoData: boolean;
+    queryData: URLSearchParams;
 };
 
 const InterviewSearchList: React.FunctionComponent<InterviewSearchListProps & WithTranslation> = (
@@ -54,7 +55,8 @@ const InterviewSearchList: React.FunctionComponent<InterviewSearchListProps & Wi
                             // automatically create new interview with this access code
                             dispatch({
                                 type: 'createNew',
-                                username: `telephone_${(Math.ceil(Math.random() * 8999) + 1000).toString()}`
+                                username: `telephone_${(Math.ceil(Math.random() * 8999) + 1000).toString()}`,
+                                queryData: props.queryData
                             });
                         }
                     }
@@ -93,7 +95,8 @@ const InterviewSearchList: React.FunctionComponent<InterviewSearchListProps & Wi
                         e.preventDefault();
                         dispatch({
                             type: 'createNew',
-                            username: `telephone_${(Math.ceil(Math.random() * 8999) + 1000).toString()}`
+                            username: `telephone_${(Math.ceil(Math.random() * 8999) + 1000).toString()}`,
+                            queryData: props.queryData
                         });
                     }}
                 >

--- a/packages/evolution-frontend/src/components/pages/InterviewsByAccessCode.tsx
+++ b/packages/evolution-frontend/src/components/pages/InterviewsByAccessCode.tsx
@@ -61,7 +61,7 @@ const InterviewsByAccessCode: React.FunctionComponent<InterviewsByCodePageProps>
                     </button>
                 </Link>
             </div>
-            <InterviewsComponent autoCreateIfNoData={createNewIfNoData} />
+            <InterviewsComponent autoCreateIfNoData={createNewIfNoData} queryData={urlSearch} />
         </div>
     );
 };

--- a/packages/evolution-frontend/src/components/pages/InterviewsByAccessCode.tsx
+++ b/packages/evolution-frontend/src/components/pages/InterviewsByAccessCode.tsx
@@ -12,6 +12,7 @@ import Loader from 'react-spinners/HashLoader';
 import { InterviewContext, interviewReducer, initialState } from '../../contexts/InterviewContext';
 import InputString from 'chaire-lib-frontend/lib/components/input/InputString';
 import { Link, RouteComponentProps } from 'react-router-dom';
+import { _booleish } from 'chaire-lib-common/lib/utils/LodashExtensions';
 
 interface MatchParams {
     accessCode: string;
@@ -36,7 +37,9 @@ const InterviewsComponent = Loadable({
 const InterviewsByAccessCode: React.FunctionComponent<InterviewsByCodePageProps> = (
     props: InterviewsByCodePageProps
 ) => {
+    const urlSearch = new URLSearchParams(props.location.search);
     const [currentCode, setCurrentCode] = React.useState(props.match.params.accessCode);
+    const [createNewIfNoData] = React.useState(_booleish(urlSearch.get('autoCreate')) === true);
     const { state, dispatch } = React.useContext(InterviewContext);
     React.useEffect(() => {
         if (props.match.params.accessCode !== state.responses.accessCode) {
@@ -58,7 +61,7 @@ const InterviewsByAccessCode: React.FunctionComponent<InterviewsByCodePageProps>
                     </button>
                 </Link>
             </div>
-            <InterviewsComponent />
+            <InterviewsComponent autoCreateIfNoData={createNewIfNoData} />
         </div>
     );
 };

--- a/packages/evolution-frontend/src/config/application.config.ts
+++ b/packages/evolution-frontend/src/config/application.config.ts
@@ -18,6 +18,11 @@ export type EvolutionApplicationConfiguration<CustomSurvey, CustomHousehold, Cus
      *
      * TODO Can these be typed? It's hard to do anything about it... Maybe they should not be in the application config but completely handled on the project side */
     projectHelpers: { [helperName: string]: () => any };
+    /**
+     * Fields that, if present in the original query string to the survey, will
+     * be pre-filled in the responses
+     */
+    allowedUrlFields: string[];
 
     // TODO The fields below are only for the administrative side of the application. The don't need to exist/be loaded for the main survey app. Add a special admin config when the admin app is separate.
     /** Get a custom admin interview stat widget, or undefined to use the default one */
@@ -42,6 +47,7 @@ setApplicationConfiguration({
     section: {},
     widgets: {},
     projectHelpers: {},
+    allowedUrlFields: [],
     getCustomInterviewStat: () => undefined,
     getCustomInterviewMap: () => undefined,
     getAdminValidations: () => undefined,

--- a/packages/evolution-frontend/src/contexts/InterviewContext.ts
+++ b/packages/evolution-frontend/src/contexts/InterviewContext.ts
@@ -4,7 +4,11 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
+import _get from 'lodash.get';
+import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import * as React from 'react';
+import appConfig from '../config/application.config';
+import { URLSearchParams } from 'url';
 
 // TODO Can this be InterviewResponses from 'evolution-common/lib/services/interviews/interview'? To be confirmed
 export type InterviewResponses = { [key: string]: any };
@@ -17,40 +21,45 @@ export type InterviewState =
     | { status: 'entering'; responses: InterviewResponses };
 
 type InterviewAction =
-    | { type: 'createNew'; username: string }
+    | { type: 'createNew'; username: string; queryData: URLSearchParams }
     | { type: 'list' }
     | { type: 'update_responses'; responses: InterviewResponses }
     | { type: 'success'; interviewUuid: string }
     | { type: 'enter'; queryData: URLSearchParams };
 
+const queryDataToResponses = (queryData: URLSearchParams, stateResponses: InterviewResponses) => {
+    const alphaNumRegex = /^[a-z0-9-_]+/i;
+    const responses: { [key: string]: string } = {};
+    appConfig.allowedUrlFields.forEach((field) => {
+        const value = queryData.get(field) as string;
+        if (!_isBlank(value)) {
+            const alphaNumSource = value.match(alphaNumRegex);
+            if (alphaNumSource && _get(stateResponses, field) !== alphaNumSource[0])
+                responses[field] = alphaNumSource[0];
+        }
+    });
+    return Object.keys(responses).length !== 0 ? Object.assign({}, stateResponses, responses) : stateResponses;
+};
+
 export function interviewReducer(state: InterviewState, action: InterviewAction): InterviewState {
     switch (action.type) {
     case 'createNew':
-        return { status: 'creating', responses: state.responses, username: action.username };
+        return {
+            status: 'creating',
+            responses: queryDataToResponses(action.queryData, state.responses),
+            username: action.username
+        };
     case 'list':
         return { ...state, status: 'list' };
     case 'success':
         return { status: 'success', responses: state.responses, interviewUuid: action.interviewUuid };
     case 'update_responses':
         return { ...state, status: 'list', responses: action.responses };
-    case 'enter': {
-        // TODO: The source param is hard-coded. If we need more than that, we should add a project config to white list fields
-        const source = action.queryData.get('source');
-        const alphaNumRegex = /^[a-z0-9-_]+/i;
-        const responses: { [key: string]: string } = {};
-        if (source) {
-            const alphaNumSource = source.match(alphaNumRegex);
-            if (alphaNumSource && state.responses.source !== alphaNumSource[0])
-                responses.source = alphaNumSource[0];
-        }
+    case 'enter':
         return {
             status: 'entering',
-            responses:
-                    Object.keys(responses).length !== 0
-                        ? Object.assign({}, state.responses, responses)
-                        : state.responses
+            responses: queryDataToResponses(action.queryData, state.responses)
         };
-    }
     }
 }
 

--- a/packages/evolution-legacy/src/actions/survey/survey.js
+++ b/packages/evolution-legacy/src/actions/survey/survey.js
@@ -217,7 +217,7 @@ export const startSetInterview = (activeSection = null, surveyUuid = undefined, 
             };
             if (preFilledResponses) {
                 Object.keys(preFilledResponses).forEach((key) => {
-                    valuesByPath[`responses._${key}`] = preFilledResponses[key];
+                    valuesByPath[`responses.${key}`] = preFilledResponses[key];
                 })
             }
             // update browser data if different:
@@ -280,7 +280,7 @@ export const startCreateInterview = (preFilledResponses = undefined) => {
             };
             if (preFilledResponses) {
                 Object.keys(preFilledResponses).forEach((key) => {
-                    responses[`responses._${key}`] = preFilledResponses[key];
+                    responses[`responses.${key}`] = preFilledResponses[key];
                 })
             }
             dispatch(startUpdateInterview(activeSection, responses, null, body.interview));


### PR DESCRIPTION
* This allows to automatically create a new survey if there are none for a given access code (with the autoCreate=true query string parameter)

* Also pre fill the responses from the query string from a white list of fields allowing this.

This will allow phone interviewers to generate a link which would open an interview with the access code and phone number already filled from the url itself. Useful for the Quebec-Levis survey