### PR TITLE
Fix language not being saved in the interview responses

### DIFF
--- a/packages/evolution-frontend/src/actions/Survey.ts
+++ b/packages/evolution-frontend/src/actions/Survey.ts
@@ -24,6 +24,7 @@ import { prepareWidgets } from './utils';
 import { UserFrontendInterviewAttributes } from '../services/interviews/interview';
 import { incrementLoadingState, decrementLoadingState } from './LoadingState';
 import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
+import i18n from 'chaire-lib-frontend/lib/config/i18n.config';
 
 // called whenever an update occurs in interview responses or when section is switched to
 export const updateSection = <CustomSurvey, CustomHousehold, CustomHome, CustomPerson>(
@@ -96,7 +97,7 @@ const startUpdateInterviewCallback = async <CustomSurvey, CustomHousehold, Custo
 
         // update language if needed:
         const oldLanguage = surveyHelper.getResponse(interview, '_language', null);
-        const actualLanguage = null; //i18n.language;
+        const actualLanguage = i18n.language;
         if (oldLanguage !== actualLanguage) {
             valuesByPath['responses._language'] = actualLanguage;
         }

--- a/packages/evolution-frontend/src/actions/__tests__/Survey.test.ts
+++ b/packages/evolution-frontend/src/actions/__tests__/Survey.test.ts
@@ -4,6 +4,10 @@ import { UserFrontendInterviewAttributes } from '../../services/interviews/inter
 import { startUpdateInterview } from '../Survey';
 import { prepareWidgets } from '../utils';
 
+jest.mock('chaire-lib-frontend/lib/config/i18n.config', () => ({
+    language: 'en'
+}))
+
 type CustomSurvey = {
     section1?: {
         q1?: string;
@@ -21,6 +25,7 @@ const interviewAttributes: UserFrontendInterviewAttributes<CustomSurvey, unknown
     participant_id: 1,
     is_completed: false,
     responses: {
+        _language: 'en',
         section1: {
             q1: 'abc',
             q2: 3


### PR DESCRIPTION
Based on my small scale testing, this seems to fix the issue. In my database, _language was always null, but now it seems to correctly show "fr" or "en". Fixes https://github.com/chairemobilite/od_mtl_2023/issues/374