### PR TITLE
admin: add link to create a new survey in main interviews page

### DIFF
--- a/locales/en/admin.json
+++ b/locales/en/admin.json
@@ -66,8 +66,7 @@
     "SearchByCode": "Search by access code"
   },
   "interviewers": {
-    "InterviewersPage": "Interviewer's page",
-    "NothingToDo": "No functionnality available yet"
+    "InterviewsSearchAndEdit": "Search And Edit Surveys"
   },
   "validationFilters": {
     "title": "Valid?",

--- a/locales/fr/admin.json
+++ b/locales/fr/admin.json
@@ -66,8 +66,7 @@
     "SearchByCode": "Chercher par code d'accès"
   },
   "interviewers": {
-    "InterviewersPage": "Page des intervieweurs",
-    "NothingToDo": "Aucune fonctionnalité disponible présentement"
+    "InterviewsSearchAndEdit": "Recherche et édition d'enquêtes"
   },
   "validationFilters": {
     "title": "Valides?",

--- a/packages/evolution-frontend/src/components/pageParts/interviews/InterviewSearchList.tsx
+++ b/packages/evolution-frontend/src/components/pageParts/interviews/InterviewSearchList.tsx
@@ -8,9 +8,9 @@ import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 
 import Interview from './InterviewSearchResult';
-import InterviewsCreateNew from './InterviewsCreateNew';
 import { InterviewContext } from '../../../contexts/InterviewContext';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
+import InterviewsCreateLink from './InterviewsCreateLink';
 
 type InterviewSearchListProps = {
     autoCreateIfNoData: boolean;
@@ -85,25 +85,7 @@ const InterviewSearchList: React.FunctionComponent<InterviewSearchListProps & Wi
             {data.map((interview) => (
                 <Interview key={interview.uuid} interview={interview} />
             ))}
-            {state.status !== 'creating' && (
-                <a
-                    href=""
-                    id={'interviewByResponseList_new'}
-                    target="_blank"
-                    rel="noreferrer"
-                    onClick={(e) => {
-                        e.preventDefault();
-                        dispatch({
-                            type: 'createNew',
-                            username: `telephone_${(Math.ceil(Math.random() * 8999) + 1000).toString()}`,
-                            queryData: props.queryData
-                        });
-                    }}
-                >
-                    {props.t('admin:interviewSearch:CreateNew')}
-                </a>
-            )}
-            {state.status === 'creating' && <InterviewsCreateNew />}
+            <InterviewsCreateLink queryData={props.queryData} />
         </ul>
     );
 };

--- a/packages/evolution-frontend/src/components/pageParts/interviews/InterviewsCreateLink.tsx
+++ b/packages/evolution-frontend/src/components/pageParts/interviews/InterviewsCreateLink.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import React from 'react';
+import { WithTranslation, withTranslation } from 'react-i18next';
+import InterviewsCreateNew from './InterviewsCreateNew';
+import { InterviewContext } from '../../../contexts/InterviewContext';
+import { URLSearchParams } from 'url';
+
+type InterviewCreateLinkProps = {
+    queryData: URLSearchParams;
+};
+
+const InterviewCreateLink: React.FunctionComponent<WithTranslation & InterviewCreateLinkProps> = (
+    props: WithTranslation & InterviewCreateLinkProps
+) => {
+    const { state, dispatch } = React.useContext(InterviewContext);
+
+    if (state.status !== 'creating') {
+        return (
+            <a
+                href=""
+                id={'interviewByResponseList_new'}
+                target="_blank"
+                rel="noreferrer"
+                onClick={(e) => {
+                    e.preventDefault();
+                    dispatch({
+                        type: 'createNew',
+                        username: `telephone_${(Math.ceil(Math.random() * 8999) + 1000).toString()}`,
+                        queryData: props.queryData
+                    });
+                }}
+            >
+                {props.t('admin:interviewSearch:CreateNew')}
+            </a>
+        );
+    } else {
+        return <InterviewsCreateNew />;
+    }
+};
+
+/** Component used to add a link to create a new interview */
+export default withTranslation(['admin', 'main'])(InterviewCreateLink);

--- a/packages/evolution-frontend/src/components/pages/InterviewsByAccessCode.tsx
+++ b/packages/evolution-frontend/src/components/pages/InterviewsByAccessCode.tsx
@@ -9,7 +9,7 @@ import { withTranslation, WithTranslation } from 'react-i18next';
 import { History } from 'history';
 import Loadable from 'react-loadable';
 import Loader from 'react-spinners/HashLoader';
-import { InterviewContext, interviewReducer, initialState } from '../../contexts/InterviewContext';
+import { InterviewContext } from '../../contexts/InterviewContext';
 import InputString from 'chaire-lib-frontend/lib/components/input/InputString';
 import { Link, RouteComponentProps } from 'react-router-dom';
 import { _booleish } from 'chaire-lib-common/lib/utils/LodashExtensions';

--- a/packages/evolution-frontend/src/components/pages/InterviewsPage.tsx
+++ b/packages/evolution-frontend/src/components/pages/InterviewsPage.tsx
@@ -6,13 +6,22 @@
  */
 import React from 'react';
 import { withTranslation, WithTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
+import { Link, RouteComponentProps } from 'react-router-dom';
+import InterviewsCreateLink from '../pageParts/interviews/InterviewsCreateLink';
 
-export const InterviewsPage: React.FunctionComponent<WithTranslation> = (props: WithTranslation) => (
-    <div className="admin">
-        {props.t('admin:interviewers:InterviewersPage')} -{' '}
-        <Link to={'/interviews/byCode'}>{props.t('admin:interviewSearch:SearchByCode')}</Link>
-    </div>
-);
+export const InterviewsPage: React.FunctionComponent<WithTranslation & RouteComponentProps> = (
+    props: WithTranslation & RouteComponentProps
+) => {
+    const urlSearch = new URLSearchParams(props.location.search);
+    return (
+        <div className="admin">
+            <div className="survey-section__content apptr__form-container">
+                <h1>{props.t('admin:interviewers:InterviewsSearchAndEdit')}</h1>
+                <Link to={'/interviews/byCode'}>{props.t('admin:interviewSearch:SearchByCode')}</Link>
+                <InterviewsCreateLink queryData={urlSearch} />
+            </div>
+        </div>
+    );
+};
 
 export default withTranslation(['admin'])(InterviewsPage);


### PR DESCRIPTION
Add a component for the interview creation link and dispatch call

Prettify the main page accessible at `/interviews` in the admin section. It is now possible to create a new interview directly from this page.

Use the creation link component in the interview search list