### PR TITLE
InputMapGoogle: Add the platform to the point properties

### DIFF
--- a/packages/evolution-frontend/package.json
+++ b/packages/evolution-frontend/package.json
@@ -30,6 +30,7 @@
     "@react-google-maps/api": "^2.12.1",
     "@turf/turf": "^6.3.0",
     "@zeit/fetch-retry": "^5.0.1",
+    "bowser": "^2.10.0",
     "chaire-lib-common": "^0.2.2",
     "chaire-lib-frontend": "^0.2.2",
     "date-fns": "^2.29.1",

--- a/packages/evolution-frontend/src/components/inputs/maps/InputMapTypes.tsx
+++ b/packages/evolution-frontend/src/components/inputs/maps/InputMapTypes.tsx
@@ -11,6 +11,7 @@ export interface FeatureGeocodedProperties {
     geocodingResultMetadata?: { [key: string]: any };
     geocodingResultsData?: { [key: string]: any };
     isGeocodingImprecise?: boolean;
+    platform?: string;
 }
 
 export type PlaceGeocodedProperties = FeatureGeocodedProperties & {

--- a/packages/evolution-frontend/src/components/inputs/maps/google/InputMapGoogle.tsx
+++ b/packages/evolution-frontend/src/components/inputs/maps/google/InputMapGoogle.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 import { GoogleMap, useJsApiLoader, Marker } from '@react-google-maps/api';
 import GeoJSON from 'geojson';
+import bowser from 'bowser';
 
 import projectConfig from 'chaire-lib-common/lib/config/shared/project.config';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
@@ -101,6 +102,7 @@ const InputMapGoogle: React.FunctionComponent<InputGoogleMapPointProps> = (props
             if (geojsonValue) {
                 geojsonValue.properties.lastAction = triggerEvent;
                 geojsonValue.properties.zoom = (map as google.maps.Map).getZoom();
+                geojsonValue.properties.platform = bowser.getParser(window.navigator.userAgent).getPlatformType();
             }
             changeValueAndPan(geojsonValue);
         },


### PR DESCRIPTION
fixes #219

Adds the platform type when a point on the map is dragged or clicked