### PR TITLE
add a way to keep the assigned value intact

### DIFF
--- a/packages/evolution-common/src/services/widgets/WidgetConfig.ts
+++ b/packages/evolution-common/src/services/widgets/WidgetConfig.ts
@@ -319,6 +319,14 @@ export type QuestionWidgetConfig<CustomSurvey, CustomHousehold, CustomHome, Cust
     path: InterviewResponsePath<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
     containsHtml?: boolean;
     label: I18nData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
+
+    /**
+    * When the conditional triggers a hide status and then a show status later on,
+    * instead of reverting to default or empty value, use the assigned value of the conditional:
+    * this is useful when we want to hide a widget but keep its assigned value intact after hide/show toggle.
+    */
+    useAssignedValueOnHide?: boolean;
+
     helpPopup?: {
         title: I18nData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;
         content: I18nData<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>;

--- a/packages/evolution-frontend/src/actions/utils/WidgetOperation.ts
+++ b/packages/evolution-frontend/src/actions/utils/WidgetOperation.ts
@@ -159,7 +159,7 @@ const prepareSimpleWidget = <CustomSurvey, CustomHousehold, CustomHome, CustomPe
             value === undefined ||
             (widgetConfig.updateDefaultValueWhenResponded === true && !pointHasMoved))
     ) {
-        const defaultValue = surveyHelper.parse(widgetConfig.defaultValue, data.interview, path, data.user);
+        const defaultValue = widgetConfig.useAssignedValueOnHide && !_isBlank(assignedValue) ? assignedValue : surveyHelper.parse(widgetConfig.defaultValue, data.interview, path, data.user);
         if (value !== defaultValue) {
             surveyHelper.setResponse(data.interview, path, defaultValue);
             data.valuesByPath['responses.' + path] = defaultValue;


### PR DESCRIPTION
when toggling between hide/show conditional status, this is useful if you want to use two different widget questions for the same value, and toggle between them according to a condition. Without this config, whenever the condition is switched back to show after a hide, the hide assigned value is replaced by the default or empty value. This is also useful to hide a question when a condition is met, but keep its assigned value active between hide and show toggles