### PR TITLE
disable form submit default so it does not trigger on any key

### DIFF
--- a/packages/evolution-legacy/src/components/survey/Survey.js
+++ b/packages/evolution-legacy/src/components/survey/Survey.js
@@ -173,7 +173,7 @@ export class Survey extends React.Component {
                   containsHtml       = {false}
                 />
               </div>)}
-              <form onSubmit={(e) => { if (e.key === 'enter' || e.which === 13 ) { e.preventDefault(); }}} className="apptr__form" id="survey_form" style={customStyle} autocomplete="off">
+              <form onSubmit={(e) => e.preventDefault() } className="apptr__form" id="survey_form" style={customStyle} autocomplete="off">
                 <SectionComponent
                   key                         = {sectionShortname}
                   loadingState                = {this.props.loadingState}


### PR DESCRIPTION
we do not use the submit event at all, since buttons have their own onClick actions, and the enter/space key trigger on these button is correctly sent to onClick action for screen readers and ARIA