### PR TITLE
validations: Change how interviews are frozen

### DIFF
--- a/locales/en/admin.json
+++ b/locales/en/admin.json
@@ -49,6 +49,7 @@
   "validatorComment": "Validator comment",
   "refreshValidationList": "Refresh list",
   "unauthorized": "You are not authorized to access these data",
+  "ValidationDataDirty": "Respondent data was modified since copied for validation. You may click the reset button to fetch the respondent's responses again.",
   "user": {
     "Username": "Username",
     "Email": "Email",

--- a/locales/fr/admin.json
+++ b/locales/fr/admin.json
@@ -49,6 +49,7 @@
   "validatorComment": "Commentaire de validation",
   "refreshValidationList": "Rafraîchir la liste",
   "unauthorized": "Vous n'êtes pas autorisé à accéder à ces données",
+  "ValidationDataDirty": "Les réponses du participant ont été modifiées depuis la copie pour validation. Vous pouvez cliquer sur l'icône de réinitialisation pour re-copier les données de l'enquête du participant.",
   "user": {
     "Username": "Nom d'utilisateur",
     "Email": "Courriel",

--- a/packages/evolution-backend/src/api/survey.validation.routes.ts
+++ b/packages/evolution-backend/src/api/survey.validation.routes.ts
@@ -87,8 +87,7 @@ router.post(
                     'validations',
                     'audits',
                     'is_valid',
-                    'is_completed',
-                    'is_frozen'
+                    'is_completed'
                 ];
                 interview.responses._updatedAt = timestamp;
                 const retInterview = await updateInterview<unknown, unknown, unknown, unknown>(interview, {

--- a/packages/evolution-backend/src/api/survey.validation.routes.ts
+++ b/packages/evolution-backend/src/api/survey.validation.routes.ts
@@ -40,7 +40,16 @@ router.get(
                     const { responses, validated_data, ...rest } = interview;
                     return res.status(200).json({
                         status: 'success',
-                        interview: { responses: validated_data, _responses: responses, ...rest }
+                        interview: {
+                            responses: validated_data,
+                            _responses: responses,
+                            ...rest,
+                            validationDataDirty:
+                                responses._updatedAt !== undefined &&
+                                interview.is_frozen !== true &&
+                                (validated_data?._validatedDataCopiedAt === undefined ||
+                                    validated_data._validatedDataCopiedAt < responses._updatedAt)
+                        }
                     });
                 } else {
                     return res.status(500).json({ status: 'failed', interview: null });

--- a/packages/evolution-backend/src/models/migrations/20230912214500_changeInterviewFreeze.ts
+++ b/packages/evolution-backend/src/models/migrations/20230912214500_changeInterviewFreeze.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { Knex } from 'knex';
+
+const interviewsTbl = 'sv_interviews';
+
+export async function up(knex: Knex): Promise<unknown> {
+    // Unfreeze interviews that are frozen, but are not marked as valid or completed
+    return await knex(interviewsTbl)
+        .update({ is_frozen: false })
+        .whereNull('is_valid')
+        .whereNull('is_completed')
+        .andWhere('is_frozen', true);
+}
+
+export async function down(knex: Knex): Promise<unknown> {
+    // Freeze any unfrozen interview that has validated_data set
+    return await knex(interviewsTbl)
+        .update({ is_frozen: true })
+        .whereNotNull('validated_data')
+        .andWhere('is_frozen', false);
+}

--- a/packages/evolution-backend/src/services/interviews/__tests__/interview.test.ts
+++ b/packages/evolution-backend/src/services/interviews/__tests__/interview.test.ts
@@ -226,6 +226,78 @@ describe('Update Interview', () => {
         expect(interviewsQueries.update).toHaveBeenCalledWith(testAttributes.uuid, expectedUpdatedValues);
     });
 
+    test('With completed', async() => {
+        // Test with true value
+        let testAttributes = _cloneDeep(interviewAttributes);
+        let valuesByPath = { 'is_completed': true };
+        let interview = await updateInterview(testAttributes, { valuesByPath, fieldsToUpdate: ['is_completed'] });
+        expect(interview.interviewId).toEqual(testAttributes.uuid);
+        expect(interview.serverValidations).toEqual(true);
+        expect(interviewsQueries.update).toHaveBeenCalledTimes(1);
+        expect(mockedServerValidate).toHaveBeenCalledTimes(1);
+        expect(mockedServerValidate).toHaveBeenCalledWith(undefined, valuesByPath, []);
+        expect(mockedServerUpdate).toHaveBeenCalledTimes(1);
+        expect(mockedServerUpdate).toHaveBeenCalledWith(testAttributes, [], { is_completed: true }, undefined);
+
+        expect(interviewsQueries.update).toHaveBeenCalledWith(testAttributes.uuid, { is_completed: true, is_frozen: true });
+
+        // Test with false value
+        testAttributes = _cloneDeep(interviewAttributes);
+        valuesByPath = { 'is_completed': false };
+        interview = await updateInterview(testAttributes, { valuesByPath, fieldsToUpdate: ['is_completed'] });
+        expect(interview.interviewId).toEqual(testAttributes.uuid);
+        expect(interview.serverValidations).toEqual(true);
+        expect(interviewsQueries.update).toHaveBeenCalledTimes(2);
+
+        expect(interviewsQueries.update).toHaveBeenCalledWith(testAttributes.uuid, { is_completed: false, is_frozen: true });
+
+        // Test with null value
+        testAttributes = _cloneDeep(interviewAttributes);
+        valuesByPath = { 'is_completed': null } as any;
+        interview = await updateInterview(testAttributes, { valuesByPath, fieldsToUpdate: ['is_completed'] });
+        expect(interview.interviewId).toEqual(testAttributes.uuid);
+        expect(interview.serverValidations).toEqual(true);
+        expect(interviewsQueries.update).toHaveBeenCalledTimes(3);
+
+        expect(interviewsQueries.update).toHaveBeenCalledWith(testAttributes.uuid, { is_completed: null });
+    });
+
+    test('With valid', async() => {
+        // Test with true value
+        let testAttributes = _cloneDeep(interviewAttributes);
+        let valuesByPath = { 'is_valid': true };
+        let interview = await updateInterview(testAttributes, { valuesByPath, fieldsToUpdate: ['is_valid'] });
+        expect(interview.interviewId).toEqual(testAttributes.uuid);
+        expect(interview.serverValidations).toEqual(true);
+        expect(interviewsQueries.update).toHaveBeenCalledTimes(1);
+        expect(mockedServerValidate).toHaveBeenCalledTimes(1);
+        expect(mockedServerValidate).toHaveBeenCalledWith(undefined, valuesByPath, []);
+        expect(mockedServerUpdate).toHaveBeenCalledTimes(1);
+        expect(mockedServerUpdate).toHaveBeenCalledWith(testAttributes, [], { is_valid: true }, undefined);
+
+        expect(interviewsQueries.update).toHaveBeenCalledWith(testAttributes.uuid, { is_valid: true, is_frozen: true });
+
+        // Test with false value
+        testAttributes = _cloneDeep(interviewAttributes);
+        valuesByPath = { 'is_valid': false };
+        interview = await updateInterview(testAttributes, { valuesByPath, fieldsToUpdate: ['is_valid'] });
+        expect(interview.interviewId).toEqual(testAttributes.uuid);
+        expect(interview.serverValidations).toEqual(true);
+        expect(interviewsQueries.update).toHaveBeenCalledTimes(2);
+
+        expect(interviewsQueries.update).toHaveBeenCalledWith(testAttributes.uuid, { is_valid: false, is_frozen: true });
+
+        // Test with null value
+        testAttributes = _cloneDeep(interviewAttributes);
+        valuesByPath = { 'is_valid': null } as any;
+        interview = await updateInterview(testAttributes, { valuesByPath, fieldsToUpdate: ['is_valid'] });
+        expect(interview.interviewId).toEqual(testAttributes.uuid);
+        expect(interview.serverValidations).toEqual(true);
+        expect(interviewsQueries.update).toHaveBeenCalledTimes(3);
+
+        expect(interviewsQueries.update).toHaveBeenCalledWith(testAttributes.uuid, { is_valid: null });
+    });
+
     test('With no field to be updated', async() => {
         const testAttributes = _cloneDeep(interviewAttributes);
         const interview = await updateInterview(testAttributes, { valuesByPath: { 'notAnInterviewField': 'abc' } });
@@ -411,9 +483,8 @@ describe('copyResponsesToValidatedData', () => {
         await copyResponsesToValidatedData(testAttributes);
         expect(testAttributes.validated_data).toEqual(expect.objectContaining(testAttributes.responses));
         expect(testAttributes.validated_data?._validatedDataCopiedAt).toBeDefined();
-        expect(testAttributes.is_frozen).toEqual(true);
         expect(mockUpdate).toHaveBeenCalledTimes(1);
-        expect(mockUpdate).toHaveBeenCalledWith(testAttributes.uuid, { is_frozen: true, validated_data: testAttributes.validated_data });
+        expect(mockUpdate).toHaveBeenCalledWith(testAttributes.uuid, { validated_data: testAttributes.validated_data });
     });
 
     test('Copy with existing validation data', async() => {
@@ -432,8 +503,7 @@ describe('copyResponsesToValidatedData', () => {
         expect(testAttributes.validated_data).toEqual(expect.objectContaining(testAttributes.responses));
         expect(testAttributes.validated_data?._validatedDataCopiedAt).toBeDefined();
         expect(testAttributes.validated_data?._validatedDataCopiedAt).not.toEqual(originalTimestamp);
-        expect(testAttributes.is_frozen).toEqual(true);
-        expect(mockUpdate).toHaveBeenCalledWith(testAttributes.uuid, { is_frozen: true, validated_data: testAttributes.validated_data });
+        expect(mockUpdate).toHaveBeenCalledWith(testAttributes.uuid, { validated_data: testAttributes.validated_data });
     });
 
     test('Copy with existing and comment', async() => {
@@ -455,8 +525,7 @@ describe('copyResponsesToValidatedData', () => {
         expect(testAttributes.validated_data).toEqual(expect.objectContaining(testAttributes.responses));
         expect(testAttributes.validated_data._validationComment).toEqual(validationComment);
         expect(testAttributes.validated_data?._validatedDataCopiedAt).toBeDefined();
-        expect(testAttributes.is_frozen).toEqual(true);
-        expect(mockUpdate).toHaveBeenCalledWith(testAttributes.uuid, { is_frozen: true, validated_data: testAttributes.validated_data });
+        expect(mockUpdate).toHaveBeenCalledWith(testAttributes.uuid, { validated_data: testAttributes.validated_data });
     });
 
 });

--- a/packages/evolution-common/src/services/interviews/interview.ts
+++ b/packages/evolution-common/src/services/interviews/interview.ts
@@ -129,6 +129,7 @@ type ValidatedResponses<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>
     CustomHome,
     CustomPerson
 > & {
+    _validatedDataCopiedAt?: number;
     _validationComment?: string;
 };
 

--- a/packages/evolution-legacy/src/actions/survey/survey.js
+++ b/packages/evolution-legacy/src/actions/survey/survey.js
@@ -47,6 +47,13 @@ export const updateSection = updateSectionTs;
 export const startUpdateInterview = startUpdateInterviewTs;
 export const updateInterview = updateInterviewTs;
 
+/**
+ * Fetch an interview from server and set it for edition in validation mode.
+ * 
+ * @param {*} interviewUuid The uuid of the interview to open
+ * @param {*} callback 
+ * @returns 
+ */
 export const startSetSurveyValidateInterview = (interviewUuid, callback = function() {}) => {
   return (dispatch, getState) => {
     return fetch(`/api/survey/validateInterview/${interviewUuid}`, {
@@ -82,33 +89,15 @@ export const startSetSurveyValidateInterview = (interviewUuid, callback = functi
   };
 };
 
-export const startResetSurveyValidateInterview = (interviewUuid, callback = function() {}) => {
-  return (dispatch, getState) => {
-    return fetch(`/api/survey/validateInterview/${interviewUuid}`, {
-      credentials: 'include'
-    })
-    .then((response) => {
-
-      if (response.status === 200) {
-        response.json().then((body) => {
-          if (body.interview)
-          {
-            const interview     = body.interview;
-            interview.responses = _cloneDeep(interview._responses);
-            dispatch(startUpdateSurveyValidateInterview('home', {
-              responses: _cloneDeep(interview._responses),
-              is_frozen: true
-            }, null, interview, callback));
-          }
-        });
-      }
-    })
-    .catch((err) => {
-      surveyHelperNew.devLog('Error fetching interview to reset.', err);
-    });
-  };
-};
-
+/**
+ * Fetch an interview from server and set it for display in a one page summary.
+ * 
+ * TODO Only the section ('home', 'validationOnePager') is different from 'startSetSurveyValidateInterview' Re-use
+ * 
+ * @param {*} interviewUuid The uuid of the interview to open
+ * @param {*} callback 
+ * @returns 
+ */
 export const startSetValidateInterview = (interviewUuid, callback = function() {}) => {
   return (dispatch, getState) => {
     return fetch(`/api/survey/validateInterview/${interviewUuid}`, {
@@ -144,6 +133,14 @@ export const startSetValidateInterview = (interviewUuid, callback = function() {
   };
 };
 
+/**
+ * Fetch an interview from server and re-initialize the validated_data to the
+ * participant's responses, but keeping the validation comments.
+ *
+ * @param {*} interviewUuid The uuid of the interview to open
+ * @param {*} callback 
+ * @returns 
+ */
 export const startResetValidateInterview = (interviewUuid, callback = function() {}) => {
   return (dispatch, getState) => {
     return fetch(`/api/survey/validateInterview/${interviewUuid}`, {

--- a/packages/evolution-legacy/src/actions/survey/survey.js
+++ b/packages/evolution-legacy/src/actions/survey/survey.js
@@ -66,18 +66,7 @@ export const startSetSurveyValidateInterview = (interviewUuid, callback = functi
           if (body.interview)
           {
             const interview = body.interview;
-            if (interview.is_frozen !== true) // we put validated_data into responses and responses into _responses
-            {
-              interview.responses = _cloneDeep(interview._responses);
-              dispatch(startUpdateSurveyValidateInterview('home', {
-                responses: _cloneDeep(interview._responses),
-                is_frozen: true
-              }, null, interview, callback));
-            }
-            else
-            {
-              dispatch(startUpdateSurveyValidateInterview('home', {}, null, interview, callback));
-            }
+            dispatch(startUpdateSurveyValidateInterview('home', {}, null, interview, callback));
 
           }
         });
@@ -110,18 +99,7 @@ export const startSetValidateInterview = (interviewUuid, callback = function() {
           if (body.interview)
           {
             const interview = body.interview;
-            if (interview.is_frozen !== true) // we put validated_data into responses and responses into _responses
-            {
-              interview.responses = _cloneDeep(interview._responses);
-              dispatch(startUpdateValidateInterview('validationOnePager', {
-                responses: _cloneDeep(interview._responses),
-                is_frozen: true
-              }, null, interview, callback));
-            }
-            else
-            {
-              dispatch(startUpdateValidateInterview('validationOnePager', {}, null, interview, callback));
-            }
+            dispatch(startUpdateValidateInterview('validationOnePager', {}, null, interview, callback));
 
           }
         });
@@ -143,7 +121,7 @@ export const startSetValidateInterview = (interviewUuid, callback = function() {
  */
 export const startResetValidateInterview = (interviewUuid, callback = function() {}) => {
   return (dispatch, getState) => {
-    return fetch(`/api/survey/validateInterview/${interviewUuid}`, {
+    return fetch(`/api/survey/validateInterview/${interviewUuid}?reset=true`, {
       credentials: 'include'
     })
     .then((response) => {
@@ -153,17 +131,7 @@ export const startResetValidateInterview = (interviewUuid, callback = function()
           if (body.interview)
           {
             const interview     = body.interview;
-            // TODO This should be done server side and the copy to validated_data should include the audit
-            // Keep the _validationComment from current responses, then copy original responses
-            const validationComment = interview.responses ? interview.responses._validationComment : undefined;
-            interview.responses = _cloneDeep(interview._responses);
-            if (validationComment) {
-                interview.responses._validationComment = validationComment;
-            }
-            dispatch(startUpdateValidateInterview('validationOnePager', {
-              responses: _cloneDeep(interview.responses),
-              is_frozen: true
-            }, null, interview, callback));
+            dispatch(startUpdateValidateInterview('validationOnePager', {}, null, interview, callback));
           }
         });
       }

--- a/packages/evolution-legacy/src/components/admin/ValidateSurvey.js
+++ b/packages/evolution-legacy/src/components/admin/ValidateSurvey.js
@@ -17,7 +17,7 @@ import Section                from '../survey/Section';
 import SectionNav             from '../survey/SectionNav';
 import { withSurveyContext } from 'evolution-frontend/lib/components/hoc/WithSurveyContextHoc';
 import LoadingPage            from '../shared/LoadingPage';
-import { startSetSurveyValidateInterview, startUpdateSurveyValidateInterview, startResetSurveyValidateInterview, startSurveyValidateAddGroupedObjects, startSurveyValidateRemoveGroupedObjects } from '../../actions/survey/survey';
+import { startSetSurveyValidateInterview, startUpdateSurveyValidateInterview, startSurveyValidateAddGroupedObjects, startSurveyValidateRemoveGroupedObjects } from '../../actions/survey/survey';
 import { InterviewContext } from 'evolution-frontend/lib/contexts/InterviewContext';
 
 export class ValidateSurvey extends React.Component {
@@ -208,7 +208,6 @@ const mapStateToProps = (state, props) => {
 const mapDispatchToProps = (dispatch, props) => ({
   startSetSurveyValidateInterview: (interviewUuid, callback)                                                 => dispatch(startSetSurveyValidateInterview(interviewUuid, callback)),
   startUpdateInterview           : (sectionShortname, valuesByPath, unsetPaths, interview, callback)         => dispatch(startUpdateSurveyValidateInterview(sectionShortname, valuesByPath, unsetPaths, interview, callback)),
-  startResetValidateInterview    : (interviewUuid, callback)                                                 => dispatch(startResetSurveyValidateInterview(interviewUuid, callback)),
   startAddGroupedObjects         : (newObjectsCount, insertSequence, path, attributes, callback, returnOnly) => dispatch(startSurveyValidateAddGroupedObjects(newObjectsCount, insertSequence, path, attributes, callback, returnOnly)),
   startRemoveGroupedObjects      : (paths, callback, returnOnly)                                             => dispatch(startSurveyValidateRemoveGroupedObjects(paths, callback, returnOnly))
 });

--- a/packages/evolution-legacy/src/components/admin/validation/InterviewSummary.js
+++ b/packages/evolution-legacy/src/components/admin/validation/InterviewSummary.js
@@ -9,7 +9,7 @@ import { withTranslation } from 'react-i18next';
 
 import { _isBlank }     from 'chaire-lib-common/lib/utils/LodashExtensions';
 import LoadingPage      from '../../shared/LoadingPage';
-import ValidationSurvey from './ValidationSurvey';
+import ValidationOnePageSummary from './ValidationOnePageSummary';
 
 class InterviewSummary extends React.Component {
   constructor(props) {
@@ -27,7 +27,7 @@ class InterviewSummary extends React.Component {
 
     return (
       <div className="admin-widget-container">
-        <ValidationSurvey
+        <ValidationOnePageSummary
           key                          = {this.props.interview.uuid}
           interviewUuid                = {this.props.interview.uuid}
           prevInterviewUuid            = {this.props.prevInterviewUuid}

--- a/packages/evolution-legacy/src/components/admin/validation/ValidationOnePageSummary.js
+++ b/packages/evolution-legacy/src/components/admin/validation/ValidationOnePageSummary.js
@@ -26,7 +26,7 @@ import * as surveyHelperNew from 'evolution-common/lib/utils/helpers';
 import  { secondsSinceMidnightToTimeStr } from 'chaire-lib-common/lib/utils/DateTimeUtils';
 import Section from '../../survey/Section';
 import { withSurveyContext } from 'evolution-frontend/lib/components/hoc/WithSurveyContextHoc';
-import ConfirmModal from '../../survey/modal/ConfirmModal';
+import FormErrors from 'chaire-lib-frontend/lib/components/pageParts/FormErrors';
 import LoadingPage from '../../shared/LoadingPage';
 import ValidationLinks from './ValidationLinks';
 import { startSetValidateInterview, startUpdateValidateInterview, startResetValidateInterview, startValidateAddGroupedObjects, startValidateRemoveGroupedObjects } from '../../../actions/survey/survey';
@@ -564,6 +564,10 @@ export class ValidationOnePageSummary extends React.Component {
                                     user={this.props.user}
                                     t={this.props.t}
                                 />
+                                { this.props.interview.validationDataDirty && <FormErrors
+                                    errors={[this.props.t(['admin:ValidationDataDirty'])]}
+                                    errorType="Warning"
+                                />}
                                 {household && <InterviewStats
                                     key={this.props.interview.id}
                                     selectPlace={this.selectPlace}

--- a/packages/evolution-legacy/src/components/admin/validation/ValidationOnePageSummary.js
+++ b/packages/evolution-legacy/src/components/admin/validation/ValidationOnePageSummary.js
@@ -48,7 +48,7 @@ if (InterviewMap === undefined) {
 let validations = appConfig.getAdminValidations();
 console.log('validations', validations);
 
-export class ValidationSurvey extends React.Component {
+export class ValidationOnePageSummary extends React.Component {
     static contextType = InterviewContext;
 
     constructor(props) {
@@ -611,4 +611,4 @@ const mapDispatchToProps = (dispatch, props) => ({
 export default connect(
     mapStateToProps,
     mapDispatchToProps
-)(withTranslation()(withSurveyContext(ValidationSurvey)));
+)(withTranslation()(withSurveyContext(ValidationOnePageSummary)));


### PR DESCRIPTION
fixes #238, fixes #239, fixes #240

* Move the copy to validated_data to a single backend function, and add the copy timestamp
* The backend now takes care to freeze the interviews whenever they are set as valid or completed by a validator, otherwise it can still be edited
* Add a migration to automatically unfreeze any interview whose valid/completed statuses are not set
* Add a warning in the one page summary if the responses were modified since the copy