### PR TITLE
Revert "InputRadioNumber: add auto focus tag"

### DIFF
--- a/packages/evolution-frontend/src/components/inputs/InputRadioNumber.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputRadioNumber.tsx
@@ -161,7 +161,6 @@ export const InputRadioNumber = <CustomSurvey, CustomHousehold, CustomHome, Cust
                                 <span>{t(['survey:SpecifyAboveLimit', 'main:SpecifyAboveLimit']) + ':'}</span>
                             </label>
                             <input
-                                autoFocus
                                 type="number"
                                 pattern="[0-9]*"
                                 className={`apptr__form-input apptr__input-string input-${

--- a/packages/evolution-frontend/src/components/inputs/__tests__/__snapshots__/InputRadioNumber.test.tsx.snap
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/__snapshots__/InputRadioNumber.test.tsx.snap
@@ -216,7 +216,6 @@ exports[`Render InputRadioNumber InputRadioNumber with selected value 1`] = `
       </span>
     </label>
     <input
-      autoFocus={true}
       className="apptr__form-input apptr__input-string input-large"
       defaultValue={4}
       id="testover-max"

--- a/packages/evolution-frontend/src/components/survey/__tests__/__snapshots__/Question.test.tsx.snap
+++ b/packages/evolution-frontend/src/components/survey/__tests__/__snapshots__/Question.test.tsx.snap
@@ -655,7 +655,6 @@ exports[`Question with widget InputRadioNumber Render widget 1`] = `
             </span>
           </label>
           <input
-            autoFocus={true}
             className="apptr__form-input apptr__input-string input-large"
             defaultValue={4}
             id="survey-question__home.regionover-max"


### PR DESCRIPTION
This reverts commit ce4b57d438c085a4ea932d8b64e7355184f61d51.

This interferes with the mechanism that is used to automatically focus on an invalid question on page load. Having the autoFocus tag here means that the survey focuses on this text field instead, which is not desirable.