### PR TITLE
db: Use onConflict to upsert in interviews accesses

### DIFF
--- a/packages/evolution-backend/src/models/__tests__/interviewsAccesses.db.test.ts
+++ b/packages/evolution-backend/src/models/__tests__/interviewsAccesses.db.test.ts
@@ -85,7 +85,7 @@ describe('userOpenedInterview', () => {
     });
 
     test('User opened existing interview once more', async() => {
-        expect(await dbQueries.userOpenedInterview({ interviewUuid: localUserInterviewAttributes.uuid, userId: localUser.id })).toEqual(false);
+        expect(await dbQueries.userOpenedInterview({ interviewUuid: localUserInterviewAttributes.uuid, userId: localUser.id })).toEqual(true);
         await assertAccessCounts(1);
     });
 


### PR DESCRIPTION
fixes #251

On conflict, ignore the insert when opening an interview and update the count when updating the interview