### PR TITLE
Renommer le domaine exemple.com en example.com (voir RFC 2606).

### DIFF
--- a/locales/fr/auth.json
+++ b/locales/fr/auth.json
@@ -61,5 +61,5 @@
   "PasswordlessHeader": "Veuillez entrer une adresse courriel pour continuer",
   "UseAnonymousLogin": "Se connecter de façon anonyme",
   "Email": "Par courriel",
-  "EmailPlaceholder": "exemple@exemple.com"
+  "EmailPlaceholder": "exemple@example.com"
 }


### PR DESCRIPTION
Voir <https://www.rfc-editor.org/rfc/rfc2606.html#section-3>

```exemple.com``` mène à un site parké/suspect.