### PR TITLE
admin: Support materialized views for monitoring

### DIFF
--- a/packages/evolution-backend/src/models/__tests__/adminViews.db.test.ts
+++ b/packages/evolution-backend/src/models/__tests__/adminViews.db.test.ts
@@ -1,0 +1,278 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import knex from 'chaire-lib-backend/lib/config/shared/db.config';
+import { v4 as uuidV4 } from 'uuid';
+import _cloneDeep from 'lodash/cloneDeep';
+import { create, truncate } from 'chaire-lib-backend/lib/models/db/default.db.queries';
+
+import dbQueries from '../adminViews.db.queries';
+import interviewsDbQueries from '../interviews.db.queries';
+
+const viewName = 'test_view';
+
+const localParticipant = {
+    id: 1,
+    email: 'test@transition.city',
+    is_valid: true
+};
+
+const otherParticipant = {
+    id: 2,
+    is_valid: true,
+    google_id: '1234'
+};
+
+const localUserInterviewAttributes = {
+    uuid: uuidV4(),
+    participant_id: localParticipant.id,
+    is_valid: false,
+    is_active: true,
+    is_completed: undefined,
+    responses: {
+        accessCode: '11111',
+        booleanField: true,
+    },
+    validations: {},
+    logs: [],
+    audits: { errorOne: 3, errorThree: 1 }
+};
+
+beforeAll(async () => {
+    jest.setTimeout(10000);
+    await knex.schema.dropMaterializedViewIfExists(viewName);
+    await truncate(knex, 'sv_materialized_views');
+    await truncate(knex, 'sv_interviews');
+    await truncate(knex, 'sv_participants');
+    await create(knex, 'sv_participants', undefined, localParticipant as any);
+    await create(knex, 'sv_participants', undefined, otherParticipant as any);
+    await truncate(knex, 'users');
+    await interviewsDbQueries.create(localUserInterviewAttributes);
+});
+
+afterAll(async() => {
+    await truncate(knex, 'sv_materialized_views');
+    await truncate(knex, 'sv_interviews');
+    await truncate(knex, 'users');
+    await truncate(knex, 'sv_participants');
+    await knex.schema.dropMaterializedViewIfExists(viewName);
+});
+
+describe('registerView', () => {
+
+    const defaultViewQuery = `select i.id, 
+        i.uuid,
+        i.participant_id,
+        i.is_valid,
+        i.is_completed,
+        CASE
+            WHEN part.google_id is not null THEN 'google'
+            WHEN part.email is null THEN 'anonymous'
+            else 'email'
+        END AS auth_method
+    from sv_interviews i
+    inner join sv_participants part on i.participant_id = part.id`;
+
+    test('Register a new view', async() => {
+        expect(await dbQueries.registerView(viewName, defaultViewQuery)).toEqual(true);
+        const data = await knex(viewName).select('*');
+        expect(data).toEqual([{
+            uuid: localUserInterviewAttributes.uuid,
+            id: expect.anything(),
+            participant_id: localUserInterviewAttributes.participant_id,
+            is_valid: localUserInterviewAttributes.is_valid,
+            is_completed: null,
+            auth_method: 'email'
+        }]);
+        expect(await dbQueries.viewExists(viewName)).toEqual(true);
+    });
+
+    test('Register a new view, with SQL error', async() => {
+        const errorViewName = 'errorView';
+        // Add a comma at the end of the view sql
+        await expect(dbQueries.registerView(errorViewName, `${defaultViewQuery},`))
+            .rejects
+            .toThrowError(expect.anything());
+        // The view should not exist in the database
+        expect(await dbQueries.viewExists(errorViewName)).toEqual(false);
+    });
+
+    test('Register an existing view, with same query', async() => {
+        const currentView = await knex('sv_materialized_views').where('view_name', viewName);
+        expect(await dbQueries.registerView(viewName, defaultViewQuery)).toEqual(true);
+
+        // Make sure the view was not updated
+        const viewAfterRegister = await knex('sv_materialized_views').where('view_name', viewName);
+        expect(viewAfterRegister[0].updated_at).toEqual(currentView[0].updated_at);
+
+        expect(await knex(viewName).select('*')).toEqual([{
+            uuid: localUserInterviewAttributes.uuid,
+            id: expect.anything(),
+            participant_id: localUserInterviewAttributes.participant_id,
+            is_valid: localUserInterviewAttributes.is_valid,
+            is_completed: null,
+            auth_method: 'email'
+        }]);
+        expect(await dbQueries.viewExists(viewName)).toEqual(true);
+    });
+
+    test('Register an existing view, with a SQL error', async() => {
+        // Add a comma at the end of the view sql
+        await expect(dbQueries.registerView(viewName, `${defaultViewQuery},`))
+            .rejects
+            .toThrowError(expect.anything());
+
+        // The view should still exist in the database and be equal to the previous
+        expect(await dbQueries.viewExists(viewName)).toEqual(true);
+        expect(await knex(viewName).select('*')).toEqual([{
+            uuid: localUserInterviewAttributes.uuid,
+            id: expect.anything(),
+            participant_id: localUserInterviewAttributes.participant_id,
+            is_valid: localUserInterviewAttributes.is_valid,
+            is_completed: null,
+            auth_method: 'email'
+        }])
+    });
+
+    test('Register an exiting view, with a different query', async() => {
+        // Use the same query, but rename the fields
+        const defaultViewQuery = `select i.id, 
+            i.uuid,
+            i.participant_id as part_id,
+            i.is_valid as valid,
+            i.is_completed as completed,
+            CASE
+                WHEN part.google_id is not null THEN 'google'
+                WHEN part.email is null THEN 'anonymous'
+                else 'email'
+            END AS auth
+        from sv_interviews i
+        inner join sv_participants part on i.participant_id = part.id`;
+
+        expect(await dbQueries.registerView(viewName, defaultViewQuery)).toEqual(true);
+        expect(await knex(viewName).select('*')).toEqual([{
+            uuid: localUserInterviewAttributes.uuid,
+            id: expect.anything(),
+            part_id: localUserInterviewAttributes.participant_id,
+            valid: localUserInterviewAttributes.is_valid,
+            completed: null,
+            auth: 'email'
+        }]);
+        expect(await dbQueries.viewExists(viewName)).toEqual(true);
+    });
+
+});
+
+test('Update database view', async () => {
+    const originalCount = 1;
+    // Validate initial state, there should be 1 interview
+    const data = await knex(viewName).select('*');
+    expect(data.length).toEqual(originalCount);
+
+    // Add an interview in the database
+    const newInterview = Object.assign({}, _cloneDeep(localUserInterviewAttributes), {
+        uuid: uuidV4(),
+        participant_id: otherParticipant.id,
+        is_completed: true
+    });
+    await interviewsDbQueries.create(newInterview);
+
+    // Make sure the view still has only 1 interview
+    const data2 = await knex(viewName).select('*');
+    expect(data2.length).toEqual(originalCount);
+
+    // Update the view, then make sure the new interview is now included
+    await dbQueries.refreshView(viewName);
+    const data3 = await knex(viewName).select('*');
+    expect(data3.length).toEqual(originalCount + 1);
+    
+});
+
+describe('Query view', () => {
+
+    test('Query all fields', async() => {
+        const data = await dbQueries.queryView(viewName);
+        expect(data).not.toEqual(false);
+        expect((data as any[]).length).toEqual(2);
+        expect(data[0]).toEqual({
+            uuid: localUserInterviewAttributes.uuid,
+            id: expect.anything(),
+            part_id: localUserInterviewAttributes.participant_id,
+            valid: localUserInterviewAttributes.is_valid,
+            completed: null,
+            auth: 'email'
+        });
+    });
+
+    test('Query only a subset of the fields', async() => {
+        const data = await dbQueries.queryView(viewName, ['id', 'auth']);
+        expect(data).not.toEqual(false);
+        expect((data as any[]).length).toEqual(2);
+        expect(data[0]).toEqual({
+            id: expect.anything(),
+            auth: 'email'
+        })
+    });
+
+    test('Query an unexisting view', async() => {
+        const data = await dbQueries.queryView('unexistingView');
+        expect(data).toEqual(false);
+    });
+
+    test('Query unexisting fields', async() => {
+        const data = await dbQueries.queryView(viewName, ['id', 'unexisting']);
+        expect(data).toEqual(false);
+    });
+
+});
+
+describe('Count by', () => {
+
+    test('Count by one field', async() => {
+        const data = await dbQueries.countByView(viewName, ['valid']);
+        expect(data).not.toEqual(false);
+        expect(data).toEqual([{
+            valid: localUserInterviewAttributes.is_valid,
+            count: 2
+        }])
+    });
+
+    test('Count by 2 fields', async() => {
+        const data = await dbQueries.countByView(viewName, ['id', 'auth']);
+        expect(data).not.toEqual(false);
+        expect((data as any[]).length).toEqual(2);
+        for (let i = 0; i < (data as any[]).length; i++) {
+            switch(data[i].auth) {
+                case 'email': expect(data[i]).toEqual({
+                    id: expect.anything(),
+                    auth: 'email',
+                    count: 1
+                });
+                break;
+                case 'google': expect(data[i]).toEqual({
+                    id: expect.anything(),
+                    auth: 'google',
+                    count: 1
+                });
+                break;
+                default:
+                    // Unexpected data
+                    expect(data[i]).toEqual(false);
+            }
+        }
+    });
+
+    test('Count on an unexisting view', async() => {
+        const data = await dbQueries.countByView('unexistingView', ['valid']);
+        expect(data).toEqual(false);
+    });
+
+    test('Count on unexisting fields', async() => {
+        const data = await dbQueries.countByView(viewName, ['id', 'unexisting']);
+        expect(data).toEqual(false);
+    });
+
+})

--- a/packages/evolution-backend/src/models/adminViews.db.queries.ts
+++ b/packages/evolution-backend/src/models/adminViews.db.queries.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import knex from 'chaire-lib-backend/lib/config/shared/db.config';
+import TrError from 'chaire-lib-common/lib/utils/TrError';
+
+const tableName = 'sv_materialized_views';
+
+const createView = async (viewName: string, viewQuery: string) => {
+    return await knex.transaction(async (trx) => {
+        await knex.schema
+            .createMaterializedView(viewName, (view) => {
+                view.as(knex.select('*').fromRaw(`(${viewQuery}) as viewTbl`));
+            })
+            .transacting(trx);
+        await knex(tableName).insert({ view_name: viewName, view_query: viewQuery }).transacting(trx);
+    });
+};
+
+const replaceView = async (viewName: string, viewQuery: string) => {
+    return await knex.transaction(async (trx) => {
+        await knex.schema.dropMaterializedViewIfExists(viewName).transacting(trx);
+        await knex.schema
+            .createMaterializedView(viewName, (view) => {
+                view.as(knex.select('*').fromRaw(`(${viewQuery}) as viewTbl`));
+            })
+            .transacting(trx);
+        await knex(tableName).update({ view_query: viewQuery }).where('view_name', viewName).transacting(trx);
+    });
+};
+
+const registerView = async (viewName: string, viewQuery: string) => {
+    try {
+        // Verify if the view exists in the view table
+        const adminView = await knex(tableName).where('view_name', viewName);
+
+        // If not, create the materialize view and register the view to the view table
+        if (adminView.length === 0) {
+            await createView(viewName, viewQuery);
+        } else if (adminView[0].view_query !== viewQuery) {
+            // If it exists, but the query is different, delete and re-create the view
+            await replaceView(viewName, viewQuery);
+        }
+
+        return true;
+    } catch (error) {
+        throw new TrError(
+            `Error registering view ${viewName} in database (knex error: ${error})`,
+            'DBADMV0001',
+            'CannotRegisterViewBecauseDatabaseError'
+        );
+    }
+};
+
+const viewExists = async (viewName: string) => {
+    try {
+        const adminView = await knex(tableName).where('view_name', viewName).select('id');
+        return adminView.length !== 0;
+    } catch (error) {
+        console.error(`Error querying the existence of admin view ${viewName}: (knex error: ${error})`);
+        return false;
+    }
+};
+
+/**
+ * Refresh the view content in the database (this re-executes the view query)
+ *
+ * @param viewName Name of the view to refresh
+ * @returns Whether the view was successfully refreshed or not
+ */
+const refreshView = async (viewName: string) => {
+    try {
+        if (!(await viewExists(viewName))) {
+            return false;
+        }
+        await knex.schema.refreshMaterializedView(viewName);
+        return true;
+    } catch (error) {
+        console.error(`Error updating view ${viewName} in database (knex error: ${error})`);
+        return false;
+    }
+};
+
+/**
+ * Query a view for various columns.
+ *
+ * Evolution does not control the views and their content. In case of errors or
+ * unexisting view, to avoid throwing exceptions, a value of `false` is
+ * returned.
+ *
+ * @param viewName The name of the view
+ * @param columns An array of columns to query
+ * @returns The records for this query, or `false` if any error occurred during
+ * the query
+ */
+const queryView = async (viewName: string, columns: string[] = []): Promise<{ [key: string]: unknown }[] | false> => {
+    try {
+        if (!(await viewExists(viewName))) {
+            return false;
+        }
+        return await knex(viewName).select(columns.length === 0 ? '*' : columns);
+    } catch (error) {
+        console.error(`Error querying view ${viewName} in database (knex error: ${error})`);
+        return false;
+    }
+};
+
+/**
+ * Query a view, with a group by and count
+ *
+ * Evolution does not control the views and their content. In case of errors or
+ * unexisting view, to avoid throwing exceptions, a value of `false` is
+ * returned.
+ *
+ * @param viewName The name of the view
+ * @param groupBy List of fields to group by
+ * @returns The records for this query, or `false` if any error occurred during
+ * the query
+ */
+const countByView = async (
+    viewName: string,
+    groupBy: string[]
+): Promise<{ count: number; [key: string]: unknown }[] | false> => {
+    try {
+        if (!(await viewExists(viewName))) {
+            return false;
+        }
+        const results = await knex(viewName)
+            .select(...groupBy)
+            .count()
+            .groupBy(groupBy);
+        return results.map(({ count, ...rest }) => ({ count: Number(count), ...rest }));
+    } catch (error) {
+        console.error(`Error counting in view ${viewName} in database (knex error: ${error})`);
+        return false;
+    }
+};
+
+export default {
+    registerView,
+    viewExists,
+    refreshView,
+    queryView,
+    countByView
+};

--- a/packages/evolution-backend/src/models/migrations/20231006093500_createAdminViewsTbl.ts
+++ b/packages/evolution-backend/src/models/migrations/20231006093500_createAdminViewsTbl.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { Knex } from 'knex';
+import { onUpdateTrigger } from '../../config/knexfile';
+
+const viewsTbl = 'sv_materialized_views';
+
+export async function up(knex: Knex): Promise<unknown> {
+    await knex.schema.createTable(viewsTbl, (table: Knex.TableBuilder) => {
+        table.increments();
+        table.string('view_name').unique();
+        table.text('view_query');
+        table.timestamps(true, true);
+    });
+    return knex.raw(onUpdateTrigger(viewsTbl));
+}
+
+export async function down(knex: Knex): Promise<unknown> {
+    const views = await knex(viewsTbl).select('view_name');
+    for (let i = 0; i < views.length; i++) {
+        await knex.schema.dropMaterializedViewIfExists(views[i].view_name);
+    }
+    return knex.schema.dropTable(viewsTbl);
+}


### PR DESCRIPTION
fixes #296

This adds support for materialized views in surveys. The server can register the view with the `registerView` method, with the corresponding SQL query at startup. If the view already exists, if verifies if the query is the same as previously. If not, the view will be dropped and re-created.

The view can be refreshed, queried with all or a subset of the fields, or using a groupBy/count query.

This commit just provides the API for view support. Surveys can then create their own views and query them. It will provide a less memory intensive way to parse all surveys for various information for monitoring purposes.