### PR TITLE
Validation one page summary: show smaller map to avoid text wrapping …

### DIFF
--- a/packages/evolution-legacy/src/styles/survey/_admin.scss
+++ b/packages/evolution-legacy/src/styles/survey/_admin.scss
@@ -114,11 +114,11 @@
 .admin__interview-map-and-stats-container {
   display: flex;
   .admin__interview-map-container {
-    width: 70%;
+    width: 50%;
     
   }
   .admin__stats-container {
-    width: 30%;
+    width: 50%;
     padding: 1rem;
   }
 }


### PR DESCRIPTION
…in info pane on the right

Before:

![image](https://github.com/chairemobilite/evolution/assets/545502/4db9d44a-57f3-42a9-b720-c3fd5cb92bb7)

After:
![image](https://github.com/chairemobilite/evolution/assets/545502/15d8f446-51e6-4072-813d-6f2d77cf0e6f)

Fixes https://github.com/chairemobilite/evolution/issues/306