### PR TITLE
db: Add an index on the responses.accessCode field

### DIFF
--- a/packages/evolution-backend/src/models/migrations/20231013123200_addAccessCodeIndex.ts
+++ b/packages/evolution-backend/src/models/migrations/20231013123200_addAccessCodeIndex.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { Knex } from 'knex';
+
+const interviewsTbl = 'sv_interviews';
+const indexName = 'idx_sv_interviews_access_code';
+
+export async function up(knex: Knex): Promise<unknown> {
+    return knex.schema.table(interviewsTbl, (table: Knex.TableBuilder) => {
+        table.index([knex.raw('("responses"->>\'accessCode\')')], indexName);
+    });
+}
+
+export async function down(knex: Knex): Promise<unknown> {
+    return knex.schema.table(interviewsTbl, (table: Knex.TableBuilder) => {
+        table.dropIndex(indexName);
+    });
+}


### PR DESCRIPTION
fixes #315

This increases performance of listing interviews by more than 10 times. From local benchmarks in a 15K record database, it does not affect perceptibly the performances of the responses updates or the survey flow. The database update/insert times are within 2% with/without the index, less than the normal variability.