### PR TITLE
remove more complex validations that should be in audits

### DIFF
--- a/packages/evolution-common/src/services/baseObjects/BaseHousehold.ts
+++ b/packages/evolution-common/src/services/baseObjects/BaseHousehold.ts
@@ -13,7 +13,6 @@ import * as HAttr from './attributeTypes/HouseholdAttributes';
 import { Uuidable } from './Uuidable';
 import { Vehicleable } from './Vehicleable';
 import { BaseVehicle } from './BaseVehicle';
-import { _isEmail } from 'chaire-lib-common/lib/utils/LodashExtensions';
 
 
 type BaseHouseholdAttributes = {
@@ -204,7 +203,7 @@ class BaseHousehold extends Uuidable implements IValidatable {
 
         // Validate category:
         if (dirtyParams.category !== undefined && typeof dirtyParams.category !== 'string') {
-            errors.push(new Error('BaseHousehold validateParams: category is not a valid household category'));
+            errors.push(new Error('BaseHousehold validateParams: category should be a string'));
         }
 
         // Validate wouldLikeToParticipateToOtherSurveys:
@@ -219,7 +218,7 @@ class BaseHousehold extends Uuidable implements IValidatable {
             } else {
                 for (let i = 0, countI = dirtyParams.homeCarParkings.length; i < countI; i++) {
                     if (typeof dirtyParams.homeCarParkings[i] !== 'string') {
-                        errors.push(new Error(`BaseHousehold validateParams: homeCarParkings index ${i} is not a valid home car parking type`));
+                        errors.push(new Error(`BaseHousehold validateParams: homeCarParkings index ${i} should be a string`));
                     }
                 }
             }
@@ -231,8 +230,8 @@ class BaseHousehold extends Uuidable implements IValidatable {
         }
 
         // Validate contactEmail:
-        if (dirtyParams.contactEmail !== undefined && !_isEmail(dirtyParams.contactEmail)) {
-            errors.push(new Error('BaseHousehold validateParams: contactEmail is invalid'));
+        if (dirtyParams.contactEmail !== undefined && typeof dirtyParams.contactEmail !== 'string') {
+            errors.push(new Error('BaseHousehold validateParams: contactEmail should be a string'));
         }
 
         return errors;

--- a/packages/evolution-common/src/services/baseObjects/BaseInterview.ts
+++ b/packages/evolution-common/src/services/baseObjects/BaseInterview.ts
@@ -12,7 +12,6 @@ import { Uuidable } from './Uuidable';
 import { BasePerson } from './BasePerson';
 import { BaseHousehold } from './BaseHousehold';
 import { BaseOrganization } from './BaseOrganization';
-import { _isEmail } from 'chaire-lib-common/lib/utils/LodashExtensions';
 
 export const devices = [
     'tablet',
@@ -122,6 +121,9 @@ export class BaseInterview extends Surveyable implements IValidatable {
 
     /**
      * Validates attribute types for BaseInterview.
+     * Any failing validation should prevent the creation of the object.
+     * Validations that should not prevent the creation of the object
+     * should be moved to survey audits.
      * @param dirtyParams The parameters to validate.
      * @returns Error[] TODO: specialize this error class
      */
@@ -196,20 +198,15 @@ export class BaseInterview extends Surveyable implements IValidatable {
         }
 
         // Validate contactPhoneNumber (if provided):
-        if (dirtyParams.contactPhoneNumber !== undefined) {
-            try {
-                const parsedPhoneNumber = parsePhoneNumber(dirtyParams.contactPhoneNumber, 'CA');
-                if (!parsedPhoneNumber.isValid()) {
-                    errors.push(new Error('BaseInterview validateParams: contactPhoneNumber is a phone number but is invalid'));
-                }
-            } catch (e) {
-                errors.push(new Error('BaseInterview validateParams: contactPhoneNumber is not a phone number'));
-            }
+        // Precise phone number validation must be done in audits, because incorrect phone number should not prevent the interview from being created.
+        if (dirtyParams.contactPhoneNumber !== undefined && typeof dirtyParams.contactPhoneNumber !== 'string') {
+            errors.push(new Error('BaseInterview validateParams: contactPhoneNumber should be a string'));
         }
 
         // Validate contactEmail (if provided):
-        if (dirtyParams.contactEmail !== undefined && !_isEmail(dirtyParams.contactEmail)) {
-            errors.push(new Error('BaseInterview validateParams: contactEmail is invalid'));
+        // Regex email validation must be done in audits, because incorrect email should not prevent the interview from being created.
+        if (dirtyParams.contactEmail !== undefined && typeof dirtyParams.contactEmail !== 'string') {
+            errors.push(new Error('BaseInterview validateParams: contactEmail should be a string'));
         }
 
         // Validate _device (if provided):

--- a/packages/evolution-common/src/services/baseObjects/BasePerson.ts
+++ b/packages/evolution-common/src/services/baseObjects/BasePerson.ts
@@ -15,7 +15,6 @@ import { BaseTrip } from './BaseTrip';
 import { BaseVehicle } from './BaseVehicle';
 import * as PAttr from './attributeTypes/PersonAttributes';
 import { Vehicleable } from './Vehicleable';
-import { _isEmail } from 'chaire-lib-common/lib/utils/LodashExtensions';
 
 type BasePersonAttributes = {
 
@@ -295,8 +294,8 @@ class BasePerson extends Uuidable implements IBasePersonAttributes, IValidatable
         }
 
         // Validate contactEmail (if provided)
-        if (dirtyParams.contactEmail !== undefined && !_isEmail(dirtyParams.contactEmail)) {
-            errors.push(new Error('BasePerson validateParams: contactEmail is invalid'));
+        if (dirtyParams.contactEmail !== undefined && typeof dirtyParams.contactEmail !== 'string') {
+            errors.push(new Error('BasePerson validateParams: contactEmail should be a string'));
         }
 
         return errors;

--- a/packages/evolution-common/src/services/baseObjects/__tests__/BaseHousehold.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/BaseHousehold.test.ts
@@ -190,7 +190,7 @@ describe('BaseHousehold Class Additional Tests', () => {
             wouldLikeToParticipateToOtherSurveys: 'true', // Should be a boolean
             homeCarParkings: [123], // Should contain valid strings
             contactPhoneNumber: 9876543210, // Should be a string
-            contactEmail: 'invalid-email', // Should be a valid email address
+            contactEmail: new Date(), // Should be a valid email address
             _weights: [
                 { weight: 5.5, method: 'foo' },
                 { weight: -3.2, method: new WeightMethod(weightMethodAttributes) },
@@ -211,11 +211,11 @@ describe('BaseHousehold Class Additional Tests', () => {
             new Error('BaseHousehold validateParams: twoWheelNumber should be a positive integer'),
             new Error('BaseHousehold validateParams: pluginHybridCarNumber should be a positive integer'),
             new Error('BaseHousehold validateParams: electricCarNumber should be a positive integer'),
-            new Error('BaseHousehold validateParams: category is not a valid household category'),
+            new Error('BaseHousehold validateParams: category should be a string'),
             new Error('BaseHousehold validateParams: wouldLikeToParticipateToOtherSurveys should be a boolean'),
-            new Error('BaseHousehold validateParams: homeCarParkings index 0 is not a valid home car parking type'),
+            new Error('BaseHousehold validateParams: homeCarParkings index 0 should be a string'),
             new Error('BaseHousehold validateParams: contactPhoneNumber should be a string'),
-            new Error('BaseHousehold validateParams: contactEmail is invalid'),
+            new Error('BaseHousehold validateParams: contactEmail should be a string'),
         ]);
     });
 

--- a/packages/evolution-common/src/services/baseObjects/__tests__/BaseInterview.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/BaseInterview.test.ts
@@ -142,8 +142,8 @@ describe('BaseInterview', () => {
             baseHousehold: 'invalid-household',
             basePerson: 'invalid-person',
             baseOrganization: 'invalid-organization',
-            contactEmail: 'foo',
-            contactPhoneNumber: '112',
+            contactEmail: new Date(),
+            contactPhoneNumber: Infinity,
             _language: 'aaa',
             _source: {},
             _isCompleted: 'true',
@@ -165,8 +165,8 @@ describe('BaseInterview', () => {
             new Error('BaseInterview validateParams: baseHousehold should be an instance of BaseHousehold'),
             new Error('BaseInterview validateParams: basePerson should be an instance of BasePerson'),
             new Error('BaseInterview validateParams: baseOrganization should be an instance of BaseOrganization'),
-            new Error('BaseInterview validateParams: contactPhoneNumber is a phone number but is invalid'),
-            new Error('BaseInterview validateParams: contactEmail is invalid'),
+            new Error('BaseInterview validateParams: contactPhoneNumber should be a string'),
+            new Error('BaseInterview validateParams: contactEmail should be a string'),
             new Error('BaseInterview validateParams: _device is invalid'),
         ]);
     });

--- a/packages/evolution-common/src/services/baseObjects/__tests__/BasePerson.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/BasePerson.test.ts
@@ -184,7 +184,7 @@ describe('BasePerson', () => {
             baseTrips: [new BaseTrip({}), 'InvalidTrip'], // Invalid type in array
             baseVehicles: [new BaseVehicle({}), 'InvalidVehicle'], // Invalid type in array
             contactPhoneNumber: 123, // Invalid type
-            contactEmail: 'invalid-email', // Invalid email format
+            contactEmail: 43.4, // Invalid email format
         };
 
         const errors = BasePerson.validateParams(params);
@@ -214,7 +214,7 @@ describe('BasePerson', () => {
             new Error('BasePerson validateParams: baseTrips should be an array of BaseTrip'),
             new Error('BasePerson validateParams: baseVehicles should be an array of BaseVehicle'),
             new Error('BasePerson validateParams: contactPhoneNumber should be a string'),
-            new Error('BasePerson validateParams: contactEmail is invalid'),
+            new Error('BasePerson validateParams: contactEmail should be a string'),
         ]);
     });
 


### PR DESCRIPTION
the validateParams function returns errors that prevent the object from being created. Only typing should be checked here, otherwise we cannot validate the interview in the admin dashbord. So validating an email, a phone number or a category should be done in survey audits instead