### PR TITLE
adminViews: Add unique field to materialized views

### DIFF
--- a/packages/evolution-backend/src/models/migrations/20231122131300_addUniqueForAdminViews.ts
+++ b/packages/evolution-backend/src/models/migrations/20231122131300_addUniqueForAdminViews.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { Knex } from 'knex';
+
+const viewsTbl = 'sv_materialized_views';
+
+export async function up(knex: Knex): Promise<unknown> {
+    return knex.schema.table(viewsTbl, (table: Knex.TableBuilder) => {
+        table.string('unique_field').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<unknown> {
+    return knex.schema.table(viewsTbl, (table: Knex.TableBuilder) => {
+        table.dropColumn('unique_field');
+    });
+}


### PR DESCRIPTION
fixes #351

Add a `unique_field` field to the `sv_materialized_views`. If set, this will create a unique index on the materialized view, allowing it to be refreshed concurrently, thus not locking the table and blocking the queries to it.