### PR TITLE
Add sendWelcomeEmail in createAndSave function

### DIFF
--- a/locales/en/server.json
+++ b/locales/en/server.json
@@ -6,5 +6,7 @@
     "resetPasswordEmailSubject": "Forgotten password",
     "resetPasswordEmailText": "Hi {{name}},\n\nYou are receiving this because you have requested the reset of the password for your account.\n\nPlease click on the following link, or paste this into your browser to complete the process\n\n{{resetPasswordUrl}}\n\nIf you did not request this, please ignore this email and your password will remain unchanged.\n\nThank you",
     "magicLinkEmailText": "Welcome!\n\nTo connect to your questionnaire, click on the following link: {{magicLinkUrl}}.\n\nThank you",
-    "magicLinkEmailSubject": "Connection to survey [do not respond]"
+    "magicLinkEmailSubject": "Connection to survey [do not respond]",
+    "welcomeEmailText": "Hello,\n\nYou have requested access to this survey.\n\nThank you for your participation.",
+    "welcomeEmailSubject": "Welcome to the survey [do not respond]"
 }

--- a/locales/fr/server.json
+++ b/locales/fr/server.json
@@ -6,5 +6,7 @@
     "resetPasswordEmailSubject": "Mot de passe oublié",
     "resetPasswordEmailText": "Bonjour {{name}},\n\nVous recevez ce courriel car vous avez demandé de recréer un mot de passe pour votre compte.\n\nPour compléter la demande, veuillez cliquer sur le lien suivant:\n\n{{resetPasswordUrl}}\n\nSi vous n'avez pas effectué cette requête de changement de mot de passe, ignorez ce message et votre mot de passe demeurera inchangé.\n\nMerci",
     "magicLinkEmailText": "Bienvenue!\n\nPour vous connecter à l'enquête, cliquer sur le lien suivant: {{magicLinkUrl}}.\n\nMerci",
-    "magicLinkEmailSubject": "Connexion à l'enquête mobilité [ne pas répondre]"
+    "magicLinkEmailSubject": "Connexion à l'enquête mobilité [ne pas répondre]",
+    "welcomeEmailText": "Bonjour,\n\nVous avez demandé l'accès à cette enquête.\n\nMerci pour votre participation.",
+    "welcomeEmailSubject": "Bienvenue à l'enquête [ne pas répondre]"
 }

--- a/packages/evolution-backend/src/services/auth/participantAuthModel.ts
+++ b/packages/evolution-backend/src/services/auth/participantAuthModel.ts
@@ -8,6 +8,8 @@ import { BaseUser } from 'chaire-lib-common/lib/services/user/userType';
 import dbQueries from '../../models/participants.db.queries';
 import { ParticipantAttributes } from '../participants/participant';
 import { AuthModelBase, NewUserParams, UserModelBase } from 'chaire-lib-backend/lib/services/auth/authModel';
+import { sendWelcomeEmail } from 'chaire-lib-backend/lib/services/auth/userEmailNotifications';
+import config from 'chaire-lib-backend/lib/config/server.config';
 
 export const sanitizeUserAttributes = (attributes: ParticipantAttributes): BaseUser => ({
     id: attributes.id,
@@ -43,6 +45,11 @@ class ParticipantAuthModel extends AuthModelBase<ParticipantModel> {
             is_test: userData.isTest === true
         });
         const user = this.newUser(userAttribs);
+
+        // Send a welcome email to the new user if the server is configured to do so
+        if (config.auth?.welcomeEmail) {
+            await sendWelcomeEmail(user);
+        }
 
         return user;
     };

--- a/packages/evolution-backend/src/services/auth/participantAuthModel.ts
+++ b/packages/evolution-backend/src/services/auth/participantAuthModel.ts
@@ -47,7 +47,7 @@ class ParticipantAuthModel extends AuthModelBase<ParticipantModel> {
         const user = this.newUser(userAttribs);
 
         // Send a welcome email to the new user if the server is configured to do so
-        if (config.auth?.welcomeEmail) {
+        if (config.auth?.welcomeEmail === true) {
             await sendWelcomeEmail(user);
         }
 


### PR DESCRIPTION
Add sendWelcomeEmail in createAndSave function

I put sendWelcomeEmail only in createAndSave, so it's only going to call if the user is new and the config is auth.welcomeEmail === true. 

I got server.json if the survey don't have a customServer file, but customServer file is the best way to implement the welcome email.