### PR TITLE
preferences: Add a HOC component to make sure preferences are loaded

### DIFF
--- a/packages/evolution-frontend/src/components/hoc/WithPreferencesHoc.tsx
+++ b/packages/evolution-frontend/src/components/hoc/WithPreferencesHoc.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import React from 'react';
+import Preferences from 'chaire-lib-common/lib/config/Preferences';
+import { LoadingPage } from 'chaire-lib-frontend/lib/components/pages';
+
+export const withPreferencesHOC = <P extends object>(WrappedComponent: React.ComponentType<P>) => {
+    const PreferencesComponentHOC: React.FunctionComponent<P> = (props: P) => {
+        const [preferencesLoaded, setPreferencesLoaded] = React.useState(false);
+        React.useEffect(() => {
+            Preferences.load().then(() => {
+                setPreferencesLoaded(true);
+            });
+        }, []);
+        return preferencesLoaded ? <WrappedComponent {...(props as P)} /> : <LoadingPage />;
+    };
+    return PreferencesComponentHOC;
+};

--- a/packages/evolution-legacy/src/components/admin/ValidateSurvey.js
+++ b/packages/evolution-legacy/src/components/admin/ValidateSurvey.js
@@ -11,7 +11,6 @@ import moment              from 'moment-business-days';
 import _get                from 'lodash/get';
 
 import config                 from 'chaire-lib-common/lib/config/shared/project.config';
-import Preferences from 'chaire-lib-common/lib/config/Preferences';
 import * as surveyHelperNew   from 'evolution-common/lib/utils/helpers';
 import Section                from '../survey/Section';
 import SectionNav             from '../survey/SectionNav';
@@ -19,6 +18,7 @@ import { withSurveyContext } from 'evolution-frontend/lib/components/hoc/WithSur
 import LoadingPage            from '../shared/LoadingPage';
 import { startSetSurveyValidateInterview, startUpdateSurveyValidateInterview, startSurveyValidateAddGroupedObjects, startSurveyValidateRemoveGroupedObjects } from '../../actions/survey/survey';
 import { InterviewContext } from 'evolution-frontend/lib/contexts/InterviewContext';
+import { withPreferencesHOC } from 'evolution-frontend/lib/components/hoc/WithPreferencesHoc';
 
 export class ValidateSurvey extends React.Component {
   static contextType = InterviewContext;
@@ -26,8 +26,7 @@ export class ValidateSurvey extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      confirmModalOpenedShortname: null,
-      preferencesLoaded: false
+      confirmModalOpenedShortname: null
     };
     // set language if empty and change locale:
     if (!props.i18n.language || config.languages.indexOf(props.i18n.language) <= -1)
@@ -62,9 +61,6 @@ export class ValidateSurvey extends React.Component {
   componentDidMount() {
     const interviewUuid = this.props.interviewUuid;
     this.props.startSetSurveyValidateInterview(interviewUuid);
-    Preferences.load().then(() => {
-        this.setState({ preferencesLoaded: true })
-    })
   }
 
   onKeyPress(e) {
@@ -215,4 +211,4 @@ const mapDispatchToProps = (dispatch, props) => ({
 export default connect(
   mapStateToProps,
   mapDispatchToProps
-)(withTranslation()(withSurveyContext(ValidateSurvey)));
+)(withTranslation()(withSurveyContext(withPreferencesHOC(ValidateSurvey))));

--- a/packages/evolution-legacy/src/components/survey/Survey.js
+++ b/packages/evolution-legacy/src/components/survey/Survey.js
@@ -11,7 +11,6 @@ import moment              from 'moment-business-days';
 import _get                from 'lodash/get';
 
 import config                                                                                         from 'chaire-lib-common/lib/config/shared/project.config';
-import Preferences from 'chaire-lib-common/lib/config/Preferences';
 import * as surveyHelperNew from 'evolution-common/lib/utils/helpers';
 import Section                                                                                        from './Section';
 import SectionNav                                                                                     from './SectionNav';
@@ -21,6 +20,7 @@ import LoadingPage                                                              
 import { validateAllWidgets } from 'evolution-frontend/lib/actions/utils';
 import { InterviewContext } from 'evolution-frontend/lib/contexts/InterviewContext';
 import { withSurveyContext } from 'evolution-frontend/lib/components/hoc/WithSurveyContextHoc';
+import { withPreferencesHOC } from 'evolution-frontend/lib/components/hoc/WithPreferencesHoc';
 
 export class Survey extends React.Component {
   static contextType = InterviewContext;
@@ -29,8 +29,7 @@ export class Survey extends React.Component {
     super(props);
     surveyHelperNew.devLog('params_survey', props.location.search)
     this.state = {
-      confirmModalOpenedShortname: null,
-      preferencesLoaded: false
+      confirmModalOpenedShortname: null
     };
     // set language if empty and change locale:
     if (!props.i18n.language || config.languages.indexOf(props.i18n.language) <= -1)
@@ -68,9 +67,6 @@ export class Survey extends React.Component {
     const pathSectionParentSection = pathSectionShortname && this.surveyContext.sections[pathSectionShortname] ? this.surveyContext.sections[pathSectionShortname].parentSection : null;
     const { state } = this.context;
     this.props.startSetInterview(existingActiveSection || pathSectionParentSection, surveyUuid, state.status === 'entering' && Object.keys(state.responses).length > 0 ? state.responses : undefined);
-    Preferences.load().then(() => {
-        this.setState({ preferencesLoaded: true })
-    });
   }
 
   onChangeSection(parentSection, activeSection, allWidgetsValid, e) {
@@ -229,4 +225,4 @@ const mapDispatchToProps = (dispatch, props) => ({
 export default connect(
   mapStateToProps,
   mapDispatchToProps
-)(withTranslation()(withSurveyContext(Survey)));
+)(withTranslation()(withSurveyContext(withPreferencesHOC(Survey))));


### PR DESCRIPTION
The `WithPreferencesHoc` component loads the preferences upon first mount, then displays the wrapped component. A loading page is shown while preferences are loading.

The Survey and ValidateSurvey components use this HOC.