### PR TITLE
audits: Use new audit table for audit filter

### DIFF
--- a/packages/evolution-frontend/src/components/pageParts/validations/InterviewListComponent.tsx
+++ b/packages/evolution-frontend/src/components/pageParts/validations/InterviewListComponent.tsx
@@ -179,7 +179,7 @@ const InterviewListComponent: React.FunctionComponent<InterviewListComponentProp
                             icon={faExclamationTriangle}
                             className="faIconNoMargin _error _red"
                             title={Object.keys(value)
-                                .map((error: any) => props.t(`survey:validations:${error}`))
+                                .map((error: any) => props.t([`survey:validations:${error}`, `surveyAdmin:${error}`]))
                                 .join('\n')}
                         />
                     ),

--- a/packages/evolution-frontend/src/components/pageParts/validations/ValidationAuditFilter.tsx
+++ b/packages/evolution-frontend/src/components/pageParts/validations/ValidationAuditFilter.tsx
@@ -90,7 +90,7 @@ export const ValidationAuditFilter = <CustomSurvey, CustomHousehold, CustomHome,
             >
                 {options.map((key, i) => (
                     <option key={`validationError_${key}`} value={key}>
-                        {key ? _truncate(t(`survey:validations:${key}`), { length: 70 }) : ''}
+                        {key ? _truncate(t([`survey:validations:${key}`, `surveyAdmin:${key}`]), { length: 70 }) : ''}
                     </option>
                 ))}
             </select>


### PR DESCRIPTION
The audit filter uses a subquery to the sv_audits table instead of the audits field of the interviews table.

The list of validation errors come from the sv_audits table as well.

Sequential tests are updated accordingly.