### PR TITLE
include survey objects when auditing

### DIFF
--- a/packages/evolution-backend/src/api/survey.validation.routes.ts
+++ b/packages/evolution-backend/src/api/survey.validation.routes.ts
@@ -38,7 +38,7 @@ router.get(
                         await copyResponsesToValidatedData(interview);
                     }
                     // Run audits on the validated_data
-                    const audits = await Audits.runAndSaveInterviewAudits(interview);
+                    const objectsAndAudits = await Audits.runAndSaveInterviewAudits(interview);
                     // TODO Here, the responses field should not make it to frontend. But make sure there are no side effect in the frontend, where the _responses is used or checked.
                     const { responses, validated_data, ...rest } = interview;
                     return res.status(200).json({
@@ -46,7 +46,7 @@ router.get(
                         interview: {
                             responses: validated_data,
                             _responses: responses,
-                            auditsV2: audits,
+                            surveyObjectsAndAudits: objectsAndAudits,
                             ...rest,
                             validationDataDirty:
                                 responses._updatedAt !== undefined &&

--- a/packages/evolution-backend/src/config/projectConfig.ts
+++ b/packages/evolution-backend/src/config/projectConfig.ts
@@ -4,7 +4,7 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import { AuditForObject } from 'evolution-common/lib/services/audits/types';
+import { AuditForObject, SurveyObjectsWithAudits } from 'evolution-common/lib/services/audits/types';
 import {
     InterviewAttributes,
     InterviewListAttributes,
@@ -31,7 +31,7 @@ interface ProjectServerConfig<CustomSurvey, CustomHousehold, CustomHome, CustomP
      */
     auditInterview?: (
         attributes: InterviewAttributes<CustomSurvey, CustomHousehold, CustomHome, CustomPerson>
-    ) => Promise<AuditForObject[]>;
+    ) => Promise<SurveyObjectsWithAudits>;
 }
 
 export const defaultConfig: ProjectServerConfig<unknown, unknown, unknown, unknown> = {

--- a/packages/evolution-common/src/services/audits/types.ts
+++ b/packages/evolution-common/src/services/audits/types.ts
@@ -40,3 +40,13 @@ export type AuditForObject = Audit & {
 };
 
 export type Audits = { [key: string]: Audit };
+
+// used when running audits on backend, returning both audits and serialized survey objects for use in frontend:
+export type SurveyObjectsWithAudits = {
+    surveyShortname?: string;
+    interview?: any; // serialized, typed in survey
+    metadata?: any; // serialized, typed in survey
+    household?: any; // serialized, typed in survey
+    home?: any; // serialized, typed in survey
+    audits: AuditForObject[];
+};


### PR DESCRIPTION
frontend will need to recreate survey objects for stats and summary, so we need to get a serialized version from the server during audit