### PR TITLE
validations: Use equality for access code search

### DIFF
--- a/packages/evolution-frontend/src/components/pageParts/validations/InterviewByCodeFilter.tsx
+++ b/packages/evolution-frontend/src/components/pageParts/validations/InterviewByCodeFilter.tsx
@@ -38,7 +38,7 @@ export const InterviewByCodeFilter = <CustomSurvey, CustomHousehold, CustomHome,
                 onValueUpdated={(newValue) => setCurrentValue(newValue.value)}
             />
             <InputButton
-                onClick={() => setFilter(!_isBlank(currentValue) ? { value: currentValue, op: 'like' } : currentValue)}
+                onClick={() => setFilter(!_isBlank(currentValue) ? { value: currentValue, op: 'eq' } : currentValue)}
                 icon={faCheckCircle}
                 label=""
                 size="small"


### PR DESCRIPTION
This uses the access code index for direct access to the interviews instead of a full table scan. That should improve query performance for large surveys.