### PR TITLE
use date strings instead of Dates in survey objects

### DIFF
--- a/packages/evolution-common/src/services/baseObjects/BaseInterview.ts
+++ b/packages/evolution-common/src/services/baseObjects/BaseInterview.ts
@@ -20,7 +20,7 @@ export type BaseInterviewAttributes = {
     _uuid?: string;
 
     accessCode?: string;
-    assignedDate?: Date | string; // date, the assigned date for the survey (trips date most of the time)
+    assignedDate?: string; // string, YYYY-MM-DD, the assigned date for the survey (trips date most of the time)
     contactPhoneNumber?: string; // phone number
     contactEmail?: string; // email
 
@@ -41,7 +41,7 @@ export class BaseInterview extends Surveyable implements IValidatable {
     _isValid: OptionalValidity;
 
     accessCode?: string;
-    assignedDate?: Date; // date, the assigned date for the survey (trips date most of the time)
+    assignedDate?: string; // string YYYY-MM-DD, the assigned date for the survey (trips date most of the time)
     contactPhoneNumber?: string; // phone number
     contactEmail?: string; // email
 
@@ -66,7 +66,7 @@ export class BaseInterview extends Surveyable implements IValidatable {
         super(params.survey, params.sample, params.sampleBatchNumber, params._uuid);
 
         this.accessCode = params.accessCode;
-        this.assignedDate = parseDate(params.assignedDate);
+        this.assignedDate = params.assignedDate; // parseDate(params.assignedDate);
         this.contactPhoneNumber = params.contactPhoneNumber;
         this.contactEmail = params.contactEmail;
 
@@ -120,7 +120,6 @@ export class BaseInterview extends Surveyable implements IValidatable {
     static validateParams(dirtyParams: { [key: string]: any }): Error[] {
         const errors: Error[] = [];
 
-        dirtyParams.assignedDate = parseDate(dirtyParams.assignedDate);
         dirtyParams._startedAt = parseDate(dirtyParams._startedAt);
         dirtyParams._updatedAt = parseDate(dirtyParams._updatedAt);
         dirtyParams._completedAt = parseDate(dirtyParams._completedAt);
@@ -160,12 +159,12 @@ export class BaseInterview extends Surveyable implements IValidatable {
             errors.push(new Error('BaseInterview validateParams: _isCompleted should be a boolean'));
         }
 
+        const assignedDateObj = parseDate(dirtyParams.assignedDate);
         // Validate assignedDate (if provided)
         if (
-            dirtyParams.assignedDate !== undefined &&
-            (!(dirtyParams.assignedDate instanceof Date) || isNaN(dirtyParams.assignedDate.getDate()))
+            dirtyParams.assignedDate !== undefined && (!(assignedDateObj instanceof Date) || (assignedDateObj !== undefined && isNaN(assignedDateObj.getDate())))
         ) {
-            errors.push(new Error('BaseInterview validateParams: invalid assignedDate'));
+            errors.push(new Error('BaseInterview validateParams: assignedDate should be a valid date string'));
         }
 
         // Validate _startedAt (if provided)

--- a/packages/evolution-common/src/services/baseObjects/BaseJourney.ts
+++ b/packages/evolution-common/src/services/baseObjects/BaseJourney.ts
@@ -20,9 +20,9 @@ import { parseDate } from '../../utils/DateUtils';
 type BaseJourneyAttributes = {
     _uuid?: string;
 
-    startDate?: Date | string;
+    startDate?: string; // string, YYYY-MM-DD
     startTime?: number;
-    endDate?: Date | string;
+    endDate?: string; // string, YYYY-MM-DD
     endTime?: number;
     name?: string;
 
@@ -37,9 +37,9 @@ class BaseJourney extends Uuidable implements IBaseJourneyAttributes, IValidatab
     _isValid: OptionalValidity;
     _weights?: Weight[];
 
-    startDate?: Date;
+    startDate?: string; // string, YYYY-MM-DD
     startTime?: number;
-    endDate?: Date;
+    endDate?: string; // string, YYYY-MM-DD
     endTime?: number;
     name?: string;
 
@@ -53,9 +53,9 @@ class BaseJourney extends Uuidable implements IBaseJourneyAttributes, IValidatab
         this._isValid = undefined;
         this._weights = params._weights;
 
-        this.startDate = parseDate(params.startDate);
+        this.startDate = params.startDate;
         this.startTime = params.startTime;
-        this.endDate = parseDate(params.endDate);
+        this.endDate = params.endDate;
         this.endTime = params.endTime;
         this.name = params.name;
     }
@@ -94,8 +94,8 @@ class BaseJourney extends Uuidable implements IBaseJourneyAttributes, IValidatab
     static validateParams(dirtyParams: { [key: string]: any }): Error[] {
         const errors: Error[] = [];
 
-        dirtyParams.startDate = parseDate(dirtyParams.startDate);
-        dirtyParams.endDate = parseDate(dirtyParams.endDate);
+        const startDateObj = parseDate(dirtyParams.startDate);
+        const endDateObj = parseDate(dirtyParams.endDate);
 
         // Validate params object:
         if (!dirtyParams || typeof dirtyParams !== 'object') {
@@ -118,9 +118,9 @@ class BaseJourney extends Uuidable implements IBaseJourneyAttributes, IValidatab
         // Validate startDate
         if (
             dirtyParams.startDate !== undefined &&
-            (!(dirtyParams.startDate instanceof Date) || isNaN(dirtyParams.startDate.getDate()))
+            (!(startDateObj instanceof Date) || (startDateObj !== undefined && isNaN(startDateObj.getDate())))
         ) {
-            errors.push(new Error('BaseJourney validateParams: startDate is required and should be a valid date'));
+            errors.push(new Error('BaseJourney validateParams: startDate is required and should be a valid date string'));
         }
 
         // Validate startTime
@@ -136,9 +136,9 @@ class BaseJourney extends Uuidable implements IBaseJourneyAttributes, IValidatab
         // Validate endDate
         if (
             dirtyParams.endDate !== undefined &&
-            (!(dirtyParams.endDate instanceof Date) || isNaN(dirtyParams.endDate.getDate()))
+            (!(endDateObj instanceof Date) || (endDateObj !== undefined && isNaN(endDateObj.getDate())))
         ) {
-            errors.push(new Error('BaseJourney validateParams: endDate is required and should be a valid date'));
+            errors.push(new Error('BaseJourney validateParams: endDate is required and should be a valid date string'));
         }
 
         // Validate endTime

--- a/packages/evolution-common/src/services/baseObjects/BaseVisitedPlace.ts
+++ b/packages/evolution-common/src/services/baseObjects/BaseVisitedPlace.ts
@@ -21,8 +21,8 @@ import { parseDate } from '../../utils/DateUtils';
 export type BaseVisitedPlaceAttributes = {
     _uuid?: string;
 
-    arrivalDate?: Date | string;
-    departureDate?: Date | string;
+    arrivalDate?: string;
+    departureDate?: string;
     arrivalTime?: number;
     departureTime?: number;
     activityCategory?: VPAttr.ActivityCategory;
@@ -43,8 +43,8 @@ export class BaseVisitedPlace extends Uuidable implements IValidatable {
 
     basePlace?: BasePlace;
 
-    arrivalDate?: Date;
-    departureDate?: Date;
+    arrivalDate?: string; // string, YYYY-MM-DD
+    departureDate?: string; // string, YYYY-MM-DD
     arrivalTime?: number; // seconds since midnight
     departureTime?: number; // seconds since midnight
     activityCategory?: VPAttr.ActivityCategory; // TODO: This should maybe removed and included in the activity object
@@ -61,8 +61,8 @@ export class BaseVisitedPlace extends Uuidable implements IValidatable {
         this._weights = params._weights;
 
         this.basePlace = params.basePlace;
-        this.arrivalDate = parseDate(params.arrivalDate);
-        this.departureDate = parseDate(params.departureDate);
+        this.arrivalDate = params.arrivalDate;
+        this.departureDate = params.departureDate;
         this.arrivalTime = params.arrivalTime;
         this.departureTime = params.departureTime;
         this.activityCategory = params.activityCategory;
@@ -120,8 +120,8 @@ export class BaseVisitedPlace extends Uuidable implements IValidatable {
     static validateParams(dirtyParams: { [key: string]: any }): Error[] {
         const errors: Error[] = [];
 
-        dirtyParams.arrivalDate = parseDate(dirtyParams.arrivalDate);
-        dirtyParams.departureDate = parseDate(dirtyParams.departureDate);
+        const arrivalDateObj = parseDate(dirtyParams.arrivalDate);
+        const departureDateObj = parseDate(dirtyParams.departureDate);
 
         // Validate params object:
         if (!dirtyParams || typeof dirtyParams !== 'object') {
@@ -152,17 +152,17 @@ export class BaseVisitedPlace extends Uuidable implements IValidatable {
         // Validate arrivalDate (if provided):
         if (
             dirtyParams.arrivalDate !== undefined &&
-            (!(dirtyParams.arrivalDate instanceof Date) || isNaN(dirtyParams.arrivalDate.getDate()))
+            (!(arrivalDateObj instanceof Date) || (arrivalDateObj !== undefined && isNaN(arrivalDateObj.getDate())))
         ) {
-            errors.push(new Error('BaseVisitedPlace validateParams: arrivalDate should be a valid Date'));
+            errors.push(new Error('BaseVisitedPlace validateParams: arrivalDate should be a valid date string'));
         }
 
         // Validate departureDate (if provided):
         if (
             dirtyParams.departureDate !== undefined &&
-            (!(dirtyParams.departureDate instanceof Date) || isNaN(dirtyParams.departureDate.getDate()))
+            (!(departureDateObj instanceof Date) || (departureDateObj !== undefined && isNaN(departureDateObj.getDate())))
         ) {
-            errors.push(new Error('BaseVisitedPlace validateParams: departureDate should be a valid Date'));
+            errors.push(new Error('BaseVisitedPlace validateParams: departureDate should be a valid date string'));
         }
 
         // Validate arrivalTime (if provided):

--- a/packages/evolution-common/src/services/baseObjects/__tests__/BaseInterview.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/BaseInterview.test.ts
@@ -60,7 +60,7 @@ describe('BaseInterview', () => {
         expect(interview._startedAt).toEqual(new Date('2023-10-05 02:34:55'));
         expect(interview._updatedAt).toEqual(new Date('2023-10-06 07:00:23'));
         expect(interview._completedAt).toEqual(new Date('2023-10-07 09:12:00'));
-        expect(interview.assignedDate).toEqual(new Date('2023-10-03'));
+        expect(interview.assignedDate).toEqual('2023-10-03');
         expect(interview.contactPhoneNumber).toEqual('+1 514-999-9999');
         expect(interview.contactEmail).toEqual('test@test.test');
         expect(interview._language).toEqual('en');
@@ -109,7 +109,7 @@ describe('BaseInterview', () => {
             _startedAt: new Date(),
             _updatedAt: new Date(),
             _completedAt: new Date(),
-            assignedDate: new Date(),
+            assignedDate: '2023-01-01',
             constactEmail: 'test@test.test',
             contactPhoneNumber: '514-999-9999 #999',
             _language: 'fr',
@@ -144,7 +144,7 @@ describe('BaseInterview', () => {
             new Error('BaseInterview validateParams: _language should be a string of two letters'),
             new Error('BaseInterview validateParams: _source should be a string'),
             new Error('BaseInterview validateParams: _isCompleted should be a boolean'),
-            new Error('BaseInterview validateParams: invalid assignedDate'),
+            new Error('BaseInterview validateParams: assignedDate should be a valid date string'),
             new Error('BaseInterview validateParams: invalid _startedAt'),
             new Error('BaseInterview validateParams: invalid _completedAt'),
             new Error('BaseInterview validateParams: invalid _updatedAt'),

--- a/packages/evolution-common/src/services/baseObjects/__tests__/BaseJourney.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/BaseJourney.test.ts
@@ -29,8 +29,8 @@ describe('BaseJourney', () => {
 
     const baseJourneyAttributes: ExtendedJourneyAttributes = {
         _uuid: validUUID,
-        startDate: new Date('2023-10-05'),
-        endDate: new Date('2023-10-06'),
+        startDate: '2023-10-05',
+        endDate: '2023-10-06',
         startTime: 36000, // 10 hours in seconds
         endTime: 72000, // 20 hours in seconds
         name: 'Journey name',
@@ -43,8 +43,8 @@ describe('BaseJourney', () => {
         expect(journey).toBeInstanceOf(BaseJourney);
         expect(journey._uuid).toEqual(validUUID);
         expect(journey.name).toEqual('Journey name');
-        expect(journey.startDate).toEqual(new Date('2023-10-05'));
-        expect(journey.endDate).toEqual(new Date('2023-10-06'));
+        expect(journey.startDate).toEqual('2023-10-05');
+        expect(journey.endDate).toEqual('2023-10-06');
         expect(journey.startTime).toEqual(36000);
         expect(journey.endTime).toEqual(72000);
         expect(journey._weights).toBeDefined();
@@ -53,8 +53,8 @@ describe('BaseJourney', () => {
     it('should create a new BaseJourney instance with minimal attributes', () => {
         const minimalAttributes: BaseJourneyAttributes = {
             _uuid: validUUID,
-            startDate: new Date('2023-10-07'),
-            endDate: new Date('2023-10-08'),
+            startDate: '2023-10-07',
+            endDate: '2023-10-08',
             startTime: 36100, // 10 hours in seconds
             endTime: 72100, // 20 hours in seconds
         };
@@ -85,9 +85,9 @@ describe('BaseJourney', () => {
     it('should validate params with valid values', () => {
         const validParams = {
             _uuid: uuidV4(),
-            startDate: new Date(),
+            startDate: '2023-01-06',
             startTime: 3600,
-            endDate: new Date(),
+            endDate: '2023-10-06',
             endTime: 7200,
             name: 'Valid Journey',
             _weights: [],
@@ -111,9 +111,9 @@ describe('BaseJourney', () => {
         expect(errors.length).toBeGreaterThan(0);
         expect(errors).toEqual([
             new Error('Uuidable validateParams: invalid uuid'),
-            new Error('BaseJourney validateParams: startDate is required and should be a valid date'),
+            new Error('BaseJourney validateParams: startDate is required and should be a valid date string'),
             new Error('BaseJourney validateParams: startTime is required and should be a non-negative number'),
-            new Error('BaseJourney validateParams: endDate is required and should be a valid date'),
+            new Error('BaseJourney validateParams: endDate is required and should be a valid date string'),
             new Error('BaseJourney validateParams: endTime is required and should be a non-negative number'),
             new Error('BaseJourney validateParams: name should be a string'),
         ]);

--- a/packages/evolution-common/src/services/baseObjects/__tests__/BaseVisitedPlace.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/BaseVisitedPlace.test.ts
@@ -43,8 +43,8 @@ describe('BaseVisitedPlace', () => {
 
     const baseVisitedPlaceAttributes: BaseVisitedPlaceAttributes = {
         _uuid: validUUID,
-        arrivalDate: new Date('2023-10-05'),
-        departureDate: new Date('2023-10-06'),
+        arrivalDate: '2023-10-05',
+        departureDate: '2023-10-06',
         arrivalTime: 36000, // 10:00 AM in seconds since midnight
         departureTime: 45000, // 12:30 PM in seconds since midnight
         activityCategory: 'school' as VPAttr.ActivityCategory,
@@ -62,8 +62,8 @@ describe('BaseVisitedPlace', () => {
         expect(visitedPlace.basePlace?.geography?.geometry?.coordinates).toEqual([23.5, -11.0033423]);
         expect(visitedPlace.basePlace?.geography?.properties).toEqual({ foo: 'boo2', bar: 'far2' });
         expect(visitedPlace.basePlace?.geography?.id).toEqual(444);
-        expect(visitedPlace.arrivalDate).toEqual(new Date('2023-10-05'));
-        expect(visitedPlace.departureDate).toEqual(new Date('2023-10-06'));
+        expect(visitedPlace.arrivalDate).toEqual('2023-10-05');
+        expect(visitedPlace.departureDate).toEqual('2023-10-06');
         expect(visitedPlace.arrivalTime).toEqual(36000);
         expect(visitedPlace.departureTime).toEqual(45000);
         expect(visitedPlace.activityCategory).toEqual('school');
@@ -129,8 +129,8 @@ describe('BaseVisitedPlace', () => {
         const validParams = {
             _uuid: uuidV4(),
             basePlace: new BasePlace({} as BasePlaceAttributes),
-            arrivalDate: new Date('2023-01-15'),
-            departureDate: new Date('2023-01-16'),
+            arrivalDate: '2023-01-15',
+            departureDate: '2023-01-16',
             arrivalTime: 36000, // 10:00 AM in seconds since midnight
             departureTime: 43200, // 12:00 PM in seconds since midnight
             activityCategory: 'work' as VPAttr.ActivityCategory,
@@ -150,8 +150,8 @@ describe('BaseVisitedPlace', () => {
         const validParams = {
             _uuid: uuidV4(),
             basePlace: new BasePlace({} as BasePlaceAttributes),
-            arrivalDate: new Date('2023-01-15'),
-            departureDate: new Date('2023-01-16'),
+            arrivalDate: '2023-01-15',
+            departureDate: '2023-01-16',
             arrivalTime: 36000,
             departureTime: 43200,
             activityCategory: 'other' as VPAttr.ActivityCategory,
@@ -177,8 +177,8 @@ describe('BaseVisitedPlace', () => {
         const errors = BaseVisitedPlace.validateParams(invalidParams);
         expect(errors).toHaveLength(7);
         expect(errors[0].message).toEqual('Uuidable validateParams: invalid uuid');
-        expect(errors[1].message).toEqual('BaseVisitedPlace validateParams: arrivalDate should be a valid Date');
-        expect(errors[2].message).toEqual('BaseVisitedPlace validateParams: departureDate should be a valid Date');
+        expect(errors[1].message).toEqual('BaseVisitedPlace validateParams: arrivalDate should be a valid date string');
+        expect(errors[2].message).toEqual('BaseVisitedPlace validateParams: departureDate should be a valid date string');
         expect(errors[3].message).toEqual('BaseVisitedPlace validateParams: arrivalTime should be a positive integer');
         expect(errors[4].message).toEqual('BaseVisitedPlace validateParams: departureTime should be a positive integer');
         expect(errors[5].message).toEqual('BaseVisitedPlace validateParams: activityCategory should be a string');
@@ -199,8 +199,8 @@ describe('BaseVisitedPlace', () => {
         const validParams = {
             _uuid: uuidV4(), // Invalid UUID
             basePlace: new BasePlace({} as BasePlaceAttributes),
-            arrivalDate: new Date('2023-01-15'),
-            departureDate: new Date('2023-01-16'),
+            arrivalDate: '2023-01-15',
+            departureDate: '2023-01-16',
             arrivalTime: 36000,
             departureTime: 43200,
             activityCategory: 'other' as VPAttr.ActivityCategory,


### PR DESCRIPTION
to make sure timezones with Date/moment do not shift days