### PR TITLE
convert Survey dates to strings

### DIFF
--- a/packages/evolution-common/src/services/baseObjects/Survey.ts
+++ b/packages/evolution-common/src/services/baseObjects/Survey.ts
@@ -18,8 +18,8 @@ type SurveyAttributes = {
     name?: string;
     shortname: string;
     description?: string;
-    startDate?: Date | string;
-    endDate?: Date | string;
+    startDate?: string; // string, YYYY-MM-DD
+    endDate?: string; // string, YYYY-MM-DD
 };
 
 type ExtendedSurveyAttributes = SurveyAttributes & { [key: string]: any };
@@ -28,8 +28,8 @@ class Survey extends Uuidable {
     name?: string;
     shortname: string;
     description?: string;
-    startDate?: Date;
-    endDate?: Date;
+    startDate?: string; // string, YYYY-MM-DD
+    endDate?: string; // string, YYYY-MM-DD
 
     constructor(params: SurveyAttributes | ExtendedSurveyAttributes) {
         super(params._uuid);
@@ -37,8 +37,8 @@ class Survey extends Uuidable {
         this.name = params.name;
         this.shortname = params.shortname;
         this.description = params.description;
-        this.startDate = parseDate(params.startDate);
-        this.endDate = parseDate(params.endDate);
+        this.startDate = params.startDate;
+        this.endDate = params.endDate;
     }
 
     // params must be sanitized and must be valid:
@@ -56,7 +56,7 @@ class Survey extends Uuidable {
 
         // Validate params object:
         if (!dirtyParams || typeof dirtyParams !== 'object') {
-            errors.push(new Error('Surevy validateParams: params is undefined or invalid'));
+            errors.push(new Error('Survey validateParams: params is undefined or invalid'));
             return errors; // stop now otherwise it will crash because params are not valid
         }
 
@@ -66,8 +66,8 @@ class Survey extends Uuidable {
             errors.push(...uuidErrors);
         }
 
-        dirtyParams.startDate = parseDate(dirtyParams.startDate);
-        dirtyParams.endDate = parseDate(dirtyParams.endDate);
+        const startDateObj = parseDate(dirtyParams.startDate);
+        const endDateObj = parseDate(dirtyParams.endDate);
 
         // validate attributes:
         if (dirtyParams.name !== undefined && typeof dirtyParams.name !== 'string') {
@@ -81,17 +81,18 @@ class Survey extends Uuidable {
         if (dirtyParams.description !== undefined && typeof dirtyParams.description !== 'string') {
             errors.push(new Error('Survey validateParams: description should be a string'));
         }
+        // Validate dates (if provided):
         if (
             dirtyParams.startDate !== undefined &&
-            (!(dirtyParams.startDate instanceof Date) || isNaN(dirtyParams.startDate.getTime()))
+            (!(startDateObj instanceof Date) || (startDateObj !== undefined && isNaN(startDateObj.getDate())))
         ) {
-            errors.push(new Error('Survey validateParams: invalid startDate'));
+            errors.push(new Error('Survey validateParams: startDate should be a valid date string'));
         }
         if (
             dirtyParams.endDate !== undefined &&
-            (!(dirtyParams.endDate instanceof Date) || isNaN(dirtyParams.endDate.getTime()))
+            (!(endDateObj instanceof Date) || (endDateObj !== undefined && isNaN(endDateObj.getDate())))
         ) {
-            errors.push(new Error('Survey validateParams: invalid endDate'));
+            errors.push(new Error('Survey validateParams: endDate should be a valid date string'));
         }
 
         return errors;

--- a/packages/evolution-common/src/services/baseObjects/__tests__/Survey.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/Survey.test.ts
@@ -12,8 +12,8 @@ describe('Survey Class', () => {
 
     const surveyName = 'Sample Survey';
     const surveyShortname = 'SS';
-    const surveyStartDate = new Date(2023, 4, 15); // May 15, 2023
-    const surveyEndDate = new Date(2023, 5, 15); // June 15, 2023
+    const surveyStartDate = '2023-04-15'; // April 15, 2023
+    const surveyEndDate = '2023-05-15'; // May 15, 2023
 
     it('should instantiate with the provided UUID', () => {
         const validUuid = uuidV4();
@@ -57,13 +57,13 @@ describe('Survey Class', () => {
         // Invalid dates:
         const invalidStartDate = Survey.validateParams({ name: 'bar', shortname: 'foo', startDate: 'foo', endDate: surveyEndDate });
         expect(invalidStartDate.length).toEqual(1);
-        expect(invalidStartDate[0].message).toEqual('Survey validateParams: invalid startDate');
-        const invalidEndDate = Survey.validateParams({ name: 'bar', shortname: 'foo', startDate: surveyStartDate, endDate: new Date('bar') });
+        expect(invalidStartDate[0].message).toEqual('Survey validateParams: startDate should be a valid date string');
+        const invalidEndDate = Survey.validateParams({ name: 'bar', shortname: 'foo', startDate: surveyStartDate, endDate: 'bar' });
         expect(invalidEndDate.length).toEqual(1);
-        expect(invalidEndDate[0].message).toEqual('Survey validateParams: invalid endDate');
-        const invalidEndDate2 = Survey.validateParams({ name: 'bar', shortname: 'foo', startDate: surveyStartDate, endDate: new Date('2021/34/45') });
+        expect(invalidEndDate[0].message).toEqual('Survey validateParams: endDate should be a valid date string');
+        const invalidEndDate2 = Survey.validateParams({ name: 'bar', shortname: 'foo', startDate: surveyStartDate, endDate: '2021-34-45' });
         expect(invalidEndDate2.length).toEqual(1);
-        expect(invalidEndDate2[0].message).toEqual('Survey validateParams: invalid endDate');
+        expect(invalidEndDate2[0].message).toEqual('Survey validateParams: endDate should be a valid date string');
 
         // Missing required attributes:
         const missingRequired = Survey.validateParams({ });


### PR DESCRIPTION
like we did for othe survey objects, to make sure there is no shift caused by timezone management in javascript Date object