### PR TITLE
Generate Sections Configs With Generator and add new Sections types

### DIFF
--- a/packages/evolution-generator/src/helpers/generator_helpers.py
+++ b/packages/evolution-generator/src/helpers/generator_helpers.py
@@ -10,6 +10,7 @@ from typing import List, Union  # Types for Python
 
 # Define constants
 MOCKER_EXCEL_FILE = "generator/examples/test.xlsx"
+INDENT = "    "  # 4-space indentation
 
 
 # Add Generator comment at the start of the file
@@ -93,11 +94,6 @@ def generate_output_file(ts_code: str, output_file: str):
     except Exception as e:
         print(f"Error generating {output_file}: {e}")
         raise e
-
-
-# 4-space indentation
-def indent(level: int) -> str:
-    return " " * 4 * level
 
 
 # Create mocked Excel data for testing

--- a/packages/evolution-generator/src/scripts/generate_choices.py
+++ b/packages/evolution-generator/src/scripts/generate_choices.py
@@ -6,6 +6,7 @@
 # These functions are intended to be invoked from the generate_survey.py script.
 from collections import defaultdict
 from helpers.generator_helpers import (
+    INDENT,
     add_generator_comment,
     is_excel_file,
     is_ts_file,
@@ -80,13 +81,14 @@ def generate_choices(input_file: str, output_file: str):
         # TODO: Separate the following code into a separate function
         # Generate TypeScript code
         ts_code: str = ""  # TypeScript code to be written to file
-        indentation: str = "    "  # 4-space indentation
 
         # Add Generator comment at the start of the file
         ts_code += add_generator_comment()
 
         # Add imports
-        ts_code += f"import {{ Choices }} from 'evolution-generator/lib/types/inputTypes';\n"
+        ts_code += (
+            f"import {{ Choices }} from 'evolution-generator/lib/types/inputTypes';\n"
+        )
         ts_code += f"import * as conditionals from './conditionals';\n\n"
 
         for choice_name, choices in choices_by_name.items():
@@ -95,21 +97,21 @@ def generate_choices(input_file: str, output_file: str):
             for index, choice in enumerate(choices):
                 if choice["spread_choices_name"] is not None:
                     # Spread choices from another choiceName when spread_choices_name is not None
-                    ts_code += f"{indentation}...{choice['spread_choices_name']}"
+                    ts_code += f"{INDENT}...{choice['spread_choices_name']}"
                 else:
                     ts_code += (
-                        f"{indentation}{{\n"
-                        f"{indentation}{indentation}value: '{choice['value']}',\n"
-                        f"{indentation}{indentation}label: {{\n"
-                        f"{indentation}{indentation}{indentation}fr: '{choice['label']['fr']}',\n"
-                        f"{indentation}{indentation}{indentation}en: '{choice['label']['en']}'\n"
-                        f"{indentation}{indentation}}}{',' if choice['conditional'] else ''}\n"
+                        f"{INDENT}{{\n"
+                        f"{INDENT}{INDENT}value: '{choice['value']}',\n"
+                        f"{INDENT}{INDENT}label: {{\n"
+                        f"{INDENT}{INDENT}{INDENT}fr: '{choice['label']['fr']}',\n"
+                        f"{INDENT}{INDENT}{INDENT}en: '{choice['label']['en']}'\n"
+                        f"{INDENT}{INDENT}}}{',' if choice['conditional'] else ''}\n"
                     )
                     # Add the 'conditional' field only if it exists
                     if "conditional" in choice and choice["conditional"] is not None:
-                        ts_code += f"{indentation}{indentation}conditional: conditionals.{choice['conditional']},\n"
+                        ts_code += f"{INDENT}{INDENT}conditional: conditionals.{choice['conditional']},\n"
 
-                    ts_code += f"{indentation}}}"
+                    ts_code += f"{INDENT}}}"
                 if index < len(choices) - 1:
                     # Add a comma for each choice except the last one
                     ts_code += ","

--- a/packages/evolution-generator/src/scripts/generate_conditionals.py
+++ b/packages/evolution-generator/src/scripts/generate_conditionals.py
@@ -7,12 +7,12 @@
 # We use importation without "/" to avoid problems when using the package.json script.
 from collections import defaultdict  # Group data by name
 from helpers.generator_helpers import (
+    INDENT, # 4-space indentation
     add_generator_comment,  # Add Generator comment at the start of the file
     get_data_from_excel,  # Read data from Excel
     get_values_from_row,  # Get values from the row
     error_when_missing_required_fields,  # Error when any required fields are None
     generate_output_file,  # Generate output file
-    indent,  # 4-space indentation
 )
 
 
@@ -88,13 +88,13 @@ def generate_typescript_code(conditional_by_name: defaultdict) -> str:
             conditionals_has_path = any(
                 "${relativePath}" in conditional["path"] for conditional in conditionals
             )
-            declare_relative_path = f"{indent(1)}const relativePath = path.substring(0, path.lastIndexOf('.')); // Remove the last key from the path{NEWLINE}"
+            declare_relative_path = f"{INDENT}const relativePath = path.substring(0, path.lastIndexOf('.')); // Remove the last key from the path{NEWLINE}"
 
             ts_code += f"\nexport const {conditional_name}: Conditional = (interview{', path' if conditionals_has_path else ''}) => {{{NEWLINE}"
             ts_code += declare_relative_path if conditionals_has_path else ""
-            ts_code += indent(1) + "return createConditionals({" + NEWLINE
-            ts_code += indent(2) + "interview," + NEWLINE
-            ts_code += indent(2) + "conditionals: [" + NEWLINE
+            ts_code += INDENT + "return createConditionals({" + NEWLINE
+            ts_code += INDENT + INDENT + "interview," + NEWLINE
+            ts_code += INDENT + INDENT + "conditionals: [" + NEWLINE
 
             # Add conditionals
             for index, conditional in enumerate(conditionals):
@@ -106,22 +106,22 @@ def generate_typescript_code(conditional_by_name: defaultdict) -> str:
                 conditional_has_path = "${relativePath}" in conditional["path"]
                 quote = "`" if conditional_has_path else "'"
 
-                ts_code += f"{indent(3)}{{{NEWLINE}"
+                ts_code += f"{INDENT}{INDENT}{INDENT}{{{NEWLINE}"
                 if conditional["logical_operator"]:
-                    ts_code += f"{indent(4)}logicalOperator: '{conditional['logical_operator']}',{NEWLINE}"
+                    ts_code += f"{INDENT}{INDENT}{INDENT}{INDENT}logicalOperator: '{conditional['logical_operator']}',{NEWLINE}"
+                ts_code += f"{INDENT}{INDENT}{INDENT}{INDENT}path: {quote}{conditional['path']}{quote},{NEWLINE}"
+                ts_code += f"{INDENT}{INDENT}{INDENT}{INDENT}comparisonOperator: '{conditional['comparison_operator']}',{NEWLINE}"
                 ts_code += (
-                    f"{indent(4)}path: {quote}{conditional['path']}{quote},{NEWLINE}"
+                    f"{INDENT}{INDENT}{INDENT}{INDENT}value: {new_value},{NEWLINE}"
                 )
-                ts_code += f"{indent(4)}comparisonOperator: '{conditional['comparison_operator']}',{NEWLINE}"
-                ts_code += f"{indent(4)}value: {new_value},{NEWLINE}"
                 if conditional["parentheses"]:
-                    ts_code += f"{indent(4)}parentheses: '{conditional['parentheses']}',{NEWLINE}"
-                ts_code += f"{indent(3)}}}"
+                    ts_code += f"{INDENT}{INDENT}{INDENT}{INDENT}parentheses: '{conditional['parentheses']}',{NEWLINE}"
+                ts_code += f"{INDENT}{INDENT}{INDENT}}}"
                 ts_code += "," if index < len(conditionals) - 1 else ""
                 ts_code += f"{NEWLINE}"
 
-            ts_code += f"{indent(2)}]{NEWLINE}"
-            ts_code += f"{indent(1)}}});{NEWLINE}"
+            ts_code += f"{INDENT}{INDENT}]{NEWLINE}"
+            ts_code += f"{INDENT}}});{NEWLINE}"
             ts_code += f"}};{NEWLINE}"
 
     except Exception as e:

--- a/packages/evolution-generator/src/scripts/generate_input_range.py
+++ b/packages/evolution-generator/src/scripts/generate_input_range.py
@@ -5,6 +5,7 @@
 # Note: This script includes functions that generate the inputRange.tsx file.
 # These functions are intended to be invoked from the generate_survey.py script.
 from helpers.generator_helpers import (
+    INDENT,
     add_generator_comment,
     is_excel_file,
     is_ts_file,
@@ -49,7 +50,6 @@ def generate_input_range(input_file: str, output_file: str):
 
         # Generate TypeScript codedict
         ts_code: str = ""  # TypeScript code to be written to file
-        indentation: str = "    "  # 4-space indentation
 
         # Add Generator comment at the start of the file
         ts_code += add_generator_comment()
@@ -89,22 +89,22 @@ def generate_input_range(input_file: str, output_file: str):
 
             # Generate TypeScript code
             ts_code += f"export const {input_range_name}: InputRangeConfig = {{\n"
-            ts_code += f"{indentation}labels: [\n"
-            ts_code += f"{indentation}{indentation}{{\n"
-            ts_code += f"{indentation}{indentation}{indentation}fr: '{label_fr_min}',\n"
-            ts_code += f"{indentation}{indentation}{indentation}en: '{label_en_min}'\n"
-            ts_code += f"{indentation}{indentation}}},\n"
-            ts_code += f"{indentation}{indentation}{{\n"
-            ts_code += f"{indentation}{indentation}{indentation}fr: '{label_fr_max}',\n"
-            ts_code += f"{indentation}{indentation}{indentation}en: '{label_en_max}'\n"
-            ts_code += f"{indentation}{indentation}}}\n"
-            ts_code += f"{indentation}],\n"
-            ts_code += f"{indentation}minValue: {min_value},\n"
-            ts_code += f"{indentation}maxValue: {max_value},\n"
-            ts_code += f"{indentation}formatLabel: (value, language) => {{\n"
-            ts_code += f"{indentation}{indentation}return value < 0 ? '' : `${{value}} ${{language === 'fr' ? '{unit_fr}' : language === 'en' ? '{unit_en}' : ''}}`;\n"
-            # ts_code += f"{indentation}{indentation}return value + ' ' + (language === 'fr' ? '{unit_fr}' : '{unit_en}');\n"
-            ts_code += f"{indentation}}}\n"
+            ts_code += f"{INDENT}labels: [\n"
+            ts_code += f"{INDENT}{INDENT}{{\n"
+            ts_code += f"{INDENT}{INDENT}{INDENT}fr: '{label_fr_min}',\n"
+            ts_code += f"{INDENT}{INDENT}{INDENT}en: '{label_en_min}'\n"
+            ts_code += f"{INDENT}{INDENT}}},\n"
+            ts_code += f"{INDENT}{INDENT}{{\n"
+            ts_code += f"{INDENT}{INDENT}{INDENT}fr: '{label_fr_max}',\n"
+            ts_code += f"{INDENT}{INDENT}{INDENT}en: '{label_en_max}'\n"
+            ts_code += f"{INDENT}{INDENT}}}\n"
+            ts_code += f"{INDENT}],\n"
+            ts_code += f"{INDENT}minValue: {min_value},\n"
+            ts_code += f"{INDENT}maxValue: {max_value},\n"
+            ts_code += f"{INDENT}formatLabel: (value, language) => {{\n"
+            ts_code += f"{INDENT}{INDENT}return value < 0 ? '' : `${{value}} ${{language === 'fr' ? '{unit_fr}' : language === 'en' ? '{unit_en}' : ''}}`;\n"
+            # ts_code += f"{INDENT}{INDENT}return value + ' ' + (language === 'fr' ? '{unit_fr}' : '{unit_en}');\n"
+            ts_code += f"{INDENT}}}\n"
             ts_code += "};\n\n"
 
         # Write TypeScript code to a file

--- a/packages/evolution-generator/src/scripts/generate_section_configs.py
+++ b/packages/evolution-generator/src/scripts/generate_section_configs.py
@@ -1,0 +1,172 @@
+# Copyright 2024, Polytechnique Montreal and contributors
+# This file is licensed under the MIT License.
+# License text available at https://opensource.org/licenses/MIT
+
+# Note: This script includes functions that generate the sectionConfigs.ts file.
+# These functions are intended to be invoked from the generate_survey.py script.
+from helpers.generator_helpers import (
+    INDENT,
+    add_generator_comment,
+    is_excel_file,
+    get_workbook,
+    sheet_exists,
+    get_headers,
+    get_data_from_excel,
+    get_values_from_row,
+)
+
+
+# Function to generate sectionConfigs.ts for each section
+def generate_section_configs(input_file: str):
+    try:
+        is_excel_file(input_file)  # Check if the input file is an Excel file
+        workbook = get_workbook(input_file)  # Get workbook from Excel file
+        sheet_exists(workbook, "Sections")  # Check if the sheet exists
+        sheet = workbook["Sections"]  # Get Sections sheet
+        previousSection = None  # Initialize previousSection as None
+        nextSection = None  # Initialize nextSection as None
+
+        # Read data from Excel and return rows and headers
+        rows, headers = get_data_from_excel(input_file, sheet_name="Sections")
+
+        # Test headers
+        get_headers(
+            sheet,
+            expected_headers=[
+                "section",
+                "title_fr",
+                "title_en",
+                "in_nav",
+                "parent_section",
+                "groups",
+            ],
+            sheet_name="Sections",
+        )
+
+        # Generate TypeScript code
+        ts_code: str = ""  # TypeScript code to be written to file
+
+        # Add Generator comment at the start of the file
+        ts_code += add_generator_comment()
+
+        # Add imports
+        ts_code += f"import {{ isSectionComplete }} from 'evolution-generator/lib/helpers/configsHelpers';\n"
+        ts_code += f"import {{ SectionConfig, SectionName }} from 'evolution-generator/lib/types/sectionsTypes';\n"
+        ts_code += f"import {{ widgetsNames }} from './widgetsNames';\n"
+        ts_code += f"import {{ preload }} from './preload';\n\n"
+
+        # Iterate through each row in the sheet, starting from the second row
+        for row_number, row in enumerate(rows[1:], start=2):
+            # Get values from the row
+            (
+                section,
+                title_fr,
+                title_en,
+                in_nav,
+                parent_section,
+                groups,
+            ) = get_values_from_row(row, headers)
+
+            # Generate code for section
+            def generate_section_code(previousSection, nextSection):
+                # TODO: Do this with survey_folder_path
+                # Get section output file
+                section_output_file = (
+                    f"../../../survey/src/survey/sections/{section}/sectionConfigs.ts"
+                )
+
+                # Generate currentSectionName
+                ts_section_code = (
+                    f"export const currentSectionName: SectionName = '{section}';\n"
+                )
+
+                # Generate previousSectionName
+                if previousSection is not None:
+                    ts_section_code += f"const previousSectionName: SectionName = '{previousSection}';\n"
+                else:
+                    ts_section_code += (
+                        "const previousSectionName: SectionName = null;\n"
+                    )
+
+                # Generate nextSectionName
+                # Check if there is a next row
+                if row_number < len(rows) - 1:
+                    next_row = rows[row_number]  # Get the next row
+                    # Get the next section from the next row
+                    nextSection = get_values_from_row(next_row, headers)[0]
+                    ts_section_code += (
+                        f"const nextSectionName: SectionName = '{nextSection}';\n"
+                    )
+                else:
+                    ts_section_code += "const nextSectionName: SectionName = null;\n"
+
+                # Generate parentSectionName
+                if parent_section is not None:
+                    ts_section_code += (
+                        f"const parentSectionName: SectionName = '{parent_section}';\n"
+                    )
+
+                # Generate config for the section
+                ts_section_code += f"\n// Config for the section\n"
+                ts_section_code += f"export const sectionConfig: SectionConfig = {{\n"
+                ts_section_code += f"{INDENT}previousSection: previousSectionName,\n"
+                ts_section_code += f"{INDENT}nextSection: nextSectionName,\n"
+                if parent_section is not None:
+                    ts_section_code += f"{INDENT}parentSection: parentSectionName,\n"
+                if in_nav == False:
+                    ts_section_code += f"{INDENT}hiddenInNav: true,\n"
+                if title_en and title_fr is not None and in_nav == True:
+                    ts_section_code += f"{INDENT}title: {{\n"
+                    ts_section_code += f"{INDENT}{INDENT}fr: '{title_fr}',\n"
+                    ts_section_code += f"{INDENT}{INDENT}en: '{title_en}'\n"
+                    ts_section_code += f"{INDENT}}},\n"
+                    ts_section_code += f"{INDENT}menuName: {{\n"
+                    ts_section_code += f"{INDENT}{INDENT}fr: '{title_fr}',\n"
+                    ts_section_code += f"{INDENT}{INDENT}en: '{title_en}'\n"
+                    ts_section_code += f"{INDENT}}},\n"
+                ts_section_code += f"{INDENT}widgets: widgetsNames,\n"
+                ts_section_code += (
+                    f"{INDENT}// Do some actions before the section is loaded\n"
+                )
+                ts_section_code += f"{INDENT}preload: preload,\n"
+
+                ts_section_code += f"{INDENT}// Allow to click on the section menu\n"
+                if previousSection is None:
+                    ts_section_code += f"{INDENT}enableConditional:true,\n"
+                else:
+                    ts_section_code += (
+                        f"{INDENT}enableConditional: function (interview) {{\n"
+                    )
+                    ts_section_code += f"{INDENT}{INDENT}return isSectionComplete({{ interview, sectionName: previousSectionName }});\n"
+                    ts_section_code += f"{INDENT}}},\n"
+                ts_section_code += f"{INDENT}// Allow to click on the section menu\n"
+                ts_section_code += (
+                    f"{INDENT}completionConditional: function (interview) {{\n"
+                )
+                ts_section_code += f"{INDENT}{INDENT}return isSectionComplete({{ interview, sectionName: currentSectionName }});\n"
+                ts_section_code += f"{INDENT}}}\n"
+                ts_section_code += f"}};\n\n"
+                ts_section_code += f"export default sectionConfig;\n"
+
+                # Write TypeScript code to a file
+                with open(
+                    section_output_file,
+                    mode="w",
+                    encoding="utf-8",
+                    newline="\n",
+                ) as ts_file:
+                    ts_file.write(ts_code + ts_section_code)
+
+                print(f"Generate {section_output_file} successfully")
+
+                previousSection = (
+                    section  # Update previousSection with the current section
+                )
+
+            # Generate section code
+            generate_section_code(previousSection, nextSection)
+
+    except Exception as e:
+        # Handle any other exceptions that might occur during script execution
+        print(f"Error with sectionConfigs.ts: {e}")
+        raise e

--- a/packages/evolution-generator/src/scripts/generate_sections.py
+++ b/packages/evolution-generator/src/scripts/generate_sections.py
@@ -6,14 +6,13 @@
 # These functions are intended to be invoked from the generate_survey.py script.
 
 from typing import List
-from helpers.generator_helpers import add_generator_comment
+from helpers.generator_helpers import INDENT, add_generator_comment
 
 
 # Function to generate sections.ts
 def generate_sections(output_file: str, sections: List[str]):
     try:
         ts_code: str = ""  # TypeScript code to be written to file
-        indentation: str = "    "  # 4-space indentation
 
         # Add Generator comment at the start of the file
         ts_code += add_generator_comment()
@@ -29,7 +28,7 @@ def generate_sections(output_file: str, sections: List[str]):
         ts_code += "const sectionsConfigs: SectionsConfigs = {\n"
         # Loop through each section and generate an export statement
         for section in sections:
-            ts_code += f"{indentation}{section}: {section}Configs,\n"
+            ts_code += f"{INDENT}{section}: {section}Configs,\n"
         ts_code += "};\n"
         ts_code += "export default sectionsConfigs;\n"
 

--- a/packages/evolution-generator/src/scripts/generate_survey.py
+++ b/packages/evolution-generator/src/scripts/generate_survey.py
@@ -9,6 +9,7 @@ from dotenv import load_dotenv  # For environment variables
 import os  # For environment variables
 import yaml  # For reading the yaml file
 from scripts.generate_excel import generate_excel
+from scripts.generate_section_configs import generate_section_configs
 from scripts.generate_sections import generate_sections
 from scripts.generate_widgets_config import generate_widgets_config
 from scripts.generate_widgets import generate_widgets
@@ -47,6 +48,9 @@ def generate_survey(config_path):
             os.getenv("OFFICE365_USERNAME_EMAIL"),
             os.getenv("OFFICE365_PASSWORD"),
         )
+
+    # Call the generate_section_configs function to generate sectionConfigs.ts
+    generate_section_configs(survey["excel_file"])
 
     # Call the generate_sections function to generate sections.tsx
     generate_sections(sections["output_file"], sections["sections"])

--- a/packages/evolution-generator/src/scripts/generate_widgets.py
+++ b/packages/evolution-generator/src/scripts/generate_widgets.py
@@ -5,9 +5,7 @@
 # Note: This script includes functions that generate the widgets.tsx file.
 # These functions are intended to be invoked from the generate_survey.py script.
 import openpyxl # Read data from Excel
-from helpers.generator_helpers import add_generator_comment
-
-indentation = "    " # Indentation of 4 spaces
+from helpers.generator_helpers import INDENT, add_generator_comment
 
 # Function to generate widgets.tsx for each section
 def generate_widgets(input_path, output_info_list):
@@ -65,7 +63,8 @@ def generate_widgets(input_path, output_info_list):
 
             # Generate widgets names
             widgets_names = '\n'.join([generate_widget_name(row, is_last_row=(index == len(section_rows) - 1)) for index, row in enumerate(section_rows)])
-            widgets_names_statements = f"export const widgetsNames = [\n{''.join(widgets_names)}\n];\n" 
+            widgets_names_import = "import { WidgetsNames } from 'evolution-generator/lib/types/sectionsTypes';\n\n"
+            widgets_names_statements = f"{widgets_names_import}export const widgetsNames: WidgetsNames = [\n{''.join(widgets_names)}\n];\n" 
 
             return {'widgetsStatements': widgets_statements, 'widgetsNamesStatements': widgets_names_statements}
 
@@ -156,9 +155,9 @@ def generate_widget_name(row, is_last_row=False):
     active = row['active']
 
     if active:
-        return f"{indentation}'{question_name}'" if is_last_row else f"{indentation}'{question_name}',"
+        return f"{INDENT}'{question_name}'" if is_last_row else f"{INDENT}'{question_name}',"
     else:
-        return f"{indentation}// '{question_name}'" if is_last_row else f"{indentation}// '{question_name}',"
+        return f"{INDENT}// '{question_name}'" if is_last_row else f"{INDENT}// '{question_name}',"
 
 # Generate Custom widget
 def generate_custom_widget(question_name):
@@ -170,28 +169,28 @@ def generate_skip_line(skip_line): return f"{'\n' if skip_line else ''}"
 
 # Generate all the widget parts
 def generate_constExport(question_name, input_type): return f"export const {question_name}: inputTypes.{input_type} = {{"
-def generate_defaultInputBase(defaultInputBase): return f"{indentation}...defaultInputBase.{defaultInputBase}"
-def generate_path(path): return f"{indentation}path: '{path}'"
-def generate_label(section, path): return f"{indentation}label: (t: TFunction) => t('{section}:{path}')"
+def generate_defaultInputBase(defaultInputBase): return f"{INDENT}...defaultInputBase.{defaultInputBase}"
+def generate_path(path): return f"{INDENT}path: '{path}'"
+def generate_label(section, path): return f"{INDENT}label: (t: TFunction) => t('{section}:{path}')"
 def generate_help_popup(help_popup, comma=True, skip_line=True):
     if help_popup:
-        return f"{indentation}helpPopup: helpPopup.{help_popup}{generate_comma(comma)}{generate_skip_line(skip_line)}"
+        return f"{INDENT}helpPopup: helpPopup.{help_popup}{generate_comma(comma)}{generate_skip_line(skip_line)}"
     else:
         return ""
-def generate_text(section, path): return f"{indentation}text: (t: TFunction) => `<p class=\"input-text\">${{t('{section}:{path}')}}</p>`"
-def generate_choices(choices): return f"{indentation}choices: choices.{choices}"
+def generate_text(section, path): return f"{INDENT}text: (t: TFunction) => `<p class=\"input-text\">${{t('{section}:{path}')}}</p>`"
+def generate_choices(choices): return f"{INDENT}choices: choices.{choices}"
 def generate_conditional(conditional): 
-    return f"{indentation}{"conditional: conditionals." + conditional if conditional else "conditional: defaultConditional"}"
+    return f"{INDENT}{"conditional: conditionals." + conditional if conditional else "conditional: defaultConditional"}"
 def generate_validation(validation):
     if not validation:
         # If validation is empty, use 'requiredValidation'
-        return f"{indentation}validations: validations.requiredValidation"
+        return f"{INDENT}validations: validations.requiredValidation"
     elif validation.endswith('CustomValidation'):
         # If validation ends with 'CustomValidation', use 'customValidation'
-        return f"{indentation}validations: customValidations.{validation}"
+        return f"{INDENT}validations: customValidations.{validation}"
     else:
         # Otherwise, use the provided validation
-        return f"{indentation}validations: validations.{validation}"
+        return f"{INDENT}validations: validations.{validation}"
 
 # Generate InputRadio widget
 def generate_radio_widget(question_name, section, path, choices, help_popup, conditional, validation):
@@ -250,7 +249,7 @@ def generate_info_text_widget(question_name, section, path, conditional):
 def generate_range_widget(question_name, section, path, input_range, conditional, validation):
     return f"{generate_constExport(question_name, 'InputRange')}\n" \
             f"{generate_defaultInputBase('inputRangeBase')},\n" \
-            f"{indentation}...inputRange.{input_range},\n" \
+            f"{INDENT}...inputRange.{input_range},\n" \
             f"{generate_path(path)},\n" \
             f"{generate_label(section, path)},\n" \
             f"{generate_conditional(conditional)},\n" \

--- a/packages/evolution-generator/src/scripts/generate_widgets_config.py
+++ b/packages/evolution-generator/src/scripts/generate_widgets_config.py
@@ -6,14 +6,13 @@
 # These functions are intended to be invoked from the generate_survey.py script.
 
 from typing import List
-from helpers.generator_helpers import add_generator_comment
+from helpers.generator_helpers import INDENT, add_generator_comment
 
 
 # Function to generate widgetsConfig.tsx
 def generate_widgets_config(output_file: str, sections: List[str]):
     try:
         ts_code: str = ""  # TypeScript code to be written to file
-        indentation: str = "    "  # 4-space indentation
 
         # Add Generator comment at the start of the file
         ts_code += add_generator_comment()
@@ -21,7 +20,9 @@ def generate_widgets_config(output_file: str, sections: List[str]):
         # Generate the import statements
         # Loop through each section and generate an import statement
         for section in sections:
-            ts_code += f"import * as {section}Widgets from './sections/{section}/widgets';\n"
+            ts_code += (
+                f"import * as {section}Widgets from './sections/{section}/widgets';\n"
+            )
 
         # Generate the widgets
         ts_code += "\n// Define all the widgets\n"
@@ -30,15 +31,17 @@ def generate_widgets_config(output_file: str, sections: List[str]):
         ts_code += "const sectionsWidgets = [\n"
         # Loop through each section and generate a sectionWidgets array
         for section in sections:
-            ts_code += f"{indentation}{section}Widgets,\n"
+            ts_code += f"{INDENT}{section}Widgets,\n"
         ts_code += "];\n"
 
         # Generate the loop to add all the widgets to the widgets object
-        ts_code += "\n// Loop all sections and add their widgets to the widgets object\n"
+        ts_code += (
+            "\n// Loop all sections and add their widgets to the widgets object\n"
+        )
         ts_code += "sectionsWidgets.forEach((section) => {\n"
-        ts_code += f"{indentation}for (const widget in section) {{\n"
-        ts_code += f"{indentation}{indentation}widgets[widget] = section[widget];\n"
-        ts_code += f"{indentation}}}\n"
+        ts_code += f"{INDENT}for (const widget in section) {{\n"
+        ts_code += f"{INDENT}{INDENT}widgets[widget] = section[widget];\n"
+        ts_code += f"{INDENT}}}\n"
         ts_code += "});\n"
 
         # // Loop all sections and add their widgets to the widgets object

--- a/packages/evolution-generator/src/types/inputTypes.ts
+++ b/packages/evolution-generator/src/types/inputTypes.ts
@@ -4,6 +4,9 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
+
+// Note: This file includes types for all the different input and widgets types used in the evolution-generator
+
 import { TFunction } from 'i18next';
 // import IconDefinition from '@fortawesome/fontawesome-svg-core/definitions/IconDefinition';
 

--- a/packages/evolution-generator/src/types/sectionsTypes.ts
+++ b/packages/evolution-generator/src/types/sectionsTypes.ts
@@ -1,7 +1,28 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+// Note: This file includes types for all the different sections types used in the evolution-generator
+
+
+export type SectionName = string | null;
+export type WidgetsNames = string[];
+// TODO: Add better types for Preload
+export type Preload = (
+    interview: any,
+    startUpdateInterview: any,
+    startAddGroupedObjects: any,
+    startRemoveGroupedObjects: any,
+    callback: any
+) => null;
+
 // Config for the section
 export type SectionConfig = {
-    previousSection: string | null;
-    nextSection: string | null;
+    previousSection: SectionName;
+    nextSection: SectionName;
     hiddenInNav?: boolean;
     title?: {
         fr: string;
@@ -12,7 +33,7 @@ export type SectionConfig = {
         en: string;
     };
     parentSection?: string;
-    widgets: string[];
+    widgets: WidgetsNames;
     groups?: {
         [groupName: string]: {
             showGroupedObjectDeleteButton: (interview: any, path: string) => boolean;
@@ -25,13 +46,7 @@ export type SectionConfig = {
             widgets: string[];
         };
     };
-    preload?: (
-        interview: any,
-        startUpdateInterview: any,
-        startAddGroupedObjects: any,
-        startRemoveGroupedObjects: any,
-        callback: any
-    ) => null;
+    preload?: Preload;
     enableConditional: ((interview: any) => boolean) | boolean;
     completionConditional: ((interview: any) => boolean) | boolean;
 };


### PR DESCRIPTION
# Pull request
fix: #402

## Description
Generate configs with Generator. This should accelerate the process of creating a new survey. It's always take some time to do that manually, and it's a pain. I also added new Sections types (for example WidgetsNames). 

Note: We still need to create Groups and Preload until we find a better solution.