### PR TITLE
Simplify generatorConfigs.yaml

### DIFF
--- a/packages/evolution-generator/src/helpers/generator_helpers.py
+++ b/packages/evolution-generator/src/helpers/generator_helpers.py
@@ -23,10 +23,10 @@ def add_generator_comment() -> str:
 
 # TODO: Add types for rows and headers
 # Read data from Excel and return rows and headers
-def get_data_from_excel(input_file: str, sheet_name: str) -> tuple:
+def get_data_from_excel(excel_file_path: str, sheet_name: str) -> tuple:
     try:
         # Load Excel file
-        workbook: Workbook = openpyxl.load_workbook(input_file, data_only=True)
+        workbook: Workbook = openpyxl.load_workbook(excel_file_path, data_only=True)
         sheet = workbook[sheet_name]  # Get InputRange sheet
         rows = list(sheet.rows)  # Get all rows in the sheet
         headers = [cell.value for cell in rows[0]]  # Get headers from the first row

--- a/packages/evolution-generator/src/scripts/generate_section_configs.py
+++ b/packages/evolution-generator/src/scripts/generate_section_configs.py
@@ -17,17 +17,17 @@ from helpers.generator_helpers import (
 
 
 # Function to generate sectionConfigs.ts for each section
-def generate_section_configs(input_file: str):
+def generate_section_configs(excel_file_path: str):
     try:
-        is_excel_file(input_file)  # Check if the input file is an Excel file
-        workbook = get_workbook(input_file)  # Get workbook from Excel file
+        is_excel_file(excel_file_path)  # Check if the input file path is an Excel file
+        workbook = get_workbook(excel_file_path)  # Get workbook from Excel file
         sheet_exists(workbook, "Sections")  # Check if the sheet exists
         sheet = workbook["Sections"]  # Get Sections sheet
         previousSection = None  # Initialize previousSection as None
         nextSection = None  # Initialize nextSection as None
 
         # Read data from Excel and return rows and headers
-        rows, headers = get_data_from_excel(input_file, sheet_name="Sections")
+        rows, headers = get_data_from_excel(excel_file_path, sheet_name="Sections")
 
         # Test headers
         get_headers(

--- a/packages/evolution-generator/src/scripts/generate_sections.py
+++ b/packages/evolution-generator/src/scripts/generate_sections.py
@@ -5,13 +5,20 @@
 # Note: This script includes functions that generate the sections.ts file.
 # These functions are intended to be invoked from the generate_survey.py script.
 
-from typing import List
-from helpers.generator_helpers import INDENT, add_generator_comment
+from helpers.generator_helpers import INDENT, get_data_from_excel, add_generator_comment
 
 
 # Function to generate sections.ts
-def generate_sections(output_file: str, sections: List[str]):
+def generate_sections(excel_file_path: str, sections_output_file_path: str):
     try:
+        # Read data from Excel and return rows and headers
+        rows, headers = get_data_from_excel(excel_file_path, sheet_name="Sections")
+
+        # Find the index of 'section' in headers
+        section_index = headers.index("section")
+        # Get all unique section names
+        section_names = set(row[section_index].value for row in rows[1:])
+
         ts_code: str = ""  # TypeScript code to be written to file
 
         # Add Generator comment at the start of the file
@@ -20,23 +27,25 @@ def generate_sections(output_file: str, sections: List[str]):
         # Generate the import statements
         ts_code += "import { SectionsConfigs } from 'evolution-generator/lib/types/sectionsTypes';\n"
         # Loop through each section and generate an import statement
-        for section in sections:
+        for section in section_names:
             ts_code += f"import {section}Configs from './sections/{section}/sectionConfigs';\n"
 
         # Generate the export statement
         ts_code += "\n// Export all the sections configs\n"
         ts_code += "const sectionsConfigs: SectionsConfigs = {\n"
         # Loop through each section and generate an export statement
-        for section in sections:
+        for section in section_names:
             ts_code += f"{INDENT}{section}: {section}Configs,\n"
         ts_code += "};\n"
         ts_code += "export default sectionsConfigs;\n"
 
         # Write TypeScript code to a file
-        with open(output_file, mode="w", encoding="utf-8", newline="\n") as ts_file:
+        with open(
+            sections_output_file_path, mode="w", encoding="utf-8", newline="\n"
+        ) as ts_file:
             ts_file.write(ts_code)
 
-        print(f"Generate {output_file} successfully")
+        print(f"Generate {sections_output_file_path} successfully")
 
     except Exception as e:
         # Handle any other exceptions that might occur during script execution

--- a/packages/evolution-generator/src/scripts/generate_survey.py
+++ b/packages/evolution-generator/src/scripts/generate_survey.py
@@ -11,7 +11,7 @@ import yaml  # For reading the yaml file
 from scripts.generate_excel import generate_excel
 from scripts.generate_section_configs import generate_section_configs
 from scripts.generate_sections import generate_sections
-from scripts.generate_widgets_config import generate_widgets_config
+from scripts.generate_widgets_configs import generate_widgets_configs
 from scripts.generate_widgets import generate_widgets
 from scripts.generate_conditionals import generate_conditionals
 from scripts.generate_choices import generate_choices
@@ -29,54 +29,73 @@ def generate_survey(config_path):
     with open(config_path, "r") as file:
         surveyGenerator = yaml.safe_load(file)
 
-    # Get the data from the YAML file
-    survey = surveyGenerator["survey"]
-    excel = surveyGenerator["excel"]
-    sections = surveyGenerator["sections"]
-    widgets = surveyGenerator["widgets"]
-    conditionals = surveyGenerator["conditionals"]
-    choices = surveyGenerator["choices"]
-    input_range = surveyGenerator["input_range"]
-    libelles = surveyGenerator["libelles"]
+        # Get the data from the YAML file
+        survey_folder_path = surveyGenerator["survey_folder_path"]
+        excel_file_path = surveyGenerator["excel_file_path"]
+        enabled_scripts = surveyGenerator["enabled_scripts"]
 
-    # Call the generate_excel function to generate the Excel file if active script
-    if excel["active_script"]:
+    # Call the generate_excel function to generate the Excel file if script enabled
+    if enabled_scripts["generate_excel"]:
         generate_excel(
             os.getenv("SHAREPOINT_URL"),
             os.getenv("EXCEL_FILE_PATH"),
-            survey["excel_file"],
+            excel_file_path,
             os.getenv("OFFICE365_USERNAME_EMAIL"),
             os.getenv("OFFICE365_PASSWORD"),
         )
 
-    # Call the generate_section_configs function to generate sectionConfigs.ts
-    generate_section_configs(survey["excel_file"])
+    # Call the generate_section_configs function to generate sectionConfigs.ts if script enabled
+    if enabled_scripts["generate_section_configs"]:
+        generate_section_configs(excel_file_path)
 
-    # Call the generate_sections function to generate sections.tsx
-    generate_sections(sections["output_file"], sections["sections"])
+    # Call the generate_sections function to generate sections.tsx if script enabled
+    if enabled_scripts["generate_sections"]:
+        sections_output_file_path = os.path.join(
+            survey_folder_path, "src", "survey", "sections.ts"
+        )
+        generate_sections(excel_file_path, sections_output_file_path)
 
-    # Call the generate_widgets_config function to generate widgetsConfig.tsx
-    generate_widgets_config(widgets["output_file"], sections["sections"])
+    # Call the generate_widgets_config function to generate widgetsConfigs.tsx if script enabled
+    if enabled_scripts["generate_widgets_configs"]:
+        widgets_configs_output_file_path = os.path.join(
+            survey_folder_path, "src", "survey", "widgetsConfigs.tsx"
+        )
+        generate_widgets_configs(excel_file_path, widgets_configs_output_file_path)
 
-    # Call the generate_widgets function to generate widgets.tsx for each section
-    generate_widgets(survey["excel_file"], widgets["output_info_list"])
+    # Call the generate_widgets function to generate widgets.tsx for each section if script enabled
+    if enabled_scripts["generate_widgets"]:
+        widgets_output_folder = os.path.join(
+            survey_folder_path, "src", "survey", "sections"
+        )
+        generate_widgets(excel_file_path, widgets_output_folder)
 
-    # Call the generate_conditionals function to generate conditionals.tsx
-    generate_conditionals(survey["excel_file"], conditionals["output_file"])
+    # Call the generate_conditionals function to generate conditionals.tsx if script enabled
+    if enabled_scripts["generate_conditionals"]:
+        conditionals_output_file_path = os.path.join(
+            survey_folder_path, "src", "survey", "common", "conditionals.tsx"
+        )
+        generate_conditionals(excel_file_path, conditionals_output_file_path)
 
-    # Call the generate_choices function to generate choices.tsx
-    generate_choices(survey["excel_file"], choices["output_file"])
+    # Call the generate_choices function to generate choices.tsx if script enabled
+    if enabled_scripts["generate_choices"]:
+        choices_output_file_path = os.path.join(
+            survey_folder_path, "src", "survey", "common", "choices.tsx"
+        )
+        generate_choices(excel_file_path, choices_output_file_path)
 
-    # Call the generate_input_range function to generate labels.tsx
-    generate_input_range(survey["excel_file"], input_range["output_file"])
+    # Call the generate_input_range function to generate labels.tsx if script enabled
+    if enabled_scripts["generate_input_range"]:
+        input_range_output_file_path = os.path.join(
+            survey_folder_path, "src", "survey", "common", "inputRange.tsx"
+        )
+        generate_input_range(excel_file_path, input_range_output_file_path)
 
-    # Call the generate_libelles function to generate the libelles locales folder
-    generate_libelles(
-        survey["excel_file"],
-        libelles["output_folder"],
-        libelles["overwrite"],
-        libelles["section"],
-    )
+    # Call the generate_libelles function to generate the libelles locales folder if script enabled
+    if enabled_scripts["generate_libelles"]:
+        libelles_output_folder_path = os.path.join(survey_folder_path, "locales")
+        generate_libelles(
+            excel_file_path, libelles_output_folder_path, overwrite=True, section=None
+        )
 
 
 # Call the generate_survey function with the config_path argument

--- a/packages/evolution-generator/src/scripts/generate_widgets_configs.py
+++ b/packages/evolution-generator/src/scripts/generate_widgets_configs.py
@@ -2,16 +2,23 @@
 # This file is licensed under the MIT License.
 # License text available at https://opensource.org/licenses/MIT
 
-# Note: This script includes functions that generate the widgetsConfig.tsx file.
+# Note: This script includes functions that generate the widgetsConfigs.tsx file.
 # These functions are intended to be invoked from the generate_survey.py script.
 
-from typing import List
-from helpers.generator_helpers import INDENT, add_generator_comment
+from helpers.generator_helpers import INDENT, get_data_from_excel, add_generator_comment
 
 
-# Function to generate widgetsConfig.tsx
-def generate_widgets_config(output_file: str, sections: List[str]):
+# Function to generate widgetsConfigs.tsx
+def generate_widgets_configs(excel_file_path: str, widgets_configs_output_file_path: str):
     try:
+        # Read data from Excel and return rows and headers
+        rows, headers = get_data_from_excel(excel_file_path, sheet_name="Sections")
+
+        # Find the index of 'section' in headers
+        section_index = headers.index("section")
+        # Get all unique section names
+        section_names = set(row[section_index].value for row in rows[1:])
+
         ts_code: str = ""  # TypeScript code to be written to file
 
         # Add Generator comment at the start of the file
@@ -19,7 +26,7 @@ def generate_widgets_config(output_file: str, sections: List[str]):
 
         # Generate the import statements
         # Loop through each section and generate an import statement
-        for section in sections:
+        for section in section_names:
             ts_code += (
                 f"import * as {section}Widgets from './sections/{section}/widgets';\n"
             )
@@ -30,7 +37,7 @@ def generate_widgets_config(output_file: str, sections: List[str]):
         ts_code += "\n// Define all the sections widgets\n"
         ts_code += "const sectionsWidgets = [\n"
         # Loop through each section and generate a sectionWidgets array
-        for section in sections:
+        for section in section_names:
             ts_code += f"{INDENT}{section}Widgets,\n"
         ts_code += "];\n"
 
@@ -56,12 +63,14 @@ def generate_widgets_config(output_file: str, sections: List[str]):
         ts_code += "export { widgets };\n"
 
         # Write TypeScript code to a file
-        with open(output_file, mode="w", encoding="utf-8", newline="\n") as ts_file:
+        with open(
+            widgets_configs_output_file_path, mode="w", encoding="utf-8", newline="\n"
+        ) as ts_file:
             ts_file.write(ts_code)
 
-        print(f"Generate {output_file} successfully")
+        print(f"Generate {widgets_configs_output_file_path} successfully")
 
     except Exception as e:
         # Handle any other exceptions that might occur during script execution
-        print(f"Error with widgetsConfig.tsx: {e}")
+        print(f"Error with widgetsConfigs.tsx: {e}")
         raise e


### PR DESCRIPTION
# Pull request

## Justification
Sometimes, we don't want to use every script from Generator for a specific survey.
Also, it's going to be way easier to configs for the new user working with Generator.

## Description
Add enabled_scripts for every script of Generator
Take the sections from Excel and not from generatorConfigs.yaml 
Remove any useless variables from generatorConfigs.yaml 
Use a survey_folder_path to keep the generator survey consistent

## After
![image](https://github.com/chairemobilite/evolution/assets/78976679/758ed763-3c1e-4e5a-b6d2-5201bed5e12a)

## Before
I can't even take a screenshot of the old configs, because it's too long (51 lines vs 13 lines).
![image](https://github.com/chairemobilite/evolution/assets/78976679/5853543a-bfbc-4c9e-b185-6cb93f39b628)
