### PR TITLE
Add get_sections_names helper function

### DIFF
--- a/packages/evolution-generator/src/helpers/generator_helpers.py
+++ b/packages/evolution-generator/src/helpers/generator_helpers.py
@@ -21,15 +21,30 @@ def add_generator_comment() -> str:
     return ts_code
 
 
-# TODO: Add types for rows and headers
+# Get sections names of Sections sheet
+def get_sections_names(rows: List, headers: List) -> List[str]:
+    # Find the index of 'section' in headers
+    section_index = headers.index("section")
+
+    # Get all unique section names
+    sections_names = []
+    for row in rows[1:]:
+        section_name = row[section_index].value
+        if section_name not in sections_names:
+            sections_names.append(section_name)
+    return sections_names
+
+
 # Read data from Excel and return rows and headers
 def get_data_from_excel(excel_file_path: str, sheet_name: str) -> tuple:
     try:
         # Load Excel file
         workbook: Workbook = openpyxl.load_workbook(excel_file_path, data_only=True)
         sheet = workbook[sheet_name]  # Get InputRange sheet
-        rows = list(sheet.rows)  # Get all rows in the sheet
-        headers = [cell.value for cell in rows[0]]  # Get headers from the first row
+        rows: List = list(sheet.rows)  # Get all rows in the sheet
+        headers: List = [
+            cell.value for cell in rows[0]
+        ]  # Get headers from the first row
 
         # Error when header has spaces
         if any(" " in header for header in headers):

--- a/packages/evolution-generator/src/scripts/generate_sections.py
+++ b/packages/evolution-generator/src/scripts/generate_sections.py
@@ -5,7 +5,12 @@
 # Note: This script includes functions that generate the sections.ts file.
 # These functions are intended to be invoked from the generate_survey.py script.
 
-from helpers.generator_helpers import INDENT, get_data_from_excel, add_generator_comment
+from helpers.generator_helpers import (
+    INDENT,
+    get_data_from_excel,
+    get_sections_names,
+    add_generator_comment,
+)
 
 
 # Function to generate sections.ts
@@ -14,10 +19,8 @@ def generate_sections(excel_file_path: str, sections_output_file_path: str):
         # Read data from Excel and return rows and headers
         rows, headers = get_data_from_excel(excel_file_path, sheet_name="Sections")
 
-        # Find the index of 'section' in headers
-        section_index = headers.index("section")
-        # Get all unique section names
-        section_names = set(row[section_index].value for row in rows[1:])
+        # Get sections names of Sections sheet
+        sections_names = get_sections_names(rows, headers)
 
         ts_code: str = ""  # TypeScript code to be written to file
 
@@ -27,14 +30,16 @@ def generate_sections(excel_file_path: str, sections_output_file_path: str):
         # Generate the import statements
         ts_code += "import { SectionsConfigs } from 'evolution-generator/lib/types/sectionsTypes';\n"
         # Loop through each section and generate an import statement
-        for section in section_names:
-            ts_code += f"import {section}Configs from './sections/{section}/sectionConfigs';\n"
+        for section in sections_names:
+            ts_code += (
+                f"import {section}Configs from './sections/{section}/sectionConfigs';\n"
+            )
 
         # Generate the export statement
         ts_code += "\n// Export all the sections configs\n"
         ts_code += "const sectionsConfigs: SectionsConfigs = {\n"
         # Loop through each section and generate an export statement
-        for section in section_names:
+        for section in sections_names:
             ts_code += f"{INDENT}{section}: {section}Configs,\n"
         ts_code += "};\n"
         ts_code += "export default sectionsConfigs;\n"

--- a/packages/evolution-generator/src/scripts/generate_widgets_configs.py
+++ b/packages/evolution-generator/src/scripts/generate_widgets_configs.py
@@ -5,19 +5,24 @@
 # Note: This script includes functions that generate the widgetsConfigs.tsx file.
 # These functions are intended to be invoked from the generate_survey.py script.
 
-from helpers.generator_helpers import INDENT, get_data_from_excel, add_generator_comment
+from helpers.generator_helpers import (
+    INDENT,
+    get_data_from_excel,
+    get_sections_names,
+    add_generator_comment,
+)
 
 
 # Function to generate widgetsConfigs.tsx
-def generate_widgets_configs(excel_file_path: str, widgets_configs_output_file_path: str):
+def generate_widgets_configs(
+    excel_file_path: str, widgets_configs_output_file_path: str
+):
     try:
         # Read data from Excel and return rows and headers
         rows, headers = get_data_from_excel(excel_file_path, sheet_name="Sections")
 
-        # Find the index of 'section' in headers
-        section_index = headers.index("section")
-        # Get all unique section names
-        section_names = set(row[section_index].value for row in rows[1:])
+        # Get sections names of Sections sheet
+        sections_names = get_sections_names(rows, headers)
 
         ts_code: str = ""  # TypeScript code to be written to file
 
@@ -26,7 +31,7 @@ def generate_widgets_configs(excel_file_path: str, widgets_configs_output_file_p
 
         # Generate the import statements
         # Loop through each section and generate an import statement
-        for section in section_names:
+        for section in sections_names:
             ts_code += (
                 f"import * as {section}Widgets from './sections/{section}/widgets';\n"
             )
@@ -37,7 +42,7 @@ def generate_widgets_configs(excel_file_path: str, widgets_configs_output_file_p
         ts_code += "\n// Define all the sections widgets\n"
         ts_code += "const sectionsWidgets = [\n"
         # Loop through each section and generate a sectionWidgets array
-        for section in section_names:
+        for section in sections_names:
             ts_code += f"{INDENT}{section}Widgets,\n"
         ts_code += "];\n"
 


### PR DESCRIPTION
# Pull request

## Description
Add get_sections_names helper function
Change sections_names ordering with List and not set
Add types to rows and headers

## Justification
The widgetsConfigs.tsx and sections.ts were not ordering the sections_names in good order when using set(). Now it's good.