### PR TITLE
Let serverFieldUpdate return a redirection URL

### DIFF
--- a/packages/evolution-backend/src/api/survey.user.routes.ts
+++ b/packages/evolution-backend/src/api/survey.user.routes.ts
@@ -122,11 +122,17 @@ export default (authorizationMiddleware, loggingMiddleware: InterviewLoggingMidd
                         fieldsToUpdate: ['responses', 'validations']
                     });
                     if (retInterview.serverValidations === true) {
-                        return res.status(200).json({
-                            status: 'success',
-                            interviewId: retInterview.interviewId,
-                            updatedValuesByPath: retInterview.serverValuesByPath
-                        });
+                        // TODO See if we can do a `res.redirect`. It does not work with a local server, as the browser gets CORS Missing Allow Origin messages
+                        return retInterview.redirectUrl === undefined
+                            ? res.status(200).json({
+                                status: 'success',
+                                interviewId: retInterview.interviewId,
+                                updatedValuesByPath: retInterview.serverValuesByPath
+                            })
+                            : res.status(200).json({
+                                status: 'redirect',
+                                redirectUrl: retInterview.redirectUrl
+                            });
                     }
                     return res.status(200).json({
                         status: 'invalid',

--- a/packages/evolution-backend/src/services/interviews/interview.ts
+++ b/packages/evolution-backend/src/services/interviews/interview.ts
@@ -91,6 +91,7 @@ export const updateInterview = async <CustomSurvey, CustomHousehold, CustomHome,
               };
           };
     serverValuesByPath: { [key: string]: unknown };
+    redirectUrl: string | undefined;
 }> => {
     const fieldsToUpdate = options.fieldsToUpdate || ['responses', 'validations'];
     const logData = options.logData || {};
@@ -102,7 +103,7 @@ export const updateInterview = async <CustomSurvey, CustomHousehold, CustomHome,
     );
     // Update values by path with caller provided values
     setInterviewFields(interview, { valuesByPath: options.valuesByPath, unsetPaths: options.unsetPaths });
-    const serverValuesByPath = await serverUpdateField(
+    const [serverValuesByPath, redirectUrl] = await serverUpdateField(
         interview,
         projectConfig.serverUpdateCallbacks,
         options.valuesByPath,
@@ -159,7 +160,7 @@ export const updateInterview = async <CustomSurvey, CustomHousehold, CustomHome,
         databaseUpdateJson.is_frozen = true;
     }
     const retInterview = await interviewsDbQueries.update(interview.uuid, databaseUpdateJson);
-    return { interviewId: retInterview.uuid, serverValidations, serverValuesByPath };
+    return { interviewId: retInterview.uuid, serverValidations, serverValuesByPath, redirectUrl };
 };
 
 export const copyResponsesToValidatedData = async <CustomSurvey, CustomHousehold, CustomHome, CustomPerson>(

--- a/packages/evolution-frontend/src/actions/Survey.ts
+++ b/packages/evolution-frontend/src/actions/Survey.ts
@@ -213,6 +213,9 @@ const startUpdateInterviewCallback = async <CustomSurvey, CustomHousehold, Custo
                 if (typeof callback === 'function') {
                     callback(updatedInterview);
                 }
+            } else if (body.status === 'redirect') {
+                // Redirect to the specified URL
+                window.location.href = body.redirectUrl;
             } else {
                 // we need to do something if no interview is returned (error)
             }


### PR DESCRIPTION
The server field update callback can now also return an array with the
fields to update, as well as a string representing an URL to redirect
to. This URL is returned from the `updateInterview` call.

The `/survey/updateInterview` route can return a response with the
status of `redirect`, along with a `redirectUrl` field. If so, the
client should redirect to this URL directly.