### PR TITLE
generator: Add twoColumns and containsHtml common properties

### DIFF
--- a/packages/evolution-generator/src/common/defaultInputBase.tsx
+++ b/packages/evolution-generator/src/common/defaultInputBase.tsx
@@ -19,8 +19,6 @@ export const inputRadioBase: inputTypes.InputRadioBase = {
     type: 'question',
     inputType: 'radio',
     datatype: 'string',
-    containsHtml: true,
-    twoColumns: false,
     columns: 1
 };
 
@@ -29,8 +27,6 @@ export const inputRadioNumberBase: inputTypes.InputRadioNumberBase = {
     type: 'question',
     inputType: 'radioNumber',
     datatype: 'integer',
-    containsHtml: true,
-    twoColumns: false,
     columns: 1,
     sameLine: true,
 };
@@ -40,8 +36,6 @@ export const inputStringBase: inputTypes.InputStringBase = {
     type: 'question',
     inputType: 'string',
     datatype: 'string',
-    containsHtml: true,
-    twoColumns: false
 };
 
 // Input Number default params
@@ -49,8 +43,6 @@ export const inputNumberBase: inputTypes.InputStringBase = {
     type: 'question',
     inputType: 'string',
     datatype: 'integer',
-    containsHtml: true,
-    twoColumns: false,
     size: 'small',
     inputFilter: (value) => {
         // Remove all non-numeric characters
@@ -62,16 +54,13 @@ export const inputNumberBase: inputTypes.InputStringBase = {
 
 // InfoText default params
 export const infoTextBase: inputTypes.InfoTextBase = {
-    type: 'text',
-    containsHtml: true
+    type: 'text'
 };
 
 // InputRange default params
 export const inputRangeBase: inputTypes.InputRangeBase = {
     type: 'question',
     inputType: 'slider',
-    containsHtml: true,
-    twoColumns: false,
     initValue: null,
     trackClassName: 'input-slider-blue'
 };
@@ -81,8 +70,6 @@ export const inputCheckboxBase: inputTypes.InputCheckboxBase = {
     type: 'question',
     inputType: 'checkbox',
     datatype: 'string',
-    containsHtml: true,
-    twoColumns: false,
     multiple: true,
     columns: 1
 };
@@ -92,7 +79,6 @@ export const inputSelectBase: inputTypes.InputSelectBase = {
     type: 'question',
     inputType: 'select',
     datatype: 'string',
-    twoColumns: false,
     hasGroups: true
 };
 
@@ -112,8 +98,6 @@ export const textBase: inputTypes.TextBase = {
     type: 'question',
     inputType: 'text',
     datatype: 'text',
-    containsHtml: true,
-    twoColumns: false
 };
 
 // Find map place default params

--- a/packages/evolution-generator/src/types/inputTypes.ts
+++ b/packages/evolution-generator/src/types/inputTypes.ts
@@ -78,8 +78,6 @@ export type InputRadioBase = {
     type: 'question';
     inputType: 'radio';
     datatype: 'string' | 'integer' | 'boolean';
-    containsHtml: ContainsHtml;
-    twoColumns: TwoColumns;
     columns: Columns;
 };
 export type InputRadio = InputRadioBase & {
@@ -90,6 +88,8 @@ export type InputRadio = InputRadioBase & {
     conditional: Conditional;
     validations?: Validations;
     addCustom?: AddCustom;
+    containsHtml: ContainsHtml;
+    twoColumns: TwoColumns;
 };
 
 /* InputRadioNumber widgetConfig Type */
@@ -97,8 +97,6 @@ export type InputRadioNumberBase = {
     type: 'question';
     inputType: 'radioNumber';
     datatype: 'integer';
-    containsHtml: ContainsHtml;
-    twoColumns: TwoColumns;
     columns: Columns;
     sameLine?: boolean;
 };
@@ -113,6 +111,8 @@ export type InputRadioNumber = InputRadioNumberBase & {
     helpPopup?: HelpPopup;
     conditional: Conditional;
     validations?: Validations;
+    containsHtml: ContainsHtml;
+    twoColumns: TwoColumns;
 };
 
 /* InputString widgetConfig Type */
@@ -120,8 +120,6 @@ export type InputStringBase = {
     type: 'question';
     inputType: 'string';
     datatype: 'string' | 'integer';
-    containsHtml: ContainsHtml;
-    twoColumns: TwoColumns;
     size?: Size;
     inputFilter?: InputFilter;
     numericKeyboard?: boolean;
@@ -136,25 +134,25 @@ export type InputString = InputStringBase & {
     validations?: Validations;
     textTransform?: 'uppercase' | 'lowercase' | 'capitalize';
     defaultValue?: DefaultValue;
+    containsHtml: ContainsHtml;
+    twoColumns: TwoColumns;
 };
 
 /* Text widgetConfig Type */
 export type InfoTextBase = {
     type: 'text';
     align?: Align;
-    containsHtml: ContainsHtml;
 };
 export type InfoText = InfoTextBase & {
     text: TextKey;
     conditional: Conditional;
+    containsHtml: ContainsHtml;
 };
 
 /* InputRange widgetConfig Type */
 export type InputRangeBase = {
     type: 'question';
     inputType: 'slider';
-    containsHtml: ContainsHtml;
-    twoColumns: TwoColumns;
     initValue: null;
     trackClassName: string;
 };
@@ -169,6 +167,8 @@ export type InputRange = InputRangeBase &
         path: Path;
         label: Label;
         conditional: Conditional;
+        containsHtml: ContainsHtml;
+        twoColumns: TwoColumns;
         validations?: Validations;
     };
 
@@ -177,8 +177,6 @@ export type InputCheckboxBase = {
     type: 'question';
     inputType: 'checkbox';
     datatype: 'string' | 'integer';
-    containsHtml: ContainsHtml;
-    twoColumns: TwoColumns;
     multiple: Multiple;
     columns: Columns;
 };
@@ -190,6 +188,8 @@ export type InputCheckbox = InputCheckboxBase & {
     conditional: Conditional;
     validations?: Validations;
     addCustom?: AddCustom;
+    containsHtml: ContainsHtml;
+    twoColumns: TwoColumns;
 };
 
 /* InputSelect widgetConfig Type */
@@ -197,7 +197,6 @@ export type InputSelectBase = {
     type: 'question';
     inputType: 'select';
     datatype: 'string';
-    twoColumns: TwoColumns;
     hasGroups: boolean;
 };
 export type InputSelect = InputSelectBase & {
@@ -206,6 +205,8 @@ export type InputSelect = InputSelectBase & {
     choices: Choices;
     conditional: Conditional;
     validations?: Validations;
+    twoColumns: TwoColumns;
+    containsHtml: ContainsHtml;
 };
 
 /* InputMultiselect widgetConfig Type */
@@ -255,14 +256,14 @@ export type TextBase = {
     type: 'question';
     inputType: 'text';
     datatype: 'text';
-    containsHtml?: ContainsHtml;
-    twoColumns: false;
 };
 export type Text = TextBase & {
     path: Path;
     label: Label;
     conditional: Conditional;
     validations?: Validations;
+    containsHtml?: ContainsHtml;
+    twoColumns: false;
 };
 
 /* Group type */


### PR DESCRIPTION
The widgets can have 2 additional properties: `twoColumns` and `containsHtml` that can be defined in the excel file.

The row is passed to the widget generator function, which can then request to generate any additional properties. A function for common question widget properties is added to generate those two properties.

Also, they are removed from the base input types and put in the input types themselves.