### PR TITLE
generator: Fix postal code regex for canadian postal code

### DIFF
--- a/packages/evolution-generator/src/common/validations.tsx
+++ b/packages/evolution-generator/src/common/validations.tsx
@@ -206,7 +206,7 @@ export const postalCodeValidation: Validations = (value) => {
             }
         },
         {
-            validation: !/^[GHJKghjk][0-9][A-Za-z]( )?[0-9][A-Za-z][0-9]\s*$/.test(String(value)),
+            validation: !/^[A-Za-z][0-9][A-Za-z]( )?[0-9][A-Za-z][0-9]\s*$/.test(String(value)),
             errorMessage: {
                 fr: 'Le code postal est invalide. Vous devez résider au Canada pour compléter ce questionnaire.',
                 en: 'Postal code is invalid. You must live in Canada to fill this questionnaire.'


### PR DESCRIPTION
The validation message says we need to be in Canada, but the regex corresponds to Quebec. This fixes for any canadian postal code. Surveys can fine-tune their territory handling afterwards.