### PR TITLE
input map: Handle the geocode API's no result

### DIFF
--- a/locales/en/main.json
+++ b/locales/en/main.json
@@ -35,5 +35,7 @@
   "AgreementText": "",
   "ErrorNotAgreed": "You must accept usage of your date to continue to the survey",
   "InterviewerMode": "Interviewer mode",
-  "ParticipantMode": "Participant mode"
+  "ParticipantMode": "Participant mode",
+  "InputMapGeocodeNoResult": "The search did not return any result",
+  "InputMapGeocodeError": "The search returned an error, please try again to locate the location or click on the map to select the location"
 }

--- a/locales/fr/main.json
+++ b/locales/fr/main.json
@@ -35,5 +35,7 @@
   "AgreementText": "",
   "ErrorNotAgreed": "Vous devez accepter l'utilisation de vos données pour continuer vers l'enquête",
   "InterviewerMode": "Mode intervieweur",
-  "ParticipantMode": "Mode participant"
+  "ParticipantMode": "Mode participant",
+  "InputMapGeocodeNoResult": "La recherche n'a retourné aucun résultat",
+  "InputMapGeocodeError": "La recherche a produit une erreur, veuillez ré-essayer de géolocaliser le lieu ou localisez-le en cliquant sur la carte"
 }

--- a/packages/evolution-frontend/src/components/inputs/InputMapFindPlace.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputMapFindPlace.tsx
@@ -21,6 +21,7 @@ import { FeatureGeocodedProperties, MarkerData, defaultIconSize, PlaceGeocodedPr
 import InputSelect from './InputSelect';
 import { CommonInputProps } from './CommonInputProps';
 import Loader from 'react-spinners/HashLoader';
+import SurveyErrorMessage from '../survey/widgets/SurveyErrorMessage';
 
 // TODO Allow to support multiple maps and geocoders
 import InputMapGoogle from './maps/google/InputMapGoogle';
@@ -49,6 +50,7 @@ interface InputMapFindPlaceState<CustomSurvey, CustomHousehold, CustomHome, Cust
      * geocoder. Some geocoders do not need any additional information, but some
      * need to match a map (for instance Google) */
     geocodingSpecificOptions: { [key: string]: unknown };
+    displayMessage?: string;
 }
 
 /**
@@ -223,7 +225,8 @@ export class InputMapFindPlace<CustomSurvey, CustomHousehold, CustomHome, Custom
                     {
                         places: features,
                         selectedPlace: isSingleResult ? features[0] : undefined,
-                        geocodingQueryString
+                        geocodingQueryString,
+                        displayMessage: features.length === 0 ? 'main:InputMapGeocodeNoResult' : undefined
                     },
                     () => {
                         // FIXME: In order to directly show the "geocoding is imprecise" warning if there is a *single* result
@@ -248,7 +251,7 @@ export class InputMapFindPlace<CustomSurvey, CustomHousehold, CustomHome, Custom
                 }
             } catch (error) {
                 surveyHelper.devLog(`Error geocoding places: ${error}`);
-                this.setState({ places: [], selectedPlace: undefined });
+                this.setState({ places: [], selectedPlace: undefined, displayMessage: 'main:InputMapGeocodeError' });
             } finally {
                 this.setState({ geocoding: false });
             }
@@ -466,6 +469,9 @@ export class InputMapFindPlace<CustomSurvey, CustomHousehold, CustomHome, Custom
                             <Loader size={30} color={'#aaaaaa'} loading={this.state.geocoding} />
                         </div>
                     </div>
+                )}
+                {this.state.displayMessage && (
+                    <SurveyErrorMessage containsHtml={false} text={this.props.t(this.state.displayMessage)} />
                 )}
 
                 {places.length > 0 && (

--- a/packages/evolution-frontend/src/components/inputs/InputMapPoint.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputMapPoint.tsx
@@ -20,6 +20,7 @@ import { CommonInputProps } from './CommonInputProps';
 // TODO Allow to support multiple maps and geocoders
 import InputMapGoogle from './maps/google/InputMapGoogle';
 import { geocodeSinglePoint } from './maps/google/GoogleGeocoder';
+import SurveyErrorMessage from '../survey/widgets/SurveyErrorMessage';
 
 export type InputMapPointProps<CustomSurvey, CustomHousehold, CustomHome, CustomPerson> = CommonInputProps<
     CustomSurvey,
@@ -36,6 +37,7 @@ interface InputMapPointState {
     defaultCenter: any;
     currentBounds?: [number, number, number, number];
     markers: MarkerData[];
+    displayMessage?: string;
 }
 
 /**
@@ -136,8 +138,10 @@ export class InputMapPoint<CustomSurvey, CustomHousehold, CustomHome, CustomPers
             try {
                 const feature = await geocodeSinglePoint(geocodingQueryString, { bbox });
                 this.onValueChange(feature);
+                this.setState({ displayMessage: feature === undefined ? 'main:InputMapGeocodeNoResult' : undefined });
             } catch (error) {
                 this.onValueChange(undefined);
+                this.setState({ displayMessage: 'main:InputMapGeocodeError' });
             }
         }
     };
@@ -182,6 +186,9 @@ export class InputMapPoint<CustomSurvey, CustomHousehold, CustomHome, CustomPers
                             this.props.user
                         )}
                     </button>
+                )}
+                {this.state.displayMessage && (
+                    <SurveyErrorMessage containsHtml={false} text={this.props.t(this.state.displayMessage)} />
                 )}
                 <div aria-hidden="true" className="survey-question__input-map-container">
                     <InputMapGoogle

--- a/packages/evolution-frontend/src/components/inputs/maps/google/GoogleGeocoder.tsx
+++ b/packages/evolution-frontend/src/components/inputs/maps/google/GoogleGeocoder.tsx
@@ -41,6 +41,9 @@ export const geocodeSinglePoint = (
                     feature.properties.geocodingQueryString = addressQueryString;
                 }
                 resolve(feature);
+            } else if (status === google.maps.GeocoderStatus.ZERO_RESULTS) {
+                // No result
+                resolve(undefined);
             } else {
                 reject(`Geocoding failed for ${addressQueryString}`);
             }
@@ -105,6 +108,12 @@ export const geocodeMultiplePlaces = (
                     >[];
 
                     resolve(places);
+                } else if (
+                    status === google.maps.places.PlacesServiceStatus.ZERO_RESULTS ||
+                    status === google.maps.places.PlacesServiceStatus.NOT_FOUND
+                ) {
+                    // No result
+                    resolve([]);
                 } else {
                     reject(`Geocoding failed for ${geocodingQueryString}`);
                 }


### PR DESCRIPTION
fixes #456

The no result is handled internally by the widget and it displays an error message corresponding to the result of the query: either no result or error.