### PR TITLE
generator: Let number textboxes use numeric keyboard

### DIFF
--- a/packages/evolution-generator/src/common/defaultInputBase.tsx
+++ b/packages/evolution-generator/src/common/defaultInputBase.tsx
@@ -48,8 +48,7 @@ export const inputNumberBase: inputTypes.InputStringBase = {
         // Remove all non-numeric characters
         return value.replace(/[^0-9]/g, '');
     },
-    // FIXME: numericKeyboard doesn't seem to work
-    numericKeyboard: true
+    keyboardInputMode: 'numeric'
 };
 
 // InfoText default params

--- a/packages/evolution-generator/src/types/inputTypes.ts
+++ b/packages/evolution-generator/src/types/inputTypes.ts
@@ -122,7 +122,7 @@ export type InputStringBase = {
     datatype: 'string' | 'integer';
     size?: Size;
     inputFilter?: InputFilter;
-    numericKeyboard?: boolean;
+    keyboardInputMode?: 'none' | 'text' | 'numeric' | 'decimal' | 'tel' | 'search' | 'email' | 'url';
     maxLength?: number;
     placeholder?: Placeholder;
 };


### PR DESCRIPTION
fixes #454

The correct property to use is `keyboardInputMode` from the WidgetConfig types.