### PR TITLE
db: Add an index on responses->>_isCompleted

### DIFF
--- a/packages/evolution-backend/src/models/migrations/20240428100400_createReponseIsCompletedIdx.ts
+++ b/packages/evolution-backend/src/models/migrations/20240428100400_createReponseIsCompletedIdx.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { Knex } from 'knex';
+
+const interviewsTbl = 'sv_interviews';
+const indexNameIsCompleted = 'idx_sv_interviews_is_completed';
+
+export async function up(knex: Knex): Promise<unknown> {
+    return knex.schema.table(interviewsTbl, (table: Knex.TableBuilder) => {
+        table.index([knex.raw('("responses"->>\'_isCompleted\')')], indexNameIsCompleted);
+    });
+}
+
+export async function down(knex: Knex): Promise<unknown> {
+    return knex.schema.table(interviewsTbl, (table: Knex.TableBuilder) => {
+        table.dropIndex([knex.raw('("responses"->>\'_isCompleted\')')], indexNameIsCompleted);
+    });
+}


### PR DESCRIPTION
This field is often used for validation filter lists and for large surveys, it can slow the queries.