### PR TITLE
Upgrade github actions in main workflow

### DIFF
--- a/.github/workflows/evolution.yml
+++ b/.github/workflows/evolution.yml
@@ -18,13 +18,13 @@ jobs:
     env:
       PROJECT_CONFIG: ${{ github.workspace }}/example/demo_survey/config.js
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: copy env file
       run: cp .env.example .env
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install
@@ -39,7 +39,7 @@ jobs:
   code-lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: Install


### PR DESCRIPTION
Old version were deprecated, see:
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/