### PR TITLE
Add a `SurveyErrorPage` to which to redirect on error

### DIFF
--- a/locales/en/main.json
+++ b/locales/en/main.json
@@ -37,5 +37,9 @@
   "InterviewerMode": "Interviewer mode",
   "ParticipantMode": "Participant mode",
   "InputMapGeocodeNoResult": "The search did not return any result",
-  "InputMapGeocodeError": "The search returned an error, please try again to locate the location or click on the map to select the location"
+  "InputMapGeocodeError": "The search returned an error, please try again to locate the location or click on the map to select the location",
+  "BackToSurveyPage": "Back to survey",
+  "AnErrorOccurred": "An error occurred.",
+  "MakeSureReliableConnection": "Make sure you have a reliable internet connection.",
+  "ErrorPersistsWhatToDo": "If the problem persists, please contact the survey administrators."
 }

--- a/locales/fr/main.json
+++ b/locales/fr/main.json
@@ -37,5 +37,9 @@
   "InterviewerMode": "Mode intervieweur",
   "ParticipantMode": "Mode participant",
   "InputMapGeocodeNoResult": "La recherche n'a retourné aucun résultat",
-  "InputMapGeocodeError": "La recherche a produit une erreur, veuillez ré-essayer de géolocaliser le lieu ou localisez-le en cliquant sur la carte"
+  "InputMapGeocodeError": "La recherche a produit une erreur, veuillez ré-essayer de géolocaliser le lieu ou localisez-le en cliquant sur la carte",
+  "BackToSurveyPage": "Retour à l'enquête",
+  "AnErrorOccurred": "Une erreur est survenue.",
+  "MakeSureReliableConnection": "Assurez-vous d'avoir une connection internet fiable.",
+  "ErrorPersistsWhatToDo": "Si le problème persiste, veuillez contacter les administrateurs de l'enquête."
 }

--- a/packages/evolution-frontend/src/components/pages/SurveyErrorPage.tsx
+++ b/packages/evolution-frontend/src/components/pages/SurveyErrorPage.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { withTranslation, WithTranslation } from 'react-i18next';
+
+export const SurveyErrorPage: React.FunctionComponent<WithTranslation> = (props: WithTranslation) => (
+    <div className="survey" style={{ display: 'block' }} id="surveyErrorPage">
+        <div className="apptr__form">
+            <p className="_large _strong _blue">{props.t(['survey:AnErrorOccurred', 'AnErrorOccurred'])}</p>
+        </div>
+        <div className="apptr__separator"></div>
+        <div className="apptr__form">
+            {props.t(['survey:MakeSureReliableConnection', 'MakeSureReliableConnection'])}
+        </div>
+        <div className="apptr__separator"></div>
+        <div className="apptr__form">{props.t(['survey:ErrorPersistsWhatToDo', 'ErrorPersistsWhatToDo'])}</div>
+        <div className="apptr__separator"></div>
+        <div className="apptr__form">
+            <Link to="/survey">{props.t(['survey:BackToSurveyPage', 'BackToSurveyPage'])}</Link>
+        </div>
+    </div>
+);
+
+export default withTranslation(['main'])(SurveyErrorPage);

--- a/packages/evolution-frontend/src/services/errorManagement/errorHandling.ts
+++ b/packages/evolution-frontend/src/services/errorManagement/errorHandling.ts
@@ -9,7 +9,7 @@ import { Dispatch } from 'redux';
 import verifyAuthentication from 'chaire-lib-frontend/lib/services/auth/verifyAuthentication';
 
 const unauthorizedPage = '/unauthorized';
-const maintenancePage = '/maintenance';
+const errorPage = '/error';
 
 export const handleHttpOtherResponseCode = async (responseCode: number, dispatch: Dispatch, history?: History) => {
     if (responseCode === 401) {
@@ -20,8 +20,16 @@ export const handleHttpOtherResponseCode = async (responseCode: number, dispatch
         if (history) {
             history.push(unauthorizedPage);
         }
+        // If history is not available, the user has still been logged out of
+        // the application, the proper flow of the application will redirect him
+        // to the right page (login or unauthorized). We don't need to set href
+        // to 'unauthorized' here.
     } else if (history) {
         // TODO Should there be other use cases that lead to other pages?
-        history.push(maintenancePage);
+        history.push(errorPage);
+    } else {
+        // Error messages need proper handling, if history is not available, we
+        // still need to redirect to error page
+        window.location.href = errorPage;
     }
 };

--- a/packages/evolution-legacy/src/apps/participant/client/SurveyRouter.js
+++ b/packages/evolution-legacy/src/apps/participant/client/SurveyRouter.js
@@ -10,7 +10,7 @@ import { Route, Switch } from 'react-router-dom';
 import HomePage from '../../../components/survey/HomePage';
 import NotFoundPage from 'chaire-lib-frontend/lib/components/pages/NotFoundPage';
 import UnauthorizedPage from 'evolution-frontend/lib/components/pages/UnauthorizedPage';
-import MaintenancePage from 'chaire-lib-frontend/lib/components/pages/MaintenancePage';
+import SurveyErrorPage from 'evolution-frontend/lib/components/pages/SurveyErrorPage';
 import LoginPage from 'evolution-frontend/lib/components/pages/auth/LoginPage';
 import RegisterWithPasswordPage from 'evolution-frontend/lib/components/pages/auth/RegisterPage';
 import ForgotPasswordPage from 'chaire-lib-frontend/lib/components/pages/ForgotPasswordPage';
@@ -42,7 +42,7 @@ const SurveyRouter = () => (
     <PublicRoute   path="/reset/:token" component={ResetPasswordPage} />
     <PublicRoute   path="/consent_form" component={config.consentFormPage === true ? ConsentFormPage : NotFoundPage}/>
     <PublicRoute   path="/unauthorized" component={UnauthorizedPage} />
-    <PublicRoute   path="/maintenance" component={() => <MaintenancePage linkPath={'/survey'}/>} />
+    <PublicRoute   path="/error" component={SurveyErrorPage} />
     <PublicRoute   path="/magic/verify" component={MagicLinkVerifyPage} />
     <PublicRoute   path="/checkMagicEmail" component={CheckMagicEmailPage} />
     <PrivateRoute  path="/survey/:sectionShortname" component={Survey} />


### PR DESCRIPTION
fixes #457

Instead of redirecting to `maintenance` page, the user is redirected to an `error` page, which indicates an error occurred, advises to check internet connection and links back to the survey.

The following locale strings can be customized by surveys, in the survey.json file:

* BackToSurveyPage
* AnErrorOccurred
* MakeSureReliableConnection
* ErrorPersistsWhatToDo