### PR TITLE
errorPage: allow html in translation strings

### DIFF
--- a/packages/evolution-frontend/src/components/pages/SurveyErrorPage.tsx
+++ b/packages/evolution-frontend/src/components/pages/SurveyErrorPage.tsx
@@ -11,14 +11,24 @@ import { withTranslation, WithTranslation } from 'react-i18next';
 export const SurveyErrorPage: React.FunctionComponent<WithTranslation> = (props: WithTranslation) => (
     <div className="survey" style={{ display: 'block' }} id="surveyErrorPage">
         <div className="apptr__form">
-            <p className="_large _strong _blue">{props.t(['survey:AnErrorOccurred', 'AnErrorOccurred'])}</p>
+            <p className="_large _strong _blue">
+                <div dangerouslySetInnerHTML={{ __html: props.t(['survey:AnErrorOccurred', 'AnErrorOccurred']) }} />
+            </p>
         </div>
         <div className="apptr__separator"></div>
         <div className="apptr__form">
-            {props.t(['survey:MakeSureReliableConnection', 'MakeSureReliableConnection'])}
+            <div
+                dangerouslySetInnerHTML={{
+                    __html: props.t(['survey:MakeSureReliableConnection', 'MakeSureReliableConnection'])
+                }}
+            />
         </div>
         <div className="apptr__separator"></div>
-        <div className="apptr__form">{props.t(['survey:ErrorPersistsWhatToDo', 'ErrorPersistsWhatToDo'])}</div>
+        <div className="apptr__form">
+            <div
+                dangerouslySetInnerHTML={{ __html: props.t(['survey:ErrorPersistsWhatToDo', 'ErrorPersistsWhatToDo']) }}
+            />
+        </div>
         <div className="apptr__separator"></div>
         <div className="apptr__form">
             <Link to="/survey">{props.t(['survey:BackToSurveyPage', 'BackToSurveyPage'])}</Link>


### PR DESCRIPTION
This will allow surveys to add html tags to the text for the survey error page, like email links.