### PR TITLE
urlRedirect: logout from the application when redirecting

### DIFF
--- a/example/demo_survey/src/server.ts
+++ b/example/demo_survey/src/server.ts
@@ -9,12 +9,12 @@ import path from 'path';
 import setupServer from 'evolution-legacy/lib/apps/participant/server';
 import { setProjectConfig } from 'evolution-backend/lib/config/projectConfig';
 import { registerTranslationDir, addTranslationNamespace } from 'chaire-lib-backend/lib/config/i18next';
-
+import serverUpdateCallbacks from './server/serverFieldUpdate';
 
 const configureServer = () => {
     // Default values for each field. Same as default config, but this is an example project, keep it here.
     setProjectConfig({
-        serverUpdateCallbacks: [],
+        serverUpdateCallbacks: serverUpdateCallbacks as any,
         serverValidations: undefined,
         roleDefinitions: undefined
     });

--- a/example/demo_survey/src/server/serverFieldUpdate.ts
+++ b/example/demo_survey/src/server/serverFieldUpdate.ts
@@ -4,10 +4,10 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-const { getResponse } = require('evolution-common/lib/utils/helpers');
-const { _isBlank } = require('chaire-lib-common/lib/utils/LodashExtensions');
+import { getResponse } from 'evolution-common/lib/utils/helpers';
+import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 
-module.exports = [
+export default [
     {
         field: 'accessCode',
         callback: (interview, value, path) => {
@@ -25,6 +25,9 @@ module.exports = [
                     'home.city': 'London',
                     'home.region': 'Ontario'
                 };
+            } else if (value === '1133-1133') {
+                // Special access code to test url redirection
+                return [{}, 'https://github.com/chairemobilite/evolution/']
             }
             return {};
         }

--- a/packages/evolution-backend/src/services/interviews/serverFieldUpdate.ts
+++ b/packages/evolution-backend/src/services/interviews/serverFieldUpdate.ts
@@ -10,8 +10,9 @@ import prefilledDbQueries from '../../models/interviewsPreFill.db.queries';
 type FieldUpdateCallbackResponseCallbackType = { [affectedResponseFieldPath: string]: unknown };
 /**
  * Return type of the callback. Either an object with the fields in the
- * 'responses' to update, or an array with the field sto update, as well as a
- * URL to which to redirect.
+ * 'responses' to update, or an array with the fields to update, as well as an
+ * external URL to which to redirect. Redirecting to an external URL will
+ * terminate the interview for the user.
  */
 type FieldUpdateCallbackReturnType =
     | FieldUpdateCallbackResponseCallbackType

--- a/packages/evolution-frontend/src/actions/Survey.ts
+++ b/packages/evolution-frontend/src/actions/Survey.ts
@@ -215,7 +215,11 @@ const startUpdateInterviewCallback = async <CustomSurvey, CustomHousehold, Custo
                     callback(updatedInterview);
                 }
             } else if (body.status === 'redirect') {
-                // Redirect to the specified URL
+                // Logout from the application and redirect to the specified URL
+                // TODO Can't use the dispatch action, as the startLogout
+                // requires the history and here it is optional. This fetch
+                // logout should be in a helper.
+                fetch('/logout', { credentials: 'include' });
                 window.location.href = body.redirectUrl;
             } else {
                 // we need to do something if no interview is returned (error)


### PR DESCRIPTION
fixes #471

Document that when redirecting to external URLs the user will be logged out

Activate the serverFieldUpdate callbacks in the demo survey and include an example of redirection when the access code is 1133-1133, the participant is redirected to evolution's github page.

Call the logout after setting the href location.