### PR TITLE
test: Bring the playwright UI testing functionality to evolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,8 @@ __pycache__/
 
 # Generator survey example
 /example/demo_survey_generator
+
+# playwright test output
+**/playwright-report/
+**/test-results/
+**/playwright.config.ts

--- a/README.md
+++ b/README.md
@@ -73,3 +73,42 @@ yarn
 yarn compile
 yarn migrate
 ```
+
+## Run UI tests for the application
+
+Evolution supports running UI tests with playwright. Surveys need to implement their own tests, but `evolution-frontend` provider a library in the `tests/ui-testing` folder.
+
+See the `examples/demo_survey/tests` folder for examples UI testing
+
+To run the tests for the demo_survey application, follow the following steps:
+
+Copy the configuration file in the repository to test and change the build to your needs
+
+```
+cp packages/evolution-frontend/playwright-example.config.ts survey/playwright.config.ts
+```
+
+Install the dependencies and browsers to use for playwright by running `yarn test:ui:install-dependencies`. This will install all playwright browsers and dependencies. It is possible to fine-tune the browsers to install. See the playwright documentation for more information (https://playwright.dev/docs/browsers).
+
+For example, to run the tests on firefox, use
+```
+npx playwright install --with-deps firefox
+```
+
+You need to start the application as you would to run it:
+
+```
+yarn build:dev or yarn build:prod
+yarn start
+```
+
+Run the UI tests
+```
+yarn test:survey
+```
+
+*Notes:* In the `test:survey` script to define in the project, add the `LOCALE_DIR` environment variable, to register the translations for the current project. For example, in the `demo_survey` project, the script is defined as follows:
+
+```
+"test:survey": "LOCALE_DIR=$(pwd)/locales npx playwright test"
+```

--- a/example/demo_survey/package.json
+++ b/example/demo_survey/package.json
@@ -24,7 +24,8 @@
         "start:tracing": "yarn babel-node -r ../../tracing.js lib/server.js --max-old-space-size=4096",
         "start:admin:tracing": "yarn babel-node -r ../../tracing.js lib/admin/server.js --max-old-space-size=4096",
         "start:debug": "cross-env DEBUG=express:* yarn babel-node --trace-warnings lib/server.js --max-old-space-size=4096",
-        "test": "cross-env NODE_ENV=test jest --config=jest.config.js"
+        "test": "cross-env NODE_ENV=test jest --config=jest.config.js",
+        "test:survey": "LOCALE_DIR=$(pwd)/locales npx playwright test"
     },
     "dependencies": {
         "@babel/cli": "^7.10.5",

--- a/example/demo_survey/tests/test-survey-UI.spec.ts
+++ b/example/demo_survey/tests/test-survey-UI.spec.ts
@@ -1,0 +1,45 @@
+import {
+    hasTitleTest,
+    hasFrenchTest,
+    hasConsentTest,
+    hasUserTest,
+    inputMapFindPlaceTest,
+    inputNextButtonTest,
+    inputRadioTest,
+    inputRangeTest,
+    inputSelectTest,
+    inputStringTest,
+    registerWithoutEmailTest,
+    startSurveyTest,
+    switchToEnglishTest
+} from 'evolution-frontend/tests/ui-testing/testHelpers';
+
+/* Test the survey */
+// Test the home page
+hasTitleTest({ title: 'Démo' });
+hasFrenchTest();
+switchToEnglishTest();
+hasConsentTest();
+startSurveyTest();
+
+// Test the login page
+registerWithoutEmailTest();
+
+// Test the home section page
+hasUserTest();
+inputStringTest({ path: 'accessCode', value: '1111-2222' });
+inputRadioTest({ path: 'household.size', value: '1' });
+inputStringTest({ path: 'household.carNumber', value: '2' });
+inputStringTest({ path: 'home.address', value: '7373 Langelier Bd' });
+inputStringTest({ path: 'home.city', value: 'Montreal' });
+inputStringTest({ path: 'home.region', value: 'Quebec' });
+inputStringTest({ path: 'home.country', value: 'Canada' });
+inputStringTest({ path: 'home.postalCode', value: 'H1S1V7' });
+//inputMapFindPlaceTest({ path: 'home.geography' });
+inputSelectTest({ path: 'home.dwellingType', value: 'tenantSingleDetachedHouse' });
+inputNextButtonTest({ text: 'Save and continue', nextPageUrl: '/survey/householdMembers' });
+
+// Test the household page
+inputStringTest({ path: 'household.persons.${personId}.age', value: '30' });
+inputRadioTest({ path: 'household.persons.${personId}.gender', value: 'male' });
+// TODO: Add more tests

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
         "test:unit": "yarn workspace evolution-common run test:unit && yarn workspace evolution-backend run test:unit && yarn workspace evolution-frontend run test:unit && yarn workspace evolution-legacy run test:unit && yarn workspace evolution-interviewer run test:unit",
         "test:sequential": "yarn workspace evolution-common run test:sequential && yarn workspace evolution-backend run test:sequential && yarn workspace evolution-frontend run test:sequential && yarn workspace evolution-interviewer run test:sequential",
         "test:generator": "python -m pytest -s -W ignore packages/evolution-generator/src/tests/",
+        "test:survey": "yarn workspace demo_survey run test:survey",
+        "test:ui:install-dependencies": "yarn workspace demo_survey run playwright install-deps && yarn workspace demo_survey run playwright install",
         "lint": "yarn workspace evolution-common run lint && yarn workspace evolution-backend run lint && yarn workspace evolution-frontend run lint && yarn workspace evolution-interviewer run lint",
         "format": "yarn workspace evolution-common run format && yarn workspace evolution-backend run format && yarn workspace evolution-frontend run format && yarn workspace evolution-interviewer run format",
         "list-tasks": "yarn workspace evolution-legacy run list-tasks",

--- a/packages/evolution-backend/package.json
+++ b/packages/evolution-backend/package.json
@@ -28,7 +28,7 @@
         "chaire-lib-backend": "^0.2.2",
         "chaire-lib-common": "^0.2.2",
         "evolution-common": "^0.2.2",
-        "express": "^4.17.1",
+        "express": "^4.19.2",
         "knex": "^3.1.0",
         "lodash": "^4.17.21",
         "moment": "^2.29.4",

--- a/packages/evolution-frontend/.eslintignore
+++ b/packages/evolution-frontend/.eslintignore
@@ -4,3 +4,5 @@ node_modules/
 jestSetup.ts
 // The webpack file is not used yet, so it's ignored for now, but it should not be and it should be typescript
 webpack.config.js
+tests/
+playwright-example.config.ts

--- a/packages/evolution-frontend/package.json
+++ b/packages/evolution-frontend/package.json
@@ -85,6 +85,7 @@
     "jest-each": "^27.3.1",
     "jest-fetch-mock": "^3.0.3",
     "mockdate": "^3.0.2",
+    "@playwright/test": "^1.41.2",
     "prettier-eslint-cli": "^7.1.0",
     "react-test-renderer": "^16.13.1",
     "ts-jest": "^27.0.7"

--- a/packages/evolution-frontend/playwright-example.config.ts
+++ b/packages/evolution-frontend/playwright-example.config.ts
@@ -1,0 +1,96 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+    // Look for test files in the "tests" directory, relative to this configuration file.
+    testDir: './tests',
+    // Ignore the test-assets directory.
+    // testIgnore: '*test-assets',
+    // Look for test files in the "todo-tests" directory.
+    // testMatch: '*todo-tests/*.spec.ts',
+    // Run all tests in parallel.
+    fullyParallel: true,
+    // Fail the build on CI if you accidentally left test.only in the source code.
+    forbidOnly: !!process.env.CI,
+    // Retry on CI only.
+    retries: process.env.CI ? 2 : 0,
+    // Each test is given 15 seconds.
+    timeout: 15000,
+    // Limit the number of workers on CI, use default locally.
+    workers: process.env.CI ? 1 : undefined,
+    // Reporter to use: [html, line, list, dot, json, junit, null]
+    reporter: 'html',
+    use: {
+        // Base URL to use in actions like `await page.goto('/')`.
+        baseURL: 'http://localhost:8080',
+        // Collect trace when retrying the failed test.
+        trace: 'on-first-retry',
+        screenshot: 'only-on-failure'
+    },
+
+    /* Configure projects for major browsers */
+    projects: [
+        // Test against desktop viewports.
+        // {
+        //     name: 'chromium',
+        //     use: { ...devices['Desktop Chrome'] }
+        // },
+        {
+            name: 'Google Chrome',
+            use: { ...devices['Desktop Chrome'], channel: 'chrome' }
+        }
+        // {
+        //     name: 'Microsoft Edge',
+        //     use: {
+        //         ...devices['Desktop Edge'],
+        //         channel: 'msedge'
+        //     }
+        // },
+        // {
+        //     name: 'firefox',
+        //     use: { ...devices['Desktop Firefox'] }
+        // },
+        // {
+        //     name: 'webkit',
+        //     use: { ...devices['Desktop Safari'] }
+        // }
+
+        /* Test against mobile viewports. */
+        // {
+        //     name: 'Mobile Chrome',
+        //     use: { ...devices['Pixel 5'] }
+        // },
+        // {
+        //     name: 'Mobile Safari',
+        //     use: { ...devices['iPhone 12'] }
+        // }
+    ],
+
+    /* Run your local dev server before starting the tests */
+    // webServer: [
+    //     {
+    //         command: 'yarn build:dev',
+    //         // url: 'http://localhost:8080',
+    //         // reuseExistingServer: !process.env.CI,
+    //     },
+    //     {
+    //         command: 'yarn start',
+    //         // url: 'http://localhost:8080',
+    //         // reuseExistingServer: !process.env.CI,
+    //     }
+    // ],
+
+    // expect: {
+    //     // Maximum time expect() should wait for the condition to be met.
+    //     timeout: 5000,
+
+    //     toHaveScreenshot: {
+    //         // An acceptable amount of pixels that could be different, unset by default.
+    //         maxDiffPixels: 10
+    //     },
+
+    //     toMatchSnapshot: {
+    //         // An acceptable ratio of pixels that are different to the total amount of pixels, between 0 and 1.
+    //         maxDiffPixelRatio: 0.1
+    //     }
+    // }
+});

--- a/packages/evolution-frontend/tests/ui-testing/configurei18n.ts
+++ b/packages/evolution-frontend/tests/ui-testing/configurei18n.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+// Since playwright tests are not run in the browser context, to use
+// translations for text validation, the i18n needs to be configured similar to
+// the backend's approach. This file was copy-pasted and adapted from the
+// chaire-lib-backend/src/config/i18next.ts file.
+import i18next from 'i18next';
+import Backend from 'i18next-fs-backend';
+import { join } from 'path';
+import fs from 'fs';
+
+// See if there are translation files for language and namespace in the registered directories
+const getTranslationPath = (lng: string, namespace: string) => {
+    if (translationPaths.length === 0) {
+        console.warn('No translation path specified');
+    }
+    for (let i = 0; i < translationPaths.length; i++) {
+        const translationPath = translationPaths[i];
+        if (fs.existsSync(`${translationPath}/${lng}/${namespace}.yml`)) {
+            return `${translationPath}/{{lng}}/{{ns}}.yml`;
+        } else if (fs.existsSync(`${translationPath}/${lng}/${namespace}.json`)) {
+            return `${translationPath}/{{lng}}/{{ns}}.json`;
+        }
+    }
+    // Default is evolution's main locales files
+    return join(__dirname, '../../../../locales/{{lng}}/{{ns}}.json');
+};
+
+const translationPaths: string[] = [];
+/**
+ * Register a directory where translation files are located. Note that this
+ * should be called before the i18n is first used by the server, otherwise, it
+ * won't be used.
+ *
+ * @param dir Absolute path to directory where the locales files are. This
+ * directory should contain one directory per locale, with the translations
+ * files in it.
+ */
+export const registerTranslationDir = (dir: string) => {
+    if (fs.existsSync(dir)) {
+        translationPaths.push(dir);
+    } else {
+        console.log(`i18next directory to register does not exist: ${dir}`);
+    }
+};
+
+const namespaces = ['main', 'auth', 'survey'];
+/**
+ * Add a translation namespace to the translation object. Note that this should
+ * be called before the i18n is first used by the server, otherwise, it won't be
+ * used.
+ *
+ * @param ns The namespace to add
+ */
+export const addTranslationNamespace = (ns: string) => {
+    if (!namespaces.includes(ns)) {
+        namespaces.push(ns);
+    }
+};
+
+let initialized = false;
+const initializeI18n = (languages: string[]) => {
+    i18next.use(Backend).init({
+        initImmediate: false,
+        load: 'languageOnly', // no region-specific,
+        supportedLngs: languages,
+        preload: languages,
+        nonExplicitSupportedLngs: false,
+        fallbackLng: languages[0] || 'en',
+        ns: namespaces,
+        defaultNS: 'server',
+        debug: false,
+        backend: {
+            loadPath: getTranslationPath
+        }
+    });
+    initialized = true;
+};
+
+const getI18n = (languages: string[]) => {
+    if (!initialized) {
+        initializeI18n(languages);
+    }
+    return i18next;
+};
+
+export default getI18n;

--- a/packages/evolution-frontend/tests/ui-testing/testHelpers.ts
+++ b/packages/evolution-frontend/tests/ui-testing/testHelpers.ts
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { test, expect, Page, BrowserContext } from '@playwright/test';
+import configureI18n, { registerTranslationDir } from './configurei18n';
+
+if (process.env.LOCALE_DIR) {
+    registerTranslationDir(process.env.LOCALE_DIR);
+}
+
+// Configure i18n for english and french language. The playwright test is not
+// run in the browser context itself, so translations need to be manually loaded
+// if we want to identify widgets by their texts.
+
+// FIXME Let surveys define their own set of languages
+const i18n = configureI18n(['en', 'fr']);
+
+// Types for the tests
+type Value = string;
+type Text = string;
+type Url = string;
+type Title = string;
+type Path = string;
+type PathAndValue = { path: Path; value: Value };
+type HasTitleTest = ({ title }: { title: Title }) => void;
+type HasFrenchTest = () => void;
+type SwitchToEnglishTest = () => void;
+type HasConsentTest = () => void;
+type StartSurveyTest = () => void;
+type RegisterWithoutEmailTest = () => void;
+type HasUserTest = () => void;
+type InputRadioTest = ({ path, value }: PathAndValue) => void;
+type InputSelectTest = ({ path, value }: PathAndValue) => void;
+type InputStringTest = ({ path, value }: PathAndValue) => void;
+type InputRangeTest = ({ path, value }: {path: Path, value: number}) => void;
+type InputMapFindPlaceTest = ({ path }: { path: Path }) => void;
+type InputNextButtonTest = ({ text, nextPageUrl }: { text: Text; nextPageUrl: Url }) => void;
+
+let page: Page;
+let context: BrowserContext;
+let personId: string;
+const savedLabels: { [key: string]: number } = {}; // Get all the saved labels
+
+// Configure the tests to run in serial mode (one after the other)
+test.describe.configure({ mode: 'serial' });
+
+// Open the browser before all the tests and go to the home page
+test.beforeAll(async ({ browser }) => {
+    context = await browser.newContext();
+    page = await context.newPage();
+    await page.goto('/');
+
+    // Listen to console logs to get the personId
+    // FIXME Find a better way to get the personId, like listen to the network requests
+    page.on('console', (msg) => {
+        if (msg.text().includes('rendering person')) {
+            const parts = msg.text().split(' ');
+            personId = parts[3]; // The personId is the fourth part of the split string
+        }
+    });
+});
+
+// Close the browser after all the tests
+test.afterAll(async ({ browser }) => {
+    browser.close;
+});
+
+// Replace ${personId} with the actual personId
+const replacePathWithPersonId = ({ path }): Path => {
+    let newPath: Path = path;
+    if (path.includes('${personId}')) {
+        newPath = path.replace('${personId}', personId);
+    }
+    return newPath;
+};
+
+// Click outside to remove focus, just fake a click on the app's outer div
+const focusOut = async () => {
+    const header = page.locator('id=item-nav-title');
+    await header.click();
+};
+
+// Test if the page has a title
+export const hasTitleTest: HasTitleTest = ({ title }) => {
+    test(`Has title ${title}`, async () => {
+        await expect(page).toHaveTitle(title);
+    });
+};
+
+// Test if the page has a french language
+export const hasFrenchTest: HasFrenchTest = () => {
+    test('Has French language', async () => {
+        const englishButton = page.getByRole('button', { name: 'English' });
+        await expect(englishButton).toHaveText('English');
+    });
+};
+
+// Test if the page has a english language after switching
+export const switchToEnglishTest: SwitchToEnglishTest = () => {
+    test('Switch to English language', async () => {
+        const englishButton = page.getByRole('button', { name: 'English' });
+        await englishButton.click();
+        const frenchButton = page.getByRole('button', { name: 'Français' });
+        await expect(frenchButton).toHaveText('Français');
+    });
+};
+
+// Test if the page has consent
+export const hasConsentTest: HasConsentTest = () => {
+    test('Has consent', async () => {
+        const consentCheckbox = page.locator('id=surveyConsent');
+        await consentCheckbox.click();
+        await expect(consentCheckbox).toBeChecked();
+    });
+};
+
+// Test if the page has a start survey button
+export const startSurveyTest: StartSurveyTest = () => {
+    test('Start survey', async () => {
+        const startSurvey = page.getByRole('button', { name: 'Start' });
+        await startSurvey.click();
+        await expect(page).toHaveURL('/login');
+    });
+};
+
+// Test if the page has a register without email button
+export const registerWithoutEmailTest: RegisterWithoutEmailTest = () => {
+    test('Register without email', async () => {
+        const registerWithoutEmail = page.getByRole('button', { name: i18n.t([
+            'survey:auth:UseAnonymousLogin',
+            'auth:UseAnonymousLogin'
+        ]) as string });
+        await registerWithoutEmail.click();
+        await expect(page).toHaveURL('/survey/home');
+    });
+};
+
+// Test if the page has a user
+export const hasUserTest: HasUserTest = () => {
+    test('Has anonym user', async () => {
+        const userName = page.getByRole('button', { name: /anonym_.*/ });
+        await expect(userName).toHaveText(/anonym_.*/);
+    });
+};
+
+// Test input radio widget
+export const inputRadioTest: InputRadioTest = ({ path, value }) => {
+    test(`Check ${value} for ${path}`, async () => {
+        const newPath = replacePathWithPersonId({ path });
+        const radio = page.locator(`id=survey-question__${newPath}_${value}__input-radio__${value}`);
+        await radio.click();
+        await expect(radio).toBeChecked();
+        await focusOut();
+    });
+};
+
+// Test input select widget
+export const inputSelectTest: InputSelectTest = ({ path, value }) => {
+    test(`Select ${value} for ${path}`, async () => {
+        const newPath = replacePathWithPersonId({ path });
+        const option = page.locator(`id=survey-question__${newPath}`);
+        option.selectOption(value);
+        await expect(option).toHaveValue(value);
+        await focusOut();
+    });
+};
+
+// Test input string widget
+export const inputStringTest: InputStringTest = ({ path, value }) => {
+    test(`Fill ${value} for ${path}`, async () => {
+        const newPath = replacePathWithPersonId({ path });
+        const inputText = page.locator(`id=survey-question__${newPath}`);
+        await inputText.fill(value);
+        await expect(inputText).toHaveValue(value);
+        await focusOut();
+    });
+};
+
+// TODO: Change the id to get all the locator correctly.
+// Test input range widget
+export const inputRangeTest: InputRangeTest = ({ path, value }) => {
+    test(`Drag ${value} for ${path}`, async () => {
+        const newPath = replacePathWithPersonId({ path });
+        const resultDiv = page.locator(`div[aria-labelledby='survey-question__${newPath}_label']`);
+        const questionLabelDiv = page.locator(`id=survey-question__${newPath}_label`);
+        const min = Number(await resultDiv.getAttribute('aria-valuemin')); // Get the min value of the range
+        const max = Number(await resultDiv.getAttribute('aria-valuemax')); // Get the max value of the range
+        const rangeLabel = String(await questionLabelDiv.textContent()); // Get the label of the range widget
+
+        // Get the label of the range widget only if it hasn't been retrieved before
+        if (!savedLabels[rangeLabel]) {
+            savedLabels[rangeLabel] = 0;
+        }
+        const slider = page.getByLabel(rangeLabel).nth(savedLabels[rangeLabel]);
+        savedLabels[rangeLabel]++;
+
+        const sliderBoundingBox = await slider.boundingBox();
+        const container = page.locator('css=.input-slider-blue').first();
+        const containerBoudingBox = await container.boundingBox();
+        const containerPercentage = (Number(value) + Math.abs(min)) / (Math.abs(max) + Math.abs(min)); // Calculate the percentage of the value in the range
+
+        // If the slider or the container are not visible, we can't test the slider
+        if (sliderBoundingBox === null || containerBoudingBox === null) {
+            return;
+        }
+
+        // Start from the middle of the slider's thumb
+        const startPoint = {
+            x: sliderBoundingBox.x + sliderBoundingBox.width / 2,
+            y: sliderBoundingBox.y + sliderBoundingBox.height / 2
+        };
+
+        // Slide it to some endpoint determined by the target percentage
+        const endPoint = {
+            x: sliderBoundingBox.x + sliderBoundingBox.width / 2 + containerBoudingBox.width * containerPercentage,
+            y: sliderBoundingBox.y + sliderBoundingBox.height / 2
+        };
+
+        // Drag and drop the slider
+        await page.mouse.move(startPoint.x, startPoint.y);
+        await page.mouse.down();
+        await page.mouse.move(endPoint.x, endPoint.y);
+        await page.mouse.up();
+
+        // Get the current value of the range
+        const ariaValuenow = await resultDiv.getAttribute('aria-valuenow');
+        expect(Number(ariaValuenow)).toBe(value);
+        await focusOut();
+    });
+};
+
+// Test input mapFindPlace widget
+export const inputMapFindPlaceTest: InputMapFindPlaceTest = ({ path }) => {
+    test('Find place on map', async () => {
+        const newPath = replacePathWithPersonId({ path });
+        // Refresh map result
+        const refreshButton = page.locator(`id=survey-question__${newPath}_refresh`);
+        await refreshButton.click();
+
+        // Select option from select
+        const select = page.locator(`id=survey-question__${newPath}_mapFindPlace`);
+        await select.press('ArrowDown');
+        await select.press('Enter');
+
+        // Confirm place
+        const confimButton = page.locator(`id=survey-question__${newPath}_confirm`);
+        await expect(confimButton).toBeVisible();
+        await confimButton.click();
+    });
+};
+
+// Test input button widget that go to the next page
+export const inputNextButtonTest: InputNextButtonTest = ({ text, nextPageUrl }) => {
+    test(`Click ${text} and go to ${nextPageUrl}`, async () => {
+        const button = page.getByRole('button', { name: text });
+        await button.click();
+        await expect(page).toHaveURL(nextPageUrl);
+    });
+};

--- a/packages/evolution-interviewer/package.json
+++ b/packages/evolution-interviewer/package.json
@@ -31,7 +31,7 @@
         "evolution-common": "^0.2.2",
         "evolution-frontend": "^0.2.2",
         "evolution-legacy": "0.2.2",
-        "express": "^4.17.1",
+        "express": "^4.19.2",
         "i18next": "^22.4.15",
         "knex": "^3.1.0",
         "lodash": "^4.17.21",

--- a/packages/evolution-legacy/package.json
+++ b/packages/evolution-legacy/package.json
@@ -66,7 +66,7 @@
     "evolution-backend": "0.2.2",
     "evolution-common": "0.2.2",
     "evolution-frontend": "0.2.2",
-    "express": "^4.17.3",
+    "express": "^4.19.2",
     "express-session": "^1.17.1",
     "glob": "^7.2.3",
     "google-maps-react": "^2.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5077,7 +5077,7 @@ abab@^2.0.5:
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"
   integrity sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==
 
-accepts@~1.3.4, accepts@~1.3.7:
+accepts@~1.3.4:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
   integrity sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==
@@ -5798,29 +5798,13 @@ bn.js@^5.1.1:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.1.2.tgz#c9686902d3c9a27729f43ab10f9d79c2004da7b0"
   integrity sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA==
 
-body-parser@1.19.0:
-  version "1.19.0"
-  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.0.tgz#96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
-  integrity sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==
-  dependencies:
-    bytes "3.1.0"
-    content-type "~1.0.4"
-    debug "2.6.9"
-    depd "~1.1.2"
-    http-errors "1.7.2"
-    iconv-lite "0.4.24"
-    on-finished "~2.3.0"
-    qs "6.7.0"
-    raw-body "2.4.0"
-    type-is "~1.6.17"
-
-body-parser@1.20.1:
-  version "1.20.1"
-  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.1.tgz#b1812a8912c195cd371a3ee5e66faa2338a5c668"
-  integrity sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==
+body-parser@1.20.2:
+  version "1.20.2"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.2.tgz#6feb0e21c4724d06de7ff38da36dad4f57a747fd"
+  integrity sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==
   dependencies:
     bytes "3.1.2"
-    content-type "~1.0.4"
+    content-type "~1.0.5"
     debug "2.6.9"
     depd "2.0.0"
     destroy "1.2.0"
@@ -5828,7 +5812,7 @@ body-parser@1.20.1:
     iconv-lite "0.4.24"
     on-finished "2.4.1"
     qs "6.11.0"
-    raw-body "2.5.1"
+    raw-body "2.5.2"
     type-is "~1.6.18"
     unpipe "1.0.0"
 
@@ -6020,11 +6004,6 @@ bundle-loader@^0.5.6:
   integrity sha512-SUgX+u/LJzlJiuoIghuubZ66eflehnjmqSfh/ib9DTe08sxRJ5F/MhHSjp7GfSJivSp8NWgez4PVNAUuMg7vSg==
   dependencies:
     loader-utils "^1.1.0"
-
-bytes@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
-  integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
 
 bytes@3.1.2, bytes@^3.1.2:
   version "3.1.2"
@@ -6643,13 +6622,6 @@ constants-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
   integrity sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=
 
-content-disposition@0.5.3:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.3.tgz#e130caf7e7279087c5616c2007d0485698984fbd"
-  integrity sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==
-  dependencies:
-    safe-buffer "5.1.2"
-
 content-disposition@0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.4.tgz#8b82b4efac82512a02bb0b1dcec9d2c5e8eb5bfe"
@@ -6661,6 +6633,11 @@ content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
+
+content-type@~1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.5.tgz#8b773162656d1d1086784c8f23a54ce6d73d7918"
+  integrity sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==
 
 convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.5.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   version "1.7.0"
@@ -6679,10 +6656,10 @@ cookie@0.4.0:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
 
-cookie@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
-  integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
+cookie@0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.6.0.tgz#2798b04b071b0ecbff0dbb62a505a8efa4e19051"
+  integrity sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==
 
 cookie@~0.4.1:
   version "0.4.1"
@@ -7241,11 +7218,6 @@ depd@2.0.0, depd@~2.0.0:
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
-depd@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
-  integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
-
 deps-regex@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/deps-regex/-/deps-regex-0.1.4.tgz#518667b7691460a5e7e0a341be76eb7ce8090184"
@@ -7263,11 +7235,6 @@ destroy@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
-
-destroy@~1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
-  integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
 
 detect-file@^1.0.0:
   version "1.0.0"
@@ -8275,53 +8242,17 @@ express-session@^1.17.1:
     safe-buffer "5.2.0"
     uid-safe "~2.1.5"
 
-express@^4.17.1:
-  version "4.17.1"
-  resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"
-  integrity sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==
-  dependencies:
-    accepts "~1.3.7"
-    array-flatten "1.1.1"
-    body-parser "1.19.0"
-    content-disposition "0.5.3"
-    content-type "~1.0.4"
-    cookie "0.4.0"
-    cookie-signature "1.0.6"
-    debug "2.6.9"
-    depd "~1.1.2"
-    encodeurl "~1.0.2"
-    escape-html "~1.0.3"
-    etag "~1.8.1"
-    finalhandler "~1.1.2"
-    fresh "0.5.2"
-    merge-descriptors "1.0.1"
-    methods "~1.1.2"
-    on-finished "~2.3.0"
-    parseurl "~1.3.3"
-    path-to-regexp "0.1.7"
-    proxy-addr "~2.0.5"
-    qs "6.7.0"
-    range-parser "~1.2.1"
-    safe-buffer "5.1.2"
-    send "0.17.1"
-    serve-static "1.14.1"
-    setprototypeof "1.1.1"
-    statuses "~1.5.0"
-    type-is "~1.6.18"
-    utils-merge "1.0.1"
-    vary "~1.1.2"
-
-express@^4.17.3:
-  version "4.18.2"
-  resolved "https://registry.yarnpkg.com/express/-/express-4.18.2.tgz#3fabe08296e930c796c19e3c516979386ba9fd59"
-  integrity sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==
+express@^4.19.2:
+  version "4.19.2"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.19.2.tgz#e25437827a3aa7f2a827bc8171bbbb664a356465"
+  integrity sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==
   dependencies:
     accepts "~1.3.8"
     array-flatten "1.1.1"
-    body-parser "1.20.1"
+    body-parser "1.20.2"
     content-disposition "0.5.4"
     content-type "~1.0.4"
-    cookie "0.5.0"
+    cookie "0.6.0"
     cookie-signature "1.0.6"
     debug "2.6.9"
     depd "2.0.0"
@@ -8549,19 +8480,6 @@ finalhandler@1.2.0:
     statuses "2.0.1"
     unpipe "~1.0.0"
 
-finalhandler@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.2.tgz#b7e7d000ffd11938d0fdb053506f6ebabe9f587d"
-  integrity sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==
-  dependencies:
-    debug "2.6.9"
-    encodeurl "~1.0.2"
-    escape-html "~1.0.3"
-    on-finished "~2.3.0"
-    parseurl "~1.3.3"
-    statuses "~1.5.0"
-    unpipe "~1.0.0"
-
 find-cache-dir@^2.0.0, find-cache-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
@@ -8707,11 +8625,6 @@ forwarded@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.2.0.tgz#2269936428aad4c15c7ebe9779a84bf0b2a81811"
   integrity sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==
-
-forwarded@~0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
-  integrity sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=
 
 fragment-cache@^0.2.1:
   version "0.2.1"
@@ -9476,17 +9389,6 @@ htmlparser2@^6.1.0:
     domutils "^2.5.2"
     entities "^2.0.0"
 
-http-errors@1.7.2:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.2.tgz#4f5029cf13239f31036e5b2e55292bcfbcc85c8f"
-  integrity sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==
-  dependencies:
-    depd "~1.1.2"
-    inherits "2.0.3"
-    setprototypeof "1.1.1"
-    statuses ">= 1.5.0 < 2"
-    toidentifier "1.0.0"
-
 http-errors@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.0.tgz#b7774a1486ef73cf7667ac9ae0858c012c57b9d3"
@@ -9497,17 +9399,6 @@ http-errors@2.0.0:
     setprototypeof "1.2.0"
     statuses "2.0.1"
     toidentifier "1.0.1"
-
-http-errors@~1.7.2:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.3.tgz#6c619e4f9c60308c38519498c14fbb10aacebb06"
-  integrity sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==
-  dependencies:
-    depd "~1.1.2"
-    inherits "2.0.4"
-    setprototypeof "1.1.1"
-    statuses ">= 1.5.0 < 2"
-    toidentifier "1.0.0"
 
 http-proxy-agent@^4.0.1:
   version "4.0.1"
@@ -13525,14 +13416,6 @@ protocol-buffers-schema@^3.3.1:
   resolved "https://registry.yarnpkg.com/protocol-buffers-schema/-/protocol-buffers-schema-3.4.0.tgz#2f0ea31ca96627d680bf2fefae7ebfa2b6453eae"
   integrity sha512-G/2kcamPF2S49W5yaMGdIpkG6+5wZF0fzBteLKgEHjbNzqjZQ85aAs1iJGto31EJaSTkNvHs5IXuHSaTLWBAiA==
 
-proxy-addr@~2.0.5:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.6.tgz#fdc2336505447d3f2f2c638ed272caf614bbb2bf"
-  integrity sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==
-  dependencies:
-    forwarded "~0.1.2"
-    ipaddr.js "1.9.1"
-
 proxy-addr@~2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
@@ -13609,11 +13492,6 @@ qs@6.11.0:
   integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
   dependencies:
     side-channel "^1.0.4"
-
-qs@6.7.0:
-  version "6.7.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
-  integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
 qs@^6.5.1:
   version "6.9.4"
@@ -13745,20 +13623,10 @@ range-parser@~1.2.1:
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
 
-raw-body@2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.4.0.tgz#a1ce6fb9c9bc356ca52e89256ab59059e13d0332"
-  integrity sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==
-  dependencies:
-    bytes "3.1.0"
-    http-errors "1.7.2"
-    iconv-lite "0.4.24"
-    unpipe "1.0.0"
-
-raw-body@2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.5.1.tgz#fe1b1628b181b700215e5fd42389f98b71392857"
-  integrity sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==
+raw-body@2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.5.2.tgz#99febd83b90e08975087e8f1f9419a149366b68a"
+  integrity sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==
   dependencies:
     bytes "3.1.2"
     http-errors "2.0.0"
@@ -14895,25 +14763,6 @@ semver@^7.3.7:
   dependencies:
     lru-cache "^6.0.0"
 
-send@0.17.1:
-  version "0.17.1"
-  resolved "https://registry.yarnpkg.com/send/-/send-0.17.1.tgz#c1d8b059f7900f7466dd4938bdc44e11ddb376c8"
-  integrity sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==
-  dependencies:
-    debug "2.6.9"
-    depd "~1.1.2"
-    destroy "~1.0.4"
-    encodeurl "~1.0.2"
-    escape-html "~1.0.3"
-    etag "~1.8.1"
-    fresh "0.5.2"
-    http-errors "~1.7.2"
-    mime "1.6.0"
-    ms "2.1.1"
-    on-finished "~2.3.0"
-    range-parser "~1.2.1"
-    statuses "~1.5.0"
-
 send@0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/send/-/send-0.18.0.tgz#670167cc654b05f5aa4a767f9113bb371bc706be"
@@ -14958,16 +14807,6 @@ serve-favicon@^2.5.0:
     parseurl "~1.3.2"
     safe-buffer "5.1.1"
 
-serve-static@1.14.1:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.14.1.tgz#666e636dc4f010f7ef29970a88a674320898b2f9"
-  integrity sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==
-  dependencies:
-    encodeurl "~1.0.2"
-    escape-html "~1.0.3"
-    parseurl "~1.3.3"
-    send "0.17.1"
-
 serve-static@1.15.0:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.15.0.tgz#faaef08cffe0a1a62f60cad0c4e513cff0ac9540"
@@ -14997,11 +14836,6 @@ setimmediate@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
-
-setprototypeof@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.1.tgz#7e95acb24aa92f5885e0abef5ba131330d4ae683"
-  integrity sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==
 
 setprototypeof@1.2.0:
   version "1.2.0"
@@ -15427,11 +15261,6 @@ statuses@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
-
-"statuses@>= 1.5.0 < 2", statuses@~1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
-  integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
 stream-browserify@^2.0.1:
   version "2.0.2"
@@ -16063,11 +15892,6 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
-toidentifier@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
-  integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
-
 toidentifier@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
@@ -16293,7 +16117,7 @@ type-fest@^1.2.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.4.0.tgz#e9fb813fe3bf1744ec359d55d1affefa76f14be1"
   integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
 
-type-is@~1.6.17, type-is@~1.6.18:
+type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
   integrity sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2513,6 +2513,13 @@
     "@types/geojson" "^7946.0.7"
     type-fest "^1.2.1"
 
+"@playwright/test@^1.41.2":
+  version "1.44.0"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.44.0.tgz#ac7a764b5ee6a80558bdc0fcbc525fcb81f83465"
+  integrity sha512-rNX5lbNidamSUorBhB4XZ9SQTjAqfe5M+p37Z8ic0jPFBMo5iCtQz1kRWkEMg+rYOKSlVycpQmpqjSFq7LXOfg==
+  dependencies:
+    playwright "1.44.0"
+
 "@popperjs/core@^2.9.2":
   version "2.11.5"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.5.tgz#db5a11bf66bdab39569719555b0f76e138d7bd64"
@@ -8695,6 +8702,11 @@ fs@0.0.2:
   resolved "https://registry.yarnpkg.com/fs/-/fs-0.0.2.tgz#e1f244ef3933c1b2a64bd4799136060d0f5914f8"
   integrity sha1-4fJE7zkzwbKmS9R5kTYGDQ9ZFPg=
 
+fsevents@2.3.2, fsevents@^2.3.2, fsevents@~2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 fsevents@^1.2.7:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.13.tgz#f325cb0455592428bcf11b383370ef70e3bfcc38"
@@ -8707,11 +8719,6 @@ fsevents@^2.1.2, fsevents@~2.1.2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
   integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
-
-fsevents@^2.3.2, fsevents@~2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
-  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -13078,6 +13085,20 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+playwright-core@1.44.0:
+  version "1.44.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.44.0.tgz#316c4f0bca0551ffb88b6eb1c97bc0d2d861b0d5"
+  integrity sha512-ZTbkNpFfYcGWohvTTl+xewITm7EOuqIqex0c7dNZ+aXsbrLj0qI8XlGKfPpipjm0Wny/4Lt4CJsWJk1stVS5qQ==
+
+playwright@1.44.0:
+  version "1.44.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.44.0.tgz#22894e9b69087f6beb639249323d80fe2b5087ff"
+  integrity sha512-F9b3GUCLQ3Nffrfb6dunPOkE5Mh68tR7zN32L4jCk4FjQamgesGay7/dAAe1WaMEGV04DkdJfcJzjoCKygUaRQ==
+  dependencies:
+    playwright-core "1.44.0"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 please-upgrade-node@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
fixes #490
    
* Add the `testHelpers` from the MJ project into Evolution
* Add an example configuration for playwright tests
* Add a section in the readme to run those tests
* Configure translations from files, similar to chaire-lib-backend, so
  that library functions can use them (for example for the anonymous
  login text).
* Display screenshots on failure