### PR TITLE
infoMap: Fix the bounds extension to avoid extending indefinitely

### DIFF
--- a/packages/evolution-frontend/src/components/survey/InfoMap.tsx
+++ b/packages/evolution-frontend/src/components/survey/InfoMap.tsx
@@ -96,7 +96,7 @@ const InfoMap: React.FC<InfoMapProps & WithTranslation> = (props: InfoMapProps &
     const linestringColor = props.widgetConfig.linestringColor || '#0000ff';
     const linestringActiveColor = props.widgetConfig.linestringActiveColor || '#00ff00';
 
-    const bounds = map ? map.getBounds() || new google.maps.LatLngBounds() : undefined;
+    const bounds = new google.maps.LatLngBounds();
 
     for (let i = 0, countI = points.length; i < countI; i++) {
         const point = points[i];


### PR DESCRIPTION
fixes #549

The bounds are initialized at every call so they can be extended the same way at every render.