### PR TITLE
inputRange: add a `includeNonApplicable` property

### DIFF
--- a/example/demo_survey/src/survey/widgets/end.tsx
+++ b/example/demo_survey/src/survey/widgets/end.tsx
@@ -343,6 +343,7 @@ export const householdSurveyAppreciation = {
     type: "question",
     path: "household.surveyAppreciation",
     inputType: "slider",
+    includeNotApplicable: true,
     datatype: "number",
     twoColumns: true,
     maxValue: 10,

--- a/locales/en/main.json
+++ b/locales/en/main.json
@@ -41,5 +41,6 @@
   "BackToSurveyPage": "Back to survey",
   "AnErrorOccurred": "An error occurred.",
   "MakeSureReliableConnection": "Make sure you have a reliable internet connection.",
-  "ErrorPersistsWhatToDo": "If the problem persists, please contact the survey administrators."
+  "ErrorPersistsWhatToDo": "If the problem persists, please contact the survey administrators.",
+  "NotApplicable": "Not applicable"
 }

--- a/locales/fr/main.json
+++ b/locales/fr/main.json
@@ -41,5 +41,6 @@
   "BackToSurveyPage": "Retour à l'enquête",
   "AnErrorOccurred": "Une erreur est survenue.",
   "MakeSureReliableConnection": "Assurez-vous d'avoir une connection internet fiable.",
-  "ErrorPersistsWhatToDo": "Si le problème persiste, veuillez contacter les administrateurs de l'enquête."
+  "ErrorPersistsWhatToDo": "Si le problème persiste, veuillez contacter les administrateurs de l'enquête.",
+  "NotApplicable": "Non applicable"
 }

--- a/packages/evolution-common/src/services/widgets/WidgetConfig.ts
+++ b/packages/evolution-common/src/services/widgets/WidgetConfig.ts
@@ -194,6 +194,10 @@ export type InputRangeType = {
     formatLabel?: (value: number, lang: string) => string;
     labels?: I18nData[];
     trackClassName?: string;
+    /** Whether to include a 'not applicable' checkbox that will disable the input */
+    includeNotApplicable?: boolean;
+    /** An optional label for the 'not applicable' text. Only used if includeNotApplicable is true */
+    notApplicableLabel?: I18nData;
 };
 
 export type InputDatePickerType = {

--- a/packages/evolution-frontend/src/components/inputs/InputCheckbox.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputCheckbox.tsx
@@ -18,7 +18,7 @@ import { CommonInputProps } from './CommonInputProps';
 import { sortByParameters } from './InputChoiceSorting';
 
 export type InputCheckboxProps = CommonInputProps & {
-    value: string;
+    value: string[];
     /** Value of the custom field if 'other' is selected */
     customValue?: string;
     inputRef?: React.LegacyRef<HTMLInputElement>;

--- a/packages/evolution-frontend/src/components/inputs/InputRange.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputRange.tsx
@@ -15,15 +15,16 @@ import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { InputRangeType } from 'evolution-common/lib/services/widgets';
 import * as surveyHelper from 'evolution-common/lib/utils/helpers';
 import { CommonInputProps } from './CommonInputProps';
+import InputCheckbox from './InputCheckbox';
 
 export type InputRangeProps = CommonInputProps & {
-    value?: number;
+    value?: number | 'na';
     inputRef?: React.LegacyRef<ReactInputRange>;
     widgetConfig: InputRangeType;
 };
 
 export const InputRange = (props: InputRangeProps & WithTranslation) => {
-    const [value, setValue] = React.useState<number | Range | undefined>(props.value);
+    const [value, setValue] = React.useState<number | Range | undefined | 'na'>(props.value);
 
     const labels = props.widgetConfig.labels;
     const labelItems = labels
@@ -73,8 +74,13 @@ export const InputRange = (props: InputRangeProps & WithTranslation) => {
                         ? (value) => formatLabelFct(value, props.i18n.language)
                         : (value) => String(value)
                 }
-                value={!_isBlank(value) && value !== undefined && value >= minValue ? value : minValue}
+                value={
+                    !_isBlank(value) && value !== undefined && typeof value !== 'string' && value >= minValue
+                        ? value
+                        : minValue
+                }
                 classNames={defaultClassNames}
+                disabled={typeof value === 'string'}
                 onChange={(value) => setValue(value)}
                 onChangeComplete={(value) => {
                     if (value < minValue) {
@@ -86,6 +92,40 @@ export const InputRange = (props: InputRangeProps & WithTranslation) => {
             />
             {labelItems.length > 0 && (
                 <div className={'survey-question__input-range_input_labels_container'}>{labelItems}</div>
+            )}
+            {props.widgetConfig.includeNotApplicable === true && (
+                <InputCheckbox
+                    id={`${props.id}_na`}
+                    onValueChange={(newVal) => {
+                        if (newVal.target.value.length > 0) {
+                            setValue('na');
+                            props.onValueChange({ target: { value: 'na' } });
+                        } else {
+                            setValue(undefined);
+                            props.onValueChange({ target: { value: undefined } });
+                        }
+                    }}
+                    value={(value as any) === 'na' ? ['na'] : ([] as any)}
+                    path={props.path}
+                    interview={props.interview}
+                    user={props.user}
+                    widgetConfig={{
+                        inputType: 'checkbox',
+                        choices: [
+                            {
+                                value: 'na',
+                                label:
+                                    surveyHelper.translateString(
+                                        props.widgetConfig.notApplicableLabel,
+                                        props.i18n,
+                                        props.interview,
+                                        props.path,
+                                        props.user
+                                    ) || props.t(['survey:main:NotApplicable', 'main:NotApplicable'])
+                            }
+                        ]
+                    }}
+                />
             )}
         </div>
     );

--- a/packages/evolution-frontend/src/components/inputs/__tests__/InputCheckbox.test.tsx
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/InputCheckbox.test.tsx
@@ -90,13 +90,13 @@ describe('Render InputCheckbox with various parameter combinations, all paramete
         conditionalFct.mockClear();
     })
 
-    test('Includes hidden values, conditional displayed, no custom, 2 columns', () => {
+    test('Includes hidden values, conditional displayed, no custom, 2 columns, 2 selected values', () => {
         const wrapper = TestRenderer.create(
             <InputCheckbox
                 id={'test'}
                 onValueChange={() => { /* nothing to do */}}
                 widgetConfig={widgetConfig}
-                value='value'
+                value={['val1', 'val2']}
                 inputRef={React.createRef()}
                 
                 interview={interviewAttributes}
@@ -110,7 +110,7 @@ describe('Render InputCheckbox with various parameter combinations, all paramete
         expect(translationFct).toHaveBeenCalledWith(i18next.t, interviewAttributes, 'foo.test', userAttributes);
     });
 
-    test('Conditional value hidden, same line', () => {
+    test('Conditional value hidden, same line, no value selected', () => {
         conditionalFct.mockReturnValueOnce(false);
         const testWidgetConfig = Object.assign({}, widgetConfig, { sameLine: true, columns: undefined });
         const wrapper = TestRenderer.create(
@@ -118,7 +118,7 @@ describe('Render InputCheckbox with various parameter combinations, all paramete
                 id={'test'}
                 onValueChange={() => { /* nothing to do */}}
                 widgetConfig={testWidgetConfig}
-                value='value'
+                value={[]}
                 inputRef={React.createRef()}
                 interview={interviewAttributes}
                 user={userAttributes}
@@ -128,7 +128,7 @@ describe('Render InputCheckbox with various parameter combinations, all paramete
         expect(wrapper).toMatchSnapshot();
     });
 
-    test('Shuffle choices', () => {
+    test('Shuffle choices, one selected value', () => {
         shuffleMock.mockReturnValue([choices[1], choices[3], choices[0], choices[2]]);
         const testWidgetConfig = Object.assign({}, widgetConfig, { shuffle: true });
         const wrapper = TestRenderer.create(
@@ -136,7 +136,7 @@ describe('Render InputCheckbox with various parameter combinations, all paramete
                 id={'test'}
                 onValueChange={() => { /* nothing to do */}}
                 widgetConfig={testWidgetConfig}
-                value='value'
+                value={['val2']}
                 inputRef={React.createRef()}
                 interview={interviewAttributes}
                 user={userAttributes}
@@ -148,14 +148,32 @@ describe('Render InputCheckbox with various parameter combinations, all paramete
         expect(shuffleMock).toHaveBeenCalledWith(choices, undefined, widgetConfig.seed);
     });
 
-    test('With custom choice', () => {
+    test('With custom choice, custom unchecked', () => {
         const testWidgetConfig = Object.assign({}, widgetConfig, { addCustom: true });
         const wrapper = TestRenderer.create(
             <InputCheckbox
                 id={'test'}
                 onValueChange={() => { /* nothing to do */}}
                 widgetConfig={testWidgetConfig}
-                value='value'
+                value={['value']}
+                inputRef={React.createRef()}
+                interview={interviewAttributes}
+                user={userAttributes}
+                path='foo.test'
+                customId='foo.test.custom'
+            />
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('With custom choice, custom checked', () => {
+        const testWidgetConfig = Object.assign({}, widgetConfig, { addCustom: true });
+        const wrapper = TestRenderer.create(
+            <InputCheckbox
+                id={'test'}
+                onValueChange={() => { /* nothing to do */}}
+                widgetConfig={testWidgetConfig}
+                value={['custom']}
                 inputRef={React.createRef()}
                 interview={interviewAttributes}
                 user={userAttributes}
@@ -194,13 +212,13 @@ describe('Render InputCheckbox with minimum parameters', () => {
         }
     };
 
-    test('Minimum parameters', () => {
+    test('Minimum parameters, one value selected', () => {
         const wrapper = TestRenderer.create(
             <InputCheckbox
                 id={'test'}
                 onValueChange={() => { /* nothing to do */}}
                 widgetConfig={widgetConfig}
-                value='value'
+                value={['val1']}
                 inputRef={React.createRef()}
                 interview={interviewAttributes}
                 user={userAttributes}
@@ -248,7 +266,7 @@ describe('Render InputCheckbox with HTML label', () => {
                 id={'test'}
                 onValueChange={() => { /* nothing to do */}}
                 widgetConfig={widgetConfig}
-                value='value'
+                value={['second value']}
                 inputRef={React.createRef()}
                 interview={interviewAttributes}
                 user={userAttributes}

--- a/packages/evolution-frontend/src/components/inputs/__tests__/InputRange.test.tsx
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/InputRange.test.tsx
@@ -143,3 +143,90 @@ describe('Should correctly render InputRange with various parameters', () => {
     });
 
 });
+
+describe('Should correctly render InputRange with not applicable', () => {
+
+    const widgetConfig = {
+        type: 'question' as const,
+        twoColumns: true,
+        path: 'test.foo',
+        containsHtml: true,
+        label: {
+            fr: `Texte en français`,
+            en: `English text`
+        },
+        inputType: 'slider' as const,
+        includeNotApplicable: true
+    }
+
+    test('Test without value', () => {
+        // Should have a blank style
+        const wrapper = TestRenderer.create(
+            <InputRange
+                id={'test'}
+                onValueChange={() => { /* nothing to do */}}
+                widgetConfig={widgetConfig}
+                value={undefined}
+                inputRef={React.createRef()}
+                interview={interviewAttributes}
+                user={userAttributes}
+                path='foo.test'
+            />
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('Test with value', () => {
+        const wrapper = TestRenderer.create(
+            <InputRange
+                id={'test'}
+                onValueChange={() => { /* nothing to do */}}
+                widgetConfig={widgetConfig}
+                value={10}
+                inputRef={React.createRef()}
+                interview={interviewAttributes}
+                user={userAttributes}
+                path='foo.test'
+            />
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('Test with a not applicable value', () => {
+        const wrapper = TestRenderer.create(
+            <InputRange
+                id={'test'}
+                onValueChange={() => { /* nothing to do */}}
+                widgetConfig={widgetConfig}
+                value={'na'}
+                inputRef={React.createRef()}
+                interview={interviewAttributes}
+                user={userAttributes}
+                path='foo.test'
+            />
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('Test with custom not applicable label', () => {
+        const widgetConfigWithLabel = {
+            ...widgetConfig,
+            notApplicableLabel: 'Custom non applicable'
+        }
+        const wrapper = TestRenderer.create(
+            <InputRange
+                id={'test'}
+                onValueChange={() => { /* nothing to do */}}
+                widgetConfig={widgetConfigWithLabel}
+                value={10}
+                inputRef={React.createRef()}
+                interview={interviewAttributes}
+                user={userAttributes}
+                path='foo.test'
+            />
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+});
+

--- a/packages/evolution-frontend/src/components/inputs/__tests__/__snapshots__/InputCheckbox.test.tsx.snap
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/__snapshots__/InputCheckbox.test.tsx.snap
@@ -36,14 +36,14 @@ exports[`Render InputCheckbox with HTML label HTML label 1`] = `
     </div>
   </div>
   <div
-    className="survey-question__input-checkbox-input-container"
+    className="survey-question__input-checkbox-input-container checked"
     onClick={[Function]}
   >
     <div
       className="label-input-container"
     >
       <input
-        checked={false}
+        checked={true}
         className="input-checkbox"
         id="test_second value__input-checkbox__second value"
         name="test_second value"
@@ -69,19 +69,19 @@ exports[`Render InputCheckbox with HTML label HTML label 1`] = `
 </div>
 `;
 
-exports[`Render InputCheckbox with minimum parameters Minimum parameters 1`] = `
+exports[`Render InputCheckbox with minimum parameters Minimum parameters, one value selected 1`] = `
 <div
   className="survey-question__input-checkbox-group-container"
 >
   <div
-    className="survey-question__input-checkbox-input-container"
+    className="survey-question__input-checkbox-input-container checked"
     onClick={[Function]}
   >
     <div
       className="label-input-container"
     >
       <input
-        checked={false}
+        checked={true}
         className="input-checkbox"
         id="test_val1__input-checkbox__val1"
         name="test_val1"
@@ -138,7 +138,7 @@ exports[`Render InputCheckbox with minimum parameters Minimum parameters 1`] = `
 </div>
 `;
 
-exports[`Render InputCheckbox with various parameter combinations, all parameters Conditional value hidden, same line 1`] = `
+exports[`Render InputCheckbox with various parameter combinations, all parameters Conditional value hidden, same line, no value selected 1`] = `
 <div
   className="survey-question__input-checkbox-group-container"
 >
@@ -274,7 +274,7 @@ exports[`Render InputCheckbox with various parameter combinations, all parameter
 </div>
 `;
 
-exports[`Render InputCheckbox with various parameter combinations, all parameters Includes hidden values, conditional displayed, no custom, 2 columns 1`] = `
+exports[`Render InputCheckbox with various parameter combinations, all parameters Includes hidden values, conditional displayed, no custom, 2 columns, 2 selected values 1`] = `
 <div
   className="survey-question__input-checkbox-group-container no-wrap"
 >
@@ -282,14 +282,14 @@ exports[`Render InputCheckbox with various parameter combinations, all parameter
     className="survey-question__input-checkbox-group-column"
   >
     <div
-      className="survey-question__input-checkbox-input-container"
+      className="survey-question__input-checkbox-input-container checked"
       onClick={[Function]}
     >
       <div
         className="label-input-container"
       >
         <input
-          checked={false}
+          checked={true}
           className="input-checkbox"
           id="test_val1__input-checkbox__val1"
           name="test_val1"
@@ -336,14 +336,14 @@ exports[`Render InputCheckbox with various parameter combinations, all parameter
       </div>
     </div>
     <div
-      className="survey-question__input-checkbox-input-container"
+      className="survey-question__input-checkbox-input-container checked"
       onClick={[Function]}
     >
       <div
         className="label-input-container"
       >
         <input
-          checked={false}
+          checked={true}
           className="input-checkbox"
           id="test_val2__input-checkbox__val2"
           name="test_val2"
@@ -449,7 +449,7 @@ exports[`Render InputCheckbox with various parameter combinations, all parameter
 </div>
 `;
 
-exports[`Render InputCheckbox with various parameter combinations, all parameters Shuffle choices 1`] = `
+exports[`Render InputCheckbox with various parameter combinations, all parameters Shuffle choices, one selected value 1`] = `
 <div
   className="survey-question__input-checkbox-group-container no-wrap"
 >
@@ -457,14 +457,14 @@ exports[`Render InputCheckbox with various parameter combinations, all parameter
     className="survey-question__input-checkbox-group-column"
   >
     <div
-      className="survey-question__input-checkbox-input-container"
+      className="survey-question__input-checkbox-input-container checked"
       onClick={[Function]}
     >
       <div
         className="label-input-container"
       >
         <input
-          checked={false}
+          checked={true}
           className="input-checkbox"
           id="test_val2__input-checkbox__val2"
           name="test_val2"
@@ -593,7 +593,235 @@ exports[`Render InputCheckbox with various parameter combinations, all parameter
 </div>
 `;
 
-exports[`Render InputCheckbox with various parameter combinations, all parameters With custom choice 1`] = `
+exports[`Render InputCheckbox with various parameter combinations, all parameters With custom choice, custom checked 1`] = `
+<div
+  className="survey-question__input-checkbox-group-container no-wrap"
+>
+  <div
+    className="survey-question__input-checkbox-group-column"
+  >
+    <div
+      className="survey-question__input-checkbox-input-container"
+      onClick={[Function]}
+    >
+      <div
+        className="label-input-container"
+      >
+        <input
+          checked={false}
+          className="input-checkbox"
+          id="test_val1__input-checkbox__val1"
+          name="test_val1"
+          onChange={[Function]}
+          onClick={[Function]}
+          type="checkbox"
+          value="val1"
+        />
+        <label
+          htmlFor="test_val1__input-checkbox__val1"
+          onClick={[Function]}
+        >
+          <span>
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-crow fa-w-20 faIconLeft"
+              data-icon="crow"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={
+                Object {
+                  "margin": "auto 0",
+                }
+              }
+              viewBox="0 0 640 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M544 32h-16.36C513.04 12.68 490.09 0 464 0c-44.18 0-80 35.82-80 80v20.98L12.09 393.57A30.216 30.216 0 0 0 0 417.74c0 22.46 23.64 37.07 43.73 27.03L165.27 384h96.49l44.41 120.1c2.27 6.23 9.15 9.44 15.38 7.17l22.55-8.21c6.23-2.27 9.44-9.15 7.17-15.38L312.94 384H352c1.91 0 3.76-.23 5.66-.29l44.51 120.38c2.27 6.23 9.15 9.44 15.38 7.17l22.55-8.21c6.23-2.27 9.44-9.15 7.17-15.38l-41.24-111.53C485.74 352.8 544 279.26 544 192v-80l96-16c0-35.35-42.98-64-96-64zm-80 72c-13.25 0-24-10.75-24-24 0-13.26 10.75-24 24-24s24 10.74 24 24c0 13.25-10.75 24-24 24z"
+                fill="currentColor"
+                style={Object {}}
+              />
+            </svg>
+          </span>
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "english value",
+              }
+            }
+          />
+        </label>
+      </div>
+    </div>
+    <div
+      className="survey-question__input-checkbox-input-container"
+      onClick={[Function]}
+    >
+      <div
+        className="label-input-container"
+      >
+        <input
+          checked={false}
+          className="input-checkbox"
+          id="test_val2__input-checkbox__val2"
+          name="test_val2"
+          onChange={[Function]}
+          onClick={[Function]}
+          type="checkbox"
+          value="val2"
+        />
+        <label
+          htmlFor="test_val2__input-checkbox__val2"
+          onClick={[Function]}
+        >
+          <span>
+            <img
+              alt="Unilingual label"
+              className="faIconLeft"
+              src="img/test.png"
+              style={
+                Object {
+                  "height": "3em",
+                  "margin": "0 0.25em 0 0",
+                }
+              }
+            />
+          </span>
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "Unilingual label",
+              }
+            }
+          />
+        </label>
+      </div>
+    </div>
+    <div
+      className="survey-question__input-checkbox-input-container"
+      onClick={[Function]}
+    >
+      <div
+        className="label-input-container"
+      >
+        <input
+          checked={false}
+          className="input-checkbox"
+          id="test_conditionalVal__input-checkbox__conditionalVal"
+          name="test_conditionalVal"
+          onChange={[Function]}
+          onClick={[Function]}
+          type="checkbox"
+          value="conditionalVal"
+        />
+        <label
+          htmlFor="test_conditionalVal__input-checkbox__conditionalVal"
+          onClick={[Function]}
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "english conditional",
+              }
+            }
+          />
+        </label>
+      </div>
+    </div>
+  </div>
+  <div
+    className="survey-question__input-checkbox-group-column"
+  >
+    <div
+      className="survey-question__input-checkbox-input-container"
+      onClick={[Function]}
+    >
+      <div
+        className="label-input-container"
+      >
+        <input
+          checked={false}
+          className="input-checkbox"
+          id="test_val3__input-checkbox__val3"
+          name="test_val3"
+          onChange={[Function]}
+          onClick={[Function]}
+          type="checkbox"
+          value="val3"
+        />
+        <label
+          htmlFor="test_val3__input-checkbox__val3"
+          onClick={[Function]}
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "Translated string",
+              }
+            }
+          />
+        </label>
+      </div>
+    </div>
+    <div
+      className="survey-question__input-checkbox-input-container checked"
+      onClick={[Function]}
+    >
+      <div
+        className="label-input-container"
+      >
+        <input
+          checked={true}
+          className="input-checkbox"
+          id="test_custom__input-checkbox__custom"
+          name="test_custom"
+          onChange={[Function]}
+          onClick={[Function]}
+          type="checkbox"
+          value="custom"
+        />
+        <label
+          htmlFor="test_custom__input-checkbox__custom"
+          onClick={[Function]}
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "Other",
+              }
+            }
+          />
+        </label>
+      </div>
+    </div>
+  </div>
+  <div
+    className="label-input-custom-container"
+  >
+    <label
+      htmlFor="foo.test.custom"
+    >
+      <span>
+        custom label
+      </span>
+    </label>
+    <input
+      autoComplete="none"
+      className="apptr__form-input input-custom apptr__input-string"
+      id="foo.test.custom"
+      name="foo.test.custom"
+      onBlur={[Function]}
+      onChange={[Function]}
+      tabIndex={-1}
+      type="text"
+      value=""
+    />
+  </div>
+</div>
+`;
+
+exports[`Render InputCheckbox with various parameter combinations, all parameters With custom choice, custom unchecked 1`] = `
 <div
   className="survey-question__input-checkbox-group-container no-wrap"
 >

--- a/packages/evolution-frontend/src/components/inputs/__tests__/__snapshots__/InputRange.test.tsx.snap
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/__snapshots__/InputRange.test.tsx.snap
@@ -172,6 +172,490 @@ exports[`Should correctly render InputRange with minimal parameters Test without
 </div>
 `;
 
+exports[`Should correctly render InputRange with not applicable Test with a not applicable value 1`] = `
+<div
+  className="survey-question__input-range_input_container_with_labels"
+>
+  <div
+    aria-disabled={true}
+    className="input-range input-range--disabled"
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onTouchStart={[Function]}
+  >
+    <span
+      className="input-range__label input-range__label--min"
+    >
+      <span
+        className="input-range__label-container"
+      >
+        -10
+      </span>
+    </span>
+    <div
+      className="myTrackClass"
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
+    >
+      <div
+        className="input-range__track input-range__track--active"
+        style={
+          Object {
+            "left": "0%",
+            "width": "0%",
+          }
+        }
+      />
+      <span
+        className="input-range__slider-container"
+        style={
+          Object {
+            "left": "0%",
+            "position": "absolute",
+          }
+        }
+      >
+        <span
+          className="input-range__label input-range__label--value"
+        >
+          <span
+            className="input-range__label-container"
+          >
+            -10
+          </span>
+        </span>
+        <div
+          aria-labelledby="test_label"
+          aria-valuemax={100}
+          aria-valuemin={-10}
+          aria-valuenow={-10}
+          className="input-range__slider"
+          draggable="false"
+          onKeyDown={[Function]}
+          onMouseDown={[Function]}
+          onTouchStart={[Function]}
+          role="slider"
+          tabIndex="0"
+        />
+      </span>
+    </div>
+    <span
+      className="input-range__label input-range__label--max"
+    >
+      <span
+        className="input-range__label-container"
+      >
+        100
+      </span>
+    </span>
+    <input
+      name="test"
+      type="hidden"
+      value={-10}
+    />
+  </div>
+  <div
+    className="survey-question__input-checkbox-group-container"
+  >
+    <div
+      className="survey-question__input-checkbox-input-container checked"
+      onClick={[Function]}
+    >
+      <div
+        className="label-input-container"
+      >
+        <input
+          checked={true}
+          className="input-checkbox"
+          id="test_na_na__input-checkbox__na"
+          name="test_na_na"
+          onChange={[Function]}
+          onClick={[Function]}
+          type="checkbox"
+          value="na"
+        />
+        <label
+          htmlFor="test_na_na__input-checkbox__na"
+          onClick={[Function]}
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "NotApplicable",
+              }
+            }
+          />
+        </label>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Should correctly render InputRange with not applicable Test with custom not applicable label 1`] = `
+<div
+  className="survey-question__input-range_input_container_with_labels"
+>
+  <div
+    aria-disabled={false}
+    className="input-range"
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onTouchStart={[Function]}
+  >
+    <span
+      className="input-range__label input-range__label--min"
+    >
+      <span
+        className="input-range__label-container"
+      >
+        -10
+      </span>
+    </span>
+    <div
+      className="myTrackClass"
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
+    >
+      <div
+        className="input-range__track input-range__track--active"
+        style={
+          Object {
+            "left": "0%",
+            "width": "18.181818181818183%",
+          }
+        }
+      />
+      <span
+        className="input-range__slider-container"
+        style={
+          Object {
+            "left": "18.181818181818183%",
+            "position": "absolute",
+          }
+        }
+      >
+        <span
+          className="input-range__label input-range__label--value"
+        >
+          <span
+            className="input-range__label-container"
+          >
+            10
+          </span>
+        </span>
+        <div
+          aria-labelledby="test_label"
+          aria-valuemax={100}
+          aria-valuemin={-10}
+          aria-valuenow={10}
+          className="input-range__slider"
+          draggable="false"
+          onKeyDown={[Function]}
+          onMouseDown={[Function]}
+          onTouchStart={[Function]}
+          role="slider"
+          tabIndex="0"
+        />
+      </span>
+    </div>
+    <span
+      className="input-range__label input-range__label--max"
+    >
+      <span
+        className="input-range__label-container"
+      >
+        100
+      </span>
+    </span>
+    <input
+      name="test"
+      type="hidden"
+      value={10}
+    />
+  </div>
+  <div
+    className="survey-question__input-checkbox-group-container"
+  >
+    <div
+      className="survey-question__input-checkbox-input-container"
+      onClick={[Function]}
+    >
+      <div
+        className="label-input-container"
+      >
+        <input
+          checked={false}
+          className="input-checkbox"
+          id="test_na_na__input-checkbox__na"
+          name="test_na_na"
+          onChange={[Function]}
+          onClick={[Function]}
+          type="checkbox"
+          value="na"
+        />
+        <label
+          htmlFor="test_na_na__input-checkbox__na"
+          onClick={[Function]}
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "Custom non applicable",
+              }
+            }
+          />
+        </label>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Should correctly render InputRange with not applicable Test with value 1`] = `
+<div
+  className="survey-question__input-range_input_container_with_labels"
+>
+  <div
+    aria-disabled={false}
+    className="input-range"
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onTouchStart={[Function]}
+  >
+    <span
+      className="input-range__label input-range__label--min"
+    >
+      <span
+        className="input-range__label-container"
+      >
+        -10
+      </span>
+    </span>
+    <div
+      className="myTrackClass"
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
+    >
+      <div
+        className="input-range__track input-range__track--active"
+        style={
+          Object {
+            "left": "0%",
+            "width": "18.181818181818183%",
+          }
+        }
+      />
+      <span
+        className="input-range__slider-container"
+        style={
+          Object {
+            "left": "18.181818181818183%",
+            "position": "absolute",
+          }
+        }
+      >
+        <span
+          className="input-range__label input-range__label--value"
+        >
+          <span
+            className="input-range__label-container"
+          >
+            10
+          </span>
+        </span>
+        <div
+          aria-labelledby="test_label"
+          aria-valuemax={100}
+          aria-valuemin={-10}
+          aria-valuenow={10}
+          className="input-range__slider"
+          draggable="false"
+          onKeyDown={[Function]}
+          onMouseDown={[Function]}
+          onTouchStart={[Function]}
+          role="slider"
+          tabIndex="0"
+        />
+      </span>
+    </div>
+    <span
+      className="input-range__label input-range__label--max"
+    >
+      <span
+        className="input-range__label-container"
+      >
+        100
+      </span>
+    </span>
+    <input
+      name="test"
+      type="hidden"
+      value={10}
+    />
+  </div>
+  <div
+    className="survey-question__input-checkbox-group-container"
+  >
+    <div
+      className="survey-question__input-checkbox-input-container"
+      onClick={[Function]}
+    >
+      <div
+        className="label-input-container"
+      >
+        <input
+          checked={false}
+          className="input-checkbox"
+          id="test_na_na__input-checkbox__na"
+          name="test_na_na"
+          onChange={[Function]}
+          onClick={[Function]}
+          type="checkbox"
+          value="na"
+        />
+        <label
+          htmlFor="test_na_na__input-checkbox__na"
+          onClick={[Function]}
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "NotApplicable",
+              }
+            }
+          />
+        </label>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Should correctly render InputRange with not applicable Test without value 1`] = `
+<div
+  className="survey-question__input-range_input_container_with_labels input-blank"
+>
+  <div
+    aria-disabled={false}
+    className="input-range"
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onTouchStart={[Function]}
+  >
+    <span
+      className="input-range__label input-range__label--min"
+    >
+      <span
+        className="input-range__label-container"
+      >
+        -10
+      </span>
+    </span>
+    <div
+      className="myTrackClass"
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
+    >
+      <div
+        className="input-range__track input-range__track--active"
+        style={
+          Object {
+            "left": "0%",
+            "width": "0%",
+          }
+        }
+      />
+      <span
+        className="input-range__slider-container"
+        style={
+          Object {
+            "left": "0%",
+            "position": "absolute",
+          }
+        }
+      >
+        <span
+          className="input-range__label input-range__label--value"
+        >
+          <span
+            className="input-range__label-container"
+          >
+            -10
+          </span>
+        </span>
+        <div
+          aria-labelledby="test_label"
+          aria-valuemax={100}
+          aria-valuemin={-10}
+          aria-valuenow={-10}
+          className="input-range__slider"
+          draggable="false"
+          onKeyDown={[Function]}
+          onMouseDown={[Function]}
+          onTouchStart={[Function]}
+          role="slider"
+          tabIndex="0"
+        />
+      </span>
+    </div>
+    <span
+      className="input-range__label input-range__label--max"
+    >
+      <span
+        className="input-range__label-container"
+      >
+        100
+      </span>
+    </span>
+    <input
+      name="test"
+      type="hidden"
+      value={-10}
+    />
+  </div>
+  <div
+    className="survey-question__input-checkbox-group-container"
+  >
+    <div
+      className="survey-question__input-checkbox-input-container"
+      onClick={[Function]}
+    >
+      <div
+        className="label-input-container"
+      >
+        <input
+          checked={false}
+          className="input-checkbox"
+          id="test_na_na__input-checkbox__na"
+          name="test_na_na"
+          onChange={[Function]}
+          onClick={[Function]}
+          type="checkbox"
+          value="na"
+        />
+        <label
+          htmlFor="test_na_na__input-checkbox__na"
+          onClick={[Function]}
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "NotApplicable",
+              }
+            }
+          />
+        </label>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Should correctly render InputRange with various parameters Test trackclass and labels 1`] = `
 <div
   className="survey-question__input-range_input_container_with_labels"

--- a/packages/evolution-generator/src/scripts/generate_widgets.py
+++ b/packages/evolution-generator/src/scripts/generate_widgets.py
@@ -383,12 +383,15 @@ def generate_info_text_widget(question_name, section, path, conditional, row):
 
 # Generate InputRange widget
 def generate_range_widget(question_name, section, path, input_range, conditional, validation, widget_label, row):
+    includeNotApplicable = row['includeNotApplicable'] if 'includeNotApplicable' in row else False
+    notApplicableConfig = "includeNotApplicable: true,\n" if includeNotApplicable else ""
     return f"{generate_constExport(question_name, 'InputRange')}\n" \
             f"{generate_defaultInputBase('inputRangeBase')},\n" \
             f"{INDENT}...inputRange.{input_range},\n" \
             f"{generate_path(path)},\n" \
             f"{generate_common_properties(row)}" \
             f"{widget_label},\n" \
+            f"{notApplicableConfig}" \
             f"{generate_conditional(conditional)},\n" \
             f"{generate_validation(validation)}\n" \
             f"}};"


### PR DESCRIPTION
fixes #539

To avoid the participant having to select a position for a question that does not apply to him, there should be a "Non applicable" option that the user can select that will disable the input range. The answer in this case, instead of a `number` will be a `string` with value `na`.