### PR TITLE
CI: force CI to run on the od_2023 branch

### DIFF
--- a/.github/workflows/evolution.yml
+++ b/.github/workflows/evolution.yml
@@ -5,9 +5,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, od_2023 ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, od_2023 ]
 
 jobs:
   build-and-test:


### PR DESCRIPTION
This branch is the one that the 2023 surveys support and where any required change will be backported.