### PR TITLE
exports: Allow to export validated or original responses by object

### DIFF
--- a/locales/en/admin.json
+++ b/locales/en/admin.json
@@ -126,7 +126,8 @@
   "HouseholdSize": "Household size",
   "Select": "Select",
   "export": {
-    "PrepareCsvExportFiles": "Prepare CSV files for export by object",
+    "PrepareValidatedCsvExportFiles": "Prepare CSV files by object (validated, if available)",
+    "PrepareParticipantCsvExportFiles": "Prepare CSV files for export by object (original responses)",
     "RefreshExportFiles": "Refresh export file list",
     "ServerErrorForExport": "Server error while preparing export files",
     "ServerExportForbidden": "You are not authorized to export data",

--- a/locales/fr/admin.json
+++ b/locales/fr/admin.json
@@ -126,7 +126,8 @@
   "HouseholdSize": "Taille du ménage",
   "Select": "Sélectionner",
   "export": {
-    "PrepareCsvExportFiles": "Préparer les fichiers CSV pour exportation par objet",
+    "PrepareValidatedCsvExportFiles": "Préparer les fichiers CSV par objet (réponses validées si disponibles)",
+    "PrepareParticipantCsvExportFiles": "Préparer les fichiers CSV par objet (réponses originales)",
     "RefreshExportFiles": "Rafraîchir la liste des fichiers d'export",
     "ServerErrorForExport": "Erreur de serveur pendant la préparation des fichiers d'export",
     "ServerExportForbidden": "Vous n'êtes pas autorisé à exporter les données d'enquête",

--- a/packages/evolution-backend/src/api/admin/__tests__/exports.routes.test.ts
+++ b/packages/evolution-backend/src/api/admin/__tests__/exports.routes.test.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import request from 'supertest';
+import express, { RequestHandler } from 'express';
+import { addExportRoutes } from '../exports.routes';
+import router from 'chaire-lib-backend/lib/api/admin.routes';
+import { exportAllToCsvByObject} from '../../../services/adminExport/exportAllToCsvByObject';
+
+// Mock the authorization function, isAuthorized returns a function
+jest.mock('chaire-lib-backend/lib/services/auth/authorization', () => jest.fn().mockReturnValue(jest.fn().mockImplementation((req, res, next) => next())));
+// Mock the export functions
+jest.mock('../../../services/adminExport/exportAllToCsvByObject', () => ({
+    exportAllToCsvByObject: jest.fn().mockReturnValue('exportStarted')
+}));
+const exportAllToCsvByObjectMock = exportAllToCsvByObject as jest.MockedFunction<typeof exportAllToCsvByObject>;
+
+let app: express.Application;
+beforeAll(() => {
+    app = express();
+    app.use(express.json() as RequestHandler);
+    addExportRoutes();
+    app.use('/api/admin', router)
+});
+
+describe('prepareCsvFileForExportByObject route', () => {
+    
+    it('Should prepare validated data by default', async () => {
+        const response = await request(app).get('/api/admin/data/prepareCsvFileForExportByObject');
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual({
+            status: 'exportStarted'
+        });
+        expect(exportAllToCsvByObjectMock).toHaveBeenCalledWith({ responseType: 'validatedIfAvailable' });
+    });
+
+    it('Should prepare validated data, if specified', async () => {
+        const response = await request(app).get('/api/admin/data/prepareCsvFileForExportByObject?responseType=validatedIfAvailable');
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual({
+            status: 'exportStarted'
+        });
+        expect(exportAllToCsvByObjectMock).toHaveBeenCalledWith({ responseType: 'validatedIfAvailable' });
+    });
+
+    it('Should prepare validated data, if invalid value is specified', async () => {
+        const response = await request(app).get('/api/admin/data/prepareCsvFileForExportByObject?responseType=unknownType');
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual({
+            status: 'exportStarted'
+        });
+        expect(exportAllToCsvByObjectMock).toHaveBeenCalledWith({ responseType: 'validatedIfAvailable' });
+    });
+
+    it('Should prepare participant data, if specified', async () => {
+        const response = await request(app).get('/api/admin/data/prepareCsvFileForExportByObject?responseType=participant');
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual({
+            status: 'exportStarted'
+        });
+        expect(exportAllToCsvByObjectMock).toHaveBeenCalledWith({ responseType: 'participant' });
+    });
+});

--- a/packages/evolution-backend/src/api/admin/exports.routes.ts
+++ b/packages/evolution-backend/src/api/admin/exports.routes.ts
@@ -18,7 +18,6 @@ import * as Status from 'chaire-lib-common/lib/utils/Status';
 import router from 'chaire-lib-backend/lib/api/admin.routes';
 
 export const addExportRoutes = () => {
-    console.log('addin export routes');
     // Get a specific export file per object
     router.get('/data/exportcsv/exports/:filePath', (req, res, next) => {
         console.log('requesting csv file from path', req.params.filePath);
@@ -56,7 +55,10 @@ export const addExportRoutes = () => {
     router.get('/data/prepareCsvFileForExportByObject', (req, res, next) => {
         console.log('preparing csv export files...');
         try {
-            const taskRunning = exportAllToCsvByObject();
+            const validatedResponses = req.query.responseType !== 'participant';
+            const taskRunning = exportAllToCsvByObject({
+                responseType: validatedResponses ? 'validatedIfAvailable' : 'participant'
+            });
             return res.status(200).json({
                 status: taskRunning
             });

--- a/packages/evolution-backend/src/services/adminExport/exportAllToCsvByObject.ts
+++ b/packages/evolution-backend/src/services/adminExport/exportAllToCsvByObject.ts
@@ -16,12 +16,12 @@ pool = workerpool.pool(__dirname + '/exportToCsvByObjectWorkerPool.js', { maxWor
 // eslint-disable-next-line @typescript-eslint/ban-types
 let runningExportNonce: undefined | Object = undefined;
 
-export const exportAllToCsvByObject = function () {
+export const exportAllToCsvByObject = function (options: ExportOptions) {
     if (runningExportNonce !== undefined) {
         return 'alreadyRunning';
     }
     runningExportNonce = new Object();
-    pool.exec('exportAllToCsvByObject')
+    pool.exec('exportAllToCsvByObject', [options])
         .then(() => console.log('Export by object completed'))
         .catch((error) => {
             console.log('Export by object failed:', error);

--- a/packages/evolution-backend/src/services/adminExport/types.ts
+++ b/packages/evolution-backend/src/services/adminExport/types.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+type ExportOptions = {
+    /** Specifies which set of responses should be exported. 'validated' means
+     * it exports the validated data if available, 'participant' is the original
+     * participant responses */
+    responseType: 'participant' | 'validatedIfAvailable';
+};

--- a/packages/evolution-frontend/src/components/admin/ExportInterviewData.tsx
+++ b/packages/evolution-frontend/src/components/admin/ExportInterviewData.tsx
@@ -22,10 +22,20 @@ const ExportInterviewData = ({ t }: WithTranslation) => {
         updateOrWaitForFiles(false);
     }, []);
 
-    const onPrepareCsvExportFiles = async () => {
+    const onPrepareCsvRespondentExportFiles = async () => {
+        return onPrepareCsvExportFiles('participant');
+    };
+
+    const onPrepareCsvValidatedExportFiles = async () => {
+        return onPrepareCsvExportFiles('validatedIfAvailable');
+    };
+
+    const onPrepareCsvExportFiles = async (
+        exportType: 'validatedIfAvailable' | 'participant' = 'validatedIfAvailable'
+    ) => {
         setIsPreparingCsvExportFiles(true);
         try {
-            const response = await fetch('/api/admin/data/prepareCsvFileForExportByObject', {
+            const response = await fetch('/api/admin/data/prepareCsvFileForExportByObject?responseType=' + exportType, {
                 method: 'GET',
                 credentials: 'include',
                 headers: {
@@ -114,7 +124,16 @@ const ExportInterviewData = ({ t }: WithTranslation) => {
     return (
         <div className="admin-widget-container">
             {isPreparingCsvExportFiles && <LoadingPage />}
-            <Button color="blue" onClick={onPrepareCsvExportFiles} label={t('admin:export:PrepareCsvExportFiles')} />
+            <Button
+                color="blue"
+                onClick={onPrepareCsvValidatedExportFiles}
+                label={t('admin:export:PrepareValidatedCsvExportFiles')}
+            />
+            <Button
+                color="blue"
+                onClick={onPrepareCsvRespondentExportFiles}
+                label={t('admin:export:PrepareParticipantCsvExportFiles')}
+            />
             {error && <FormErrors errors={[error]} />}
             {csvExportFilesReady && <ul>{csvFileExportLinks}</ul>}
             <ul>


### PR DESCRIPTION
fixes #557

The export task receives an option parameter, which has a `responseType` field, with values 'validatedIfAvailable' or 'participant'. The exported file names will be prefixed with either validated or participant depending on the response type.

In the UI widget, there are 2 export buttons, one for each type of export.