### PR TITLE
exports: Allow to export validated or original responses by object

### DIFF
--- a/packages/evolution-backend/src/services/adminExport/exportAllToCsvByObject.ts
+++ b/packages/evolution-backend/src/services/adminExport/exportAllToCsvByObject.ts
@@ -16,12 +16,12 @@ pool = workerpool.pool(__dirname + '/exportToCsvByObjectWorkerPool.js', { maxWor
 // eslint-disable-next-line @typescript-eslint/ban-types
 let runningExportNonce: undefined | Object = undefined;
 
-export const exportAllToCsvByObject = function () {
+export const exportAllToCsvByObject = function (options: ExportOptions) {
     if (runningExportNonce !== undefined) {
         return 'alreadyRunning';
     }
     runningExportNonce = new Object();
-    pool.exec('exportAllToCsvByObject')
+    pool.exec('exportAllToCsvByObject', [options])
         .then(() => console.log('Export by object completed'))
         .catch((error) => {
             console.log('Export by object failed:', error);

--- a/packages/evolution-backend/src/services/adminExport/types.ts
+++ b/packages/evolution-backend/src/services/adminExport/types.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+type ExportOptions = {
+    /** Specifies which set of responses should be exported. 'validated' means
+     * it exports the validated data if available, 'participant' is the original
+     * participant responses */
+    responseType: 'participant' | 'validatedIfAvailable';
+};


### PR DESCRIPTION
fixes #557

The export task receives an option parameter, which has a `responseType` field, with values 'validatedIfAvailable' or 'participant'. The exported file names will be prefixed with either validated or participant depending on the response type.

NOTE: The routes and widgets are in the individual surveys in this branch, they will need to be updated.