### PR TITLE
widgets: The type of a widget config cannot be a function

### DIFF
--- a/packages/evolution-legacy/src/components/survey/GroupedObject.js
+++ b/packages/evolution-legacy/src/components/survey/GroupedObject.js
@@ -98,16 +98,6 @@ export class GroupedObject extends React.Component {
         startAddGroupedObjects     : this.props.startAddGroupedObjects,
         startRemoveGroupedObjects  : this.props.startRemoveGroupedObjects
       };
-      
-      if (typeof widgetConfig.type === 'function') // custom widget component
-      {
-        const WidgetComponent = widgetConfig.type();
-        return <WidgetComponent {...defaultProps}
-          groupConfig                     = {this.props.groupsConfig[widgetShortname]}
-          groupsConfig                    = {this.props.groupsConfig}
-          parentObjectIds                 = {parentObjectIds}
-        />;
-      }
 
       switch(widgetConfig.type)
       {

--- a/packages/evolution-legacy/src/components/survey/Section.js
+++ b/packages/evolution-legacy/src/components/survey/Section.js
@@ -191,28 +191,17 @@ export class Section extends React.Component {
         startRemoveGroupedObjects  : this.props.startRemoveGroupedObjects
       };
 
-      if (typeof widgetConfig.type === 'function') // custom widget component
+      switch(widgetConfig.type)
       {
-        const WidgetComponent = widgetConfig.type();
-        widgetsComponentByShortname[widgetShortname] = <WidgetComponent {...defaultProps}
+        case 'text':              widgetsComponentByShortname[widgetShortname] = <Text            {...defaultProps} />; break;
+        case 'infoMap':           widgetsComponentByShortname[widgetShortname] = <InfoMap         {...defaultProps} />; break;
+        case 'button':            widgetsComponentByShortname[widgetShortname] = <Button          {...defaultProps} />; break;
+        case 'question':          widgetsComponentByShortname[widgetShortname] = <Question        {...defaultProps} />; break;
+        case 'group':             widgetsComponentByShortname[widgetShortname] = <Group           {...defaultProps}
           groupConfig                     = {this.props.groups[widgetShortname]}
+          groupsConfig                    = {this.props.groups}
           parentObjectIds                 = {{}}
-        />;
-      }
-      else
-      {
-        switch(widgetConfig.type)
-        {
-          case 'text':              widgetsComponentByShortname[widgetShortname] = <Text            {...defaultProps} />; break;
-          case 'infoMap':           widgetsComponentByShortname[widgetShortname] = <InfoMap         {...defaultProps} />; break;
-          case 'button':            widgetsComponentByShortname[widgetShortname] = <Button          {...defaultProps} />; break;
-          case 'question':          widgetsComponentByShortname[widgetShortname] = <Question        {...defaultProps} />; break;
-          case 'group':             widgetsComponentByShortname[widgetShortname] = <Group           {...defaultProps}
-            groupConfig                     = {this.props.groups[widgetShortname]}
-            groupsConfig                    = {this.props.groups}
-            parentObjectIds                 = {{}}
-          />; break;
-        }
+        />; break;
       }
     }
 


### PR DESCRIPTION
If a widget can have multiple types, it is preferable to use 2 widgets with conditionals mutually exclusive, or create a specific widget that can be multiple types (eg. radio or select), but allowing any type in a single widget can be tricky as there isn't much in common between a text and a radio widgets, for example, it requires to put all the possible configs for all types.