### PR TITLE
groups: Use a single group configuration for all groups

### DIFF
--- a/example/demo_survey/locales/en/survey.json
+++ b/example/demo_survey/locales/en/survey.json
@@ -13,9 +13,11 @@
         "start": "Start",
         "info": "You will need this information if you want to reconnect to your interview or if you want to use another computer to access it."
     },
-    "person": {
+    "householdMembers": {
         "deleteThisGroupedObject": "Delete this person",
-        "addGroupedObject": "Add a person",
+        "addGroupedObject": "Add a person"
+    },
+    "person": {
         "dayScheduleFor": "Day schedule for",
         "yourDaySchedule": "Your day schedule"
     },
@@ -75,7 +77,7 @@
             "carPassenger": "Car passenger"
         }
     },
-    "mode": {
+    "segments": {
         "deleteThisGroupedObject": "Delete this mode of transport",
         "addGroupedObject": "Add a mode of transport"
     },

--- a/example/demo_survey/locales/fr/survey.json
+++ b/example/demo_survey/locales/fr/survey.json
@@ -13,9 +13,11 @@
         "start": "Débuter",
         "info": "Vous aurez besoin de ces informations si vous désirez vous reconnecter à votre entrevue ou si vous désirez y accéder à partir d’un autre ordinateur."
     },
-    "person": {
+    "householdMembers": {
         "deleteThisGroupedObject": "Supprimer cette personne",
-        "addGroupedObject": "Ajouter une personne",
+        "addGroupedObject": "Ajouter une personne"
+    },
+    "person": {
         "dayScheduleFor": "Horaire de la journée de",
         "yourDaySchedule": "Votre horaire de la journée"
     },
@@ -75,7 +77,7 @@
             "carPassenger": "Auto passager"
         }
     },
-    "mode": {
+    "segments": {
         "deleteThisGroupedObject": "Supprimer ce mode de transport",
         "addGroupedObject": "Ajouter un mode de transport"
     },

--- a/example/demo_survey/src/survey/sections.ts
+++ b/example/demo_survey/src/survey/sections.ts
@@ -31,24 +31,6 @@ const homeWidgets = [
   'homeGeography'
 ];
 
-const personsWidgets = [
-  'personNickname',
-  'personAge',
-  'personGender',
-  'personOccupation',
-  'personDrivingLicenseOwner',
-  'personTransitPassOwner',
-  'personTransitPasses',
-  'personCarsharingMember',
-  'personBikesharingMember',
-  'personHasDisability',
-  'personCellphoneOwner'
-];
-if (config.isPartTwo !== true)
-{
-  personsWidgets.push("personDidTrips");
-}
-
 let profileWidgets = [];
 
 if (config.isPartTwo === true)
@@ -154,31 +136,6 @@ export default {
       'householdMembers',
       'buttonSaveNextSectionHouseholdMembers'
     ],
-    groups: {
-      'householdMembers': {
-        showGroupedObjectDeleteButton: function(interview, path) { 
-          const countPersons = helper.countPersons(interview);
-          if (config.isPartTwo === true)
-          {
-            return countPersons > 1;
-          }
-          const householdSize = surveyHelperNew.getResponse(interview, 'household.size', null);
-          return countPersons > householdSize;
-        },
-        showGroupedObjectAddButton: function(interview, path) {
-          //const hasGroupedObjects = Object.keys(_get(interview, `groups.householdMembers`, {})).length > 0;
-          //const householdSize     = surveyHelperNew.getResponse(interview, 'household.size', null);
-          //const persons           = surveyHelperNew.getResponse(interview, path, {});
-          return true;//hasGroupedObjects && Object.keys(persons).length < householdSize;
-        },
-        groupedObjectAddButtonLabel: {
-          fr: "Ajouter une personne manquante",
-          en: "Add a missing person"
-        },
-        addButtonSize: 'small' as const,
-        widgets: personsWidgets
-      }
-    },
     preload: function(interview, startUpdateInterview, startAddGroupedObjects, startRemoveGroupedObjects, callback) {
       const groupedObjects       = surveyHelperNew.getResponse(interview, 'household.persons');
       const groupedObjectIds     = groupedObjects ? Object.keys(groupedObjects) : [];
@@ -431,39 +388,6 @@ export default {
       //'personLastVisitedPlaceNotHome',
       'buttonVisitedPlacesConfirmNextSection'
     ],
-    groups: {
-      'personVisitedPlaces': {
-        showGroupedObjectDeleteButton: false,
-        deleteConfirmPopup: {
-          content: {
-            fr: function(interview) {
-              return `Confirmez-vous que vous voulez retirer ce lieu?`;
-            },
-            en: function(interview) {
-              return `Do you confirm that you want to remove this location?`;
-            }
-          }
-        },
-        showGroupedObjectAddButton:    true,
-        addButtonLocation: 'both' as const,
-        widgets: [
-          "visitedPlaceActivity",
-          "visitedPlaceAlreadyVisited",
-          "visitedPlaceShortcut",
-          "visitedPlaceName",
-          "visitedPlaceGeography",
-          //"visitedPlaceArrivalAndDepartureTime",
-          "visitedPlaceArrivalTime",
-          "visitedPlaceDepartureTime",
-          "visitedPlaceNextPlaceCategory",
-          //"visitedPlaceWentBackHomeDirectlyAfter",
-          //"visitedPlaceIsNotLast",
-          "buttonSaveVisitedPlace",
-          "buttonCancelVisitedPlace",
-          "buttonDeleteVisitedPlace"
-        ]
-      }
-    },
     preload: function (interview, startUpdateInterview, startAddGroupedObjects, startRemoveGroupedObjects, callback) {
       
       const person = helper.getPerson(interview);
@@ -548,80 +472,6 @@ export default {
       'personVisitedPlacesMap',
       'buttonConfirmNextSection'
     ],
-    groups: {
-      'personTrips': {
-        showGroupedObjectDeleteButton: false,
-        showGroupedObjectAddButton: false,
-        widgets: [
-          'segmentIntro',
-          'segments',
-          'tripJunctionGeography',
-          //'introButtonSaveTrip',
-          'buttonSaveTrip'
-        ]
-      },
-      'segments': {
-        showTitle: false,
-        showGroupedObjectDeleteButton: function(interview, path) {
-          const segment = surveyHelperNew.getResponse(interview, path, {});
-          return (segment && segment['_sequence'] > 1);
-        },
-        showGroupedObjectAddButton: function(interview, path) {
-          const segments      = surveyHelperNew.getResponse(interview, path, {});
-          const segmentsArray = Object.values(segments).sort((segmentA, segmentB) => {
-            return segmentA['_sequence'] - segmentB['_sequence'];
-          });
-          const segmentsCount = segmentsArray.length;
-          const lastSegment   = segmentsArray[segmentsCount - 1];
-          return segmentsCount === 0 || (lastSegment  && lastSegment.isNotLast === true);
-        },
-        groupedObjectAddButtonLabel: {
-          fr: function(interview, path) {
-            const segments      = surveyHelperNew.getResponse(interview, path, {});
-            const segmentsCount = Object.keys(segments).length;
-            if (segmentsCount === 0)
-            {
-              return 'Sélectionner le premier (ou le seul) mode de transport utilisé pour ce déplacement';
-            }
-            else
-            {
-              return 'Sélectionner le mode de transport suivant';
-            }
-          },
-          en: function(interview, path) {
-            const segments = surveyHelperNew.getResponse(interview, path, {});
-            const segmentsCount = Object.keys(segments).length;
-            if (segmentsCount === 0)
-            {
-              return 'Select the first mode of transport used during this trip';
-            }
-            else
-            {
-              return 'Select the next mode of transport';
-            }
-          }
-        },
-        addButtonLocation: 'bottom' as const,
-        widgets: [
-          'segmentMode',
-          //'segmentParkingType',
-          'segmentParkingPaymentType',
-          'segmentVehicleOccupancy',
-          'segmentVehicleType',
-          'segmentDriver',
-          'segmentBridgesAndTunnels',
-          'segmentHighways',
-          'segmentUsedBikesharing',
-          'segmentSubwayStationStart',
-          'segmentSubwayStationEnd',
-          'segmentSubwayTransferStations',
-          'segmentTrainStationStart',
-          'segmentTrainStationEnd',
-          'segmentBusLines',
-          'segmentIsNotLast'
-        ]
-      }
-    },
     preload: function (interview, startUpdateInterview, startAddGroupedObjects, startRemoveGroupedObjects, callback) {
       
       const person = helper.getPerson(interview);
@@ -913,7 +763,18 @@ export default {
           en: "Add a missing person"
         },
         addButtonSize: 'small' as const,
-        widgets: [...personsWidgets, 
+        widgets: [
+          'personNickname',
+          'personAge',
+          'personGender',
+          'personOccupation',
+          'personDrivingLicenseOwner',
+          'personTransitPassOwner',
+          'personTransitPasses',
+          'personCarsharingMember',
+          'personBikesharingMember',
+          'personHasDisability',
+          'personCellphoneOwner', 
           "groupedPersonWorkOnTheRoad",
           "groupedPersonUsualWorkPlaceIsHome",
           "groupedPersonUsualWorkPlaceName",

--- a/example/demo_survey/src/survey/templates/SegmentsSection.tsx
+++ b/example/demo_survey/src/survey/templates/SegmentsSection.tsx
@@ -104,7 +104,7 @@ export class SegmentsSection extends React.Component<any, any> {
     
     surveyHelper.devLog('%c rendering section ' + this.props.shortname, 'background: rgba(0,0,255,0.1);')
     const widgetsComponentsByShortname = {};
-    const groupConfig                  = this.props.groups['personTrips'];
+    const personTripsConfig            = this.props.surveyContext.widgets['personTrips'];
     const person                       = helper.getPerson(this.props.interview);
 
     const trips      = helper.getTrips(person);
@@ -148,8 +148,6 @@ export class SegmentsSection extends React.Component<any, any> {
         case 'button':   component = <Button   {...defaultProps} />; break;
         case 'question': component = <Question {...defaultProps} />; break;
         case 'group':    component = <Group    {...defaultProps}
-          groupConfig     = {this.props.groups[widgetShortname]}
-          groupsConfig    = {this.props.groups}
           parentObjectIds = {{}}
         />;
       }
@@ -243,10 +241,9 @@ export class SegmentsSection extends React.Component<any, any> {
         selectedTrip = (
           <li className="no-bullet" style={{marginTop: "-0.4rem"}} key={`survey-trip-item-selected__${i}`}>
             <GroupedObject
-              groupConfig                 = {this.props.groups['personTrips']}
-              groupsConfig                = {this.props.groups}
-              path                        = {tripPath}
+              widgetConfig                = {personTripsConfig}
               shortname                   = 'personTrips'
+              path                        = {tripPath}
               loadingState                = {this.props.loadingState}
               objectId                    = {trip._uuid}
               parentObjectIds             = {parentObjectIds}

--- a/example/demo_survey/src/survey/templates/VisitedPlacesSection.tsx
+++ b/example/demo_survey/src/survey/templates/VisitedPlacesSection.tsx
@@ -137,7 +137,7 @@ export class VisitedPlacesSection extends React.Component<any, any> {
 
     surveyHelper.devLog('%c rendering section ' + this.props.shortname, 'background: rgba(0,0,255,0.1);')
     const widgetsComponentsByShortname = {};
-    const groupConfig                  = this.props.groups['personVisitedPlaces'];
+    const personVisitedPlacesConfig    = this.props.surveyContext.widgets['personVisitedPlaces'];
     const person                       = helper.getPerson(this.props.interview);
     const householdSize                = surveyHelper.getResponse(this.props.interview, 'household.size', null);
     const isAlone                      = householdSize === 1;
@@ -258,8 +258,6 @@ export class VisitedPlacesSection extends React.Component<any, any> {
         case 'button':   component = <Button   {...defaultProps} />; break;
         case 'question': component = <Question {...defaultProps} />; break;
         case 'group':    component = <Group    {...defaultProps}
-          groupConfig     = {this.props.groups[widgetShortname]}
-          groupsConfig    = {this.props.groups}
           parentObjectIds = {{}}
         />;
       }
@@ -328,11 +326,11 @@ export class VisitedPlacesSection extends React.Component<any, any> {
                   <ConfirmModal 
                     isOpen        = {true}
                     closeModal    = {() => this.setState({confirmDeleteVisitedPlace: null})}
-                    text          = {surveyHelper.parseString(groupConfig.deleteConfirmPopup.content[this.props.i18n.language] || groupConfig.deleteConfirmPopup.content, this.props.interview, this.props.path)}
-                    title         = {groupConfig.deleteConfirmPopup.title && groupConfig.deleteConfirmPopup.title[this.props.i18n.language] ? surveyHelper.parseString(groupConfig.deleteConfirmPopup.title[this.props.i18n.language] || groupConfig.deleteConfirmPopup.title, this.props.interview, this.props.path) : null}
+                    text          = {surveyHelper.parseString(personVisitedPlacesConfig.deleteConfirmPopup.content[this.props.i18n.language] || personVisitedPlacesConfig.deleteConfirmPopup.content, this.props.interview, this.props.path)}
+                    title         = {personVisitedPlacesConfig.deleteConfirmPopup.title && personVisitedPlacesConfig.deleteConfirmPopup.title[this.props.i18n.language] ? surveyHelper.parseString(personVisitedPlacesConfig.deleteConfirmPopup.title[this.props.i18n.language] || personVisitedPlacesConfig.deleteConfirmPopup.title, this.props.interview, this.props.path) : null}
                     cancelAction  = {null}
                     confirmAction = {() => this.deleteVisitedPlace(person, visitedPlacePath, visitedPlace, visitedPlaces)}
-                    containsHtml  = {groupConfig.deleteConfirmPopup.containsHtml}
+                    containsHtml  = {personVisitedPlacesConfig.deleteConfirmPopup.containsHtml}
                   />
                 </div>)
             }
@@ -349,10 +347,9 @@ export class VisitedPlacesSection extends React.Component<any, any> {
         const selectedVisitedPlaceComponent = (
           <li className='no-bullet' style={{marginTop: "-0.4rem"}} key={`survey-visited-place-item-selected__${i}`}>
             <GroupedObject
-              groupConfig                 = {this.props.groups['personVisitedPlaces']}
-              groupsConfig                = {this.props.groups}
-              path                        = {visitedPlacePath}
+              widgetConfig                 = {personVisitedPlacesConfig}
               shortname                   = 'personVisitedPlaces'
+              path                        = {visitedPlacePath}
               loadingState                = {this.props.loadingState}
               objectId                    = {visitedPlace._uuid}
               parentObjectIds             = {parentObjectIds}

--- a/example/demo_survey/src/survey/widgets/householdMembers.tsx
+++ b/example/demo_survey/src/survey/widgets/householdMembers.tsx
@@ -22,26 +22,64 @@ import config from 'chaire-lib-common/lib/config/shared/project.config';
 import waterBoundaries  from '../waterBoundaries.json';
 import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
 import { UserInterviewAttributes } from 'evolution-common/lib/services/interviews/interview';
+import { GroupConfig } from 'evolution-common/src/services/widgets';
 
-export const householdMembers = {
+const personsWidgets = [
+    'personNickname',
+    'personAge',
+    'personGender',
+    'personOccupation',
+    'personDrivingLicenseOwner',
+    'personTransitPassOwner',
+    'personTransitPasses',
+    'personCarsharingMember',
+    'personBikesharingMember',
+    'personHasDisability',
+    'personCellphoneOwner'
+];
+if (config.isPartTwo !== true)
+{
+    personsWidgets.push("personDidTrips");
+}
+
+export const householdMembers: GroupConfig = {
   type: "group",
   path: 'household.persons',
-  groupShortname: 'household_members',
-  shortname: 'person',
   deleteConfirmPopup: {
     content: {
         fr: 'supprimer',
         en: 'delete'
     }
   },
-  groupName: {
+  title: {
     fr: "Membres du ménage",
     en: "Household members"
   },
   name: {
-    fr: function(groupedObject, sequence) { return `Personne ${sequence || groupedObject['_sequence']} ${groupedObject.nickname ? `• **${groupedObject.nickname}**` : ''}`; },
-    en: function(groupedObject, sequence) { return `Person ${sequence || groupedObject['_sequence']} ${groupedObject.nickname ? `• **${groupedObject.nickname}**` : ''}`; }
-  }
+    fr: function(groupedObject: any, sequence) { return `Personne ${sequence || groupedObject['_sequence']} ${groupedObject.nickname ? `• **${groupedObject.nickname}**` : ''}`; },
+    en: function(groupedObject: any, sequence) { return `Person ${sequence || groupedObject['_sequence']} ${groupedObject.nickname ? `• **${groupedObject.nickname}**` : ''}`; }
+  },
+  showGroupedObjectDeleteButton: function(interview, path) { 
+    const countPersons = helper.countPersons(interview);
+    if (config.isPartTwo === true)
+    {
+      return countPersons > 1;
+    }
+    const householdSize = surveyHelperNew.getResponse(interview, 'household.size', null) as number;
+    return countPersons > householdSize;
+  },
+  showGroupedObjectAddButton: function(interview, path) {
+    //const hasGroupedObjects = Object.keys(_get(interview, `groups.householdMembers`, {})).length > 0;
+    //const householdSize     = surveyHelperNew.getResponse(interview, 'household.size', null);
+    //const persons           = surveyHelperNew.getResponse(interview, path, {});
+    return true;//hasGroupedObjects && Object.keys(persons).length < householdSize;
+  },
+  groupedObjectAddButtonLabel: {
+    fr: "Ajouter une personne manquante",
+    en: "Add a missing person"
+  },
+  addButtonSize: 'small' as const,
+  widgets: personsWidgets
 };
 
 export const personAge = {

--- a/example/demo_survey/src/survey/widgets/segments.tsx
+++ b/example/demo_survey/src/survey/widgets/segments.tsx
@@ -18,13 +18,12 @@ import helper from '../helper';
 import subwayStations from '../subwayStations.json';
 import trainStations  from '../trainStations.json';
 import busRoutes  from '../busRoutes.json';
+import { GroupConfig } from 'evolution-common/lib/services/widgets';
 
-export const personTrips = {
+export const personTrips: GroupConfig = {
   type: "group",
   path: "household.persons.{_activePersonId}.trips",
-  groupShortname: 'trips',
-  shortname: 'trip',
-  groupName: {
+  title: {
     fr: "Déplacements",
     en: "Trips"
   },
@@ -50,23 +49,88 @@ export const personTrips = {
   name: {
     fr: "",
     en: ""
-  }
-  
+  },
+  showGroupedObjectDeleteButton: false,
+  showGroupedObjectAddButton: false,
+  widgets: [
+    'segmentIntro',
+    'segments',
+    'tripJunctionGeography',
+    //'introButtonSaveTrip',
+    'buttonSaveTrip'
+  ]
 };
 
-export const segments = {
+export const segments: GroupConfig = {
   type: "group",
   path: "segments",
-  groupShortname: 'segments',
-  shortname: 'mode',
-  groupName: {
+  title: {
     fr: "Modes",
     en: "Modes"
   },
   name: {
     fr: (groupedObject, sequence, interview, path) => (`Mode de transport ${sequence}`),
     en: (groupedObject, sequence, interview, path) => (`Mode of transport ${sequence}`)
-  }
+  },
+  showTitle: false,
+  showGroupedObjectDeleteButton: function(interview, path) {
+    const segment = surveyHelperNew.getResponse(interview, path, {});
+    return (segment && segment['_sequence'] > 1);
+  },
+  showGroupedObjectAddButton: function(interview, path) {
+    const segments      = surveyHelperNew.getResponse(interview, path, {});
+    const segmentsArray = Object.values(segments).sort((segmentA, segmentB) => {
+      return segmentA['_sequence'] - segmentB['_sequence'];
+    });
+    const segmentsCount = segmentsArray.length;
+    const lastSegment   = segmentsArray[segmentsCount - 1];
+    return segmentsCount === 0 || (lastSegment  && lastSegment.isNotLast === true);
+  },
+  groupedObjectAddButtonLabel: {
+    fr: function(interview, path) {
+      const segments      = surveyHelperNew.getResponse(interview, path, {});
+      const segmentsCount = Object.keys(segments).length;
+      if (segmentsCount === 0)
+      {
+        return 'Sélectionner le premier (ou le seul) mode de transport utilisé pour ce déplacement';
+      }
+      else
+      {
+        return 'Sélectionner le mode de transport suivant';
+      }
+    },
+    en: function(interview, path) {
+      const segments = surveyHelperNew.getResponse(interview, path, {});
+      const segmentsCount = Object.keys(segments).length;
+      if (segmentsCount === 0)
+      {
+        return 'Select the first mode of transport used during this trip';
+      }
+      else
+      {
+        return 'Select the next mode of transport';
+      }
+    }
+  },
+  addButtonLocation: 'bottom' as const,
+  widgets: [
+    'segmentMode',
+    //'segmentParkingType',
+    'segmentParkingPaymentType',
+    'segmentVehicleOccupancy',
+    'segmentVehicleType',
+    'segmentDriver',
+    'segmentBridgesAndTunnels',
+    'segmentHighways',
+    'segmentUsedBikesharing',
+    'segmentSubwayStationStart',
+    'segmentSubwayStationEnd',
+    'segmentSubwayTransferStations',
+    'segmentTrainStationStart',
+    'segmentTrainStationEnd',
+    'segmentBusLines',
+    'segmentIsNotLast'
+  ]
 }
 
 export const segmentIntro = {

--- a/example/demo_survey/src/survey/widgets/visitedPlaces.tsx
+++ b/example/demo_survey/src/survey/widgets/visitedPlaces.tsx
@@ -35,6 +35,7 @@ import i18n              from 'chaire-lib-frontend/lib/config/i18n.config';
 import helper from '../helper';
 import { UserInterviewAttributes } from 'evolution-common/lib/services/interviews/interview';
 import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
+import { GroupConfig } from 'evolution-common/lib/services/widgets';
 
 export const visitedPlacesIntro = {
   type: "text",
@@ -288,12 +289,10 @@ export const personVisitedPlacesMap = {
   }
 };
 
-export const personVisitedPlaces = {
+export const personVisitedPlaces: GroupConfig = {
   type: "group",
   path: "household.persons.{_activePersonId}.visitedPlaces",
-  groupShortname: 'visitedPlaces',
-  shortname: 'visitedPlace',
-  groupName: {
+  title: {
     fr: "Lieux visités",
     en: "Visited places"
   },
@@ -317,15 +316,44 @@ export const personVisitedPlaces = {
     }
   },
   name: {
-    fr: function(groupedObject, sequence) { 
+    fr: function(groupedObject: any, sequence) {
       const locationStr = (sequence === 1 || groupedObject['_sequence'] === 1 )? 'Lieu de départ de la journée' : `Lieu ${sequence || groupedObject['_sequence']}`;
       return `${locationStr} ${groupedObject.name ? `• **${groupedObject.name}**` : groupedObject.activity ? `• **${i18n.t(`survey:visitedPlace:activities:${groupedObject.activity}`)}**` : ''}`; 
     },
-    en: function(groupedObject, sequence) { 
+    en: function(groupedObject: any, sequence) {
       const locationStr = (sequence === 1 || groupedObject['_sequence'] === 1 )? 'Departure place for this day' : `Location ${sequence || groupedObject['_sequence']}`;
       return `${locationStr} ${groupedObject.name ? `• **${groupedObject.name}**` : groupedObject.activity ? `• **${i18n.t(`survey:visitedPlace:activities:${groupedObject.activity}`)}**` : ''}`;
     }
-  }
+  },
+  showGroupedObjectDeleteButton: false,
+  deleteConfirmPopup: {
+    content: {
+      fr: function(interview) {
+        return `Confirmez-vous que vous voulez retirer ce lieu?`;
+      },
+      en: function(interview) {
+        return `Do you confirm that you want to remove this location?`;
+      }
+    }
+  },
+  showGroupedObjectAddButton:    true,
+  addButtonLocation: 'both' as const,
+  widgets: [
+    "visitedPlaceActivity",
+    "visitedPlaceAlreadyVisited",
+    "visitedPlaceShortcut",
+    "visitedPlaceName",
+    "visitedPlaceGeography",
+    //"visitedPlaceArrivalAndDepartureTime",
+    "visitedPlaceArrivalTime",
+    "visitedPlaceDepartureTime",
+    "visitedPlaceNextPlaceCategory",
+    //"visitedPlaceWentBackHomeDirectlyAfter",
+    //"visitedPlaceIsNotLast",
+    "buttonSaveVisitedPlace",
+    "buttonCancelVisitedPlace",
+    "buttonDeleteVisitedPlace"
+  ]
 };
 
 export const visitedPlaceName = {

--- a/packages/evolution-common/src/services/widgets/WidgetConfig.ts
+++ b/packages/evolution-common/src/services/widgets/WidgetConfig.ts
@@ -16,7 +16,7 @@ import {
     ParsingFunctionWithCallbacks
 } from '../../utils/helpers';
 import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
-import { i18n } from 'i18next';
+import { TFunction, i18n } from 'i18next';
 
 type IconData = {
     url: string | ParsingFunction<string>;
@@ -374,22 +374,57 @@ export type InfoMapWidgetConfig = {
     linestringActiveColor?: string;
 };
 
+export type GroupNameLangData = {
+    [lang: string]:
+        | string
+        | ((object: unknown, sequence: number, interview?: UserInterviewAttributes, path?: string) => string);
+};
+
+export type GroupNameTranslatableStringFunction = (
+    t: TFunction,
+    object: unknown,
+    sequence: number,
+    interview?: UserInterviewAttributes,
+    path?: string
+) => string;
+
+export type GroupNameI18nData = string | GroupNameLangData | GroupNameTranslatableStringFunction;
+
 export type GroupConfig = {
     type: 'group';
     path: string;
     widgets: string[];
-    conditional?: ParsingFunction<boolean | [boolean] | [boolean, unknown]>;
-    showTitle?: boolean;
-    groupedObjectConditional?: ParsingFunction<boolean>;
-    showGroupedObjectAddButton: ParsingFunction<boolean>;
+    showTitle?: boolean | ParsingFunction<boolean>;
+    /** Title of the group, that will be displayed if showTitle is true */
+    title?: I18nData;
+    /** A translatable string that will be the title of individual group objects */
+    name?: GroupNameI18nData;
+    conditional?: boolean | ParsingFunction<boolean | [boolean] | [boolean, unknown]>;
+    /** Whether to show a specific grouped object
+     * FIXME: Is this redundant with filter?
+     */
+    groupedObjectConditional?: boolean | ParsingFunction<boolean>;
+    showGroupedObjectAddButton?: boolean | ParsingFunction<boolean>;
     groupedObjectAddButtonLabel?: I18nData;
-    showGroupedObjectDeleteButton: ParsingFunction<boolean>;
+    showGroupedObjectDeleteButton?: boolean | ParsingFunction<boolean>;
     groupedObjectDeleteButtonLabel?: I18nData;
     deleteConfirmPopup?: {
         content: I18nData;
+        conditional?: boolean | ParsingFunction<boolean>;
+        title?: I18nData;
+        cancelAction?: React.MouseEventHandler;
+        containsHtml?: boolean;
     };
     addButtonLocation?: 'bottom' | 'top' | 'both';
     addButtonSize?: string;
+    /**
+     * A function to filter the grouped objects and returns an object containing only the filtered objects
+     * FIXME: Redundant with groupedObjectConditional?
+     */
+    filter?: (
+        interview: UserInterviewAttributes,
+        objects: { [objectId: string]: unknown }
+    ) => { [objectId: string]: unknown };
 };
 
 export type WidgetConfig =

--- a/packages/evolution-frontend/src/actions/utils/__tests__/WidgetOperation.test.ts
+++ b/packages/evolution-frontend/src/actions/utils/__tests__/WidgetOperation.test.ts
@@ -38,11 +38,6 @@ const sections = {
         widgets: ['widget1', 'widget2']
     },
     [groupSection]: {
-        groups: {
-            [group1Name]: {
-                widgets: ['widget3']
-            }
-        },
         widgets: [group1Name]
     },
     [choiceSection]: {
@@ -84,7 +79,8 @@ const widgets = {
     },
     [group1Name]: {
         type: 'group',
-        path: `groupResponses`
+        path: `groupResponses`,
+        widgets: ['widget3']
     }
 };
 const mockedDefaultValue = widgets.widget3.defaultValue as jest.MockedFunction<any>;

--- a/packages/evolution-frontend/src/components/hoc/__tests__/WithSurveyContextHoc.test.tsx
+++ b/packages/evolution-frontend/src/components/hoc/__tests__/WithSurveyContextHoc.test.tsx
@@ -17,7 +17,7 @@ interface TestProps {
 export const BaseTestComponent: React.FunctionComponent<{}> = (props: {}) => {
     const [devMode, dispatchSurvey] = React.useReducer(surveyReducer, { devMode: false });
     return (
-        <SurveyContext.Provider value={{ sections: { key1: 'a', key2: 2}, widgets: {}, ...devMode, dispatch: dispatchSurvey }}>
+        <SurveyContext.Provider value={{ sections: { key1: { widgets: ['a'] }, key2: { widgets: [] }}, widgets: {}, ...devMode, dispatch: dispatchSurvey }}>
             <TestComponentWithContext foo='This is a test component'/>
         </SurveyContext.Provider>
     );

--- a/packages/evolution-frontend/src/components/survey/__tests__/GroupWidgets.test.tsx
+++ b/packages/evolution-frontend/src/components/survey/__tests__/GroupWidgets.test.tsx
@@ -1,0 +1,396 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import _cloneDeep from 'lodash/cloneDeep';
+import React from 'react';
+import TestRenderer from 'react-test-renderer';
+import { render } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+expect.extend(toHaveNoViolations);
+
+import { Group, GroupedObject } from '../GroupWidgets';
+import each from 'jest-each';
+import { interviewAttributes } from '../../inputs/__tests__/interviewData.test';
+
+
+// Mock the react-datepicker files to avoid jest compilation errors
+jest.mock('react-datepicker/dist/react-datepicker.css', () => {});
+// Mock the react-input-range files to avoid jest compilation errors
+jest.mock('react-input-range/src/js/input-range/default-class-names', () => ({
+    activeTrack: 'input-range__track input-range__track--active',
+    disabledInputRange: 'input-range input-range--disabled',
+    inputRange: 'input-range',
+    labelContainer: 'input-range__label-container',
+    maxLabel: 'input-range__label input-range__label--max',
+    minLabel: 'input-range__label input-range__label--min',
+    slider: 'input-range__slider',
+    sliderContainer: 'input-range__slider-container',
+    track: 'input-range__track input-range__track--background',
+    valueLabel: 'input-range__label input-range__label--value',
+}));
+
+jest.mock('react-input-range/lib/css/index.css', () => {});
+
+// Add widgets to the survey context
+const widgets = {
+    widgetText: {
+        type: 'text' as const,
+        text: 'This is a text widget'
+    },
+    widgetQuestion: {
+        type: 'question' as const,
+        path: 'quest',
+        label: 'Test Question Label',
+        inputType: 'string' as const
+    },
+};
+const nestedGroupWidget = {
+    widgetGroups: {
+        type: 'group' as const,
+        path: 'myNestedGroups',
+        widgets: Object.keys(widgets),
+        title: 'Nested group title',
+        name: jest.fn().mockImplementation((_t, _obj, seq) => `Nested object at index ${seq}`),
+    }
+}
+const surveyContext = { widgets: { ...widgets, ...nestedGroupWidget } };
+const path = 'myGroups';
+const commonWidgetConfig = {
+    type: 'group' as const,
+    path,
+    widgets: Object.keys(widgets)
+};
+
+// Mock the HOC
+jest.mock('../../hoc/WithSurveyContextHoc', () => ({
+    withSurveyContext: (Component: React.ComponentType) => (props: any) => <Component {...props} surveyContext={surveyContext} />
+}));
+
+// Mock data and functions
+const userAttributes = {
+    id: 1,
+    username: 'foo',
+    preferences: {  },
+    serializedPermissions: [],
+    isAuthorized: () => true,
+    is_admin: false,
+    pages: [],
+    showUserInfo: true
+};
+const startUpdateInterviewMock = jest.fn();
+const startAddGroupedObjectsMock = jest.fn();
+const startRemoveGroupedObjectsMock = jest.fn();
+
+// Add some grouped object data in the interview
+const interview = _cloneDeep(interviewAttributes);
+const groupedObjectIds = [ 'obj0Uuid', 'obj1Uuid', 'obj2Uuid' ];
+interview.responses.myGroups = {
+    [groupedObjectIds[0]]: {
+        _uuid: groupedObjectIds[0],
+        _sequence: 0,
+        quest: 'Some answer'
+    },
+    [groupedObjectIds[1]]: {
+        _uuid: groupedObjectIds[1],
+        _sequence: 1,
+        quest: 'Some other answer'
+    },
+    [groupedObjectIds[2]]: {
+        _uuid: groupedObjectIds[2],
+        _sequence: 2
+    }
+};
+// Make all widgets visible
+(interview as any).groups = {
+    myGroup: {
+        [groupedObjectIds[0]]: {
+            widgetText: { isVisible: true },
+            widgetQuestion: { isVisible: true, value: interview.responses.myGroups[groupedObjectIds[0]].quest }
+        },
+        [groupedObjectIds[1]]: {
+            widgetText: { isVisible: true },
+            widgetQuestion: { isVisible: true, value: interview.responses.myGroups[groupedObjectIds[1]].quest }
+        },
+        [groupedObjectIds[2]]: {
+            widgetText: { isVisible: true },
+            widgetQuestion: { isVisible: true, value: interview.responses.myGroups[groupedObjectIds[2]].quest }
+        }
+    }
+}
+
+describe('Group', () => {
+
+    each([
+        ['Default values', commonWidgetConfig],
+        ['All values set, all true, add button default data, filter show all', {
+            ...commonWidgetConfig,
+            showTitle: true,
+            title: 'Group Title',
+            name: jest.fn().mockImplementation((_t, _obj, seq) => `Grouped object at index ${seq}`),
+            conditional: true,
+            groupedObjectConditional: true,
+            showGroupedObjectAddButton: jest.fn().mockReturnValue(true),
+            groupedObjectAddButtonLabel: jest.fn().mockReturnValue('Add a new grouped object in my group'),
+            showGroupedObjectDeleteButton: jest.fn().mockReturnValue(true),
+            groupedObjectDeleteButtonLabel: jest.fn().mockReturnValue('Delete this grouped object from my group'),
+            addButtonLocation: 'both',
+            addButtonSize: 'small',
+            filter: jest.fn().mockImplementation((interview, objects) => objects)
+        }],
+        ['All values set, false when possible', {
+            ...commonWidgetConfig,
+            showTitle: false,
+            title: 'Group Title',
+            name: jest.fn().mockImplementation((_t, _obj, seq) => `Grouped object at index ${seq}`),
+            conditional: true,
+            groupedObjectConditional: true,
+            showGroupedObjectAddButton: jest.fn().mockReturnValue(false),
+            groupedObjectAddButtonLabel: jest.fn().mockReturnValue('Add a new grouped object in my group'),
+            showGroupedObjectDeleteButton: jest.fn().mockReturnValue(false),
+            groupedObjectDeleteButtonLabel: jest.fn().mockReturnValue('Delete this grouped object from my group'),
+            addButtonLocation: 'both',
+            addButtonSize: 'small',
+            filter: jest.fn().mockImplementation((interview, objects) => objects)
+        }],
+        ['With object filter, show even sequenced objects', {
+            ...commonWidgetConfig,
+            name: jest.fn().mockImplementation((_t, _obj, seq) => `Grouped object at index ${seq}`),
+            filter: jest.fn().mockImplementation((interview, objects) => {
+                const retObjects = {};
+                Object.keys(objects).forEach((key) => {
+                    if (objects[key]._sequence % 2 === 0) {
+                        retObjects[key] = objects[key];
+                    }
+                });
+                return retObjects;
+            })
+        }],
+        ['With grouped object conditional filter, show only object 1', {
+            ...commonWidgetConfig,
+            name: jest.fn().mockImplementation((_t, _obj, seq) => `Grouped object at index ${seq}`),
+            groupedObjectConditional: jest.fn().mockImplementation((interview, path: string) => path.includes(groupedObjectIds[1]) === true)
+        }],
+        ['Add button top, default label, medium', {
+            ...commonWidgetConfig,
+            showGroupedObjectAddButton: jest.fn().mockReturnValue(true),
+            addButtonLocation: 'top',
+            addButtonSize: 'small'
+        }],
+        ['Conditional false, should not display', {
+            conditional: jest.fn().mockReturnValue(false)
+        }]
+    ]).describe('%s', (_widget, widgetConfig) => {
+    
+        test('Render widget', () => {
+    
+            const wrapper = TestRenderer.create(
+                <Group
+                    path={'myGroups'}
+                    widgetConfig={widgetConfig}
+                    interview={interview}
+                    user={userAttributes}
+                    shortname={'myGroup'}
+                    section={''}
+                    startUpdateInterview={startUpdateInterviewMock}
+                    startAddGroupedObjects={startAddGroupedObjectsMock}
+                    startRemoveGroupedObjects={startRemoveGroupedObjectsMock}
+                    loadingState={0}
+                    parentObjectIds={{}}
+                />
+            );
+            expect(wrapper).toMatchSnapshot();
+        });
+    
+        test('Widget accessibility', async () => {
+            const { container } = render(
+                <Group
+                    path={'myGroups'}
+                    widgetConfig={widgetConfig}
+                    interview={interview}
+                    user={userAttributes}
+                    shortname={'myGroup'}
+                    section={''}
+                    startUpdateInterview={startUpdateInterviewMock}
+                    startAddGroupedObjects={startAddGroupedObjectsMock}
+                    startRemoveGroupedObjects={startRemoveGroupedObjectsMock}
+                    loadingState={0}
+                    parentObjectIds={{}}
+                />
+            );
+            const results = await axe(container);
+            expect(results).toHaveNoViolations();
+        });
+    });
+
+    test('Nested groups, should display widgets with right path', () => {
+        const interviewWithNested = _cloneDeep(interviewAttributes);
+        const groupedObjectIds = [ 'obj0Uuid', 'obj1Uuid', 'obj2Uuid' ];
+        const nestedGroupObjectIds = [ 'nestedObj0Uuid', 'nestedObj1Uuid' ];
+        interviewWithNested.responses.myGroups = {
+            [groupedObjectIds[0]]: {
+                _uuid: groupedObjectIds[0],
+                _sequence: 0,
+                myNestedGroups: {
+                    [nestedGroupObjectIds[0]]: {
+                        _uuid: nestedGroupObjectIds[0],
+                        _sequence: 0,
+                        quest: 'Some answer'
+                    },
+                    [nestedGroupObjectIds[1]]: {
+                        _uuid: nestedGroupObjectIds[1],
+                        _sequence: 1,
+                        quest: 'Some other answer'
+                    }
+                }
+            },
+            [groupedObjectIds[1]]: {
+                _uuid: groupedObjectIds[1],
+                _sequence: 1,
+                widgetGroup: {}
+            },
+            [groupedObjectIds[2]]: {
+                _uuid: groupedObjectIds[2],
+                _sequence: 2
+            }
+        };
+        // Make all widgets visible
+        (interviewWithNested as any).groups = {
+            myGroups: {
+                [groupedObjectIds[0]]: {
+                    widgetGroup: { isVisible: true }
+                },
+                [groupedObjectIds[1]]: {
+                    widgetGroup: { isVisible: true }
+                },
+                [groupedObjectIds[2]]: {
+                    widgetGroup: { isVisible: true }
+                }
+            },
+            widgetGroups: {
+                [nestedGroupObjectIds[0]]: {
+                    widgetText: { isVisible: true },
+                    widgetQuestion: { isVisible: true, value: interviewWithNested.responses.myGroups[groupedObjectIds[0]].myNestedGroups[nestedGroupObjectIds[0]].quest }
+                },
+                [nestedGroupObjectIds[1]]: {
+                    widgetText: { isVisible: true },
+                    widgetQuestion: { isVisible: true, value: interviewWithNested.responses.myGroups[groupedObjectIds[0]].myNestedGroups[nestedGroupObjectIds[1]].quest }
+                }
+            }
+        }
+
+        // Group with nested group widgetConfig
+        const widgetConfig = {
+            type: 'group' as const,
+            path,
+            shortname: 'myGroup',
+            widgets: Object.keys(nestedGroupWidget),
+            name: jest.fn().mockImplementation((_t, _obj, seq) => `Grouped object at index ${seq}`),
+        };
+
+        const wrapper = TestRenderer.create(
+            <Group
+                path={'myGroups'}
+                widgetConfig={widgetConfig}
+                interview={interviewWithNested}
+                user={userAttributes}
+                shortname={'myGroup'}
+                section={''}
+                startUpdateInterview={startUpdateInterviewMock}
+                startAddGroupedObjects={startAddGroupedObjectsMock}
+                startRemoveGroupedObjects={startRemoveGroupedObjectsMock}
+                loadingState={0}
+                parentObjectIds={{}}
+            />
+        );
+        expect(wrapper).toMatchSnapshot();
+    })
+
+});
+
+describe('Grouped Object', () => {
+
+    each([
+        ['Default values', commonWidgetConfig],
+        ['All values set, all true, add button default label, filter show all', {
+            ...commonWidgetConfig,
+            showTitle: true,
+            title: 'Group Title',
+            name: jest.fn().mockImplementation((_t, _obj, seq) => `Grouped object at index ${seq}`),
+            conditional: true,
+            groupedObjectConditional: true,
+            showGroupedObjectAddButton: jest.fn().mockReturnValue(true),
+            groupedObjectAddButtonLabel: jest.fn().mockReturnValue('Add a new grouped object in my group'),
+            showGroupedObjectDeleteButton: jest.fn().mockReturnValue(true),
+            groupedObjectDeleteButtonLabel: jest.fn().mockReturnValue('Delete this grouped object from my group'),
+            addButtonLocation: 'both',
+            addButtonSize: 'small',
+            filter: jest.fn().mockImplementation((interview, objects) => objects)
+        }],
+        ['All values set, add/delete button false', {
+            ...commonWidgetConfig,
+            showTitle: false,
+            title: 'Group Title',
+            name: jest.fn().mockImplementation((_t, _obj, seq) => `Grouped object at index ${seq}`),
+            conditional: true,
+            groupedObjectConditional: true,
+            showGroupedObjectAddButton: jest.fn().mockReturnValue(false),
+            groupedObjectAddButtonLabel: jest.fn().mockReturnValue('Add a new grouped object in my group'),
+            showGroupedObjectDeleteButton: jest.fn().mockReturnValue(false),
+            groupedObjectDeleteButtonLabel: jest.fn().mockReturnValue('Delete this grouped object from my group'),
+            addButtonLocation: 'both',
+            addButtonSize: 'small',
+            filter: jest.fn().mockImplementation((interview, objects) => objects)
+        }]
+    ]).describe('%s', (_widget, widgetConfig) => {
+
+        const groupedObjectPath = `${path}.${groupedObjectIds[0]}`;
+    
+        test('Render widget', () => {
+    
+            const wrapper = TestRenderer.create(
+                <GroupedObject
+                    path={groupedObjectPath}
+                    widgetConfig={widgetConfig}
+                    interview={interview}
+                    user={userAttributes}
+                    shortname={'myGroup'}
+                    section={''}
+                    startUpdateInterview={startUpdateInterviewMock}
+                    startAddGroupedObjects={startAddGroupedObjectsMock}
+                    startRemoveGroupedObjects={startRemoveGroupedObjectsMock}
+                    loadingState={0}
+                    parentObjectIds={{}}
+                    objectId={groupedObjectIds[0]}
+                    sequence={0}
+                />
+            );
+            expect(wrapper).toMatchSnapshot();
+        });
+    
+        test('Widget accessibility', async () => {
+            const { container } = render(
+                <GroupedObject
+                    path={groupedObjectPath}
+                    widgetConfig={widgetConfig}
+                    interview={interview}
+                    user={userAttributes}
+                    shortname={'myGroup'}
+                    section={''}
+                    startUpdateInterview={startUpdateInterviewMock}
+                    startAddGroupedObjects={startAddGroupedObjectsMock}
+                    startRemoveGroupedObjects={startRemoveGroupedObjectsMock}
+                    loadingState={0}
+                    parentObjectIds={{}}
+                    objectId={groupedObjectIds[0]}
+                    sequence={0}
+                />
+            );
+            const results = await axe(container);
+            expect(results).toHaveNoViolations();
+        });
+    });
+
+});

--- a/packages/evolution-frontend/src/components/survey/__tests__/__snapshots__/GroupWidgets.test.tsx.snap
+++ b/packages/evolution-frontend/src/components/survey/__tests__/__snapshots__/GroupWidgets.test.tsx.snap
@@ -1,0 +1,2098 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Group Add button top, default label, medium Render widget 1`] = `
+<section
+  className="survey-group"
+>
+  <div
+    className="content-container"
+  >
+    <div
+      className="survey-group__content"
+    >
+      <h2
+        className="survey-group__title"
+      >
+        myGroup.title
+      </h2>
+      <div
+        className="center"
+      >
+        <button
+          className="button blue center small"
+          onClick={[Function]}
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            className="svg-inline--fa fa-plus-circle fa-w-16 faIconLeft"
+            data-icon="plus-circle"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
+            style={Object {}}
+            viewBox="0 0 512 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm144 276c0 6.6-5.4 12-12 12h-92v92c0 6.6-5.4 12-12 12h-56c-6.6 0-12-5.4-12-12v-92h-92c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h92v-92c0-6.6 5.4-12 12-12h56c6.6 0 12 5.4 12 12v92h92c6.6 0 12 5.4 12 12v56z"
+              fill="currentColor"
+              style={Object {}}
+            />
+          </svg>
+          myGroup.addGroupedObject
+        </button>
+      </div>
+      <div
+        className="survey-group-object"
+      >
+        <div
+          className="content-container"
+        >
+          <div
+            className="survey-group-object__content"
+          >
+            <div
+              className="survey-section__text"
+            >
+              <div
+                className="left "
+              >
+                <p>
+                  This is a text widget
+                </p>
+              </div>
+            </div>
+            <div
+              className="apptr__form-container question-type-string question-filled"
+              onClick={[Function]}
+              style={
+                Object {
+                  "position": "relative",
+                }
+              }
+            >
+              <div
+                className="apptr__form-label-container"
+              >
+                <label
+                  htmlFor="survey-question__myGroups.obj0Uuid.quest"
+                >
+                  <div
+                    className="label"
+                  >
+                    <p>
+                      Test Question Label
+                    </p>
+                  </div>
+                </label>
+              </div>
+              <div
+                className="apptr__form-input-container "
+              >
+                <input
+                  autoComplete="none"
+                  className="apptr__form-input apptr__input-string input-large"
+                  id="survey-question__myGroups.obj0Uuid.quest"
+                  maxLength={255}
+                  name="survey-question__myGroups.obj0Uuid.quest"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  style={
+                    Object {
+                      "textTransform": "none",
+                    }
+                  }
+                  type="text"
+                  value="Some answer"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="survey-group-object"
+      >
+        <div
+          className="content-container"
+        >
+          <div
+            className="survey-group-object__content"
+          >
+            <div
+              className="survey-section__text"
+            >
+              <div
+                className="left "
+              >
+                <p>
+                  This is a text widget
+                </p>
+              </div>
+            </div>
+            <div
+              className="apptr__form-container question-type-string question-filled"
+              onClick={[Function]}
+              style={
+                Object {
+                  "position": "relative",
+                }
+              }
+            >
+              <div
+                className="apptr__form-label-container"
+              >
+                <label
+                  htmlFor="survey-question__myGroups.obj1Uuid.quest"
+                >
+                  <div
+                    className="label"
+                  >
+                    <p>
+                      Test Question Label
+                    </p>
+                  </div>
+                </label>
+              </div>
+              <div
+                className="apptr__form-input-container "
+              >
+                <input
+                  autoComplete="none"
+                  className="apptr__form-input apptr__input-string input-large"
+                  id="survey-question__myGroups.obj1Uuid.quest"
+                  maxLength={255}
+                  name="survey-question__myGroups.obj1Uuid.quest"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  style={
+                    Object {
+                      "textTransform": "none",
+                    }
+                  }
+                  type="text"
+                  value="Some other answer"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="survey-group-object"
+      >
+        <div
+          className="content-container"
+        >
+          <div
+            className="survey-group-object__content"
+          >
+            <div
+              className="survey-section__text"
+            >
+              <div
+                className="left "
+              >
+                <p>
+                  This is a text widget
+                </p>
+              </div>
+            </div>
+            <div
+              className="apptr__form-container question-type-string question-filled"
+              onClick={[Function]}
+              style={
+                Object {
+                  "position": "relative",
+                }
+              }
+            >
+              <div
+                className="apptr__form-label-container"
+              >
+                <label
+                  htmlFor="survey-question__myGroups.obj2Uuid.quest"
+                >
+                  <div
+                    className="label"
+                  >
+                    <p>
+                      Test Question Label
+                    </p>
+                  </div>
+                </label>
+              </div>
+              <div
+                className="apptr__form-input-container "
+              >
+                <input
+                  autoComplete="none"
+                  className="apptr__form-input apptr__input-string input-large"
+                  id="survey-question__myGroups.obj2Uuid.quest"
+                  maxLength={255}
+                  name="survey-question__myGroups.obj2Uuid.quest"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  style={
+                    Object {
+                      "textTransform": "none",
+                    }
+                  }
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+`;
+
+exports[`Group All values set, all true, add button default data, filter show all Render widget 1`] = `
+<section
+  className="survey-group"
+>
+  <div
+    className="content-container"
+  >
+    <div
+      className="survey-group__content"
+    >
+      <h2
+        className="survey-group__title"
+      >
+        Group Title
+      </h2>
+      <div
+        className="center"
+      >
+        <button
+          className="button blue center small"
+          onClick={[Function]}
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            className="svg-inline--fa fa-plus-circle fa-w-16 faIconLeft"
+            data-icon="plus-circle"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
+            style={Object {}}
+            viewBox="0 0 512 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm144 276c0 6.6-5.4 12-12 12h-92v92c0 6.6-5.4 12-12 12h-56c-6.6 0-12-5.4-12-12v-92h-92c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h92v-92c0-6.6 5.4-12 12-12h56c6.6 0 12 5.4 12 12v92h92c6.6 0 12 5.4 12 12v56z"
+              fill="currentColor"
+              style={Object {}}
+            />
+          </svg>
+          Add a new grouped object in my group
+        </button>
+      </div>
+      <div
+        className="survey-group-object"
+      >
+        <div
+          className="content-container"
+        >
+          <div
+            className="survey-group-object__content"
+          >
+            <h3
+              className="survey-group-object__title"
+            >
+              <p>
+                Grouped object at index 0
+              </p>
+            </h3>
+            <div
+              className="center"
+            >
+              <button
+                className="button red small"
+                onClick={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="svg-inline--fa fa-trash-alt fa-w-14 faIconLeft"
+                  data-icon="trash-alt"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  style={Object {}}
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M32 464a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128H32zm272-256a16 16 0 0 1 32 0v224a16 16 0 0 1-32 0zm-96 0a16 16 0 0 1 32 0v224a16 16 0 0 1-32 0zm-96 0a16 16 0 0 1 32 0v224a16 16 0 0 1-32 0zM432 32H312l-9.4-18.7A24 24 0 0 0 281.1 0H166.8a23.72 23.72 0 0 0-21.4 13.3L136 32H16A16 16 0 0 0 0 48v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16V48a16 16 0 0 0-16-16z"
+                    fill="currentColor"
+                    style={Object {}}
+                  />
+                </svg>
+                Delete this grouped object from my group
+              </button>
+            </div>
+            <div
+              className="survey-section__text"
+            >
+              <div
+                className="left "
+              >
+                <p>
+                  This is a text widget
+                </p>
+              </div>
+            </div>
+            <div
+              className="apptr__form-container question-type-string question-filled"
+              onClick={[Function]}
+              style={
+                Object {
+                  "position": "relative",
+                }
+              }
+            >
+              <div
+                className="apptr__form-label-container"
+              >
+                <label
+                  htmlFor="survey-question__myGroups.obj0Uuid.quest"
+                >
+                  <div
+                    className="label"
+                  >
+                    <p>
+                      Test Question Label
+                    </p>
+                  </div>
+                </label>
+              </div>
+              <div
+                className="apptr__form-input-container "
+              >
+                <input
+                  autoComplete="none"
+                  className="apptr__form-input apptr__input-string input-large"
+                  id="survey-question__myGroups.obj0Uuid.quest"
+                  maxLength={255}
+                  name="survey-question__myGroups.obj0Uuid.quest"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  style={
+                    Object {
+                      "textTransform": "none",
+                    }
+                  }
+                  type="text"
+                  value="Some answer"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="survey-group-object"
+      >
+        <div
+          className="content-container"
+        >
+          <div
+            className="survey-group-object__content"
+          >
+            <h3
+              className="survey-group-object__title"
+            >
+              <p>
+                Grouped object at index 1
+              </p>
+            </h3>
+            <div
+              className="center"
+            >
+              <button
+                className="button red small"
+                onClick={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="svg-inline--fa fa-trash-alt fa-w-14 faIconLeft"
+                  data-icon="trash-alt"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  style={Object {}}
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M32 464a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128H32zm272-256a16 16 0 0 1 32 0v224a16 16 0 0 1-32 0zm-96 0a16 16 0 0 1 32 0v224a16 16 0 0 1-32 0zm-96 0a16 16 0 0 1 32 0v224a16 16 0 0 1-32 0zM432 32H312l-9.4-18.7A24 24 0 0 0 281.1 0H166.8a23.72 23.72 0 0 0-21.4 13.3L136 32H16A16 16 0 0 0 0 48v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16V48a16 16 0 0 0-16-16z"
+                    fill="currentColor"
+                    style={Object {}}
+                  />
+                </svg>
+                Delete this grouped object from my group
+              </button>
+            </div>
+            <div
+              className="survey-section__text"
+            >
+              <div
+                className="left "
+              >
+                <p>
+                  This is a text widget
+                </p>
+              </div>
+            </div>
+            <div
+              className="apptr__form-container question-type-string question-filled"
+              onClick={[Function]}
+              style={
+                Object {
+                  "position": "relative",
+                }
+              }
+            >
+              <div
+                className="apptr__form-label-container"
+              >
+                <label
+                  htmlFor="survey-question__myGroups.obj1Uuid.quest"
+                >
+                  <div
+                    className="label"
+                  >
+                    <p>
+                      Test Question Label
+                    </p>
+                  </div>
+                </label>
+              </div>
+              <div
+                className="apptr__form-input-container "
+              >
+                <input
+                  autoComplete="none"
+                  className="apptr__form-input apptr__input-string input-large"
+                  id="survey-question__myGroups.obj1Uuid.quest"
+                  maxLength={255}
+                  name="survey-question__myGroups.obj1Uuid.quest"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  style={
+                    Object {
+                      "textTransform": "none",
+                    }
+                  }
+                  type="text"
+                  value="Some other answer"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="survey-group-object"
+      >
+        <div
+          className="content-container"
+        >
+          <div
+            className="survey-group-object__content"
+          >
+            <h3
+              className="survey-group-object__title"
+            >
+              <p>
+                Grouped object at index 2
+              </p>
+            </h3>
+            <div
+              className="center"
+            >
+              <button
+                className="button red small"
+                onClick={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="svg-inline--fa fa-trash-alt fa-w-14 faIconLeft"
+                  data-icon="trash-alt"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  style={Object {}}
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M32 464a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128H32zm272-256a16 16 0 0 1 32 0v224a16 16 0 0 1-32 0zm-96 0a16 16 0 0 1 32 0v224a16 16 0 0 1-32 0zm-96 0a16 16 0 0 1 32 0v224a16 16 0 0 1-32 0zM432 32H312l-9.4-18.7A24 24 0 0 0 281.1 0H166.8a23.72 23.72 0 0 0-21.4 13.3L136 32H16A16 16 0 0 0 0 48v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16V48a16 16 0 0 0-16-16z"
+                    fill="currentColor"
+                    style={Object {}}
+                  />
+                </svg>
+                Delete this grouped object from my group
+              </button>
+            </div>
+            <div
+              className="survey-section__text"
+            >
+              <div
+                className="left "
+              >
+                <p>
+                  This is a text widget
+                </p>
+              </div>
+            </div>
+            <div
+              className="apptr__form-container question-type-string question-filled"
+              onClick={[Function]}
+              style={
+                Object {
+                  "position": "relative",
+                }
+              }
+            >
+              <div
+                className="apptr__form-label-container"
+              >
+                <label
+                  htmlFor="survey-question__myGroups.obj2Uuid.quest"
+                >
+                  <div
+                    className="label"
+                  >
+                    <p>
+                      Test Question Label
+                    </p>
+                  </div>
+                </label>
+              </div>
+              <div
+                className="apptr__form-input-container "
+              >
+                <input
+                  autoComplete="none"
+                  className="apptr__form-input apptr__input-string input-large"
+                  id="survey-question__myGroups.obj2Uuid.quest"
+                  maxLength={255}
+                  name="survey-question__myGroups.obj2Uuid.quest"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  style={
+                    Object {
+                      "textTransform": "none",
+                    }
+                  }
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="center"
+      >
+        <button
+          className="button blue center small"
+          onClick={[Function]}
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            className="svg-inline--fa fa-plus-circle fa-w-16 faIconLeft"
+            data-icon="plus-circle"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
+            style={Object {}}
+            viewBox="0 0 512 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm144 276c0 6.6-5.4 12-12 12h-92v92c0 6.6-5.4 12-12 12h-56c-6.6 0-12-5.4-12-12v-92h-92c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h92v-92c0-6.6 5.4-12 12-12h56c6.6 0 12 5.4 12 12v92h92c6.6 0 12 5.4 12 12v56z"
+              fill="currentColor"
+              style={Object {}}
+            />
+          </svg>
+          Add a new grouped object in my group
+        </button>
+      </div>
+    </div>
+  </div>
+</section>
+`;
+
+exports[`Group All values set, false when possible Render widget 1`] = `
+<section
+  className="survey-group"
+>
+  <div
+    className="content-container"
+  >
+    <div
+      className="survey-group__content"
+    >
+      <div
+        className="survey-group-object"
+      >
+        <div
+          className="content-container"
+        >
+          <div
+            className="survey-group-object__content"
+          >
+            <h3
+              className="survey-group-object__title"
+            >
+              <p>
+                Grouped object at index 0
+              </p>
+            </h3>
+            <div
+              className="survey-section__text"
+            >
+              <div
+                className="left "
+              >
+                <p>
+                  This is a text widget
+                </p>
+              </div>
+            </div>
+            <div
+              className="apptr__form-container question-type-string question-filled"
+              onClick={[Function]}
+              style={
+                Object {
+                  "position": "relative",
+                }
+              }
+            >
+              <div
+                className="apptr__form-label-container"
+              >
+                <label
+                  htmlFor="survey-question__myGroups.obj0Uuid.quest"
+                >
+                  <div
+                    className="label"
+                  >
+                    <p>
+                      Test Question Label
+                    </p>
+                  </div>
+                </label>
+              </div>
+              <div
+                className="apptr__form-input-container "
+              >
+                <input
+                  autoComplete="none"
+                  className="apptr__form-input apptr__input-string input-large"
+                  id="survey-question__myGroups.obj0Uuid.quest"
+                  maxLength={255}
+                  name="survey-question__myGroups.obj0Uuid.quest"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  style={
+                    Object {
+                      "textTransform": "none",
+                    }
+                  }
+                  type="text"
+                  value="Some answer"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="survey-group-object"
+      >
+        <div
+          className="content-container"
+        >
+          <div
+            className="survey-group-object__content"
+          >
+            <h3
+              className="survey-group-object__title"
+            >
+              <p>
+                Grouped object at index 1
+              </p>
+            </h3>
+            <div
+              className="survey-section__text"
+            >
+              <div
+                className="left "
+              >
+                <p>
+                  This is a text widget
+                </p>
+              </div>
+            </div>
+            <div
+              className="apptr__form-container question-type-string question-filled"
+              onClick={[Function]}
+              style={
+                Object {
+                  "position": "relative",
+                }
+              }
+            >
+              <div
+                className="apptr__form-label-container"
+              >
+                <label
+                  htmlFor="survey-question__myGroups.obj1Uuid.quest"
+                >
+                  <div
+                    className="label"
+                  >
+                    <p>
+                      Test Question Label
+                    </p>
+                  </div>
+                </label>
+              </div>
+              <div
+                className="apptr__form-input-container "
+              >
+                <input
+                  autoComplete="none"
+                  className="apptr__form-input apptr__input-string input-large"
+                  id="survey-question__myGroups.obj1Uuid.quest"
+                  maxLength={255}
+                  name="survey-question__myGroups.obj1Uuid.quest"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  style={
+                    Object {
+                      "textTransform": "none",
+                    }
+                  }
+                  type="text"
+                  value="Some other answer"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="survey-group-object"
+      >
+        <div
+          className="content-container"
+        >
+          <div
+            className="survey-group-object__content"
+          >
+            <h3
+              className="survey-group-object__title"
+            >
+              <p>
+                Grouped object at index 2
+              </p>
+            </h3>
+            <div
+              className="survey-section__text"
+            >
+              <div
+                className="left "
+              >
+                <p>
+                  This is a text widget
+                </p>
+              </div>
+            </div>
+            <div
+              className="apptr__form-container question-type-string question-filled"
+              onClick={[Function]}
+              style={
+                Object {
+                  "position": "relative",
+                }
+              }
+            >
+              <div
+                className="apptr__form-label-container"
+              >
+                <label
+                  htmlFor="survey-question__myGroups.obj2Uuid.quest"
+                >
+                  <div
+                    className="label"
+                  >
+                    <p>
+                      Test Question Label
+                    </p>
+                  </div>
+                </label>
+              </div>
+              <div
+                className="apptr__form-input-container "
+              >
+                <input
+                  autoComplete="none"
+                  className="apptr__form-input apptr__input-string input-large"
+                  id="survey-question__myGroups.obj2Uuid.quest"
+                  maxLength={255}
+                  name="survey-question__myGroups.obj2Uuid.quest"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  style={
+                    Object {
+                      "textTransform": "none",
+                    }
+                  }
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+`;
+
+exports[`Group Conditional false, should not display Render widget 1`] = `null`;
+
+exports[`Group Default values Render widget 1`] = `
+<section
+  className="survey-group"
+>
+  <div
+    className="content-container"
+  >
+    <div
+      className="survey-group__content"
+    >
+      <h2
+        className="survey-group__title"
+      >
+        myGroup.title
+      </h2>
+      <div
+        className="survey-group-object"
+      >
+        <div
+          className="content-container"
+        >
+          <div
+            className="survey-group-object__content"
+          >
+            <div
+              className="survey-section__text"
+            >
+              <div
+                className="left "
+              >
+                <p>
+                  This is a text widget
+                </p>
+              </div>
+            </div>
+            <div
+              className="apptr__form-container question-type-string question-filled"
+              onClick={[Function]}
+              style={
+                Object {
+                  "position": "relative",
+                }
+              }
+            >
+              <div
+                className="apptr__form-label-container"
+              >
+                <label
+                  htmlFor="survey-question__myGroups.obj0Uuid.quest"
+                >
+                  <div
+                    className="label"
+                  >
+                    <p>
+                      Test Question Label
+                    </p>
+                  </div>
+                </label>
+              </div>
+              <div
+                className="apptr__form-input-container "
+              >
+                <input
+                  autoComplete="none"
+                  className="apptr__form-input apptr__input-string input-large"
+                  id="survey-question__myGroups.obj0Uuid.quest"
+                  maxLength={255}
+                  name="survey-question__myGroups.obj0Uuid.quest"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  style={
+                    Object {
+                      "textTransform": "none",
+                    }
+                  }
+                  type="text"
+                  value="Some answer"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="survey-group-object"
+      >
+        <div
+          className="content-container"
+        >
+          <div
+            className="survey-group-object__content"
+          >
+            <div
+              className="survey-section__text"
+            >
+              <div
+                className="left "
+              >
+                <p>
+                  This is a text widget
+                </p>
+              </div>
+            </div>
+            <div
+              className="apptr__form-container question-type-string question-filled"
+              onClick={[Function]}
+              style={
+                Object {
+                  "position": "relative",
+                }
+              }
+            >
+              <div
+                className="apptr__form-label-container"
+              >
+                <label
+                  htmlFor="survey-question__myGroups.obj1Uuid.quest"
+                >
+                  <div
+                    className="label"
+                  >
+                    <p>
+                      Test Question Label
+                    </p>
+                  </div>
+                </label>
+              </div>
+              <div
+                className="apptr__form-input-container "
+              >
+                <input
+                  autoComplete="none"
+                  className="apptr__form-input apptr__input-string input-large"
+                  id="survey-question__myGroups.obj1Uuid.quest"
+                  maxLength={255}
+                  name="survey-question__myGroups.obj1Uuid.quest"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  style={
+                    Object {
+                      "textTransform": "none",
+                    }
+                  }
+                  type="text"
+                  value="Some other answer"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="survey-group-object"
+      >
+        <div
+          className="content-container"
+        >
+          <div
+            className="survey-group-object__content"
+          >
+            <div
+              className="survey-section__text"
+            >
+              <div
+                className="left "
+              >
+                <p>
+                  This is a text widget
+                </p>
+              </div>
+            </div>
+            <div
+              className="apptr__form-container question-type-string question-filled"
+              onClick={[Function]}
+              style={
+                Object {
+                  "position": "relative",
+                }
+              }
+            >
+              <div
+                className="apptr__form-label-container"
+              >
+                <label
+                  htmlFor="survey-question__myGroups.obj2Uuid.quest"
+                >
+                  <div
+                    className="label"
+                  >
+                    <p>
+                      Test Question Label
+                    </p>
+                  </div>
+                </label>
+              </div>
+              <div
+                className="apptr__form-input-container "
+              >
+                <input
+                  autoComplete="none"
+                  className="apptr__form-input apptr__input-string input-large"
+                  id="survey-question__myGroups.obj2Uuid.quest"
+                  maxLength={255}
+                  name="survey-question__myGroups.obj2Uuid.quest"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  style={
+                    Object {
+                      "textTransform": "none",
+                    }
+                  }
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="center"
+      >
+        <button
+          className="button blue center large"
+          onClick={[Function]}
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            className="svg-inline--fa fa-plus-circle fa-w-16 faIconLeft"
+            data-icon="plus-circle"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
+            style={Object {}}
+            viewBox="0 0 512 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm144 276c0 6.6-5.4 12-12 12h-92v92c0 6.6-5.4 12-12 12h-56c-6.6 0-12-5.4-12-12v-92h-92c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h92v-92c0-6.6 5.4-12 12-12h56c6.6 0 12 5.4 12 12v92h92c6.6 0 12 5.4 12 12v56z"
+              fill="currentColor"
+              style={Object {}}
+            />
+          </svg>
+          myGroup.addGroupedObject
+        </button>
+      </div>
+    </div>
+  </div>
+</section>
+`;
+
+exports[`Group Nested groups, should display widgets with right path 1`] = `
+<section
+  className="survey-group"
+>
+  <div
+    className="content-container"
+  >
+    <div
+      className="survey-group__content"
+    >
+      <h2
+        className="survey-group__title"
+      >
+        myGroup.title
+      </h2>
+      <div
+        className="survey-group-object"
+      >
+        <div
+          className="content-container"
+        >
+          <div
+            className="survey-group-object__content"
+          >
+            <h3
+              className="survey-group-object__title"
+            >
+              <p>
+                Grouped object at index 0
+              </p>
+            </h3>
+            <section
+              className="survey-group"
+            >
+              <div
+                className="content-container"
+              >
+                <div
+                  className="survey-group__content"
+                >
+                  <h2
+                    className="survey-group__title"
+                  >
+                    Nested group title
+                  </h2>
+                  <div
+                    className="survey-group-object"
+                  >
+                    <div
+                      className="content-container"
+                    >
+                      <div
+                        className="survey-group-object__content"
+                      >
+                        <h3
+                          className="survey-group-object__title"
+                        >
+                          <p>
+                            Nested object at index 0
+                          </p>
+                        </h3>
+                        <div
+                          className="survey-section__text"
+                        >
+                          <div
+                            className="left "
+                          >
+                            <p>
+                              This is a text widget
+                            </p>
+                          </div>
+                        </div>
+                        <div
+                          className="apptr__form-container question-type-string question-filled"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "position": "relative",
+                            }
+                          }
+                        >
+                          <div
+                            className="apptr__form-label-container"
+                          >
+                            <label
+                              htmlFor="survey-question__myGroups.obj0Uuid.myNestedGroups.nestedObj0Uuid.quest"
+                            >
+                              <div
+                                className="label"
+                              >
+                                <p>
+                                  Test Question Label
+                                </p>
+                              </div>
+                            </label>
+                          </div>
+                          <div
+                            className="apptr__form-input-container "
+                          >
+                            <input
+                              autoComplete="none"
+                              className="apptr__form-input apptr__input-string input-large"
+                              id="survey-question__myGroups.obj0Uuid.myNestedGroups.nestedObj0Uuid.quest"
+                              maxLength={255}
+                              name="survey-question__myGroups.obj0Uuid.myNestedGroups.nestedObj0Uuid.quest"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              style={
+                                Object {
+                                  "textTransform": "none",
+                                }
+                              }
+                              type="text"
+                              value="Some answer"
+                            />
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="survey-group-object"
+                  >
+                    <div
+                      className="content-container"
+                    >
+                      <div
+                        className="survey-group-object__content"
+                      >
+                        <h3
+                          className="survey-group-object__title"
+                        >
+                          <p>
+                            Nested object at index 1
+                          </p>
+                        </h3>
+                        <div
+                          className="survey-section__text"
+                        >
+                          <div
+                            className="left "
+                          >
+                            <p>
+                              This is a text widget
+                            </p>
+                          </div>
+                        </div>
+                        <div
+                          className="apptr__form-container question-type-string question-filled"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "position": "relative",
+                            }
+                          }
+                        >
+                          <div
+                            className="apptr__form-label-container"
+                          >
+                            <label
+                              htmlFor="survey-question__myGroups.obj0Uuid.myNestedGroups.nestedObj1Uuid.quest"
+                            >
+                              <div
+                                className="label"
+                              >
+                                <p>
+                                  Test Question Label
+                                </p>
+                              </div>
+                            </label>
+                          </div>
+                          <div
+                            className="apptr__form-input-container "
+                          >
+                            <input
+                              autoComplete="none"
+                              className="apptr__form-input apptr__input-string input-large"
+                              id="survey-question__myGroups.obj0Uuid.myNestedGroups.nestedObj1Uuid.quest"
+                              maxLength={255}
+                              name="survey-question__myGroups.obj0Uuid.myNestedGroups.nestedObj1Uuid.quest"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              style={
+                                Object {
+                                  "textTransform": "none",
+                                }
+                              }
+                              type="text"
+                              value="Some other answer"
+                            />
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="center"
+                  >
+                    <button
+                      className="button blue center large"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        className="svg-inline--fa fa-plus-circle fa-w-16 faIconLeft"
+                        data-icon="plus-circle"
+                        data-prefix="fas"
+                        focusable="false"
+                        role="img"
+                        style={Object {}}
+                        viewBox="0 0 512 512"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm144 276c0 6.6-5.4 12-12 12h-92v92c0 6.6-5.4 12-12 12h-56c-6.6 0-12-5.4-12-12v-92h-92c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h92v-92c0-6.6 5.4-12 12-12h56c6.6 0 12 5.4 12 12v92h92c6.6 0 12 5.4 12 12v56z"
+                          fill="currentColor"
+                          style={Object {}}
+                        />
+                      </svg>
+                      widgetGroups.addGroupedObject
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </section>
+          </div>
+        </div>
+      </div>
+      <div
+        className="survey-group-object"
+      >
+        <div
+          className="content-container"
+        >
+          <div
+            className="survey-group-object__content"
+          >
+            <h3
+              className="survey-group-object__title"
+            >
+              <p>
+                Grouped object at index 1
+              </p>
+            </h3>
+            <section
+              className="survey-group"
+            >
+              <div
+                className="content-container"
+              >
+                <div
+                  className="survey-group__content"
+                >
+                  <h2
+                    className="survey-group__title"
+                  >
+                    Nested group title
+                  </h2>
+                  <div
+                    className="center"
+                  >
+                    <button
+                      className="button blue center large"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        className="svg-inline--fa fa-plus-circle fa-w-16 faIconLeft"
+                        data-icon="plus-circle"
+                        data-prefix="fas"
+                        focusable="false"
+                        role="img"
+                        style={Object {}}
+                        viewBox="0 0 512 512"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm144 276c0 6.6-5.4 12-12 12h-92v92c0 6.6-5.4 12-12 12h-56c-6.6 0-12-5.4-12-12v-92h-92c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h92v-92c0-6.6 5.4-12 12-12h56c6.6 0 12 5.4 12 12v92h92c6.6 0 12 5.4 12 12v56z"
+                          fill="currentColor"
+                          style={Object {}}
+                        />
+                      </svg>
+                      widgetGroups.addGroupedObject
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </section>
+          </div>
+        </div>
+      </div>
+      <div
+        className="survey-group-object"
+      >
+        <div
+          className="content-container"
+        >
+          <div
+            className="survey-group-object__content"
+          >
+            <h3
+              className="survey-group-object__title"
+            >
+              <p>
+                Grouped object at index 2
+              </p>
+            </h3>
+            <section
+              className="survey-group"
+            >
+              <div
+                className="content-container"
+              >
+                <div
+                  className="survey-group__content"
+                >
+                  <h2
+                    className="survey-group__title"
+                  >
+                    Nested group title
+                  </h2>
+                  <div
+                    className="center"
+                  >
+                    <button
+                      className="button blue center large"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        className="svg-inline--fa fa-plus-circle fa-w-16 faIconLeft"
+                        data-icon="plus-circle"
+                        data-prefix="fas"
+                        focusable="false"
+                        role="img"
+                        style={Object {}}
+                        viewBox="0 0 512 512"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm144 276c0 6.6-5.4 12-12 12h-92v92c0 6.6-5.4 12-12 12h-56c-6.6 0-12-5.4-12-12v-92h-92c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h92v-92c0-6.6 5.4-12 12-12h56c6.6 0 12 5.4 12 12v92h92c6.6 0 12 5.4 12 12v56z"
+                          fill="currentColor"
+                          style={Object {}}
+                        />
+                      </svg>
+                      widgetGroups.addGroupedObject
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </section>
+          </div>
+        </div>
+      </div>
+      <div
+        className="center"
+      >
+        <button
+          className="button blue center large"
+          onClick={[Function]}
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            className="svg-inline--fa fa-plus-circle fa-w-16 faIconLeft"
+            data-icon="plus-circle"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
+            style={Object {}}
+            viewBox="0 0 512 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm144 276c0 6.6-5.4 12-12 12h-92v92c0 6.6-5.4 12-12 12h-56c-6.6 0-12-5.4-12-12v-92h-92c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h92v-92c0-6.6 5.4-12 12-12h56c6.6 0 12 5.4 12 12v92h92c6.6 0 12 5.4 12 12v56z"
+              fill="currentColor"
+              style={Object {}}
+            />
+          </svg>
+          myGroup.addGroupedObject
+        </button>
+      </div>
+    </div>
+  </div>
+</section>
+`;
+
+exports[`Group With grouped object conditional filter, show only object 1 Render widget 1`] = `
+<section
+  className="survey-group"
+>
+  <div
+    className="content-container"
+  >
+    <div
+      className="survey-group__content"
+    >
+      <h2
+        className="survey-group__title"
+      >
+        myGroup.title
+      </h2>
+      <div
+        className="survey-group-object"
+      >
+        <div
+          className="content-container"
+        >
+          <div
+            className="survey-group-object__content"
+          >
+            <h3
+              className="survey-group-object__title"
+            >
+              <p>
+                Grouped object at index 1
+              </p>
+            </h3>
+            <div
+              className="survey-section__text"
+            >
+              <div
+                className="left "
+              >
+                <p>
+                  This is a text widget
+                </p>
+              </div>
+            </div>
+            <div
+              className="apptr__form-container question-type-string question-filled"
+              onClick={[Function]}
+              style={
+                Object {
+                  "position": "relative",
+                }
+              }
+            >
+              <div
+                className="apptr__form-label-container"
+              >
+                <label
+                  htmlFor="survey-question__myGroups.obj1Uuid.quest"
+                >
+                  <div
+                    className="label"
+                  >
+                    <p>
+                      Test Question Label
+                    </p>
+                  </div>
+                </label>
+              </div>
+              <div
+                className="apptr__form-input-container "
+              >
+                <input
+                  autoComplete="none"
+                  className="apptr__form-input apptr__input-string input-large"
+                  id="survey-question__myGroups.obj1Uuid.quest"
+                  maxLength={255}
+                  name="survey-question__myGroups.obj1Uuid.quest"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  style={
+                    Object {
+                      "textTransform": "none",
+                    }
+                  }
+                  type="text"
+                  value="Some other answer"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="center"
+      >
+        <button
+          className="button blue center large"
+          onClick={[Function]}
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            className="svg-inline--fa fa-plus-circle fa-w-16 faIconLeft"
+            data-icon="plus-circle"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
+            style={Object {}}
+            viewBox="0 0 512 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm144 276c0 6.6-5.4 12-12 12h-92v92c0 6.6-5.4 12-12 12h-56c-6.6 0-12-5.4-12-12v-92h-92c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h92v-92c0-6.6 5.4-12 12-12h56c6.6 0 12 5.4 12 12v92h92c6.6 0 12 5.4 12 12v56z"
+              fill="currentColor"
+              style={Object {}}
+            />
+          </svg>
+          myGroup.addGroupedObject
+        </button>
+      </div>
+    </div>
+  </div>
+</section>
+`;
+
+exports[`Group With object filter, show even sequenced objects Render widget 1`] = `
+<section
+  className="survey-group"
+>
+  <div
+    className="content-container"
+  >
+    <div
+      className="survey-group__content"
+    >
+      <h2
+        className="survey-group__title"
+      >
+        myGroup.title
+      </h2>
+      <div
+        className="survey-group-object"
+      >
+        <div
+          className="content-container"
+        >
+          <div
+            className="survey-group-object__content"
+          >
+            <h3
+              className="survey-group-object__title"
+            >
+              <p>
+                Grouped object at index 0
+              </p>
+            </h3>
+            <div
+              className="survey-section__text"
+            >
+              <div
+                className="left "
+              >
+                <p>
+                  This is a text widget
+                </p>
+              </div>
+            </div>
+            <div
+              className="apptr__form-container question-type-string question-filled"
+              onClick={[Function]}
+              style={
+                Object {
+                  "position": "relative",
+                }
+              }
+            >
+              <div
+                className="apptr__form-label-container"
+              >
+                <label
+                  htmlFor="survey-question__myGroups.obj0Uuid.quest"
+                >
+                  <div
+                    className="label"
+                  >
+                    <p>
+                      Test Question Label
+                    </p>
+                  </div>
+                </label>
+              </div>
+              <div
+                className="apptr__form-input-container "
+              >
+                <input
+                  autoComplete="none"
+                  className="apptr__form-input apptr__input-string input-large"
+                  id="survey-question__myGroups.obj0Uuid.quest"
+                  maxLength={255}
+                  name="survey-question__myGroups.obj0Uuid.quest"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  style={
+                    Object {
+                      "textTransform": "none",
+                    }
+                  }
+                  type="text"
+                  value="Some answer"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="survey-group-object"
+      >
+        <div
+          className="content-container"
+        >
+          <div
+            className="survey-group-object__content"
+          >
+            <h3
+              className="survey-group-object__title"
+            >
+              <p>
+                Grouped object at index 2
+              </p>
+            </h3>
+            <div
+              className="survey-section__text"
+            >
+              <div
+                className="left "
+              >
+                <p>
+                  This is a text widget
+                </p>
+              </div>
+            </div>
+            <div
+              className="apptr__form-container question-type-string question-filled"
+              onClick={[Function]}
+              style={
+                Object {
+                  "position": "relative",
+                }
+              }
+            >
+              <div
+                className="apptr__form-label-container"
+              >
+                <label
+                  htmlFor="survey-question__myGroups.obj2Uuid.quest"
+                >
+                  <div
+                    className="label"
+                  >
+                    <p>
+                      Test Question Label
+                    </p>
+                  </div>
+                </label>
+              </div>
+              <div
+                className="apptr__form-input-container "
+              >
+                <input
+                  autoComplete="none"
+                  className="apptr__form-input apptr__input-string input-large"
+                  id="survey-question__myGroups.obj2Uuid.quest"
+                  maxLength={255}
+                  name="survey-question__myGroups.obj2Uuid.quest"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  style={
+                    Object {
+                      "textTransform": "none",
+                    }
+                  }
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="center"
+      >
+        <button
+          className="button blue center large"
+          onClick={[Function]}
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            className="svg-inline--fa fa-plus-circle fa-w-16 faIconLeft"
+            data-icon="plus-circle"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
+            style={Object {}}
+            viewBox="0 0 512 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm144 276c0 6.6-5.4 12-12 12h-92v92c0 6.6-5.4 12-12 12h-56c-6.6 0-12-5.4-12-12v-92h-92c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h92v-92c0-6.6 5.4-12 12-12h56c6.6 0 12 5.4 12 12v92h92c6.6 0 12 5.4 12 12v56z"
+              fill="currentColor"
+              style={Object {}}
+            />
+          </svg>
+          myGroup.addGroupedObject
+        </button>
+      </div>
+    </div>
+  </div>
+</section>
+`;
+
+exports[`Grouped Object All values set, add/delete button false Render widget 1`] = `
+<div
+  className="survey-group-object"
+>
+  <div
+    className="content-container"
+  >
+    <div
+      className="survey-group-object__content"
+    >
+      <h3
+        className="survey-group-object__title"
+      >
+        <p>
+          Grouped object at index 0
+        </p>
+      </h3>
+      <div
+        className="survey-section__text"
+      >
+        <div
+          className="left "
+        >
+          <p>
+            This is a text widget
+          </p>
+        </div>
+      </div>
+      <div
+        className="apptr__form-container question-type-string question-filled"
+        onClick={[Function]}
+        style={
+          Object {
+            "position": "relative",
+          }
+        }
+      >
+        <div
+          className="apptr__form-label-container"
+        >
+          <label
+            htmlFor="survey-question__myGroups.obj0Uuid.quest"
+          >
+            <div
+              className="label"
+            >
+              <p>
+                Test Question Label
+              </p>
+            </div>
+          </label>
+        </div>
+        <div
+          className="apptr__form-input-container "
+        >
+          <input
+            autoComplete="none"
+            className="apptr__form-input apptr__input-string input-large"
+            id="survey-question__myGroups.obj0Uuid.quest"
+            maxLength={255}
+            name="survey-question__myGroups.obj0Uuid.quest"
+            onBlur={[Function]}
+            onChange={[Function]}
+            style={
+              Object {
+                "textTransform": "none",
+              }
+            }
+            type="text"
+            value="Some answer"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Grouped Object All values set, all true, add button default label, filter show all Render widget 1`] = `
+<div
+  className="survey-group-object"
+>
+  <div
+    className="content-container"
+  >
+    <div
+      className="survey-group-object__content"
+    >
+      <h3
+        className="survey-group-object__title"
+      >
+        <p>
+          Grouped object at index 0
+        </p>
+      </h3>
+      <div
+        className="center"
+      >
+        <button
+          className="button red small"
+          onClick={[Function]}
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            className="svg-inline--fa fa-trash-alt fa-w-14 faIconLeft"
+            data-icon="trash-alt"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
+            style={Object {}}
+            viewBox="0 0 448 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M32 464a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128H32zm272-256a16 16 0 0 1 32 0v224a16 16 0 0 1-32 0zm-96 0a16 16 0 0 1 32 0v224a16 16 0 0 1-32 0zm-96 0a16 16 0 0 1 32 0v224a16 16 0 0 1-32 0zM432 32H312l-9.4-18.7A24 24 0 0 0 281.1 0H166.8a23.72 23.72 0 0 0-21.4 13.3L136 32H16A16 16 0 0 0 0 48v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16V48a16 16 0 0 0-16-16z"
+              fill="currentColor"
+              style={Object {}}
+            />
+          </svg>
+          Delete this grouped object from my group
+        </button>
+      </div>
+      <div
+        className="survey-section__text"
+      >
+        <div
+          className="left "
+        >
+          <p>
+            This is a text widget
+          </p>
+        </div>
+      </div>
+      <div
+        className="apptr__form-container question-type-string question-filled"
+        onClick={[Function]}
+        style={
+          Object {
+            "position": "relative",
+          }
+        }
+      >
+        <div
+          className="apptr__form-label-container"
+        >
+          <label
+            htmlFor="survey-question__myGroups.obj0Uuid.quest"
+          >
+            <div
+              className="label"
+            >
+              <p>
+                Test Question Label
+              </p>
+            </div>
+          </label>
+        </div>
+        <div
+          className="apptr__form-input-container "
+        >
+          <input
+            autoComplete="none"
+            className="apptr__form-input apptr__input-string input-large"
+            id="survey-question__myGroups.obj0Uuid.quest"
+            maxLength={255}
+            name="survey-question__myGroups.obj0Uuid.quest"
+            onBlur={[Function]}
+            onChange={[Function]}
+            style={
+              Object {
+                "textTransform": "none",
+              }
+            }
+            type="text"
+            value="Some answer"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Grouped Object Default values Render widget 1`] = `
+<div
+  className="survey-group-object"
+>
+  <div
+    className="content-container"
+  >
+    <div
+      className="survey-group-object__content"
+    >
+      <div
+        className="survey-section__text"
+      >
+        <div
+          className="left "
+        >
+          <p>
+            This is a text widget
+          </p>
+        </div>
+      </div>
+      <div
+        className="apptr__form-container question-type-string question-filled"
+        onClick={[Function]}
+        style={
+          Object {
+            "position": "relative",
+          }
+        }
+      >
+        <div
+          className="apptr__form-label-container"
+        >
+          <label
+            htmlFor="survey-question__myGroups.obj0Uuid.quest"
+          >
+            <div
+              className="label"
+            >
+              <p>
+                Test Question Label
+              </p>
+            </div>
+          </label>
+        </div>
+        <div
+          className="apptr__form-input-container "
+        >
+          <input
+            autoComplete="none"
+            className="apptr__form-input apptr__input-string input-large"
+            id="survey-question__myGroups.obj0Uuid.quest"
+            maxLength={255}
+            name="survey-question__myGroups.obj0Uuid.quest"
+            onBlur={[Function]}
+            onChange={[Function]}
+            style={
+              Object {
+                "textTransform": "none",
+              }
+            }
+            type="text"
+            value="Some answer"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/evolution-frontend/src/components/survey/widgets/DeleteGroupedObjectButton.tsx
+++ b/packages/evolution-frontend/src/components/survey/widgets/DeleteGroupedObjectButton.tsx
@@ -14,7 +14,6 @@ import {
     parseString,
     translateString
 } from 'evolution-common/lib/utils/helpers';
-import { withSurveyContext, WithSurveyContextProps } from '../../hoc/WithSurveyContextHoc';
 import ConfirmModal from 'chaire-lib-frontend/lib/components/modal/ConfirmModal';
 import { faTrashAlt } from '@fortawesome/free-solid-svg-icons';
 import { UserInterviewAttributes } from 'evolution-common/lib/services/interviews/interview';
@@ -23,11 +22,13 @@ import { GroupConfig } from 'evolution-common/lib/services/widgets/WidgetConfig'
 
 type DeleteGroupedObjectButton = InterviewUpdateCallbacks & {
     interview: UserInterviewAttributes;
-    user: CliUser;
+    user?: CliUser;
     path: string;
     shortname: string;
-    groupConfig: GroupConfig;
-    widgetConfig: any;
+    widgetConfig: Pick<
+        GroupConfig,
+        'showGroupedObjectDeleteButton' | 'groupedObjectDeleteButtonLabel' | 'deleteConfirmPopup'
+    >;
 };
 
 const DeleteGroupedObjectButton: React.FC<DeleteGroupedObjectButton & WithTranslation> = (props) => {
@@ -37,7 +38,7 @@ const DeleteGroupedObjectButton: React.FC<DeleteGroupedObjectButton & WithTransl
         e.preventDefault();
         const hasConfirmPopup = props.widgetConfig.deleteConfirmPopup;
         const confirmPopupConditional = hasConfirmPopup
-            ? parseBoolean(props.widgetConfig.deleteConfirmPopup.conditional, props.interview, props.path, props.user)
+            ? parseBoolean(props.widgetConfig.deleteConfirmPopup?.conditional, props.interview, props.path, props.user)
             : true;
 
         if (hasConfirmPopup && confirmPopupConditional === true) {
@@ -57,30 +58,22 @@ const DeleteGroupedObjectButton: React.FC<DeleteGroupedObjectButton & WithTransl
     const widgetConfig = props.widgetConfig;
 
     const showDeleteButton = parseBoolean(
-        props.groupConfig.showGroupedObjectDeleteButton,
+        props.widgetConfig.showGroupedObjectDeleteButton,
         props.interview,
         props.path,
         props.user,
         false
     );
     const deleteButtonLabel =
-        parseString(
-            props.groupConfig.groupedObjectDeleteButtonLabel
-                ? props.groupConfig.groupedObjectDeleteButtonLabel[props.i18n.language] ||
-                      props.groupConfig.groupedObjectDeleteButtonLabel
-                : null,
-            props.interview,
-            props.path
-        ) || props.t(`survey:${widgetConfig.shortname}:deleteThisGroupedObject`);
+        translateString(props.widgetConfig.groupedObjectDeleteButtonLabel, props.i18n, props.interview, props.path) ||
+        props.t(`survey:${props.shortname}:deleteThisGroupedObject`);
 
-    return (
+    return showDeleteButton ? (
         <div className="center">
-            {showDeleteButton && (
-                <button type="button" className="button red small" onClick={beforeRemoveGroupedObject}>
-                    <FontAwesomeIcon icon={faTrashAlt} className="faIconLeft" />
-                    {deleteButtonLabel}
-                </button>
-            )}
+            <button type="button" className="button red small" onClick={beforeRemoveGroupedObject}>
+                <FontAwesomeIcon icon={faTrashAlt} className="faIconLeft" />
+                {deleteButtonLabel}
+            </button>
             {deletePlaceModalOpened &&
                 widgetConfig.deleteConfirmPopup &&
                 widgetConfig.deleteConfirmPopup.content &&
@@ -105,11 +98,11 @@ const DeleteGroupedObjectButton: React.FC<DeleteGroupedObjectButton & WithTransl
                         }
                         cancelAction={widgetConfig.deleteConfirmPopup.cancelAction}
                         confirmAction={(e) => onRemoveGroupedObject(e)}
-                        containsHtml={widgetConfig.containsHtml}
+                        containsHtml={widgetConfig.deleteConfirmPopup.containsHtml}
                     />
                 </div>
             )}
         </div>
-    );
+    ) : null;
 };
 export default withTranslation()(DeleteGroupedObjectButton);

--- a/packages/evolution-frontend/src/components/survey/widgets/__tests__/DeleteGroupedObjectButton.test.tsx
+++ b/packages/evolution-frontend/src/components/survey/widgets/__tests__/DeleteGroupedObjectButton.test.tsx
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import _cloneDeep from 'lodash/cloneDeep';
+import React from 'react';
+import TestRenderer from 'react-test-renderer';
+import each from 'jest-each';
+import { mount } from 'enzyme';
+
+import DeleteGroupedObjectButton from '../DeleteGroupedObjectButton';
+import { interviewAttributes } from '../../../inputs/__tests__/interviewData.test';
+
+const commonWidgetConfig = {
+    type: 'group' as const,
+    path: 'household.myGroup',
+    showGroupedObjectDeleteButton: true   
+};
+
+const startUpdateInterviewMock = jest.fn();
+const startAddGroupedObjectsMock = jest.fn();
+const startRemoveGroupedObjectsMock = jest.fn();
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+each([
+    ['Display with default label', commonWidgetConfig],
+    ['Display with custom label', {
+        ...commonWidgetConfig,
+        groupedObjectDeleteButtonLabel: jest.fn().mockReturnValue('Delete for unit test')
+    }],
+    ['Display is false', {
+        ...commonWidgetConfig,
+        showGroupedObjectDeleteButton: false
+    }]
+]).describe('DeleteGroupedObjectButton layout: %s', (_widget, widgetConfig) => {
+
+    test('Render widget', () => {
+
+        const wrapper = TestRenderer.create(
+            <DeleteGroupedObjectButton
+                path='home.region'
+                widgetConfig={widgetConfig}
+                shortname='myGroup'
+                interview={interviewAttributes}
+                startUpdateInterview={startUpdateInterviewMock}
+                startAddGroupedObjects={startAddGroupedObjectsMock}
+                startRemoveGroupedObjects={startRemoveGroupedObjectsMock}
+            />
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+});
+
+describe('DeleteGroupedObjectButton behavior', () => {
+
+    const path = 'persons.0'
+
+    test('Click on button, no confirm modal', () => {
+        const buttonWidget = mount(<DeleteGroupedObjectButton
+            path={path}
+            widgetConfig={commonWidgetConfig}
+            shortname='myGroup'
+            interview={interviewAttributes}
+            startUpdateInterview={startUpdateInterviewMock}
+            startAddGroupedObjects={startAddGroupedObjectsMock}
+            startRemoveGroupedObjects={startRemoveGroupedObjectsMock}
+        />);
+
+        // Find and click on the button itself and make sure the action has been called
+        const button = buttonWidget.find('.button');
+        button.simulate('click');
+
+        // The next action should have been called
+        buttonWidget.update();
+        expect(startRemoveGroupedObjectsMock).toHaveBeenCalledTimes(1);
+        expect(startRemoveGroupedObjectsMock).toHaveBeenCalledWith(path);
+    });
+    
+    test('Click on button, confirm modal, confirm', () => {
+        const widgetConfig = {
+            ...commonWidgetConfig,
+            deleteConfirmPopup: {
+                content: {
+                    en: 'Are you sure you want to delete this item?'
+                },
+                title: 'Delete item',
+                cancelAction: jest.fn().mockReturnValue('cancelAction'),
+                containsHtml: false
+            },
+            showGroupedObjectDeleteButton: true
+        }
+        const buttonWidget = mount(<DeleteGroupedObjectButton
+            path={path}
+            widgetConfig={widgetConfig}
+            shortname='myGroup'
+            interview={interviewAttributes}
+            startUpdateInterview={startUpdateInterviewMock}
+            startAddGroupedObjects={startAddGroupedObjectsMock}
+            startRemoveGroupedObjects={startRemoveGroupedObjectsMock}
+        />);
+
+        // Find and click on the button itself and make sure the action has been called
+        const button = buttonWidget.find('.button');
+        button.simulate('click');
+
+        // The next action should have been called
+        buttonWidget.update();
+        expect(startRemoveGroupedObjectsMock).not.toHaveBeenCalled();
+
+        // Find and click on the modal's confirm button
+        const confirmModal = buttonWidget.find('.react-modal');
+        expect(confirmModal).toMatchSnapshot();
+        const confirmButton = confirmModal.findWhere(node => node.type() === 'button' && node.text() === 'Confirm');
+        confirmButton.first().simulate('click');
+        expect(startRemoveGroupedObjectsMock).toHaveBeenCalledTimes(1);
+        expect(startRemoveGroupedObjectsMock).toHaveBeenCalledWith(path);
+    });
+
+    test('Click on button, confirm modal, cancel', () => {
+        const widgetConfig = {
+            ...commonWidgetConfig,
+            deleteConfirmPopup: {
+                content: {
+                    en: 'Are you sure you want to delete this item?'
+                },
+                title: 'Delete item',
+                cancelAction: jest.fn().mockReturnValue('cancelAction'),
+                containsHtml: false
+            },
+            showGroupedObjectDeleteButton: true
+        }
+        const buttonWidget = mount(<DeleteGroupedObjectButton
+            path={path}
+            widgetConfig={widgetConfig}
+            shortname='myGroup'
+            interview={interviewAttributes}
+            startUpdateInterview={startUpdateInterviewMock}
+            startAddGroupedObjects={startAddGroupedObjectsMock}
+            startRemoveGroupedObjects={startRemoveGroupedObjectsMock}
+        />);
+
+        // Find and click on the button itself and make sure the action has been called
+        const button = buttonWidget.find('.button');
+        button.simulate('click');
+
+        // The next action should have been called
+        buttonWidget.update();
+        expect(startRemoveGroupedObjectsMock).not.toHaveBeenCalled();
+
+        // Find and click on the modal's cancel button
+        const confirmModal = buttonWidget.find('.react-modal');
+        expect(confirmModal).toMatchSnapshot();
+        const cancelButton = confirmModal.findWhere(node => node.type() === 'button' && node.text() === 'Cancel');
+        cancelButton.first().simulate('click');
+        expect(startRemoveGroupedObjectsMock).not.toHaveBeenCalled();
+        expect(widgetConfig.deleteConfirmPopup.cancelAction).toHaveBeenCalled();
+    });
+
+    test('Click on button, conditional modal, should not be displayed', () => {
+        const widgetConfig = {
+            ...commonWidgetConfig,
+            deleteConfirmPopup: {
+                content: {
+                    en: 'Are you sure you want to delete this item?'
+                },
+                title: 'Delete item',
+                cancelAction: jest.fn().mockReturnValue('cancelAction'),
+                containsHtml: false,
+                conditional: jest.fn().mockReturnValue(false)
+            },
+            showGroupedObjectDeleteButton: true
+        }
+        const buttonWidget = mount(<DeleteGroupedObjectButton
+            path={path}
+            widgetConfig={widgetConfig}
+            interview={interviewAttributes}
+            shortname='myGroup'
+            startUpdateInterview={startUpdateInterviewMock}
+            startAddGroupedObjects={startAddGroupedObjectsMock}
+            startRemoveGroupedObjects={startRemoveGroupedObjectsMock}
+        />);
+
+        // Find and click on the button itself and make sure the action has been called
+        const button = buttonWidget.find('.button');
+        button.simulate('click');
+
+        // The conditional returned false, so the next action should be called directly
+        buttonWidget.update();
+        expect(widgetConfig.deleteConfirmPopup.conditional).toHaveBeenCalledTimes(1);
+        expect(widgetConfig.deleteConfirmPopup.conditional).toHaveBeenCalledWith(interviewAttributes, path, undefined);
+        expect(startRemoveGroupedObjectsMock).toHaveBeenCalledWith(path);
+    });
+
+    test('Click on button, conditional modal, should be displayed', () => {
+        const widgetConfig = {
+            ...commonWidgetConfig,
+            deleteConfirmPopup: {
+                content: {
+                    en: 'Are you sure you want to delete this item?'
+                },
+                title: 'Delete item',
+                cancelAction: jest.fn().mockReturnValue('cancelAction'),
+                containsHtml: false,
+                conditional: jest.fn().mockReturnValue(true)
+            },
+            showGroupedObjectDeleteButton: true
+        }
+        const buttonWidget = mount(<DeleteGroupedObjectButton
+            path={path}
+            widgetConfig={widgetConfig}
+            interview={interviewAttributes}
+            shortname='myGroup'
+            startUpdateInterview={startUpdateInterviewMock}
+            startAddGroupedObjects={startAddGroupedObjectsMock}
+            startRemoveGroupedObjects={startRemoveGroupedObjectsMock}
+        />);
+
+        // Find and click on the button itself and make sure the action has been called
+        const button = buttonWidget.find('.button');
+        button.simulate('click');
+
+        // The conditional returned false, so the next action should be called directly
+        buttonWidget.update();
+        expect(widgetConfig.deleteConfirmPopup.conditional).toHaveBeenCalledTimes(1);
+        expect(widgetConfig.deleteConfirmPopup.conditional).toHaveBeenCalledWith(interviewAttributes, path, undefined);
+        
+        // Just make sure the react modal is there
+        const confirmModal = buttonWidget.find('.react-modal');
+        expect(confirmModal).toMatchSnapshot();
+    });
+
+});

--- a/packages/evolution-frontend/src/components/survey/widgets/__tests__/__snapshots__/DeleteGroupedObjectButton.test.tsx.snap
+++ b/packages/evolution-frontend/src/components/survey/widgets/__tests__/__snapshots__/DeleteGroupedObjectButton.test.tsx.snap
@@ -1,0 +1,1472 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DeleteGroupedObjectButton behavior Click on button, conditional modal, should be displayed 1`] = `
+Array [
+  <Modal
+    ariaHideApp={true}
+    bodyOpenClassName="ReactModal__Body--open"
+    className="react-modal"
+    closeTimeoutMS={0}
+    contentElement={[Function]}
+    contentLabel="Delete item"
+    isOpen={true}
+    onRequestClose={[Function]}
+    overlayClassName="react-modal-overlay"
+    overlayElement={[Function]}
+    parentSelector={[Function]}
+    portalClassName="ReactModalPortal"
+    preventScroll={false}
+    role="dialog"
+    shouldCloseOnEsc={true}
+    shouldCloseOnOverlayClick={true}
+    shouldFocusAfterRender={true}
+    shouldReturnFocusAfterClose={true}
+  >
+    <Portal
+      containerInfo={
+        <div
+          class="ReactModalPortal"
+        >
+          <div
+            class="ReactModal__Overlay ReactModal__Overlay--after-open react-modal-overlay"
+          >
+            <div
+              aria-label="Delete item"
+              aria-modal="true"
+              class="ReactModal__Content ReactModal__Content--after-open react-modal"
+              role="dialog"
+              tabindex="-1"
+            >
+              <div>
+                <div
+                  class="center"
+                >
+                  <p>
+                    Delete item
+                  </p>
+                </div>
+                <div
+                  class="confirm-popup"
+                >
+                  <p>
+                    Are you sure you want to delete this item?
+                  </p>
+                </div>
+                <div
+                  class="tr__form-buttons-container _center"
+                >
+                  <div
+                    class="center"
+                  >
+                    <button
+                      class="button grey"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                  <div
+                    class="center"
+                  >
+                    <button
+                      class="button blue"
+                    >
+                      Confirm
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      }
+    >
+      <ModalPortal
+        ariaHideApp={true}
+        bodyOpenClassName="ReactModal__Body--open"
+        className="react-modal"
+        closeTimeoutMS={0}
+        contentElement={[Function]}
+        contentLabel="Delete item"
+        defaultStyles={
+          Object {
+            "content": Object {
+              "WebkitOverflowScrolling": "touch",
+              "background": "#fff",
+              "border": "1px solid #ccc",
+              "borderRadius": "4px",
+              "bottom": "40px",
+              "left": "40px",
+              "outline": "none",
+              "overflow": "auto",
+              "padding": "20px",
+              "position": "absolute",
+              "right": "40px",
+              "top": "40px",
+            },
+            "overlay": Object {
+              "backgroundColor": "rgba(255, 255, 255, 0.75)",
+              "bottom": 0,
+              "left": 0,
+              "position": "fixed",
+              "right": 0,
+              "top": 0,
+            },
+          }
+        }
+        isOpen={true}
+        onRequestClose={[Function]}
+        overlayClassName="react-modal-overlay"
+        overlayElement={[Function]}
+        parentSelector={[Function]}
+        portalClassName="ReactModalPortal"
+        preventScroll={false}
+        role="dialog"
+        shouldCloseOnEsc={true}
+        shouldCloseOnOverlayClick={true}
+        shouldFocusAfterRender={true}
+        shouldReturnFocusAfterClose={true}
+        style={
+          Object {
+            "content": Object {},
+            "overlay": Object {},
+          }
+        }
+      >
+        <div
+          className="ReactModal__Overlay ReactModal__Overlay--after-open react-modal-overlay"
+          onClick={[Function]}
+          onMouseDown={[Function]}
+          style={Object {}}
+        >
+          <div
+            aria-label="Delete item"
+            aria-modal={true}
+            className="ReactModal__Content ReactModal__Content--after-open react-modal"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            role="dialog"
+            style={Object {}}
+            tabIndex="-1"
+          >
+            <div>
+              <div
+                className="center"
+              >
+                <ReactMarkdown
+                  remarkPlugins={
+                    Array [
+                      Array [
+                        [Function],
+                        Object {
+                          "singleTilde": false,
+                        },
+                      ],
+                    ]
+                  }
+                  transformLinkUri={[Function]}
+                >
+                  <p
+                    key="p-1-1-0"
+                  >
+                    Delete item
+                  </p>
+                </ReactMarkdown>
+              </div>
+              <ReactMarkdown
+                className="confirm-popup"
+                remarkPlugins={
+                  Array [
+                    Array [
+                      [Function],
+                      Object {
+                        "singleTilde": false,
+                      },
+                    ],
+                  ]
+                }
+                transformLinkUri={[Function]}
+              >
+                <div
+                  className="confirm-popup"
+                >
+                  <p
+                    key="p-1-1-0"
+                  >
+                    Are you sure you want to delete this item?
+                  </p>
+                </div>
+              </ReactMarkdown>
+              <div
+                className="tr__form-buttons-container _center"
+              >
+                <div
+                  className="center"
+                  key="cancel"
+                >
+                  <button
+                    className="button grey"
+                    onClick={[Function]}
+                  >
+                    Cancel
+                  </button>
+                </div>
+                <div
+                  className="center"
+                  key="confirm"
+                >
+                  <button
+                    className="button blue"
+                    onClick={[Function]}
+                  >
+                    Confirm
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </ModalPortal>
+    </Portal>
+  </Modal>,
+  <ModalPortal
+    ariaHideApp={true}
+    bodyOpenClassName="ReactModal__Body--open"
+    className="react-modal"
+    closeTimeoutMS={0}
+    contentElement={[Function]}
+    contentLabel="Delete item"
+    defaultStyles={
+      Object {
+        "content": Object {
+          "WebkitOverflowScrolling": "touch",
+          "background": "#fff",
+          "border": "1px solid #ccc",
+          "borderRadius": "4px",
+          "bottom": "40px",
+          "left": "40px",
+          "outline": "none",
+          "overflow": "auto",
+          "padding": "20px",
+          "position": "absolute",
+          "right": "40px",
+          "top": "40px",
+        },
+        "overlay": Object {
+          "backgroundColor": "rgba(255, 255, 255, 0.75)",
+          "bottom": 0,
+          "left": 0,
+          "position": "fixed",
+          "right": 0,
+          "top": 0,
+        },
+      }
+    }
+    isOpen={true}
+    onRequestClose={[Function]}
+    overlayClassName="react-modal-overlay"
+    overlayElement={[Function]}
+    parentSelector={[Function]}
+    portalClassName="ReactModalPortal"
+    preventScroll={false}
+    role="dialog"
+    shouldCloseOnEsc={true}
+    shouldCloseOnOverlayClick={true}
+    shouldFocusAfterRender={true}
+    shouldReturnFocusAfterClose={true}
+    style={
+      Object {
+        "content": Object {},
+        "overlay": Object {},
+      }
+    }
+  >
+    <div
+      className="ReactModal__Overlay ReactModal__Overlay--after-open react-modal-overlay"
+      onClick={[Function]}
+      onMouseDown={[Function]}
+      style={Object {}}
+    >
+      <div
+        aria-label="Delete item"
+        aria-modal={true}
+        className="ReactModal__Content ReactModal__Content--after-open react-modal"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="dialog"
+        style={Object {}}
+        tabIndex="-1"
+      >
+        <div>
+          <div
+            className="center"
+          >
+            <ReactMarkdown
+              remarkPlugins={
+                Array [
+                  Array [
+                    [Function],
+                    Object {
+                      "singleTilde": false,
+                    },
+                  ],
+                ]
+              }
+              transformLinkUri={[Function]}
+            >
+              <p
+                key="p-1-1-0"
+              >
+                Delete item
+              </p>
+            </ReactMarkdown>
+          </div>
+          <ReactMarkdown
+            className="confirm-popup"
+            remarkPlugins={
+              Array [
+                Array [
+                  [Function],
+                  Object {
+                    "singleTilde": false,
+                  },
+                ],
+              ]
+            }
+            transformLinkUri={[Function]}
+          >
+            <div
+              className="confirm-popup"
+            >
+              <p
+                key="p-1-1-0"
+              >
+                Are you sure you want to delete this item?
+              </p>
+            </div>
+          </ReactMarkdown>
+          <div
+            className="tr__form-buttons-container _center"
+          >
+            <div
+              className="center"
+              key="cancel"
+            >
+              <button
+                className="button grey"
+                onClick={[Function]}
+              >
+                Cancel
+              </button>
+            </div>
+            <div
+              className="center"
+              key="confirm"
+            >
+              <button
+                className="button blue"
+                onClick={[Function]}
+              >
+                Confirm
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </ModalPortal>,
+  <div
+    aria-label="Delete item"
+    aria-modal={true}
+    className="ReactModal__Content ReactModal__Content--after-open react-modal"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
+    role="dialog"
+    style={Object {}}
+    tabIndex="-1"
+  >
+    <div>
+      <div
+        className="center"
+      >
+        <ReactMarkdown
+          remarkPlugins={
+            Array [
+              Array [
+                [Function],
+                Object {
+                  "singleTilde": false,
+                },
+              ],
+            ]
+          }
+          transformLinkUri={[Function]}
+        >
+          <p
+            key="p-1-1-0"
+          >
+            Delete item
+          </p>
+        </ReactMarkdown>
+      </div>
+      <ReactMarkdown
+        className="confirm-popup"
+        remarkPlugins={
+          Array [
+            Array [
+              [Function],
+              Object {
+                "singleTilde": false,
+              },
+            ],
+          ]
+        }
+        transformLinkUri={[Function]}
+      >
+        <div
+          className="confirm-popup"
+        >
+          <p
+            key="p-1-1-0"
+          >
+            Are you sure you want to delete this item?
+          </p>
+        </div>
+      </ReactMarkdown>
+      <div
+        className="tr__form-buttons-container _center"
+      >
+        <div
+          className="center"
+          key="cancel"
+        >
+          <button
+            className="button grey"
+            onClick={[Function]}
+          >
+            Cancel
+          </button>
+        </div>
+        <div
+          className="center"
+          key="confirm"
+        >
+          <button
+            className="button blue"
+            onClick={[Function]}
+          >
+            Confirm
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`DeleteGroupedObjectButton behavior Click on button, confirm modal, cancel 1`] = `
+Array [
+  <Modal
+    ariaHideApp={true}
+    bodyOpenClassName="ReactModal__Body--open"
+    className="react-modal"
+    closeTimeoutMS={0}
+    contentElement={[Function]}
+    contentLabel="Delete item"
+    isOpen={true}
+    onRequestClose={[Function]}
+    overlayClassName="react-modal-overlay"
+    overlayElement={[Function]}
+    parentSelector={[Function]}
+    portalClassName="ReactModalPortal"
+    preventScroll={false}
+    role="dialog"
+    shouldCloseOnEsc={true}
+    shouldCloseOnOverlayClick={true}
+    shouldFocusAfterRender={true}
+    shouldReturnFocusAfterClose={true}
+  >
+    <Portal
+      containerInfo={
+        <div
+          class="ReactModalPortal"
+        >
+          <div
+            class="ReactModal__Overlay ReactModal__Overlay--after-open react-modal-overlay"
+          >
+            <div
+              aria-label="Delete item"
+              aria-modal="true"
+              class="ReactModal__Content ReactModal__Content--after-open react-modal"
+              role="dialog"
+              tabindex="-1"
+            >
+              <div>
+                <div
+                  class="center"
+                >
+                  <p>
+                    Delete item
+                  </p>
+                </div>
+                <div
+                  class="confirm-popup"
+                >
+                  <p>
+                    Are you sure you want to delete this item?
+                  </p>
+                </div>
+                <div
+                  class="tr__form-buttons-container _center"
+                >
+                  <div
+                    class="center"
+                  >
+                    <button
+                      class="button grey"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                  <div
+                    class="center"
+                  >
+                    <button
+                      class="button blue"
+                    >
+                      Confirm
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      }
+    >
+      <ModalPortal
+        ariaHideApp={true}
+        bodyOpenClassName="ReactModal__Body--open"
+        className="react-modal"
+        closeTimeoutMS={0}
+        contentElement={[Function]}
+        contentLabel="Delete item"
+        defaultStyles={
+          Object {
+            "content": Object {
+              "WebkitOverflowScrolling": "touch",
+              "background": "#fff",
+              "border": "1px solid #ccc",
+              "borderRadius": "4px",
+              "bottom": "40px",
+              "left": "40px",
+              "outline": "none",
+              "overflow": "auto",
+              "padding": "20px",
+              "position": "absolute",
+              "right": "40px",
+              "top": "40px",
+            },
+            "overlay": Object {
+              "backgroundColor": "rgba(255, 255, 255, 0.75)",
+              "bottom": 0,
+              "left": 0,
+              "position": "fixed",
+              "right": 0,
+              "top": 0,
+            },
+          }
+        }
+        isOpen={true}
+        onRequestClose={[Function]}
+        overlayClassName="react-modal-overlay"
+        overlayElement={[Function]}
+        parentSelector={[Function]}
+        portalClassName="ReactModalPortal"
+        preventScroll={false}
+        role="dialog"
+        shouldCloseOnEsc={true}
+        shouldCloseOnOverlayClick={true}
+        shouldFocusAfterRender={true}
+        shouldReturnFocusAfterClose={true}
+        style={
+          Object {
+            "content": Object {},
+            "overlay": Object {},
+          }
+        }
+      >
+        <div
+          className="ReactModal__Overlay ReactModal__Overlay--after-open react-modal-overlay"
+          onClick={[Function]}
+          onMouseDown={[Function]}
+          style={Object {}}
+        >
+          <div
+            aria-label="Delete item"
+            aria-modal={true}
+            className="ReactModal__Content ReactModal__Content--after-open react-modal"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            role="dialog"
+            style={Object {}}
+            tabIndex="-1"
+          >
+            <div>
+              <div
+                className="center"
+              >
+                <ReactMarkdown
+                  remarkPlugins={
+                    Array [
+                      Array [
+                        [Function],
+                        Object {
+                          "singleTilde": false,
+                        },
+                      ],
+                    ]
+                  }
+                  transformLinkUri={[Function]}
+                >
+                  <p
+                    key="p-1-1-0"
+                  >
+                    Delete item
+                  </p>
+                </ReactMarkdown>
+              </div>
+              <ReactMarkdown
+                className="confirm-popup"
+                remarkPlugins={
+                  Array [
+                    Array [
+                      [Function],
+                      Object {
+                        "singleTilde": false,
+                      },
+                    ],
+                  ]
+                }
+                transformLinkUri={[Function]}
+              >
+                <div
+                  className="confirm-popup"
+                >
+                  <p
+                    key="p-1-1-0"
+                  >
+                    Are you sure you want to delete this item?
+                  </p>
+                </div>
+              </ReactMarkdown>
+              <div
+                className="tr__form-buttons-container _center"
+              >
+                <div
+                  className="center"
+                  key="cancel"
+                >
+                  <button
+                    className="button grey"
+                    onClick={[Function]}
+                  >
+                    Cancel
+                  </button>
+                </div>
+                <div
+                  className="center"
+                  key="confirm"
+                >
+                  <button
+                    className="button blue"
+                    onClick={[Function]}
+                  >
+                    Confirm
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </ModalPortal>
+    </Portal>
+  </Modal>,
+  <ModalPortal
+    ariaHideApp={true}
+    bodyOpenClassName="ReactModal__Body--open"
+    className="react-modal"
+    closeTimeoutMS={0}
+    contentElement={[Function]}
+    contentLabel="Delete item"
+    defaultStyles={
+      Object {
+        "content": Object {
+          "WebkitOverflowScrolling": "touch",
+          "background": "#fff",
+          "border": "1px solid #ccc",
+          "borderRadius": "4px",
+          "bottom": "40px",
+          "left": "40px",
+          "outline": "none",
+          "overflow": "auto",
+          "padding": "20px",
+          "position": "absolute",
+          "right": "40px",
+          "top": "40px",
+        },
+        "overlay": Object {
+          "backgroundColor": "rgba(255, 255, 255, 0.75)",
+          "bottom": 0,
+          "left": 0,
+          "position": "fixed",
+          "right": 0,
+          "top": 0,
+        },
+      }
+    }
+    isOpen={true}
+    onRequestClose={[Function]}
+    overlayClassName="react-modal-overlay"
+    overlayElement={[Function]}
+    parentSelector={[Function]}
+    portalClassName="ReactModalPortal"
+    preventScroll={false}
+    role="dialog"
+    shouldCloseOnEsc={true}
+    shouldCloseOnOverlayClick={true}
+    shouldFocusAfterRender={true}
+    shouldReturnFocusAfterClose={true}
+    style={
+      Object {
+        "content": Object {},
+        "overlay": Object {},
+      }
+    }
+  >
+    <div
+      className="ReactModal__Overlay ReactModal__Overlay--after-open react-modal-overlay"
+      onClick={[Function]}
+      onMouseDown={[Function]}
+      style={Object {}}
+    >
+      <div
+        aria-label="Delete item"
+        aria-modal={true}
+        className="ReactModal__Content ReactModal__Content--after-open react-modal"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="dialog"
+        style={Object {}}
+        tabIndex="-1"
+      >
+        <div>
+          <div
+            className="center"
+          >
+            <ReactMarkdown
+              remarkPlugins={
+                Array [
+                  Array [
+                    [Function],
+                    Object {
+                      "singleTilde": false,
+                    },
+                  ],
+                ]
+              }
+              transformLinkUri={[Function]}
+            >
+              <p
+                key="p-1-1-0"
+              >
+                Delete item
+              </p>
+            </ReactMarkdown>
+          </div>
+          <ReactMarkdown
+            className="confirm-popup"
+            remarkPlugins={
+              Array [
+                Array [
+                  [Function],
+                  Object {
+                    "singleTilde": false,
+                  },
+                ],
+              ]
+            }
+            transformLinkUri={[Function]}
+          >
+            <div
+              className="confirm-popup"
+            >
+              <p
+                key="p-1-1-0"
+              >
+                Are you sure you want to delete this item?
+              </p>
+            </div>
+          </ReactMarkdown>
+          <div
+            className="tr__form-buttons-container _center"
+          >
+            <div
+              className="center"
+              key="cancel"
+            >
+              <button
+                className="button grey"
+                onClick={[Function]}
+              >
+                Cancel
+              </button>
+            </div>
+            <div
+              className="center"
+              key="confirm"
+            >
+              <button
+                className="button blue"
+                onClick={[Function]}
+              >
+                Confirm
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </ModalPortal>,
+  <div
+    aria-label="Delete item"
+    aria-modal={true}
+    className="ReactModal__Content ReactModal__Content--after-open react-modal"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
+    role="dialog"
+    style={Object {}}
+    tabIndex="-1"
+  >
+    <div>
+      <div
+        className="center"
+      >
+        <ReactMarkdown
+          remarkPlugins={
+            Array [
+              Array [
+                [Function],
+                Object {
+                  "singleTilde": false,
+                },
+              ],
+            ]
+          }
+          transformLinkUri={[Function]}
+        >
+          <p
+            key="p-1-1-0"
+          >
+            Delete item
+          </p>
+        </ReactMarkdown>
+      </div>
+      <ReactMarkdown
+        className="confirm-popup"
+        remarkPlugins={
+          Array [
+            Array [
+              [Function],
+              Object {
+                "singleTilde": false,
+              },
+            ],
+          ]
+        }
+        transformLinkUri={[Function]}
+      >
+        <div
+          className="confirm-popup"
+        >
+          <p
+            key="p-1-1-0"
+          >
+            Are you sure you want to delete this item?
+          </p>
+        </div>
+      </ReactMarkdown>
+      <div
+        className="tr__form-buttons-container _center"
+      >
+        <div
+          className="center"
+          key="cancel"
+        >
+          <button
+            className="button grey"
+            onClick={[Function]}
+          >
+            Cancel
+          </button>
+        </div>
+        <div
+          className="center"
+          key="confirm"
+        >
+          <button
+            className="button blue"
+            onClick={[Function]}
+          >
+            Confirm
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`DeleteGroupedObjectButton behavior Click on button, confirm modal, confirm 1`] = `
+Array [
+  <Modal
+    ariaHideApp={true}
+    bodyOpenClassName="ReactModal__Body--open"
+    className="react-modal"
+    closeTimeoutMS={0}
+    contentElement={[Function]}
+    contentLabel="Delete item"
+    isOpen={true}
+    onRequestClose={[Function]}
+    overlayClassName="react-modal-overlay"
+    overlayElement={[Function]}
+    parentSelector={[Function]}
+    portalClassName="ReactModalPortal"
+    preventScroll={false}
+    role="dialog"
+    shouldCloseOnEsc={true}
+    shouldCloseOnOverlayClick={true}
+    shouldFocusAfterRender={true}
+    shouldReturnFocusAfterClose={true}
+  >
+    <Portal
+      containerInfo={
+        <div
+          class="ReactModalPortal"
+        >
+          <div
+            class="ReactModal__Overlay ReactModal__Overlay--after-open react-modal-overlay"
+          >
+            <div
+              aria-label="Delete item"
+              aria-modal="true"
+              class="ReactModal__Content ReactModal__Content--after-open react-modal"
+              role="dialog"
+              tabindex="-1"
+            >
+              <div>
+                <div
+                  class="center"
+                >
+                  <p>
+                    Delete item
+                  </p>
+                </div>
+                <div
+                  class="confirm-popup"
+                >
+                  <p>
+                    Are you sure you want to delete this item?
+                  </p>
+                </div>
+                <div
+                  class="tr__form-buttons-container _center"
+                >
+                  <div
+                    class="center"
+                  >
+                    <button
+                      class="button grey"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                  <div
+                    class="center"
+                  >
+                    <button
+                      class="button blue"
+                    >
+                      Confirm
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      }
+    >
+      <ModalPortal
+        ariaHideApp={true}
+        bodyOpenClassName="ReactModal__Body--open"
+        className="react-modal"
+        closeTimeoutMS={0}
+        contentElement={[Function]}
+        contentLabel="Delete item"
+        defaultStyles={
+          Object {
+            "content": Object {
+              "WebkitOverflowScrolling": "touch",
+              "background": "#fff",
+              "border": "1px solid #ccc",
+              "borderRadius": "4px",
+              "bottom": "40px",
+              "left": "40px",
+              "outline": "none",
+              "overflow": "auto",
+              "padding": "20px",
+              "position": "absolute",
+              "right": "40px",
+              "top": "40px",
+            },
+            "overlay": Object {
+              "backgroundColor": "rgba(255, 255, 255, 0.75)",
+              "bottom": 0,
+              "left": 0,
+              "position": "fixed",
+              "right": 0,
+              "top": 0,
+            },
+          }
+        }
+        isOpen={true}
+        onRequestClose={[Function]}
+        overlayClassName="react-modal-overlay"
+        overlayElement={[Function]}
+        parentSelector={[Function]}
+        portalClassName="ReactModalPortal"
+        preventScroll={false}
+        role="dialog"
+        shouldCloseOnEsc={true}
+        shouldCloseOnOverlayClick={true}
+        shouldFocusAfterRender={true}
+        shouldReturnFocusAfterClose={true}
+        style={
+          Object {
+            "content": Object {},
+            "overlay": Object {},
+          }
+        }
+      >
+        <div
+          className="ReactModal__Overlay ReactModal__Overlay--after-open react-modal-overlay"
+          onClick={[Function]}
+          onMouseDown={[Function]}
+          style={Object {}}
+        >
+          <div
+            aria-label="Delete item"
+            aria-modal={true}
+            className="ReactModal__Content ReactModal__Content--after-open react-modal"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            role="dialog"
+            style={Object {}}
+            tabIndex="-1"
+          >
+            <div>
+              <div
+                className="center"
+              >
+                <ReactMarkdown
+                  remarkPlugins={
+                    Array [
+                      Array [
+                        [Function],
+                        Object {
+                          "singleTilde": false,
+                        },
+                      ],
+                    ]
+                  }
+                  transformLinkUri={[Function]}
+                >
+                  <p
+                    key="p-1-1-0"
+                  >
+                    Delete item
+                  </p>
+                </ReactMarkdown>
+              </div>
+              <ReactMarkdown
+                className="confirm-popup"
+                remarkPlugins={
+                  Array [
+                    Array [
+                      [Function],
+                      Object {
+                        "singleTilde": false,
+                      },
+                    ],
+                  ]
+                }
+                transformLinkUri={[Function]}
+              >
+                <div
+                  className="confirm-popup"
+                >
+                  <p
+                    key="p-1-1-0"
+                  >
+                    Are you sure you want to delete this item?
+                  </p>
+                </div>
+              </ReactMarkdown>
+              <div
+                className="tr__form-buttons-container _center"
+              >
+                <div
+                  className="center"
+                  key="cancel"
+                >
+                  <button
+                    className="button grey"
+                    onClick={[Function]}
+                  >
+                    Cancel
+                  </button>
+                </div>
+                <div
+                  className="center"
+                  key="confirm"
+                >
+                  <button
+                    className="button blue"
+                    onClick={[Function]}
+                  >
+                    Confirm
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </ModalPortal>
+    </Portal>
+  </Modal>,
+  <ModalPortal
+    ariaHideApp={true}
+    bodyOpenClassName="ReactModal__Body--open"
+    className="react-modal"
+    closeTimeoutMS={0}
+    contentElement={[Function]}
+    contentLabel="Delete item"
+    defaultStyles={
+      Object {
+        "content": Object {
+          "WebkitOverflowScrolling": "touch",
+          "background": "#fff",
+          "border": "1px solid #ccc",
+          "borderRadius": "4px",
+          "bottom": "40px",
+          "left": "40px",
+          "outline": "none",
+          "overflow": "auto",
+          "padding": "20px",
+          "position": "absolute",
+          "right": "40px",
+          "top": "40px",
+        },
+        "overlay": Object {
+          "backgroundColor": "rgba(255, 255, 255, 0.75)",
+          "bottom": 0,
+          "left": 0,
+          "position": "fixed",
+          "right": 0,
+          "top": 0,
+        },
+      }
+    }
+    isOpen={true}
+    onRequestClose={[Function]}
+    overlayClassName="react-modal-overlay"
+    overlayElement={[Function]}
+    parentSelector={[Function]}
+    portalClassName="ReactModalPortal"
+    preventScroll={false}
+    role="dialog"
+    shouldCloseOnEsc={true}
+    shouldCloseOnOverlayClick={true}
+    shouldFocusAfterRender={true}
+    shouldReturnFocusAfterClose={true}
+    style={
+      Object {
+        "content": Object {},
+        "overlay": Object {},
+      }
+    }
+  >
+    <div
+      className="ReactModal__Overlay ReactModal__Overlay--after-open react-modal-overlay"
+      onClick={[Function]}
+      onMouseDown={[Function]}
+      style={Object {}}
+    >
+      <div
+        aria-label="Delete item"
+        aria-modal={true}
+        className="ReactModal__Content ReactModal__Content--after-open react-modal"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="dialog"
+        style={Object {}}
+        tabIndex="-1"
+      >
+        <div>
+          <div
+            className="center"
+          >
+            <ReactMarkdown
+              remarkPlugins={
+                Array [
+                  Array [
+                    [Function],
+                    Object {
+                      "singleTilde": false,
+                    },
+                  ],
+                ]
+              }
+              transformLinkUri={[Function]}
+            >
+              <p
+                key="p-1-1-0"
+              >
+                Delete item
+              </p>
+            </ReactMarkdown>
+          </div>
+          <ReactMarkdown
+            className="confirm-popup"
+            remarkPlugins={
+              Array [
+                Array [
+                  [Function],
+                  Object {
+                    "singleTilde": false,
+                  },
+                ],
+              ]
+            }
+            transformLinkUri={[Function]}
+          >
+            <div
+              className="confirm-popup"
+            >
+              <p
+                key="p-1-1-0"
+              >
+                Are you sure you want to delete this item?
+              </p>
+            </div>
+          </ReactMarkdown>
+          <div
+            className="tr__form-buttons-container _center"
+          >
+            <div
+              className="center"
+              key="cancel"
+            >
+              <button
+                className="button grey"
+                onClick={[Function]}
+              >
+                Cancel
+              </button>
+            </div>
+            <div
+              className="center"
+              key="confirm"
+            >
+              <button
+                className="button blue"
+                onClick={[Function]}
+              >
+                Confirm
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </ModalPortal>,
+  <div
+    aria-label="Delete item"
+    aria-modal={true}
+    className="ReactModal__Content ReactModal__Content--after-open react-modal"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
+    role="dialog"
+    style={Object {}}
+    tabIndex="-1"
+  >
+    <div>
+      <div
+        className="center"
+      >
+        <ReactMarkdown
+          remarkPlugins={
+            Array [
+              Array [
+                [Function],
+                Object {
+                  "singleTilde": false,
+                },
+              ],
+            ]
+          }
+          transformLinkUri={[Function]}
+        >
+          <p
+            key="p-1-1-0"
+          >
+            Delete item
+          </p>
+        </ReactMarkdown>
+      </div>
+      <ReactMarkdown
+        className="confirm-popup"
+        remarkPlugins={
+          Array [
+            Array [
+              [Function],
+              Object {
+                "singleTilde": false,
+              },
+            ],
+          ]
+        }
+        transformLinkUri={[Function]}
+      >
+        <div
+          className="confirm-popup"
+        >
+          <p
+            key="p-1-1-0"
+          >
+            Are you sure you want to delete this item?
+          </p>
+        </div>
+      </ReactMarkdown>
+      <div
+        className="tr__form-buttons-container _center"
+      >
+        <div
+          className="center"
+          key="cancel"
+        >
+          <button
+            className="button grey"
+            onClick={[Function]}
+          >
+            Cancel
+          </button>
+        </div>
+        <div
+          className="center"
+          key="confirm"
+        >
+          <button
+            className="button blue"
+            onClick={[Function]}
+          >
+            Confirm
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`DeleteGroupedObjectButton layout: Display is false Render widget 1`] = `null`;
+
+exports[`DeleteGroupedObjectButton layout: Display with custom label Render widget 1`] = `
+<div
+  className="center"
+>
+  <button
+    className="button red small"
+    onClick={[Function]}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-trash-alt fa-w-14 faIconLeft"
+      data-icon="trash-alt"
+      data-prefix="fas"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 448 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M32 464a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128H32zm272-256a16 16 0 0 1 32 0v224a16 16 0 0 1-32 0zm-96 0a16 16 0 0 1 32 0v224a16 16 0 0 1-32 0zm-96 0a16 16 0 0 1 32 0v224a16 16 0 0 1-32 0zM432 32H312l-9.4-18.7A24 24 0 0 0 281.1 0H166.8a23.72 23.72 0 0 0-21.4 13.3L136 32H16A16 16 0 0 0 0 48v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16V48a16 16 0 0 0-16-16z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    Delete for unit test
+  </button>
+</div>
+`;
+
+exports[`DeleteGroupedObjectButton layout: Display with default label Render widget 1`] = `
+<div
+  className="center"
+>
+  <button
+    className="button red small"
+    onClick={[Function]}
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-trash-alt fa-w-14 faIconLeft"
+      data-icon="trash-alt"
+      data-prefix="fas"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 448 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M32 464a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128H32zm272-256a16 16 0 0 1 32 0v224a16 16 0 0 1-32 0zm-96 0a16 16 0 0 1 32 0v224a16 16 0 0 1-32 0zm-96 0a16 16 0 0 1 32 0v224a16 16 0 0 1-32 0zM432 32H312l-9.4-18.7A24 24 0 0 0 281.1 0H166.8a23.72 23.72 0 0 0-21.4 13.3L136 32H16A16 16 0 0 0 0 48v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16V48a16 16 0 0 0-16-16z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+    myGroup.deleteThisGroupedObject
+  </button>
+</div>
+`;

--- a/packages/evolution-frontend/src/contexts/SurveyContext.ts
+++ b/packages/evolution-frontend/src/contexts/SurveyContext.ts
@@ -5,9 +5,8 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import * as React from 'react';
+import { SurveySections } from '../services/interviews/interview';
 
-// TODO Properly type this
-export type SurveySections = { [key: string]: any };
 // TODO This type is probably WidgetConfig from '../services/widgets'. But it is not complete yet and it's to be confirmed
 export type SurveyWidgets = { [key: string]: any };
 

--- a/packages/evolution-frontend/src/services/interviews/interview.ts
+++ b/packages/evolution-frontend/src/services/interviews/interview.ts
@@ -63,31 +63,9 @@ export type FrontendInterviewAttributes = {
 
 export type UserFrontendInterviewAttributes = FrontendInterviewAttributes & UserInterviewAttributes;
 
-export type SurveySectionGroup = {
-    widgets: string[];
-    /** Whether to show the title of this group section */
-    showTitle?: boolean | ParsingFunction<boolean>;
-    showGroupedObjectAddButton?: boolean | ParsingFunction<boolean>;
-    groupedObjectAddButtonLabel?: I18nData;
-    addButtonLocation?: 'top' | 'bottom' | 'both';
-    addButtonSize?: 'small' | 'medium' | 'large';
-    showGroupedObjectDeleteButton?: boolean | ParsingFunction<boolean>;
-    groupedObjectDeleteButtonLabel?: I18nData;
-    groupedObjectConditional?: boolean | ParsingFunction<boolean>;
-    /** FIXME The generator has this field in its type, but the GroupedObject
-     * does not use it from groupConfig, but from some widgetConfig. When this
-     * is out of evolution-legacy, see if they are the same */
-    deleteConfirmPopup?: {
-        content: I18nData;
-    };
-};
-
 // TODO Properly type this
 export type SurveySection = {
     widgets: string[];
-    groups?: {
-        [groupName: string]: SurveySectionGroup;
-    };
     [key: string]: unknown;
 };
 export type SurveySections = { [sectionName: string]: SurveySection };

--- a/packages/evolution-generator/src/scripts/generate_section_configs.py
+++ b/packages/evolution-generator/src/scripts/generate_section_configs.py
@@ -38,8 +38,7 @@ def generate_section_configs(excel_file_path: str):
                 "title_en",
                 "in_nav",
                 "template",
-                "parent_section",
-                "groups",
+                "parent_section"
             ],
             sheet_name="Sections",
         )
@@ -65,8 +64,7 @@ def generate_section_configs(excel_file_path: str):
                 title_en,
                 in_nav,
                 template,
-                parent_section,
-                groups,
+                parent_section
             ) = get_values_from_row(row, headers)
 
             # Generate code for section
@@ -78,14 +76,8 @@ def generate_section_configs(excel_file_path: str):
                     f"../../../survey/src/survey/sections/{section}/sectionConfigs.ts"
                 )
 
-                # Check if the section has groups
-                has_groups = groups is not None and groups != ""
                 # Check if the sections has template
                 has_template = template is not None and template == True 
-
-                # Add imports for groups if the section has groups
-                if has_groups:
-                    ts_section_code += f"import * as groups from './groups';\n"
 
                 # Add imports for template if the section has template
                 if has_template:
@@ -162,13 +154,6 @@ def generate_section_configs(excel_file_path: str):
                 )
                 ts_section_code += f"{INDENT}{INDENT}return isSectionComplete({{ interview, sectionName: currentSectionName }});\n"
                 ts_section_code += f"{INDENT}}}"
-                if has_groups:
-                    # Split the groups string into a list of group names
-                    group_names = groups.split(",")
-                    ts_section_code += f",\n{INDENT}groups: {{\n"
-                    for group_name in group_names:
-                        ts_section_code += f"{INDENT}{INDENT}{group_name}: groups.{group_name},\n"
-                    ts_section_code += f"{INDENT}}},\n"
                 ts_section_code += f"\n}};\n\n"
                 ts_section_code += f"export default sectionConfig;\n"
 

--- a/packages/evolution-generator/src/types/inputTypes.ts
+++ b/packages/evolution-generator/src/types/inputTypes.ts
@@ -9,7 +9,7 @@
 
 import { UserInterviewAttributes } from 'evolution-common/lib/services/interviews/interview';
 import { InterviewUpdateCallbacks, ParsingFunctionWithCallbacks } from 'evolution-common/lib/utils/helpers';
-import { InfoMapWidgetConfig } from 'evolution-common/lib/services/widgets/WidgetConfig';
+import { GroupConfig, InfoMapWidgetConfig } from 'evolution-common/lib/services/widgets/WidgetConfig';
 import { TFunction } from 'i18next';
 
 /* Define types for all the different input types */
@@ -270,16 +270,7 @@ export type Text = TextBase & {
 };
 
 /* Group type */
-export type Group = {
-    type: 'group';
-    path: Path;
-    groupShortname: string;
-    shortname: string;
-    groupName: Label;
-    name: { fr: NameFunction; en: NameFunction };
-    filter?: (interview, groupedObjects) => any;
-    conditional?: Conditional;
-};
+export type Group = GroupConfig;
 
 /* InputMapFindPlace widgetConfig Type */
 export type InputMapFindPlaceBase = {

--- a/packages/evolution-legacy/src/components/admin/ValidateSurvey.js
+++ b/packages/evolution-legacy/src/components/admin/ValidateSurvey.js
@@ -156,7 +156,6 @@ export class ValidateSurvey extends React.Component {
                   nextSection                 = {sectionConfig.nextSection}
                   widgets                     = {sectionConfig.widgets}
                   preload                     = {sectionConfig.preload}
-                  groups                      = {sectionConfig.groups}
                   interview                   = {this.props.interview}
                   errors                      = {this.props.errors}
                   user                        = {this.props.user}

--- a/packages/evolution-legacy/src/components/survey/Section.js
+++ b/packages/evolution-legacy/src/components/survey/Section.js
@@ -198,9 +198,8 @@ export class Section extends React.Component {
         case 'button':            widgetsComponentByShortname[widgetShortname] = <Button          {...defaultProps} />; break;
         case 'question':          widgetsComponentByShortname[widgetShortname] = <Question        {...defaultProps} />; break;
         case 'group':             widgetsComponentByShortname[widgetShortname] = <Group           {...defaultProps}
-          groupConfig                     = {this.props.groups[widgetShortname]}
-          groupsConfig                    = {this.props.groups}
           parentObjectIds                 = {{}}
+          shortname = {widgetShortname}
         />; break;
       }
     }

--- a/packages/evolution-legacy/src/components/survey/Survey.js
+++ b/packages/evolution-legacy/src/components/survey/Survey.js
@@ -169,7 +169,6 @@ export class Survey extends React.Component {
                   nextSection                 = {sectionConfig.nextSection}
                   widgets                     = {sectionConfig.widgets}
                   preload                     = {sectionConfig.preload}
-                  groups                      = {sectionConfig.groups}
                   interview                   = {this.props.interview}
                   errors                      = {this.props.errors}
                   user                        = {this.props.user}


### PR DESCRIPTION
There is no separate groups configuration in the section definition
anymore. Instead, all the attributes that were described there are added
to the group widget itself so there's only one place to configure the
group

** Breaking change **

* The `groupName` property is renamed to `title`
* The `groupShortname` does not exist anymore as it was not used
* The `groups` definitions in the sections need to be moved to the
  corresponding widget of type `group`.
* Specific group templates may need to be updated.
* The group widget config's `shortname` field must match the last part
  of the path where are stored those objects.
