### PR TITLE
server: Add a deferred server update callback mechanism

### DIFF
--- a/example/demo_survey/src/server/serverFieldUpdate.ts
+++ b/example/demo_survey/src/server/serverFieldUpdate.ts
@@ -10,7 +10,10 @@ import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 export default [
     {
         field: 'accessCode',
-        callback: (interview, value, path) => {
+        callback: (interview, value, path, registerUpdateOperation) => {
+            if (typeof value !== 'string') {
+                return {};
+            }
             // Sample server update: Move the home to Caraquet, NB if access code starts with 111 and the city is not set
             if (value.startsWith('111')) {
                 if (_isBlank(getResponse(interview, 'home.city'))) {
@@ -28,7 +31,33 @@ export default [
             } else if (value === '1133-1133') {
                 // Special access code to test url redirection
                 return [{}, 'https://github.com/chairemobilite/evolution/']
+            } else if (value.startsWith('222')) {
+                // Use the update operation to set the city to Calgary, but 5 seconds later
+                registerUpdateOperation({
+                    opName: 'city',
+                    opUniqueId: 1,
+                    operation: () => new Promise((resolve) => {
+                        setTimeout(() => {
+                            resolve({
+                                'home.city': 'Calgary'
+                            });
+                        }, 5000);
+                    })
+                });
+                // Use the update operation to set the province to Alberta, but 10 seconds later
+                registerUpdateOperation({
+                    opName: 'province',
+                    opUniqueId: 1,
+                    operation: () => new Promise((resolve) => {
+                        setTimeout(() => {
+                            resolve({
+                                'home.region': 'Alberta'
+                            });
+                        }, 10000);
+                    })
+                });
             }
+            
             return {};
         }
     }

--- a/packages/evolution-backend/package.json
+++ b/packages/evolution-backend/package.json
@@ -29,6 +29,7 @@
         "chaire-lib-common": "^0.2.2",
         "evolution-common": "^0.2.2",
         "express": "^4.19.2",
+        "express-session": "^1.17.1",
         "knex": "^3.1.0",
         "lodash": "^4.17.21",
         "moment": "^2.29.4",

--- a/packages/evolution-backend/src/api/express-session.d.ts
+++ b/packages/evolution-backend/src/api/express-session.d.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2022, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import session from 'express-session';
+
+// Custom type declaraction merging for express-session's SessionData type, as suggested in the express-session documentation
+declare module 'express-session' {
+    interface SessionData {
+        // Additional values by path to send to the client upon next request
+        clientValues?: {
+            interviewId: string;
+            updatedPaths: string[];
+        };
+    }
+}

--- a/packages/evolution-backend/src/services/interviews/__tests__/serverFieldUpdate.test.ts
+++ b/packages/evolution-backend/src/services/interviews/__tests__/serverFieldUpdate.test.ts
@@ -2,6 +2,7 @@ import { v4 as uuidV4 } from 'uuid';
 import each from 'jest-each';
 import updateServerFields, { getPreFilledResponsesByPath, setPreFilledResponses } from '../serverFieldUpdate';
 import prefilledDbQueries from '../../../models/interviewsPreFill.db.queries';
+import TestUtils from 'chaire-lib-common/lib/test/TestUtils';
 
 jest.mock('../../../models/interviewsPreFill.db.queries', ()  => ({
     getByReferenceValue: jest.fn(),
@@ -9,6 +10,7 @@ jest.mock('../../../models/interviewsPreFill.db.queries', ()  => ({
 }));
 const mockGetByReferenceValue = prefilledDbQueries.getByReferenceValue as jest.MockedFunction<typeof prefilledDbQueries.getByReferenceValue>;
 const mockSetPreFilledResponsesForRef = prefilledDbQueries.setPreFilledResponsesForRef as jest.MockedFunction<typeof prefilledDbQueries.setPreFilledResponsesForRef>;
+const deferredUpdateCallback = jest.fn();
 
 const interviewAttributes = {
     uuid: uuidV4(),
@@ -31,6 +33,7 @@ const interviewAttributes = {
 } as any;
 const testRedirectUrl = 'http://localhost:8080/test'
 
+const mockedOperation = jest.fn();
 const updateCallbacks = [
     {
         field: 'testFields.fieldA',
@@ -54,6 +57,16 @@ const updateCallbacks = [
             }
             return {};
         })
+    }, {
+        field: 'testFields.callback',
+        callback: jest.fn().mockImplementation((interview, fieldValue, fieldPath: string, registerCallback) => {
+            registerCallback({
+                opName: 'testFields.callback',
+                opUniqueId: fieldValue,
+                operation: mockedOperation.mockResolvedValue({ 'testFields.callbackResponse': `${fieldValue}.appended` })
+            })
+            return {};
+        })
     }
 ];
 
@@ -73,13 +86,13 @@ describe('Simple field update', () => {
         ['Field update, no URL return', { 'responses._isCompleted' : false }, [], 2, {}, undefined],
         ['No data', { }, undefined],
     ]).test('%s', async (_description, valuesByPath, unsetPath, called: number | false = false, expectedFieldValues: { [path: string]: unknown } = {}, expectedUrl = undefined) => {
-        expect(await updateServerFields(interviewAttributes, updateCallbacks, valuesByPath, unsetPath)).toEqual([expectedFieldValues, expectedUrl]);
+        expect(await updateServerFields(interviewAttributes, updateCallbacks, valuesByPath, unsetPath, deferredUpdateCallback)).toEqual([expectedFieldValues, expectedUrl]);
         if (called !== false) {
             expect(updateCallbacks[called].callback).toHaveBeenCalledTimes(1);
             if (called === 0) {
-                expect(updateCallbacks[called].callback).toHaveBeenCalledWith(interviewAttributes, valuesByPath['responses.testFields.fieldA'], 'testFields.fieldA');
+                expect(updateCallbacks[called].callback).toHaveBeenCalledWith(interviewAttributes, valuesByPath['responses.testFields.fieldA'], 'testFields.fieldA', expect.anything());
             } else if (called === 2) {
-                expect(updateCallbacks[called].callback).toHaveBeenCalledWith(interviewAttributes, valuesByPath['responses._isCompleted'], '_isCompleted');
+                expect(updateCallbacks[called].callback).toHaveBeenCalledWith(interviewAttributes, valuesByPath['responses._isCompleted'], '_isCompleted', expect.anything());
             }
             
         } else {
@@ -87,26 +100,134 @@ describe('Simple field update', () => {
                 expect(updateCallbacks[i].callback).not.toHaveBeenCalled();
             }
         }
+        expect(deferredUpdateCallback).not.toHaveBeenCalled();
     });
 });
 
 describe('Field with placeholder and regex', () => {
     test('Field in valuesByPath, should return updated value', async () => {
         const valuesByPath = { 'responses.household.persons.1.origin': 'foo' };
-        expect(await updateServerFields(interviewAttributes, updateCallbacks, valuesByPath, [])).toEqual([{ 'responses.household.persons.1.new': 'FOO' }, undefined]);
-        expect(updateCallbacks[1].callback).toHaveBeenCalledWith(interviewAttributes, valuesByPath['responses.household.persons.1.origin'], 'household.persons.1.origin');
+        expect(await updateServerFields(interviewAttributes, updateCallbacks, valuesByPath, [], deferredUpdateCallback)).toEqual([{ 'responses.household.persons.1.new': 'FOO' }, undefined]);
+        expect(updateCallbacks[1].callback).toHaveBeenCalledWith(interviewAttributes, valuesByPath['responses.household.persons.1.origin'], 'household.persons.1.origin', expect.anything());
     });
 
     test('Field in unsetPath, should return updated value', async() => {
         const unsetPath = [ 'responses.household.persons.2.origin' ];
         expect(await updateServerFields(interviewAttributes, updateCallbacks, {}, unsetPath)).toEqual([{ 'responses.household.persons.2.new': 'FOO' }, undefined]);
-        expect(updateCallbacks[1].callback).toHaveBeenCalledWith(interviewAttributes, undefined, 'household.persons.2.origin');
+        expect(updateCallbacks[1].callback).toHaveBeenCalledWith(interviewAttributes, undefined, 'household.persons.2.origin', undefined);
 
     });
 });
 
 test('No field update callbacks', async () => {
     expect(await updateServerFields(interviewAttributes, [], { someField: 'abc' }, [])).toEqual([{}, undefined]);
+});
+
+describe('With an update execution callback registration', () => {
+    test('One execution callback call', async () => {
+        const valuesByPath = { 'responses.testFields.callback': 'bar' };
+        expect(await updateServerFields(interviewAttributes, updateCallbacks, valuesByPath, [], deferredUpdateCallback)).toEqual([{ }, undefined]);
+
+        // Flush promises to make sure the execution callback has been called
+        await TestUtils.flushPromises();
+        expect(updateCallbacks[3].callback).toHaveBeenCalledWith(interviewAttributes, valuesByPath['responses.testFields.callback'], 'testFields.callback', expect.anything());
+        expect(deferredUpdateCallback).toHaveBeenCalledWith({ 'responses.testFields.callbackResponse' : 'bar.appended' });
+    });
+
+    test('Multiple calls to same execution, sequentially', async () => {
+        const valuesByPath = { 'responses.testFields.callback': 'bar' };
+        expect(await updateServerFields(interviewAttributes, updateCallbacks, valuesByPath, [], deferredUpdateCallback)).toEqual([{ }, undefined]);
+
+        // Flush promises to make sure the execution callback has been called
+        await TestUtils.flushPromises();
+
+        // Make a second call with other values
+        const valuesByPath2 = { 'responses.testFields.callback': 'foo' };
+        expect(await updateServerFields(interviewAttributes, updateCallbacks, valuesByPath2, [], deferredUpdateCallback)).toEqual([{ }, undefined]);
+
+        // Flush promises to make sure the execution callback has been called
+        await TestUtils.flushPromises();
+
+        expect(deferredUpdateCallback).toHaveBeenCalledWith({ 'responses.testFields.callbackResponse' : 'bar.appended' });
+        expect(deferredUpdateCallback).toHaveBeenCalledWith({ 'responses.testFields.callbackResponse' : 'foo.appended' });
+    });
+
+    test('Multiple calls to same execution, at the same time', async () => {
+        const valuesByPath = { 'responses.testFields.callback': 'bar' };
+        let finishOp1 = false;
+        const call1Response = { 'testFields.callbackResponse' : 'bar.appended.call1' }
+
+        let promiseComplete: Promise<any> | undefined = undefined;
+        mockedOperation.mockImplementationOnce(() => {
+            promiseComplete = new Promise((resolve) => {
+                const waitFinish = () => setTimeout(() => {
+                    if (finishOp1) {
+                        console.log('resolving');
+                        resolve(call1Response);
+                    } else {
+                        waitFinish();
+                    }
+                }, 1000)
+                waitFinish();
+            });
+            return promiseComplete;
+        });
+        // First call should execute the operation
+        await updateServerFields(interviewAttributes, updateCallbacks, valuesByPath, [], deferredUpdateCallback);
+        // Second call should not execute anything
+        await updateServerFields(interviewAttributes, updateCallbacks, valuesByPath, [], deferredUpdateCallback);
+
+        // Let the operation terminate
+        finishOp1 = true;
+        await (promiseComplete as unknown as Promise<any>); 
+
+        // Flush promises to make sure the execution callback has been completed. It should be called only once
+        await TestUtils.flushPromises();
+        expect(updateCallbacks[3].callback).toHaveBeenCalledWith(interviewAttributes, valuesByPath['responses.testFields.callback'], 'testFields.callback', expect.anything());
+        expect(deferredUpdateCallback).toHaveBeenCalledTimes(1)
+        expect(deferredUpdateCallback).toHaveBeenCalledWith(Object.keys(call1Response).reduce((acc, key) => { 
+            acc[`responses.${key}`] = call1Response[key];
+            return acc;
+        }, {}));
+    });
+
+    test('Multiple calls, with different unique ID, with cancellation', async () => {
+        const valuesByPath = { 'responses.testFields.callback': 'bar' };
+        let finishOp1 = false;
+        const call1Response = { 'testFields.callbackResponse' : 'bar.appended.call1' }
+
+        let promiseComplete: Promise<any> | undefined = undefined;
+        mockedOperation.mockImplementationOnce(() => {
+            promiseComplete = new Promise((resolve) => {
+                const waitFinish = () => setTimeout(() => {
+                    if (finishOp1) {
+                        console.log('resolving');
+                        resolve(call1Response);
+                    } else {
+                        waitFinish();
+                    }
+                }, 1000)
+                waitFinish();
+            });
+            return promiseComplete;
+        });
+        // First call should execute the operation
+        await updateServerFields(interviewAttributes, updateCallbacks, valuesByPath, [], deferredUpdateCallback);
+        // Make a second call with other values, should cancel the first one
+        const valuesByPath2 = { 'responses.testFields.callback': 'foo' };
+        await updateServerFields(interviewAttributes, updateCallbacks, valuesByPath2, [], deferredUpdateCallback);
+
+        // Flush promises to make sure the second operation terminate first
+        await TestUtils.flushPromises();
+
+        // Let the first operation terminate, it is cancelled, the results should be ignored
+        finishOp1 = true;
+        await (promiseComplete as unknown as Promise<any>); 
+        
+        // Test that the deferred callback was called only once, with the results of the last operation
+        expect(deferredUpdateCallback).toHaveBeenCalledTimes(1)
+        expect(deferredUpdateCallback).toHaveBeenCalledWith({ 'responses.testFields.callbackResponse' : 'foo.appended' });
+    });
 });
 
 test('Test with exceptions', async () => {

--- a/packages/evolution-backend/src/services/interviews/interview.ts
+++ b/packages/evolution-backend/src/services/interviews/interview.ts
@@ -10,7 +10,7 @@ import _cloneDeep from 'lodash/cloneDeep';
 import moment from 'moment';
 import { UserAttributes } from 'chaire-lib-backend/lib/services/users/user';
 import serverValidate, { ServerValidation } from '../validations/serverValidation';
-import serverUpdateField, { ServerFieldUpdateCallback } from './serverFieldUpdate';
+import serverUpdateField from './serverFieldUpdate';
 import config from 'chaire-lib-backend/lib/config/server.config';
 import interviewsDbQueries from '../../models/interviews.db.queries';
 import { UserInterviewAttributes, InterviewAttributes } from 'evolution-common/lib/services/interviews/interview';
@@ -47,26 +47,39 @@ export const setInterviewFields = (
  * Update an interview, given the paths to update. If database logs are
  * configured, a new log will be saved for this update.
  *
- * TODO: Rename to save, as it conveys more the fact that it is saved in the db than update
+ * TODO: Rename to save, as it conveys more the fact that it is saved in the db
+ * than update
  *
  * @param {InterviewAttributes} interview The base interview to update, as
  * fetched in the database
- * @param {{valuesByPath: { [key: string]: unknown }; unsetPaths?: string[];
- * serverValidations?: ServerValidation; fieldsToUpdate?: (keyof
- * InterviewAttributes)[]; logData?: { [key: string]: unknown };}} options The
- * `valuesByPath` is a key-value map of values to update in the interview. The
- * key is the dot-separated hierarchical path to the field to update. For
- * example, to update a field in response, it could be `{
- * 'responses.mySection.myField': 'myValue' }`. The `unsetPaths` array is an
- * array of dot-separated paths whose value to unset. The 'serverValidations'
- * are the validations to do on the data. If any new field to set does not
- * validate, the value will be set in the responses object, but a corresponding
- * value will be set to false in the validations object. The 'fieldsToUpdate'
- * makes sure only those fields are updated in the interview. Since there is no
- * control on the paths of the valuesByPath keys, it avoids updating fields in
- * code path where they should not be updated. The 'logData' object contains
- * data that should be added to the log object of the current update, if log is
- * enabled.
+ * @param {Object} options - The options to update the interview
+ * @param {{ [key: string]: unknown }} options.valuesByPath - A key-value map of
+ * values to update in the interview. The key is the dot-separated hierarchical
+ * path to the field to update. For example, to update a field in response, it
+ * could be `{ 'responses.mySection.myField': 'myValue' }`.
+ * @param {string[] | undefined} options.unsetPaths - array of dot-separated
+ * paths whose value to unset.
+ * @param {ServerValidation | undefined} options.serverValidations - Server-side
+ * validations to do on the data. If any new field to set does not validate, the
+ * value will be set in the responses object, but a corresponding value will be
+ * set to false in the validations object.
+ * @param {(keyof InterviewAttributes)[] | undefined} options.fieldsToUpdate -
+ * Array of fields that can be updated in the response. This makes sure only
+ * those fields are updated in the interview. Since there is no control on the
+ * paths of the valuesByPath keys, it avoids updating fields in code path where
+ * they should not be updated
+ * @param {{ [key: string]: unknown } | undefined} options.logData - An object
+ * contains data that should be added to the log object of the current update,
+ * if log is enabled.
+ * @param {boolean | undefined} options.logDatabaseUpdates - This can override
+ * the default database logging setting to avoid logging certain changes, like
+ * auditing. For this value to have effect, logging must be enabled in the
+ * configuration.
+ * @param {((valuesByPath: { [key: string]: any }) => Promise<void> |
+ * undefined)} options.deferredUpdateCallback - A callback passed to the server
+ * update callbacks, that can be optionally called to send the response to the
+ * client.  It should be used by update callbacks that can take a lot of time to
+ * execute instead of blocking the current update call.
  **/
 export const updateInterview = async (
     interview: InterviewAttributes,
@@ -77,6 +90,7 @@ export const updateInterview = async (
         serverValidations?: ServerValidation;
         fieldsToUpdate?: (keyof InterviewAttributes)[];
         logData?: { [key: string]: unknown };
+        deferredUpdateCallback?: (valuesByPath: { [key: string]: unknown }) => Promise<void>;
     }
 ): Promise<{
     interviewId: string | undefined;
@@ -98,13 +112,31 @@ export const updateInterview = async (
         options.valuesByPath,
         options.unsetPaths || []
     );
+
+    // Generates an execution callback function that will save the asynchronous values by path to set before calling the executionCallback argument
+    const deferredSaveFct = async (serverValuesByPath: { [key: string]: unknown }) => {
+        // Reload the interview as it may be outdated
+        const reloadedInterview = await interviewsDbQueries.getInterviewByUuid(interview.uuid);
+        if (!reloadedInterview) {
+            return;
+        }
+        // Call the update function again, but without the execution callback to avoid endless loops if the call is made again
+        await updateInterview(reloadedInterview, {
+            logDatabaseUpdates: options.logDatabaseUpdates,
+            valuesByPath: serverValuesByPath,
+            fieldsToUpdate: options.fieldsToUpdate,
+            logData: { server: true }
+        });
+        options.deferredUpdateCallback!(serverValuesByPath);
+    };
     // Update values by path with caller provided values
     setInterviewFields(interview, { valuesByPath: options.valuesByPath, unsetPaths: options.unsetPaths });
     const [serverValuesByPath, redirectUrl] = await serverUpdateField(
         interview,
         projectConfig.serverUpdateCallbacks,
         options.valuesByPath,
-        options.unsetPaths
+        options.unsetPaths,
+        options.deferredUpdateCallback !== undefined ? deferredSaveFct : undefined
     );
     // Update values with server updated values
     if (Object.keys(serverValuesByPath).length > 0) {

--- a/packages/evolution-backend/src/services/interviews/serverFieldUpdate.ts
+++ b/packages/evolution-backend/src/services/interviews/serverFieldUpdate.ts
@@ -20,13 +20,60 @@ type FieldUpdateCallbackReturnType =
 
 /**
  * Type for callbacks when a response field gets updated.
+ *
+ * @param {Object} args The arguments to pass to the registration call
+ * @param {string} args.opName The name of the operation to register
+ * @param {unknown} args.opUniqueId The unique identifier of the operation. It
+ * should be such that when comparing with `===` returns true, it is the same
+ * operation. Otherwise, it is a different one.
+ * @param {Function} args.operation  The operation to register is a function
+ *     that receives a `isCancelled` callback to verify the cancellation status
+ *     of the operation. The execution itself should be done in this function.
+ *     It should return an object where the keys are the path in the responses
+ *     field and the value is the value to update.
+ *
+ *     It is the responsibility of the operation to check if it is cancelled once
+ *     in a while. A good practice is to check it at least every 100ms, or at
+ *     least every 1000 iterations of a loop. If a cancelled operation
+ *     terminates, its values will be ignored.
+ */
+type RegisterUpdateOperationType = (args: {
+    opName: string;
+    opUniqueId: unknown;
+    operation: (isCancelled: () => boolean) => Promise<FieldUpdateCallbackResponseCallbackType>;
+}) => Promise<void>;
+
+/**
+ * Type for callbacks when a response field gets updated.
  */
 export type ServerFieldUpdateCallback = {
     field: string | { regex: string };
+    /**
+     *
+     * @param interview The interview to update
+     * @param newValue The new value to set for the field, as received from the
+       client
+     * @param path The path of the value to update in the interview
+     * @param registerUpdateOperation A function that can optionally be called
+     * to register a long-running, time-consuming operations. This will run the
+     * operation in the background and will not block the current update call.
+     * When the response is obtained, it will automatically notify the interview
+     * to save the responses data and send it back to the client later, if
+     * necessary. To avoid many operations running at the same time for a given
+     * field, the registration function takes a name to associate with, and a
+     * unique operation identifier. If an operation with the same name is
+     * registered again with the same identifier, it will be ignored. Otherwise,
+     * it will cancel the previous operation and start the new one.
+     *
+     * Not that a single server update callback can register multiple
+     * operations, if they are under different names.
+     * @returns
+     */
     callback: (
         interview: InterviewAttributes,
         newValue: unknown | undefined,
-        path: string
+        path: string,
+        registerUpdateOperation?: RegisterUpdateOperationType
     ) => Promise<FieldUpdateCallbackReturnType>;
 };
 
@@ -67,6 +114,68 @@ const getUpdateCallbackForPath = (
     return serverCallback !== undefined ? [responsePath, serverCallback] : undefined;
 };
 
+class InterviewUpdateOperation {
+    private static runningQueries: { [interviewId: string]: { [opName: string]: unknown } } = {};
+
+    private static getCurrentOperation = (opName: string, interviewId: string) => {
+        return (InterviewUpdateOperation.runningQueries[interviewId] || {})[opName];
+    };
+
+    constructor(
+        private interviewUuid: string,
+        private deferredUpdateCallback: (valuesByPath: { [key: string]: unknown }) => Promise<void>
+    ) {
+        // Nothing else to do
+    }
+
+    public registerOperation = async (args: {
+        opName: string;
+        opUniqueId: unknown;
+        operation: (isCancelled: () => boolean) => Promise<{ [path: string]: unknown }>;
+    }): Promise<void> => {
+        const currentOp = InterviewUpdateOperation.getCurrentOperation(args.opName, this.interviewUuid);
+        if (currentOp !== undefined && currentOp === args.opUniqueId) {
+            // The same operation is already running, ignore
+            return;
+        }
+        // Register the current operation
+        InterviewUpdateOperation.runningQueries[this.interviewUuid] = {
+            ...(InterviewUpdateOperation.runningQueries[this.interviewUuid] || {}),
+            [args.opName]: args.opUniqueId
+        };
+        const isCancelled = () =>
+            InterviewUpdateOperation.getCurrentOperation(args.opName, this.interviewUuid) !== args.opUniqueId;
+        try {
+            const responsesByPath = await args.operation(isCancelled);
+            if (isCancelled()) {
+                return;
+            }
+
+            // Convert the responses to the format expected by the deferred callback
+            const asyncServerValuesByPath = {};
+            Object.keys(responsesByPath).forEach((key) => {
+                asyncServerValuesByPath[`responses.${key}`] = responsesByPath[key];
+            });
+
+            // Call the update callback
+            this.deferredUpdateCallback(asyncServerValuesByPath);
+        } catch (error) {
+            console.log(
+                'error while running server update callback operation for interview %s, name %s, opId %s: %s',
+                this.interviewUuid,
+                args.opName,
+                args.opUniqueId,
+                error
+            );
+        } finally {
+            // Reset the callback for this name
+            if (!isCancelled()) {
+                delete InterviewUpdateOperation.runningQueries[this.interviewUuid][args.opName];
+            }
+        }
+    };
+}
+
 /**
  * Get the values by path that should be updated, given the current values by
  * path.
@@ -82,13 +191,19 @@ const getUpdateCallbackForPath = (
  * callbacks to call when fields are updated
  * @param {{ [key: string]: any }} valuesByPath The valuesByPath to update
  * @param {string[]} unsetValues The valuesbyPath to set to undefined
+ * @param {((valuesByPath: { [key: string]: any }) => Promise<void> |
+ * undefined)} deferredUpdateCallback A callback passed to the server update
+ * callbacks, that can be optionally called to send the response to the client.
+ * It should be used by update callbacks that can take a lot of time to execute
+ * instead of blocking the current update call.
  * @return {*}  {Promise<{ [key: string]: any }>}
  */
 const updateFields = async (
     interview: InterviewAttributes,
     serverUpdateCallbacks: ServerFieldUpdateCallback[],
     valuesByPath: { [key: string]: unknown },
-    unsetValues?: string[]
+    unsetValues?: string[],
+    deferredUpdateCallback?: (valuesByPath: { [key: string]: unknown }) => Promise<void>
 ): Promise<[{ [key: string]: any }, string | undefined]> => {
     if (serverUpdateCallbacks.length === 0) {
         return [{}, undefined];
@@ -100,11 +215,18 @@ const updateFields = async (
     const callbacks = Object.keys(valuesByPath)
         .map((path) => getUpdateCallbackForPath(serverUpdateCallbacks, path))
         .filter((callbackPair) => callbackPair !== undefined);
+
+    // Map callback results to responses before calling the asynchronous execution callback is specified
+    const deferredCallback =
+        deferredUpdateCallback !== undefined
+            ? new InterviewUpdateOperation(interview.uuid, deferredUpdateCallback).registerOperation
+            : undefined;
+
     for (let i = 0; i < callbacks.length; i++) {
         const [path, serverCallback] = callbacks[i] as [string, ServerFieldUpdateCallback];
         const [updatedValuesByPath, callbackUrl] = await waitExecuteCallback(
             interview,
-            serverCallback.callback(interview, valuesByPath[`responses.${path}`], path),
+            serverCallback.callback(interview, valuesByPath[`responses.${path}`], path, deferredCallback),
             path
         );
         Object.assign(serverValuesByPath, updatedValuesByPath);
@@ -120,7 +242,7 @@ const updateFields = async (
             const [path, serverCallback] = callbacks[i] as [string, ServerFieldUpdateCallback];
             const [updatedValuesByPath, callbackUrl] = await waitExecuteCallback(
                 interview,
-                serverCallback.callback(interview, undefined, path),
+                serverCallback.callback(interview, undefined, path, deferredCallback),
                 path
             );
             Object.assign(serverValuesByPath, updatedValuesByPath);


### PR DESCRIPTION
fixes #582

Add an extra parameter for server update callbacks, so that callbacks
that have time-consuming operations (like routing calculations) can
register the operation, which can then execute without blocking the
current client update call.

The callbacks can return quickly empty or other values, but register
an operation, identified by a `opName` and `opUniqueId`. The `opName`
ensures that only one operation for that name will be considered. The
`opUniqueId` allows to cancel any previous operation with the same name.
The `operation` to register is a function that receives a `isCancelled`
function and returns a promise that will run in the background. The
promise should return the values by path to set in the interview. The
interview will be saved with the new values and those can be sent back
to the client at the next update call.

The deferred update callback will save the updated values in the user's
session and they will be added to the returned server values in the next
client response.

Example usage of this mechanism

```
field: 'accessCode',
callback: (interview, value, path, registerUpdateOperation) => {
    // Use the update operation to set the city to Calgary, but 5 seconds later
    registerUpdateOperation({
        opName: 'city',
        opUniqueId: 1,
        operation: () => new Promise((resolve) => {
            setTimeout(() => {
                resolve({
                    'home.city': 'Calgary'
                });
            }, 5000);
        })
    });
}
```