### PR TITLE
sections: Make sure the invalid widget has an ID before focusing

### DIFF
--- a/packages/evolution-legacy/src/components/survey/Section.js
+++ b/packages/evolution-legacy/src/components/survey/Section.js
@@ -58,8 +58,8 @@ export class Section extends React.Component {
     if (!this.props.allWidgetsValid && this.props.submitted && this.props.loadingState === 0)
     {
       const invalidInputs = document.querySelectorAll('.question-invalid input');
-      if (invalidInputs.length > 0) {
-        // Focus on invalid input if found
+      if (invalidInputs.length > 0 && invalidInputs[0].id) {
+        // Focus on invalid input if found and it has an ID (inputRanges do not have IDs, the library used does not support it)
         const inputElement = document.getElementById(invalidInputs[0].id);
         if (inputElement) {
           inputElement.focus();


### PR DESCRIPTION
Some widgets, like InputRange, do not have an ID (and cannot have one, as the library used does not allow to set it), but they can be invalid. To automatically scroll to the invalid question, we make sure the input has an ID before focusing on it. Otherwise, we use the other code path that just scrolls the page to make the widget visible.