### PR TITLE
survey: Move the add/remove grouped object actions to typescript

### DIFF
--- a/example/demo_survey/src/survey/sections.ts
+++ b/example/demo_survey/src/survey/sections.ts
@@ -524,9 +524,7 @@ export default {
         }
         if (tripsPathsToRemove.length > 0)
         {
-          let updateValuePaths = {};
-          let unsetValuePaths  = [];
-          [updateValuePaths, unsetValuePaths] = surveyHelper.removeGroupedObjects(tripsPathsToRemove, interview);
+          const [updateValuePaths, unsetValuePaths] = surveyHelper.removeGroupedObjects(interview, tripsPathsToRemove);
           tripsUpdatesUnsetPaths  = tripsUpdatesUnsetPaths.concat(unsetValuePaths);
           tripsUpdatesValueByPath = Object.assign(tripsUpdatesValueByPath, updateValuePaths);
         }

--- a/packages/evolution-common/src/services/widgets/WidgetConfig.ts
+++ b/packages/evolution-common/src/services/widgets/WidgetConfig.ts
@@ -11,7 +11,6 @@ import { UserInterviewAttributes, InterviewResponsePath, InterviewResponses } fr
 import {
     ParsingFunction,
     I18nData,
-    StartUpdateInterview,
     InterviewUpdateCallbacks,
     ParsingFunctionWithCallbacks
 } from '../../utils/helpers';

--- a/packages/evolution-legacy/src/actions/survey/survey.js
+++ b/packages/evolution-legacy/src/actions/survey/survey.js
@@ -34,7 +34,13 @@ import surveyHelper                                     from '../../helpers/surv
 import * as surveyHelperNew                             from 'evolution-common/lib/utils/helpers';
 import { incrementLoadingState, decrementLoadingState } from '../shared/loadingState.js';
 import config                                           from 'chaire-lib-common/lib/config/shared/project.config';
-import { updateSection as updateSectionTs, startUpdateInterview as startUpdateInterviewTs, updateInterview as updateInterviewTs } from 'evolution-frontend/lib/actions/Survey';
+import { 
+    updateSection as updateSectionTs,
+    startUpdateInterview as startUpdateInterviewTs,
+    updateInterview as updateInterviewTs,
+    startAddGroupedObjects as startAddGroupedObjectsTs,
+    startRemoveGroupedObjects as startRemoveGroupedObjectsTs
+} from 'evolution-frontend/lib/actions/Survey';
 import { handleHttpOtherResponseCode } from 'evolution-frontend/lib/services/errorManagement/errorHandling';
 
 //export const setInterview = (interview) => ({
@@ -47,6 +53,8 @@ import { handleHttpOtherResponseCode } from 'evolution-frontend/lib/services/err
 export const updateSection = updateSectionTs;
 export const startUpdateInterview = startUpdateInterviewTs;
 export const updateInterview = updateInterviewTs;
+export const startAddGroupedObjects = startAddGroupedObjectsTs;
+export const startRemoveGroupedObjects = startRemoveGroupedObjectsTs;
 
 /**
  * Fetch an interview from server and set it for edition in validation mode.
@@ -539,40 +547,6 @@ export const startUpdateValidateInterview = function(sectionShortname, valuesByP
   };
 };
 
-export const startAddGroupedObjects = (newObjectsCount, insertSequence, path, attributes = [], callback, returnOnly = false) => {
-  surveyHelperNew.devLog(`Add ${newObjectsCount} grouped objects for path ${path} at sequence ${insertSequence}`);
-  return (dispatch, getState) => {
-    const interview           = _cloneDeep(getState().survey.interview); // needed because we cannot mutate state
-    const changedValuesByPath = surveyHelper.addGroupedObjects(interview, newObjectsCount, insertSequence, path, attributes || []);
-    if (returnOnly)
-    {
-      return changedValuesByPath;
-    }
-    else
-    {
-      dispatch(startUpdateInterview(null, changedValuesByPath, null, null, callback));
-    }
-  };
-};
-
-export const startRemoveGroupedObjects = function(paths, callback, returnOnly = false) {
-  surveyHelperNew.devLog(`Remove grouped objects at paths`, paths);
-  return (dispatch, getState) => {
-    const interview    = _cloneDeep(getState().survey.interview); // needed because we cannot mutate state
-    let   unsetPaths   = [];
-    let   valuesByPath = {};
-    [valuesByPath, unsetPaths] = surveyHelper.removeGroupedObjects(paths, interview);
-    if (returnOnly)
-    {
-      return [valuesByPath, unsetPaths];
-    }
-    else
-    {
-      dispatch(startUpdateInterview(null, valuesByPath, unsetPaths, null, callback));
-    }
-  };
-};
-
 export const startValidateAddGroupedObjects = (newObjectsCount, insertSequence, path, attributes = [], callback, returnOnly = false) => {
   surveyHelperNew.devLog(`Add ${newObjectsCount} grouped objects for path ${path} at sequence ${insertSequence}`);
   return (dispatch, getState) => {
@@ -595,7 +569,7 @@ export const startSurveyValidateRemoveGroupedObjects = function(paths, callback,
     const interview    = _cloneDeep(getState().survey.interview); // needed because we cannot mutate state
     let   unsetPaths   = [];
     let   valuesByPath = {};
-    [valuesByPath, unsetPaths] = surveyHelper.removeGroupedObjects(paths, interview);
+    [valuesByPath, unsetPaths] = surveyHelper.removeGroupedObjects(interview, paths);
     if (returnOnly)
     {
       return [valuesByPath, unsetPaths];
@@ -629,7 +603,7 @@ export const startValidateRemoveGroupedObjects = function(paths, callback, retur
     const interview    = _cloneDeep(getState().survey.interview); // needed because we cannot mutate state
     let   unsetPaths   = [];
     let   valuesByPath = {};
-    [valuesByPath, unsetPaths] = surveyHelper.removeGroupedObjects(paths, interview);
+    [valuesByPath, unsetPaths] = surveyHelper.removeGroupedObjects(interview, paths);
     if (returnOnly)
     {
       return [valuesByPath, unsetPaths];

--- a/packages/evolution-legacy/src/helpers/survey/helper.js
+++ b/packages/evolution-legacy/src/helpers/survey/helper.js
@@ -717,7 +717,7 @@ export default {
         {
           let updateValuePaths = {};
           let unsetValuePaths  = [];
-          [updateValuePaths, unsetValuePaths] = surveyHelper.removeGroupedObjects(tripsPathsToRemove, interview);
+          [updateValuePaths, unsetValuePaths] = surveyHelper.removeGroupedObjects(interview, tripsPathsToRemove);
           tripsUpdatesUnsetPaths  = tripsUpdatesUnsetPaths.concat(unsetValuePaths);
           tripsUpdatesValueByPath = Object.assign(tripsUpdatesValueByPath, updateValuePaths);
         }

--- a/packages/evolution-legacy/src/helpers/survey/survey.js
+++ b/packages/evolution-legacy/src/helpers/survey/survey.js
@@ -105,70 +105,9 @@ export default {
 
   interpolatePath: Helpers.interpolatePath,
 
-  
+  addGroupedObjects: Helpers.addGroupedObjects,
 
-  addGroupedObjects: function(interview, newObjectsCount, insertSequence, path, attributes = [])
-  {
-    const changedValuesByPath = {};
-    const groupedObjects      = _get(interview.responses, path, {});
-    const groupedObjectsArray = sortBy(Object.values(groupedObjects),['_sequence']);
-    if (LE._isBlank(insertSequence) || insertSequence === -1)
-    {
-      insertSequence = groupedObjectsArray.length + 1;
-    }
-    else {
-      // increment sequences of groupedObjects after the insertSequence:
-      for(let seq = insertSequence, count = groupedObjectsArray.length; seq <= count; seq++)
-      {
-        const groupedObject = groupedObjectsArray[seq - 1];
-        changedValuesByPath[`responses.${path}.${groupedObject._uuid}._sequence`] = seq + newObjectsCount;
-      }
-    }
-    for (let i = 0; i < newObjectsCount; i++)
-    {
-      const uniqueId            = uuidV4();
-      const newSequence         = insertSequence + i;
-      const newObjectAttributes = attributes[i] ? attributes[i] : {};
-      changedValuesByPath[`responses.${path}.${uniqueId}`] = {'_sequence': newSequence, '_uuid': uniqueId, ...newObjectAttributes};
-      changedValuesByPath[`validations.${path}.${uniqueId}`] = {};
-    }
-    return changedValuesByPath;
-  },
-
-  removeGroupedObjects: function(paths, interview)
-  {
-    // allow single path:
-    if (!Array.isArray(paths))
-    {
-      paths = [paths];
-    }
-
-    if (paths.length === 0) {
-        return [{}, []];
-    }
-
-    const unsetPaths   = [];
-    const valuesByPath = {};
-    let pathRemovedCount = 0;
-
-    const groupedObjects        = Helpers.getResponse(interview, paths[0], {}, '../');
-    const groupedObjectsArray   = sortBy(Object.values(groupedObjects),['_sequence']);
-
-    for (let i = 0, count = groupedObjectsArray.length; i < count; i++) {
-        const groupedObject = groupedObjectsArray[i];
-        const groupedObjectPath = Helpers.getPath(paths[0], `../${groupedObject._uuid}`);
-        if (paths.includes(groupedObjectPath)) {
-            unsetPaths.push(`responses.${groupedObjectPath}`);
-            unsetPaths.push(`validations.${groupedObjectPath}`);
-            pathRemovedCount++;
-        } else {
-            if (pathRemovedCount > 0) {
-                valuesByPath['responses.' + groupedObjectPath + '._sequence'] = groupedObject._sequence - pathRemovedCount;
-            }
-        }
-    }
-    return [valuesByPath, unsetPaths];
-  },
+  removeGroupedObjects: Helpers.removeGroupedObjects,
 
   validateButtonAction: function(callbacks, _interview, path, section, sections, saveCallback) {
     callbacks.startUpdateInterview(section, { '_all': true }, null, null, (interview) => {


### PR DESCRIPTION
Document and type and function parameters

Also type those functions in the InterviewUpdateCallbakcs type.

** Breaking change **

If surveys were calling directly the removeGroupedObjects helper function, the order of the argument has changed for consistency with those of the addGroupedObjects function. It is now `interview, paths` instead of the reverse.