### PR TITLE
Add InputDatePicker type in inputTypes.ts

### DIFF
--- a/packages/evolution-generator/src/types/inputTypes.ts
+++ b/packages/evolution-generator/src/types/inputTypes.ts
@@ -298,3 +298,21 @@ export type InputMapFindPlace = InputMapFindPlaceBase & {
 
 /* InfoMap widgetConfig Type */
 export type InfoMap = InfoMapWidgetConfig;
+
+/* InputDatePicker widgetConfig Type */
+export type InputDatePicker = {
+    type: 'question';
+    inputType: 'datePicker';
+    path: Path;
+    label: Label;
+    datatype: 'number';
+    containsHtml: ContainsHtml;
+    twoColumns: TwoColumns;
+    showTimeSelect: boolean;
+    placeholderText: Title;
+    locale: { fr: string; en: string };
+    maxDate: (interview, path) => Date;
+    minDate: (interview, path) => Date;
+    conditional: Conditional;
+    validations: Validations;
+};


### PR DESCRIPTION
# Pull request

## Justification
There is no type for InputDatePicker, it's easy to make errors with this input.

## Description
Add InputDatePicker type in inputTypes.ts