### PR TITLE
od helpers: Replace arguments with a single object

### DIFF
--- a/example/demo_survey/src/survey/sections.ts
+++ b/example/demo_survey/src/survey/sections.ts
@@ -338,10 +338,10 @@ export default {
       }
       else if (person.didTripsOnTripsDate === 'yes' || person.didTripsOnTripsDate === true)
       {
-        const journeys = odSurveyHelper.getJourneysArray(person);
+        const journeys = odSurveyHelper.getJourneysArray({ person });
         if (journeys.length >= 1) {
             const currentJourney = journeys[0];
-            const visitedPlaces = odSurveyHelper.getVisitedPlacesArray(currentJourney);
+            const visitedPlaces = odSurveyHelper.getVisitedPlacesArray({ journey: currentJourney });
             if (visitedPlaces.length >= 1)
             {
               const firstVisitedPlace         = visitedPlaces[0];
@@ -358,7 +358,7 @@ export default {
                 ...(addGroupedObjects(interview, 1, 1, `household.persons.${person._uuid}.journeys`, [])),
             }, null, null, (updatedInterview) => {
                 const _person = helper.getPerson(updatedInterview);
-                const journeys = odSurveyHelper.getJourneysArray(_person);
+                const journeys = odSurveyHelper.getJourneysArray({ person: _person });
                 const currentJourney = journeys[0];
                 startUpdateInterview('visitedPlaces', {
                     [`responses._activeJourneyId`]: currentJourney._uuid
@@ -425,9 +425,9 @@ export default {
       }
       
       // Journeys should not be empty
-      const journeys = odSurveyHelper.getJourneysArray(person);
+      const journeys = odSurveyHelper.getJourneysArray({ person });
       const currentJourney = journeys[0];
-      const visitedPlaces             = odSurveyHelper.getVisitedPlacesArray(currentJourney);
+      const visitedPlaces             = odSurveyHelper.getVisitedPlacesArray({ journey: currentJourney });
       const activeVisitedPlaceId      = getResponse(interview, '_activeVisitedPlaceId', null);
       let   foundSelectedVisitedPlace = false;
       let   addValuesByPath           = {};
@@ -499,12 +499,12 @@ export default {
         }, null, null, callback);
         return null;
       }
-      const journeys = odSurveyHelper.getJourneysArray(person);
+      const journeys = odSurveyHelper.getJourneysArray({ person });
       const currentJourney = journeys[0];
       let   tripsUpdatesValueByPath  = {};
       let   tripsUpdatesUnsetPaths   = [];
       const tripsPath                = `household.persons.${person._uuid}.journeys.${currentJourney._uuid}.trips`;
-      const visitedPlaces            = odSurveyHelper.getVisitedPlacesArray(currentJourney);
+      const visitedPlaces            = odSurveyHelper.getVisitedPlacesArray({ journey: currentJourney });
       let   trips                    = helper.getTrips(currentJourney);
       //const activeTripId             = getResponse(interview, '_activeTripId', null);
       //let   foundSelectedTrip        = false;

--- a/example/demo_survey/src/survey/templates/SegmentsSection.tsx
+++ b/example/demo_survey/src/survey/templates/SegmentsSection.tsx
@@ -107,7 +107,7 @@ export class SegmentsSection extends React.Component<any, any> {
     const widgetsComponentsByShortname = {};
     const personTripsConfig            = this.props.surveyContext.widgets['personTrips'];
     const person                       = helper.getPerson(this.props.interview);
-    const journeys = odSurveyHelper.getJourneysArray(person);
+    const journeys = odSurveyHelper.getJourneysArray({ person });
     const currentJourney = journeys[0];
 
     const trips      = currentJourney.trips || {};

--- a/example/demo_survey/src/survey/templates/VisitedPlacesSection.tsx
+++ b/example/demo_survey/src/survey/templates/VisitedPlacesSection.tsx
@@ -62,9 +62,9 @@ export class VisitedPlacesSection extends React.Component<any, any> {
     }
     this.props.startAddGroupedObjects(1, sequence, path, [], (function(interview) {
       const person             = helper.getPerson(interview);
-      const journeys           = odSurveyHelper.getJourneysArray(person);
+      const journeys           = odSurveyHelper.getJourneysArray({ person });
       const currentJourney     = journeys[0];
-      const visitedPlaces      = odSurveyHelper.getVisitedPlacesArray(currentJourney);
+      const visitedPlaces      = odSurveyHelper.getVisitedPlacesArray({ journey: currentJourney });
       const lastVisitedPlace   = visitedPlaces[visitedPlaces.length - 1];
       const updateValuesByPath = {};
       if (lastVisitedPlace && sequence === lastVisitedPlace._sequence) // we are inserting a new visited place at the end
@@ -142,7 +142,7 @@ export class VisitedPlacesSection extends React.Component<any, any> {
     const widgetsComponentsByShortname = {};
     const personVisitedPlacesConfig    = this.props.surveyContext.widgets['personVisitedPlaces'];
     const person                       = helper.getPerson(this.props.interview);
-    const journeys = odSurveyHelper.getJourneysArray(person);
+    const journeys = odSurveyHelper.getJourneysArray({ person });
     const currentJourney = journeys[0];
     const householdSize                = surveyHelper.getResponse(this.props.interview, 'household.size', null);
     const isAlone                      = householdSize === 1;
@@ -158,9 +158,9 @@ export class VisitedPlacesSection extends React.Component<any, any> {
     {
       const _person                         = persons[_personId];
       let   atLeastOneCompletedVisitedPlace = false;
-      const _journeys = odSurveyHelper.getJourneysArray(_person);
+      const _journeys = odSurveyHelper.getJourneysArray({ person: _person});
       const _currentJourney = _journeys[0];
-      const visitedPlaces = _currentJourney !== undefined ? odSurveyHelper.getVisitedPlacesArray(_currentJourney) : [];
+      const visitedPlaces = _currentJourney !== undefined ? odSurveyHelper.getVisitedPlacesArray({ journey: _currentJourney }) : [];
       const personVisitedPlacesSchedules    = [];
       for (let i = 0, count = visitedPlaces.length; i < count; i++)
       {
@@ -273,7 +273,7 @@ export class VisitedPlacesSection extends React.Component<any, any> {
 
     // setup visited places:
 
-    const visitedPlaces          = odSurveyHelper.getVisitedPlacesArray(currentJourney);
+    const visitedPlaces          = odSurveyHelper.getVisitedPlacesArray({ journey: currentJourney});
     const lastVisitedPlace       = helper.getLastVisitedPlace(visitedPlaces);
     const visitedPlacesList      = [];
 

--- a/example/demo_survey/src/survey/widgets/home.tsx
+++ b/example/demo_survey/src/survey/widgets/home.tsx
@@ -185,7 +185,7 @@ export const householdCarNumber = {
     }
   },
   validations: function(value, customValue, interview, path, customPath) {
-    const householdSize: any = getHousehold(interview).size;
+    const householdSize: any = getHousehold({ interview }).size;
     return [
       {
         validation: (isNaN(Number(value)) || !Number.isInteger(Number(value))),

--- a/example/demo_survey/src/survey/widgets/profile.tsx
+++ b/example/demo_survey/src/survey/widgets/profile.tsx
@@ -37,30 +37,30 @@ export const personWorkOnTheRoad = {
   ],
   label: {
     fr: function(interview, path) {
-      const householdSize = getHousehold(interview).size;
+      const householdSize = getHousehold({ interview }).size;
       if (householdSize === 1)
       {
         return `Travaillez-vous sur la route de manière régulière (${surveyHelperNew.getResponse(interview, path, null, '../gender') == 'female' ? "livreuse, représentante, conductrice, policière" : "livreur, représentant, chauffeur, policier"}, etc.)?`;
       }
       const person       = helper.getPerson(interview);
       const genderString = helper.getGenderString(person, "livreuse, représentante, conductrice, policière", "livreur, représentant, chauffeur, policier", "livreur/se, représentant(e), conducteur/trice, policier/ère", "livreur/se, représentant(e), conducteur/trice, policier/ère")
-      return `Est-ce que ${getActivePerson(interview).nickname || ''} travaille sur la route de manière régulière (${genderString}, etc.)?`;
+      return `Est-ce que ${getActivePerson({ interview }).nickname || ''} travaille sur la route de manière régulière (${genderString}, etc.)?`;
     },
     en: function(interview, path) {
-      const householdSize = getHousehold(interview).size;
+      const householdSize = getHousehold({ interview }).size;
       if (householdSize === 1)
       {
         return `Do you work on the road on a regular basis (deliverer, representative, driver, police officer, etc.)?`;
       }
-      return `Does ${getActivePerson(interview).nickname || ''} work on the road on a regular basis (deliverer, representative, driver, police officer, etc.)?`;
+      return `Does ${getActivePerson({ interview }).nickname || ''} work on the road on a regular basis (deliverer, representative, driver, police officer, etc.)?`;
     }
   },
   conditional: function(interview, path) {
-    const occupation = (getActivePerson(interview) as any).occupation;
+    const occupation = (getActivePerson({ interview }) as any).occupation;
     return (!_isBlank(occupation) && helper.isWorker(occupation));
   },
   validations: function(value, customValue, interview, path, customPath) {
-    const occupation = (getActivePerson(interview) as any).occupation;
+    const occupation = (getActivePerson({ interview }) as any).occupation;
     return [
       {
         validation: _isBlank(value) && !_isBlank(occupation) && helper.isWorker(occupation),

--- a/example/demo_survey/src/survey/widgets/segments.tsx
+++ b/example/demo_survey/src/survey/widgets/segments.tsx
@@ -2760,7 +2760,7 @@ export const segmentParkingPaymentType = {
                 },
                 conditional: function(interview, path) {
                   const person = helper.getPerson(interview);
-                  const journeys = odSurveyHelper.getJourneysArray(person);
+                  const journeys = odSurveyHelper.getJourneysArray({ person });
                   const currentJourney = journeys[journeys.length - 1];
                   const trip: any = surveyHelperNew.getResponse(interview, path, null, '../../');
                   const visitedPlaces = currentJourney.visitedPlaces;

--- a/example/demo_survey/src/survey/widgets/visitedPlaces.tsx
+++ b/example/demo_survey/src/survey/widgets/visitedPlaces.tsx
@@ -413,8 +413,8 @@ export const visitedPlaceActivity = {
   label: {
     fr: function(interview, path) {
       const person = helper.getPerson(interview);
-      const journey = odSurveyHelper.getJourneysArray(person)[0];
-      const visitedPlaces = odSurveyHelper.getVisitedPlacesArray(journey);
+      const journey = odSurveyHelper.getJourneysArray({ person })[0];
+      const visitedPlaces = odSurveyHelper.getVisitedPlacesArray({ journey });
       const householdSize = surveyHelperNew.getResponse(interview, 'household.size', null);
       if (householdSize === 1)
       {
@@ -429,8 +429,8 @@ export const visitedPlaceActivity = {
     },
     en: function(interview, path) {
       const person = helper.getPerson(interview);
-      const journey = odSurveyHelper.getJourneysArray(person)[0];
-      const visitedPlaces = odSurveyHelper.getVisitedPlacesArray(journey);
+      const journey = odSurveyHelper.getJourneysArray({ person })[0];
+      const visitedPlaces = odSurveyHelper.getVisitedPlacesArray({ journey });
       const householdSize = surveyHelperNew.getResponse(interview, 'household.size', null);
       if (householdSize === 1)
       {
@@ -1331,7 +1331,7 @@ export const visitedPlaceNextPlaceCategory = {
       },
       conditional: function(interview) {
         const person         = helper.getPerson(interview);
-        const journeys = odSurveyHelper.getJourneysArray(person);
+        const journeys = odSurveyHelper.getJourneysArray({ person });
         const currentJourney = journeys[0];
         const visitedPlaceId = helper.getActiveVisitedPlaceId(interview);
         const visitedPlace: any  = surveyHelperNew.getResponse(interview, `household.persons.${person._uuid}.journeys.${currentJourney._uuid}.visitedPlaces.${visitedPlaceId}`, null);
@@ -1600,9 +1600,9 @@ export const buttonSaveVisitedPlace = {
   align: 'center',
   saveCallback: function(callbacks: surveyHelperNew.InterviewUpdateCallbacks, interview: UserInterviewAttributes, path: string, user?: CliUser) {
     const person                   = helper.getPerson(interview);
-    const journeys = odSurveyHelper.getJourneysArray(person);
+    const journeys = odSurveyHelper.getJourneysArray({ person });
     const currentJourney = journeys[0];
-    const visitedPlaces            = odSurveyHelper.getVisitedPlacesArray(currentJourney);
+    const visitedPlaces            = odSurveyHelper.getVisitedPlacesArray({ journey: currentJourney });
     const visitedPlace: any        = surveyHelperNew.getResponse(interview, path, null, '../');
     const visitedPlacePath         = `household.persons.${person._uuid}.journeys.${currentJourney._uuid}.visitedPlaces.${visitedPlace._uuid}`;
     const previousVisitedPlace     = helper.getPreviousVisitedPlace(visitedPlace._uuid, visitedPlaces);

--- a/packages/evolution-common/src/services/odSurvey/__tests__/helpers.test.ts
+++ b/packages/evolution-common/src/services/odSurvey/__tests__/helpers.test.ts
@@ -88,7 +88,7 @@ each([
 ]).test('getHousehold: %s', (_title, responses, expected) => {
     const interview = _cloneDeep(interviewAttributes);
     interview.responses = responses;
-    expect(Helpers.getHousehold(interview)).toEqual(expected);
+    expect(Helpers.getHousehold({ interview })).toEqual(expected);
 });
 
 each([
@@ -102,55 +102,55 @@ each([
     const interview = _cloneDeep(interviewAttributesWithHh);
     interview.responses = responses;
     interview.responses._activePersonId = currentPersonId;
-    expect(Helpers.getActivePerson(interview)).toEqual(expected);
+    expect(Helpers.getActivePerson({ interview })).toEqual(expected);
 });
 
 describe('getPersons', () => {
     test('test without household', () => {
-        expect(Helpers.getPersons(interviewAttributes)).toEqual({});
+        expect(Helpers.getPersons({ interview: interviewAttributes })).toEqual({});
     });
 
     test('test without persons', () => {
         const attributes = _cloneDeep(interviewAttributes) as any;
         attributes.household = {};
-        expect(Helpers.getPersons(interviewAttributes)).toEqual({});
+        expect(Helpers.getPersons({ interview: attributes })).toEqual({});
     });
 
     test('empty persons', () => {
         const attributes = _cloneDeep(interviewAttributes) as any;
         attributes.household = { size: 0, persons: {} };
-        expect(Helpers.getPersons(interviewAttributes)).toEqual({});
+        expect(Helpers.getPersons({ interview: attributes })).toEqual({});
     });
 
     test('with persons', () => {
-        expect(Helpers.getPersons(interviewAttributesWithHh)).toEqual((interviewAttributesWithHh.responses as any).household.persons);
+        expect(Helpers.getPersons({ interview: interviewAttributesWithHh })).toEqual((interviewAttributesWithHh.responses as any).household.persons);
     });
 
     test('array: test without household', () => {
-        expect(Helpers.getPersonsArray(interviewAttributes)).toEqual([]);
+        expect(Helpers.getPersonsArray({ interview: interviewAttributes })).toEqual([]);
     });
 
     test('array: test without persons', () => {
         const attributes = _cloneDeep(interviewAttributes) as any;
         attributes.household = {};
-        expect(Helpers.getPersonsArray(interviewAttributes)).toEqual([]);
+        expect(Helpers.getPersonsArray({ interview: attributes })).toEqual([]);
     });
 
     test('array: empty persons', () => {
         const attributes = _cloneDeep(interviewAttributes) as any;
         attributes.household = { size: 0, persons: {} };
-        expect(Helpers.getPersonsArray(interviewAttributes)).toEqual([]);
+        expect(Helpers.getPersonsArray({ interview: attributes })).toEqual([]);
     });
 
     test('array: with persons, unordered', () => {
-        expect(Helpers.getPersonsArray(interviewAttributesWithHh)).toEqual(Object.values((interviewAttributesWithHh.responses as any).household.persons));
+        expect(Helpers.getPersonsArray({ interview: interviewAttributesWithHh })).toEqual(Object.values((interviewAttributesWithHh.responses as any).household.persons));
     });
 
     test('array: with persons, ordered', () => {
         const attributes = _cloneDeep(interviewAttributesWithHh) as any;
         attributes.responses.household.persons.personId1._sequence = 2;
         attributes.responses.household.persons.personId2._sequence = 1;
-        expect(Helpers.getPersonsArray(attributes)).toEqual([attributes.responses.household.persons.personId2, attributes.responses.household.persons.personId1]);
+        expect(Helpers.getPersonsArray({ interview: attributes })).toEqual([attributes.responses.household.persons.personId2, attributes.responses.household.persons.personId1]);
     });
 });
 
@@ -167,7 +167,7 @@ each([
 ]).test('getPerson: %s', (_title, responses, personId, expected) => {
     const interview = _cloneDeep(interviewAttributesWithHh);
     interview.responses = responses;
-    expect(Helpers.getPerson(interview, personId)).toEqual(expected);
+    expect(Helpers.getPerson({ interview, personId })).toEqual(expected);
 });
 
 each([
@@ -203,7 +203,7 @@ each([
 ]).test('countPersons: %s', (_title, responses, expected) => {
     const interview = _cloneDeep(interviewAttributesWithHh);
     interview.responses = responses;
-    expect(Helpers.countPersons(interview)).toEqual(expected);
+    expect(Helpers.countPersons({ interview })).toEqual(expected);
 });
 
 each([
@@ -293,7 +293,7 @@ each([
     const interview = _cloneDeep(interviewAttributesWithHh);
     interview.responses = responses;
     const person = typeof personIdOrPerson === 'string' ? responses.household!.persons![personIdOrPerson] : personIdOrPerson;
-    expect(Helpers.isSelfDeclared(interview, person)).toEqual(expected);
+    expect(Helpers.isSelfDeclared({ interview, person })).toEqual(expected);
 });
 
 each([
@@ -363,7 +363,7 @@ each([
     const interview = _cloneDeep(interviewAttributesWithHh);
     interview.responses = responses;
     const person = typeof personIdOrPerson === 'string' ? responses.household!.persons![personIdOrPerson] : personIdOrPerson;
-    expect(Helpers.getCountOrSelfDeclared(interview, person)).toEqual(expected);
+    expect(Helpers.getCountOrSelfDeclared({ interview, person })).toEqual(expected);
 });
 
 describe('getJourneys', () => {
@@ -388,35 +388,35 @@ describe('getJourneys', () => {
     }
 
     test('object: test without journeys', () => {
-        expect(Helpers.getJourneys(person)).toEqual({});
+        expect(Helpers.getJourneys({ person })).toEqual({});
     });
 
     test('object: empty journeys', () => {
         const attributes = _cloneDeep(person);
         attributes.journeys = { };
-        expect(Helpers.getJourneys(attributes)).toEqual({});
+        expect(Helpers.getJourneys({ person: attributes })).toEqual({});
     });
 
     test('object: with journeys, ordered', () => {
         const attributes = _cloneDeep(person);
         attributes.journeys = journeys;
-        expect(Helpers.getJourneys(attributes)).toEqual(journeys);
+        expect(Helpers.getJourneys({ person: attributes })).toEqual(journeys);
     });
 
     test('array: test without journeys', () => {
-        expect(Helpers.getJourneysArray(person)).toEqual([]);
+        expect(Helpers.getJourneysArray({ person })).toEqual([]);
     });
 
     test('array: empty journeys', () => {
         const attributes = _cloneDeep(person);
         attributes.journeys = { };
-        expect(Helpers.getJourneysArray(attributes)).toEqual([]);
+        expect(Helpers.getJourneysArray({ person: attributes })).toEqual([]);
     });
 
     test('array: with journeys, ordered', () => {
         const attributes = _cloneDeep(person);
         attributes.journeys = journeys;
-        expect(Helpers.getJourneysArray(attributes)).toEqual([journeys.journeyId2, journeys.journeyId1]);
+        expect(Helpers.getJourneysArray({ person: attributes })).toEqual([journeys.journeyId2, journeys.journeyId1]);
     });
 
     each([
@@ -514,7 +514,7 @@ describe('getJourneys', () => {
         const interview = _cloneDeep(interviewAttributesWithHh);
         interview.responses = responses;
         const person = personId === null ? null : interview.responses?.household?.persons ? interview.responses?.household?.persons[personId] : null
-        expect(Helpers.getActiveJourney(interview, person)).toEqual(expected);
+        expect(Helpers.getActiveJourney({ interview, person })).toEqual(expected);
     });
 
 });
@@ -540,35 +540,35 @@ describe('getVisitedPlaces', () => {
     }
 
     test('object: test without visited places', () => {
-        expect(Helpers.getVisitedPlaces(journey)).toEqual({});
+        expect(Helpers.getVisitedPlaces({ journey })).toEqual({});
     });
 
     test('object: empty visited places', () => {
         const attributes = _cloneDeep(journey);
         attributes.visitedPlaces = { };
-        expect(Helpers.getVisitedPlaces(attributes)).toEqual({});
+        expect(Helpers.getVisitedPlaces({ journey: attributes })).toEqual({});
     });
 
     test('object: with visited places, ordered', () => {
         const attributes = _cloneDeep(journey);
         attributes.visitedPlaces = visitedPlaces;
-        expect(Helpers.getVisitedPlaces(attributes)).toEqual(visitedPlaces);
+        expect(Helpers.getVisitedPlaces({ journey: attributes })).toEqual(visitedPlaces);
     });
 
     test('array: test without visited places', () => {
-        expect(Helpers.getVisitedPlacesArray(journey)).toEqual([]);
+        expect(Helpers.getVisitedPlacesArray({ journey })).toEqual([]);
     });
 
     test('array: empty visited places', () => {
         const attributes = _cloneDeep(journey);
         attributes.visitedPlaces = { };
-        expect(Helpers.getVisitedPlacesArray(attributes)).toEqual([]);
+        expect(Helpers.getVisitedPlacesArray({ journey: attributes })).toEqual([]);
     });
 
     test('array: with visited places, ordered', () => {
         const attributes = _cloneDeep(journey);
         attributes.visitedPlaces = visitedPlaces;
-        expect(Helpers.getVisitedPlacesArray(attributes)).toEqual([visitedPlaces.visitedPlace2, visitedPlaces.visitedPlace1]);
+        expect(Helpers.getVisitedPlacesArray({ journey: attributes })).toEqual([visitedPlaces.visitedPlace2, visitedPlaces.visitedPlace1]);
     });
 
 });
@@ -704,11 +704,11 @@ describe('replaceVisitedPlaceShortcuts', () => {
     }
 
     test('Place is not a shortcut', () => {
-        expect(Helpers.replaceVisitedPlaceShortcuts(shortcutInterview, 'household.persons.person1.journeys.journey1.visitedPlaces.basicPlace1')).toBeUndefined();
+        expect(Helpers.replaceVisitedPlaceShortcuts({ interview: shortcutInterview, shortcutTo: 'household.persons.person1.journeys.journey1.visitedPlaces.basicPlace1' })).toBeUndefined();
     });
 
     test('Place is a shortcut to a shorcut', () => {
-        expect(Helpers.replaceVisitedPlaceShortcuts(shortcutInterview, 'household.persons.person3.journeys.journey1.visitedPlaces.shortcutToBasic2')).toEqual({
+        expect(Helpers.replaceVisitedPlaceShortcuts({ interview: shortcutInterview, shortcutTo: 'household.persons.person3.journeys.journey1.visitedPlaces.shortcutToBasic2' })).toEqual({
             updatedValuesByPath: {
                 ['responses.household.persons.person1.journeys.journey1.visitedPlaces.shortcutToShortcut.shortcut']: ((shortcutInterview.responses.household!.persons!.person3.journeys!.journey1.visitedPlaces || {})['shortcutToBasic2'] as any).shortcut,
                 ['responses.household.persons.person1.journeys.journey1.visitedPlaces.shortcutToShortcut.geography']: (shortcutInterview.responses.household!.persons!.person3.journeys!.journey1.visitedPlaces || {})['shortcutToBasic2'].geography
@@ -718,7 +718,7 @@ describe('replaceVisitedPlaceShortcuts', () => {
     });
 
     test('Place shortcut to one other place', () => {
-        expect(Helpers.replaceVisitedPlaceShortcuts(shortcutInterview, 'household.persons.person2.journeys.journey1.visitedPlaces.basicPlace2')).toEqual({
+        expect(Helpers.replaceVisitedPlaceShortcuts({ interview: shortcutInterview, shortcutTo: 'household.persons.person2.journeys.journey1.visitedPlaces.basicPlace2' })).toEqual({
             updatedValuesByPath: {
                 ['responses.household.persons.person3.journeys.journey1.visitedPlaces.shortcutToBasic2.name']: ((shortcutInterview.responses.household!.persons!.person2.journeys!.journey1.visitedPlaces || {})['basicPlace2'] as any).name,
                 ['responses.household.persons.person3.journeys.journey1.visitedPlaces.shortcutToBasic2.geography']: (shortcutInterview.responses.household!.persons!.person2.journeys!.journey1.visitedPlaces || {})['basicPlace2'].geography
@@ -728,7 +728,7 @@ describe('replaceVisitedPlaceShortcuts', () => {
     });
 
     test('Place shortcut to many places from many persons', () => {
-        expect(Helpers.replaceVisitedPlaceShortcuts(shortcutInterview, 'household.persons.person1.journeys.journey1.visitedPlaces.usedAsShortcut')).toEqual({
+        expect(Helpers.replaceVisitedPlaceShortcuts({ interview: shortcutInterview, shortcutTo: 'household.persons.person1.journeys.journey1.visitedPlaces.usedAsShortcut' })).toEqual({
             updatedValuesByPath: {
                 ['responses.household.persons.person2.journeys.journey1.visitedPlaces.isAShortcut.name']: ((shortcutInterview.responses.household!.persons!.person1.journeys!.journey1.visitedPlaces || {})['usedAsShortcut'] as any).name,
                 ['responses.household.persons.person2.journeys.journey1.visitedPlaces.isAShortcut.geography']: (shortcutInterview.responses.household!.persons!.person1.journeys!.journey1.visitedPlaces || {})['usedAsShortcut'].geography,
@@ -760,35 +760,35 @@ describe('getTrips', () => {
     }
 
     test('object: test without trips', () => {
-        expect(Helpers.getTrips(journey)).toEqual({});
+        expect(Helpers.getTrips({ journey })).toEqual({});
     });
 
     test('object: empty trips', () => {
         const attributes = _cloneDeep(journey);
         attributes.trips = { };
-        expect(Helpers.getTrips(attributes)).toEqual({});
+        expect(Helpers.getTrips({ journey: attributes })).toEqual({});
     });
 
     test('object: with trips', () => {
         const attributes = _cloneDeep(journey);
         attributes.trips = trips;
-        expect(Helpers.getTrips(attributes)).toEqual(trips);
+        expect(Helpers.getTrips({ journey: attributes })).toEqual(trips);
     });
 
     test('array: test without trips', () => {
-        expect(Helpers.getTripsArray(journey)).toEqual([]);
+        expect(Helpers.getTripsArray({ journey })).toEqual([]);
     });
 
     test('array: empty trips', () => {
         const attributes = _cloneDeep(journey);
         attributes.trips = { };
-        expect(Helpers.getTripsArray(attributes)).toEqual([]);
+        expect(Helpers.getTripsArray({ journey: attributes })).toEqual([]);
     });
 
     test('array: with trips, ordered', () => {
         const attributes = _cloneDeep(journey);
         attributes.trips = trips;
-        expect(Helpers.getTripsArray(attributes)).toEqual([trips.trip2, trips.trip1]);
+        expect(Helpers.getTripsArray({ journey: attributes })).toEqual([trips.trip2, trips.trip1]);
     });
 
     each([
@@ -840,7 +840,7 @@ describe('getTrips', () => {
         }
         const journey = testData.testPersonId && testData.testJourneyId ? interview.responses.household!.persons![testData.testPersonId].journeys![testData.testJourneyId] : null;
         const result = expectResult ? interview.responses.household!.persons![(testData.testPersonId || testData.activePersonId) as string].journeys![(testData.testJourneyId || testData.activeJourneyId) as string].trips![testData.activeTripId!] : null;
-        const activeTrip = Helpers.getActiveTrip(interview, journey);
+        const activeTrip = Helpers.getActiveTrip({ interview, journey });
         if (expectResult) {
             expect(activeTrip).toBeTruthy();
             expect(activeTrip).toEqual(result);
@@ -856,7 +856,7 @@ describe('getTrips', () => {
     ]).test('getPreviousTrip: %s', (_title, currentTrip, previousTrip) => {
         const attributes = _cloneDeep(journey);
         attributes.trips = trips;
-        expect(Helpers.getPreviousTrip(currentTrip, attributes)).toEqual(previousTrip)
+        expect(Helpers.getPreviousTrip({ currentTrip, journey: attributes })).toEqual(previousTrip)
     });
 
 });
@@ -865,32 +865,32 @@ describe('getOrigin/getDestination', () => {
 
     test('getOrigin, existing', () => {
         const journey = interviewAttributesForTestCases.responses.household!.persons!.personId1.journeys!.journeyId1;
-        expect(Helpers.getOrigin(journey.trips!.tripId1P1, journey.visitedPlaces!)).toEqual(journey.visitedPlaces!.homePlace1P1);
+        expect(Helpers.getOrigin({ trip: journey.trips!.tripId1P1, visitedPlaces: journey.visitedPlaces! })).toEqual(journey.visitedPlaces!.homePlace1P1);
     });
 
     test('getOrigin, unexisting', () => {
         const journey = interviewAttributesForTestCases.responses.household!.persons!.personId1.journeys!.journeyId1;
-        expect(Helpers.getOrigin(journey.trips!.tripId1P1, {})).toEqual(null);
+        expect(Helpers.getOrigin({ trip: journey.trips!.tripId1P1, visitedPlaces: {} })).toEqual(null);
     });
 
     test('getOrigin, trip without origin', () => {
         const journey = interviewAttributesForTestCases.responses.household!.persons!.personId2.journeys!.journeyId2;
-        expect(Helpers.getOrigin(journey.trips!.tripId3P2, journey.visitedPlaces!)).toEqual(null);
+        expect(Helpers.getOrigin({ trip: journey.trips!.tripId3P2, visitedPlaces: journey.visitedPlaces! })).toEqual(null);
     });
 
     test('getDestination, existing', () => {
         const journey = interviewAttributesForTestCases.responses.household!.persons!.personId1.journeys!.journeyId1;
-        expect(Helpers.getDestination(journey.trips!.tripId1P1, journey.visitedPlaces!)).toEqual(journey.visitedPlaces!.workPlace1P1);
+        expect(Helpers.getDestination({ trip: journey.trips!.tripId1P1, visitedPlaces: journey.visitedPlaces! })).toEqual(journey.visitedPlaces!.workPlace1P1);
     });
 
     test('getDestination: unexisting', () => {
         const journey = interviewAttributesForTestCases.responses.household!.persons!.personId1.journeys!.journeyId1;
-        expect(Helpers.getDestination(journey.trips!.tripId1P1, {})).toEqual(null);
+        expect(Helpers.getDestination({ trip: journey.trips!.tripId1P1, visitedPlaces: {} })).toEqual(null);
     });
 
     test('getDestination, trip without origin', () => {
         const journey = interviewAttributesForTestCases.responses.household!.persons!.personId2.journeys!.journeyId2;
-        expect(Helpers.getDestination(journey.trips!.tripId3P2, journey.visitedPlaces!)).toEqual(null);
+        expect(Helpers.getDestination({ trip: journey.trips!.tripId3P2, visitedPlaces: journey.visitedPlaces! })).toEqual(null);
     });
 
 });
@@ -925,7 +925,7 @@ describe('getVisitedPlaceNames', () => {
             'mocked 4'
         ]
     ]).test('%s', (_title, visitedPlace, mockedTVal, expected) => {
-        const name = Helpers.getVisitedPlaceName(mockedT, visitedPlace, interviewAttributesForTestCases);
+        const name = Helpers.getVisitedPlaceName({ t: mockedT, visitedPlace, interview: interviewAttributesForTestCases });
         if (mockedTVal) {
             expect(mockedT).toHaveBeenCalledWith(mockedTVal);
         } else {
@@ -960,7 +960,7 @@ describe('getVisitedPlaceGeography', () => {
             null
         ]
     ]).test('%s', (_title, visitedPlace, expected) => {
-        const geography = Helpers.getVisitedPlaceGeography(visitedPlace, interviewAttributesForTestCases);
+        const geography = Helpers.getVisitedPlaceGeography({ visitedPlace, interview: interviewAttributesForTestCases });
         if (expected) {
             expect(geography).toEqual(expected);
         } else {
@@ -989,35 +989,35 @@ describe('getTrips', () => {
     }
 
     test('object: test without segments', () => {
-        expect(Helpers.getSegments(trip)).toEqual({});
+        expect(Helpers.getSegments({ trip })).toEqual({});
     });
 
     test('object: empty segments', () => {
         const attributes = _cloneDeep(trip);
         attributes.segments = { };
-        expect(Helpers.getSegments(attributes)).toEqual({});
+        expect(Helpers.getSegments({ trip: attributes })).toEqual({});
     });
 
     test('object: with segments', () => {
         const attributes = _cloneDeep(trip);
         attributes.segments = segments;
-        expect(Helpers.getSegments(attributes)).toEqual(segments);
+        expect(Helpers.getSegments({ trip: attributes })).toEqual(segments);
     });
 
     test('array: test without segments', () => {
-        expect(Helpers.getSegmentsArray(trip)).toEqual([]);
+        expect(Helpers.getSegmentsArray({ trip })).toEqual([]);
     });
 
     test('array: empty segments', () => {
         const attributes = _cloneDeep(trip);
         attributes.segments = { };
-        expect(Helpers.getSegmentsArray(attributes)).toEqual([]);
+        expect(Helpers.getSegmentsArray({ trip: attributes })).toEqual([]);
     });
 
     test('array: with segments, ordered', () => {
         const attributes = _cloneDeep(trip);
         attributes.segments = segments;
-        expect(Helpers.getSegmentsArray(attributes)).toEqual([segments.segment2, segments.segment1]);
+        expect(Helpers.getSegmentsArray({ trip: attributes })).toEqual([segments.segment2, segments.segment1]);
     });
 
 });

--- a/packages/evolution-common/src/utils/helpers.ts
+++ b/packages/evolution-common/src/utils/helpers.ts
@@ -371,10 +371,9 @@ export const setResponse = (
  *
  * @param interview The interview object
  * @returns The household object
- * @deprecated use {@link odSurveyHelpers.getHousehold} instead, this is just an
- * alias
+ * @deprecated use {@link odSurveyHelpers.getHousehold} instead
  */
-export const getHousehold = odSurveyHelpers.getHousehold;
+export const getHousehold = (interview) => odSurveyHelpers.getHousehold({ interview });
 
 /**
  * Get the currently active person, as defined in the interview responses. If
@@ -384,10 +383,9 @@ export const getHousehold = odSurveyHelpers.getHousehold;
  *
  * @param interview The interview object
  * @returns The current person object
- * @deprecated use {@link odSurveyHelpers.getActivePerson} instead. This is
- * just an alias
+ * @deprecated use {@link odSurveyHelpers.getActivePerson} instead
  */
-export const getCurrentPerson = odSurveyHelpers.getActivePerson;
+export const getCurrentPerson = (interview) => odSurveyHelpers.getActivePerson({ interview });
 
 /**
  * Get a validation value value for a specific path in the interview
@@ -469,24 +467,24 @@ export const isPhoneNumber = (maybeNumber: string) => {
 };
 
 /**
- * @deprecated Use {@link odSurveyHelpers.getPersons} instead, this is just an alias
+ * @deprecated Use {@link odSurveyHelpers.getPersons} instead
  * */
-export const getPersons = odSurveyHelpers.getPersons;
+export const getPersons = (interview) => odSurveyHelpers.getPersons({ interview });
 
 /**
- * @deprecated Use {@link odSurveyHelpers.getPersonsArray} instead, this is just an alias
+ * @deprecated Use {@link odSurveyHelpers.getPersonsArray} instead
  */
-export const getPersonsArray = odSurveyHelpers.getPersonsArray;
+export const getPersonsArray = (interview) => odSurveyHelpers.getPersonsArray({ interview });
 
 /**
- * @deprecated Use {@link odSurveyHelpers.getVisitedPlaces} instead, this is just an alias
+ * @deprecated Use {@link odSurveyHelpers.getVisitedPlaces} instead
  */
-export const getVisitedPlaces = odSurveyHelpers.getVisitedPlaces;
+export const getVisitedPlaces = (journey) => odSurveyHelpers.getVisitedPlaces({ journey });
 
 /**
- * @deprecated Use {@link odSurveyHelpers.getVisitedPlacesArray} instead, this is just an alias
+ * @deprecated Use {@link odSurveyHelpers.getVisitedPlacesArray} instead
  */
-export const getVisitedPlacesArray = odSurveyHelpers.getVisitedPlacesArray;
+export const getVisitedPlacesArray = (journey) => odSurveyHelpers.getVisitedPlacesArray({ journey });
 
 /**
  * Replace visited places that are shortcuts to the given location by the data
@@ -494,9 +492,10 @@ export const getVisitedPlacesArray = odSurveyHelpers.getVisitedPlacesArray;
  * use the first place as new shortcut
  * @param interview The interview
  * @param visitedPlacesPath The path of the visited place to replace
- * @deprecated Use {@link odSurveyHelpers.replaceVisitedPlaceShortcuts} instead, this is just an alias
+ * @deprecated Use {@link odSurveyHelpers.replaceVisitedPlaceShortcuts} instead
  */
-export const replaceVisitedPlaceShortcuts = odSurveyHelpers.replaceVisitedPlaceShortcuts;
+export const replaceVisitedPlaceShortcuts = (interview, visitedPlacesPath) =>
+    odSurveyHelpers.replaceVisitedPlaceShortcuts({ interview, shortcutTo: visitedPlacesPath });
 
 const startDateGreaterEqual = (startDate: number | undefined, compare: string | undefined): boolean | null => {
     const interviewStart = startDate ? moment.unix(startDate) : undefined;

--- a/packages/evolution-legacy/src/helpers/survey/helper.js
+++ b/packages/evolution-legacy/src/helpers/survey/helper.js
@@ -224,7 +224,7 @@ const getSegments = function(trip, asArray = true) {
   return asArray ? [] : {};
 };
 
-const getPersons = (interview, asArray = false) => asArray ? odSurveyHelper.getPersonsArray(interview) : odSurveyHelper.getPersons(interview);
+const getPersons = (interview, asArray = false) => asArray ? odSurveyHelper.getPersonsArray({interview}) : odSurveyHelper.getPersons({interview});
 
 const countPersons = function(interview)
 {
@@ -234,8 +234,8 @@ const countPersons = function(interview)
 
 const getVisitedPlaces = (person, asArray = true) => {
     // get the first journey for the person
-    var journey = odSurveyHelper.getJourneysArray(person)[0];
-    return asArray ? odSurveyHelper.getVisitedPlacesArray(journey) : odSurveyHelper.getVisitedPlaces(journey);
+    var journey = odSurveyHelper.getJourneysArray({person})[0];
+    return asArray ? odSurveyHelper.getVisitedPlacesArray({journey}) : odSurveyHelper.getVisitedPlaces({journey});
 }
 
 const getTrips = function(journey, asArray = true)
@@ -577,7 +577,7 @@ export default {
   {
     person       = person || getPerson(interview);
     // get the first journey for the person
-    var journey = odSurveyHelper.getJourneysArray(person)[0];
+    var journey = odSurveyHelper.getJourneysArray({person})[0];
     const trips = journey.trips;
     const activeTripId = surveyHelperNew.getResponse(interview, '_activeTripId', null);
     return activeTripId ? trips[activeTripId] : null;


### PR DESCRIPTION
fixes #603

All new OD survey helpers take an object as argument, instead of positioned ones. This will ensure uniformity, as some helpers to come will have more arguments. It also simplifies specifying optional arguments.

The helper functions that were aliases to the OD survey ones keep their previous signature, to reduce breaking changes as these can possibly be used by [un-tested/any-typed] surveys.