### PR TITLE
Remove the transition on InputRange

### DIFF
--- a/packages/evolution-legacy/src/styles/survey/_question.scss
+++ b/packages/evolution-legacy/src/styles/survey/_question.scss
@@ -398,6 +398,11 @@ label strong, .apptr__form__label-standalone strong {
   margin: 0 auto;
 }
 
+// Slider container
+.input-range__slider-container {
+  transition: none; // Do not use transition or the slider will be very slow
+}
+
 .input-range__label-container {
   font-weight: 500;
   left: 0;


### PR DESCRIPTION
# Pull request
For: https://github.com/chairemobilite/od_mj_2023/issues/271

Note: I initially thought I needed to improve the performance of the InputRange, but then I discovered there was a hidden CSS transition of 0.3 seconds, so I was able to resolve the issue with just 1 line of code!

## Description
Remove the transition on InputRange so the slider is not slow anymore.

## Videos
Before:
[bug-range-input-firefox.webm](https://github.com/chairemobilite/od_mj_2023/assets/78976679/76991fff-df4b-4a44-8b6a-4a58621e6a7e)

After:
[Screencast from 2024-07-22 11:35:46 AM.webm](https://github.com/user-attachments/assets/e0aa3af5-d085-4255-995f-01fba30dec96)



