### PR TITLE
Generator: Remove invalid error in generate_UI_tests

### DIFF
--- a/packages/evolution-generator/src/scripts/generate_UI_tests.py
+++ b/packages/evolution-generator/src/scripts/generate_UI_tests.py
@@ -103,10 +103,6 @@ def generate_UI_tests(input_file: str, output_file: str):
             conditional = row_dict["conditional"]
             choices = row_dict["choices"]
 
-            # Check if the row is valid
-            if question_name is None or input_type is None or path is None:
-                raise Exception("Invalid row data in Widgets sheet")
-
             # Check if we've moved to a new section
             if section != current_section:
                 current_section = section  # Update the current section tracker


### PR DESCRIPTION
# Pull request

## Justification
I think this was a bad idea, to have an error if the questionName, path, or inputType is None. For example, we don't always have the path for Custom inputType, so it's better to still generate the template-tests-UI.ts even without that. I cannot use this script in MJ without this pull request.

## Description
Remove invalid error in generate_UI_tests. 