### PR TITLE
config: Type the Evolution-specific configuration options

### DIFF
--- a/packages/evolution-common/src/config/__tests__/project.config.initialized.test.ts
+++ b/packages/evolution-common/src/config/__tests__/project.config.initialized.test.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import projectConfig from "../project.config";
+
+// Mock the project config from evolution-common, which might already have been
+// loaded before the first import to the evolution project config. The
+// configuration should not be overwritten
+jest.mock('chaire-lib-common/lib/config/shared/project.config', () => ({
+    ...jest.requireActual('chaire-lib-common/lib/config/shared/project.config'),
+    __esModule: true,
+    default: {
+        region: 'FR',
+        selfResponseMinimumAge: 18,
+        logDatabaseUpdates: true
+    }
+}));
+
+test('test initialized values', () => {
+    expect(projectConfig).toEqual(expect.objectContaining({
+        region: 'FR',
+        selfResponseMinimumAge: 18,
+        logDatabaseUpdates: true
+    }));
+});

--- a/packages/evolution-common/src/config/__tests__/project.config.test.ts
+++ b/packages/evolution-common/src/config/__tests__/project.config.test.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import projectConfig from "../project.config";
+
+test('test default values', () => {
+    expect(projectConfig).toEqual(expect.objectContaining({
+        region: 'CA',
+        selfResponseMinimumAge: 14,
+        logDatabaseUpdates: false
+    }));
+});

--- a/packages/evolution-common/src/config/project.config.ts
+++ b/packages/evolution-common/src/config/project.config.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import projectConfig, {
+    ProjectConfiguration,
+    setProjectConfiguration
+} from 'chaire-lib-common/lib/config/shared/project.config';
+
+/**
+ * Specific configuration for the Evolution project
+ */
+export type EvolutionProjectConfiguration = {
+    /** Used for Google Maps localization. See
+     * https://developers.google.com/maps/coverage for possible region codes */
+    region: string;
+    /** Whether to log database updates. FIXME This should be server-side only
+     * */
+    logDatabaseUpdates: boolean;
+    /** Age for self response. For household surveys, it is the age from which
+     * respondents will be invited to complete their own trips. Defaults to 14
+     * */
+    selfResponseMinimumAge: number;
+    // TODO Add more project configuration types
+};
+
+// Make sure default values are set
+setProjectConfiguration<EvolutionProjectConfiguration>(
+    Object.assign(
+        {
+            region: 'CA',
+            logDatabaseUpdates: false,
+            selfResponseMinimumAge: 14
+        },
+        projectConfig
+    )
+);
+
+export default projectConfig as ProjectConfiguration<EvolutionProjectConfiguration>;

--- a/packages/evolution-common/src/services/odSurvey/helpers.ts
+++ b/packages/evolution-common/src/services/odSurvey/helpers.ts
@@ -17,7 +17,7 @@ import {
     VisitedPlace
 } from '../interviews/interview';
 import { TFunction } from 'i18next';
-import config from 'chaire-lib-common/lib/config/shared/project.config';
+import config from '../../config/project.config';
 
 // This file contains helper function that retrieves various data from the
 // responses field of the interview
@@ -27,10 +27,6 @@ import config from 'chaire-lib-common/lib/config/shared/project.config';
 // stabilized and are ready to be used during the survey
 
 // Person and household related functions
-
-// Age for self response. It can be configured ine the survey's configuration by setting the `selfResponseMinimumAge` property
-// TODO Type and document this configuration property
-const selfResponseAge = config.selfResponseMinimumAge || 14;
 
 /**
  * Get a person by its ID or the currently actively person if no ID is specified
@@ -151,7 +147,7 @@ export const isSelfDeclared = ({
     person: Person;
 }): boolean => {
     const persons: any = getPersonsArray({ interview });
-    const personsCanSelfRespond = persons.filter((p: Person) => p.age && p.age >= selfResponseAge);
+    const personsCanSelfRespond = persons.filter((p: Person) => p.age && p.age >= config.selfResponseMinimumAge);
     return (
         (personsCanSelfRespond.length === 1 && person._uuid === personsCanSelfRespond[0]._uuid) ||
         (!_isBlank(person.whoWillAnswerForThisPerson) ? person.whoWillAnswerForThisPerson === person._uuid : false)

--- a/packages/evolution-frontend/src/components/inputs/InputMapPoint.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputMapPoint.tsx
@@ -10,7 +10,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faMapMarkerAlt } from '@fortawesome/free-solid-svg-icons/faMapMarkerAlt';
 
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
-import projectConfig from 'chaire-lib-common/lib/config/shared/project.config';
+import projectConfig from 'evolution-common/lib/config/project.config';
 import { InputMapPointType } from 'evolution-common/lib/services/widgets';
 import * as surveyHelper from 'evolution-common/lib/utils/helpers';
 import { WithTranslation, withTranslation } from 'react-i18next';


### PR DESCRIPTION
Add a file in evolution-common, `project.config.ts`, which extends chaire-lib's project configuration types.

Start documenting a few of the evolution project's configuration property and set default values for them.

Import this new project.config file instead of the chaire-lib's one, to be able to call directly the typed properties.