### PR TITLE
Routing: use transition public API for routing in surveys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,12 @@ PHOTON_OSM_SEARCH_API_URL=PHOTONOSMSEARCHAPIURL
 #SSL_PRIVATE_KEY=/path/to/privkey.pem
 #SSL_CERT=/path/to/sslcert.pem
 
+# Set the 3 following variables to be able to route with the Transition public
+# API, with data from a specific Transition instance
+#TRANSITION_API_URL=http://transition.example.org
+#TRANSITION_API_USERNAME=
+#TRANSITION_API_PASSWORD=
+
 ##############################################################
 # Mailing configuration, required for sending emails to users
 # strategy can be 'smtp' or 'sendmail'

--- a/packages/evolution-backend/src/config/__tests__/projectConfig.test.ts
+++ b/packages/evolution-backend/src/config/__tests__/projectConfig.test.ts
@@ -7,11 +7,6 @@
 import { InterviewListAttributes, InterviewStatusAttributesBase } from 'evolution-common/lib/services/interviews/interview';
 import projectConfig, { defaultConfig, setProjectConfig } from '../projectConfig';
 
-type CustomSurvey = {
-    accessCode?: string;
-    foo?: string;
-}
-
 const interview: InterviewListAttributes = {
     id: 1,
     uuid: 'arbitrary',
@@ -93,4 +88,78 @@ describe('Validation List Filter', () => {
         });
     })
 });
+
+describe('Transition API configuration', () => {
+
+    beforeEach(() => {
+        // Undefine all environment variables and transitionApi config
+        delete process.env.TRANSITION_API_URL;
+        delete process.env.TRANSITION_API_USERNAME;
+        delete process.env.TRANSITION_API_PASSWORD;
+        projectConfig.transitionApi = undefined;
+    });
+
+    test('Default value should not be set', () => {
+        setProjectConfig({
+            // Nothing to set
+        });
+        expect(projectConfig.transitionApi).toBeUndefined();
+    });
+
+    test('Should use environment variables if set', () => {
+        process.env.TRANSITION_API_URL = 'https://transition.from.env';
+        process.env.TRANSITION_API_USERNAME = 'username.env';
+        process.env.TRANSITION_API_PASSWORD = 'password.env';
+        setProjectConfig({
+            // Nothing to set
+        });
+        expect(projectConfig.transitionApi).toEqual({
+            url: 'https://transition.from.env',
+            username: 'username.env',
+            password: 'password.env'
+        });
+    });
+
+    test('Missing password, should not be set', () => {
+        process.env.TRANSITION_API_URL = 'https://transition.from.env';
+        process.env.TRANSITION_API_USERNAME = 'username.env';
+        setProjectConfig({
+            // Nothing to set
+        });
+        expect(projectConfig.transitionApi).toBeUndefined()
+    });
+
+    test('Should use the values specified in the config if set', () => {
+        setProjectConfig({
+            transitionApi: {
+                url: 'http://transition',
+                username: 'user',
+                password: 'password'
+            }
+        });
+        expect(projectConfig.transitionApi).toEqual({
+            url: 'http://transition',
+            username: 'user',
+            password: 'password'
+        });
+    });
+
+    test('Should use values in config if both environment and config set', () => {
+        process.env.TRANSITION_API_URL = 'https://transition.from.env';
+        process.env.TRANSITION_API_USERNAME = 'username.env';
+        process.env.TRANSITION_API_PASSWORD = 'password.env';
+        setProjectConfig({
+            transitionApi: {
+                url: 'http://transition',
+                username: 'user',
+                password: 'password'
+            }
+        });
+        expect(projectConfig.transitionApi).toEqual({
+            url: 'http://transition',
+            username: 'user',
+            password: 'password'
+        });
+    });
+})
 

--- a/packages/evolution-backend/src/config/projectConfig.ts
+++ b/packages/evolution-backend/src/config/projectConfig.ts
@@ -28,6 +28,28 @@ interface ProjectServerConfig {
      * individual audits. It is optional. If the survey does not require auditing, just leave blank.
      */
     auditInterview?: (attributes: InterviewAttributes) => Promise<SurveyObjectsWithAudits>;
+    /**
+     * Configuration of a Transition instance for route calculations. If not
+     * set, route calculations will not use the Transition public API for
+     * eventual route calculations.
+     */
+    transitionApi?: {
+        /**
+         * URL for the Transition API. Can be set by setting the
+         * TRANSITION_API_URL environment variable
+         */
+        url: string;
+        /**
+         * Username for the Transition API. Can be set by setting the
+         * TRANSITION_API_USERNAME environment variable
+         */
+        username: string;
+        /**
+         * Password for the Transition API. Can be set by setting the
+         * TRANSITION_API_PASSWORD environment variable
+         */
+        password: string;
+    };
 }
 
 export const defaultConfig: ProjectServerConfig = {
@@ -80,6 +102,22 @@ const projectConfig = Object.assign({}, defaultConfig);
  * @param config The project specific configuration elements
  */
 export const setProjectConfig = (config: Partial<ProjectServerConfig>) => {
+    // Try to set the transition API object from the environment variables.
+    // FIXME For now, it is either set in the config or in the environment
+    // variables. Consider a mix to support for example url in config and
+    // credentials in env.
+    if (!config.transitionApi) {
+        const transitionUrl = process.env.TRANSITION_API_URL;
+        const transitionUsername = process.env.TRANSITION_API_USERNAME;
+        const transitionPassword = process.env.TRANSITION_API_PASSWORD;
+        if (transitionUrl && transitionUsername && transitionPassword) {
+            config.transitionApi = {
+                url: transitionUrl,
+                username: transitionUsername,
+                password: transitionPassword
+            };
+        }
+    }
     Object.assign(projectConfig, config);
 };
 

--- a/packages/evolution-backend/src/services/routing/RouteCalculationFromTransition.ts
+++ b/packages/evolution-backend/src/services/routing/RouteCalculationFromTransition.ts
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+// This file contains route calculation utilities that can be used by the
+// survey. The should call chaire-lib's routing services to calculate the route.
+import { RoutingOrTransitMode } from 'chaire-lib-common/lib/config/routingModes';
+import { RouteCalculationParameter, RoutingTimeDistanceResultByMode } from './types';
+import projectConfig from '../../config/projectConfig';
+import { URL } from 'url';
+
+// A name for this calculation source
+const CALCULATION_SOURCE = 'transitionApi';
+
+// Cache the authentication token, as global variable for this file
+// FIXME Consider using a class to encapsulate the token and calculation method
+// TODO Handle token expiration. For now though, the evolution app will restart more often than the token expiration
+let token: string | undefined = undefined;
+
+const getTransitionUrl = (transitionUrl: string) =>
+    new URL(transitionUrl.startsWith('http') ? transitionUrl : `http://${transitionUrl}`);
+
+const getToken = async () => {
+    if (token !== undefined) {
+        return token;
+    }
+
+    const transitionUrlObj = getTransitionUrl(projectConfig.transitionApi!.url);
+    transitionUrlObj.pathname = '/token';
+    const response = await fetch(transitionUrlObj.toString(), {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+            usernameOrEmail: projectConfig.transitionApi!.username,
+            password: projectConfig.transitionApi!.password
+        })
+    });
+
+    // FIXME Every request will try to get a token, even if the previous one
+    // failed. Should we cache the error and not retry? Or retry only after x
+    // time, possibly using an exponential backoff?
+    if (response.status !== 200) {
+        throw new Error(`Cannot get token from transition: ${response.status}`);
+    }
+
+    const tokenResponse = await response.text();
+    token = tokenResponse;
+    return token;
+};
+
+/**
+ * Calculate the routes for a list of modes
+ * @param modes The list of modes to calculate the routes for
+ * @param parameters The parameters for the route calculation
+ * @param withGeojson Whether to include the GeoJSON in the response
+ */
+export default async (
+    modes: RoutingOrTransitMode[],
+    parameters: RouteCalculationParameter
+): Promise<RoutingTimeDistanceResultByMode> => {
+    const transitionUrl = projectConfig.transitionApi?.url;
+    if (transitionUrl === undefined) {
+        throw new Error('Transition URL not set in project config');
+    }
+
+    const transitionUrlObj = getTransitionUrl(transitionUrl);
+    transitionUrlObj.pathname = '/api/v1/route';
+    transitionUrlObj.searchParams.append('withGeojson', 'false');
+
+    try {
+        const response = await fetch(transitionUrlObj.toString(), {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${await getToken()}`
+            },
+            body: JSON.stringify({
+                routingModes: modes,
+                originGeojson: parameters.origin,
+                destinationGeojson: parameters.destination,
+                departureTimeSecondsSinceMidnight: parameters.departureSecondsSinceMidnight,
+                scenarioId: parameters.transitScenario
+            })
+        });
+
+        if (response.status !== 200) {
+            throw new Error(`Unsuccessful response code from transition: ${response.status}`);
+        }
+        const routingResponse = await response.json();
+        const routingResultsByMode: RoutingTimeDistanceResultByMode = {};
+        modes.forEach((mode) => {
+            const routingForMode = routingResponse.result[mode];
+
+            routingResultsByMode[mode] =
+                routingForMode === undefined || routingForMode.paths === undefined || routingForMode.paths.length === 0
+                    ? {
+                        status: 'no_routing_found',
+                        source: CALCULATION_SOURCE
+                    }
+                    : {
+                        status: 'success',
+                        source: CALCULATION_SOURCE,
+                        distanceM:
+                              mode === 'transit'
+                                  ? routingForMode.paths[0].totalDistance
+                                  : routingForMode.paths[0].distanceMeters,
+                        travelTimeS:
+                              mode === 'transit'
+                                  ? routingForMode.paths[0].totalTravelTime
+                                  : routingForMode.paths[0].travelTimeSeconds
+                    };
+        });
+        return routingResultsByMode;
+    } catch (error) {
+        console.error('Error fetching transition route', error);
+        const routingResultsByMode: RoutingTimeDistanceResultByMode = {};
+        modes.forEach((mode) => {
+            routingResultsByMode[mode] = {
+                status: 'error',
+                error: String(error),
+                source: CALCULATION_SOURCE
+            };
+        });
+        return routingResultsByMode;
+    }
+};

--- a/packages/evolution-backend/src/services/routing/__tests__/RouteCalculation.test.ts
+++ b/packages/evolution-backend/src/services/routing/__tests__/RouteCalculation.test.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { calculateTimeDistanceByMode } from '../';
+import each from 'jest-each';
+import routeFromTransition from '../RouteCalculationFromTransition';
+import projectConfig from '../../../config/projectConfig';
+
+jest.mock('../RouteCalculationFromTransition', () => jest.fn());
+const mockedRouteFromTransition = routeFromTransition as jest.MockedFunction<typeof routeFromTransition>;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+})
+
+describe('calculateTimeDistanceByMode: invalid parameters', () => {
+
+    each([
+        ['Invalid origin', 'origin', { type: 'LineString' as const, coordinates: [[0, 0], [1, 1]] }, 'Invalid origin or destination'],
+        ['Invalid destination', 'destination', { type: 'LineString' as const, coordinates: [[0, 0], [1, 1]] }, 'Invalid origin or destination'],
+        ['Negative trip time', 'departureSecondsSinceMidnight', -1, 'Invalid departure time'],
+        ['Mixed day/month in date', 'departureDateString', '2024-23-05', 'Invalid trip date'],
+        ['Invalid date string', 'departureDateString', 'not a date', 'Invalid trip date'],
+    ]).test('Invalid parameters: %s', async (_, testedParam, value, expected) => {
+        const validParameters = {
+            origin: { type: 'Point' as const, coordinates: [0, 0] },
+            destination: { type: 'Point' as const, coordinates: [0, 0] },
+            departureSecondsSinceMidnight: 10000,
+            departureDateString: '2024-05-23'
+        };
+        const parameters = { ...validParameters, [testedParam]: value };
+        await expect(calculateTimeDistanceByMode(['walking'], parameters)).rejects.toThrow(expected);
+    });
+
+    test('No scenario, but transit requested', async () => {
+        const validParameters = {
+            origin: { type: 'Point' as const, coordinates: [0, 0] },
+            destination: { type: 'Point' as const, coordinates: [0, 0] },
+            departureSecondsSinceMidnight: 10000,
+            departureDateString: '2024-05-23'
+        };
+        await expect(calculateTimeDistanceByMode(['walking', 'transit'], validParameters)).rejects.toThrow('Transit mode requested without a scenario');
+    });
+
+});
+
+describe('calculateTimeDistanceByMode with Transition', () => {
+    projectConfig.transitionApi = {
+        url: 'http://transition',
+        username: 'user',
+        password: 'password'
+    };
+
+    test('Throw an error', async () => {
+        const validParameters = {
+            origin: { type: 'Point' as const, coordinates: [0, 0] },
+            destination: { type: 'Point' as const, coordinates: [0, 0] },
+            departureSecondsSinceMidnight: 10000,
+            departureDateString: '2024-05-23'
+        };
+        mockedRouteFromTransition.mockRejectedValueOnce(new Error('Transition URL not set in project config'));
+        await expect(calculateTimeDistanceByMode(['walking'], validParameters)).rejects.toThrow('Transition URL not set in project config');
+        expect(mockedRouteFromTransition).toHaveBeenCalledTimes(1);
+        expect(mockedRouteFromTransition).toHaveBeenCalledWith(['walking'], validParameters);
+    });
+
+    test('Return calculation results', async () => {
+        const validParameters = {
+            origin: { type: 'Point' as const, coordinates: [0, 0] },
+            destination: { type: 'Point' as const, coordinates: [0, 0] },
+            departureSecondsSinceMidnight: 10000,
+            departureDateString: '2024-05-23'
+        };
+        const routingResults = {
+            walking: { status: 'success' as const, distanceM: 1000, travelTimeS: 600, source: 'transitionApi' }
+        }
+        mockedRouteFromTransition.mockResolvedValueOnce(routingResults);
+        const result = await calculateTimeDistanceByMode(['walking'], validParameters);
+        expect(mockedRouteFromTransition).toHaveBeenCalledTimes(1);
+        expect(mockedRouteFromTransition).toHaveBeenCalledWith(['walking'], validParameters);
+        expect(result).toEqual(routingResults);
+    });
+
+});
+
+test('calculateTimeDistanceByMode no method', async () => {
+    projectConfig.transitionApi = undefined;
+
+    const validParameters = {
+        origin: { type: 'Point' as const, coordinates: [0, 0] },
+        destination: { type: 'Point' as const, coordinates: [0, 0] },
+        departureSecondsSinceMidnight: 10000,
+        departureDateString: '2024-05-23'
+    };
+    await expect(calculateTimeDistanceByMode(['walking'], validParameters)).rejects.toThrow('No routing method available');
+    expect(mockedRouteFromTransition).not.toHaveBeenCalled();
+});

--- a/packages/evolution-backend/src/services/routing/__tests__/RouteCalculationFromTransition.test.ts
+++ b/packages/evolution-backend/src/services/routing/__tests__/RouteCalculationFromTransition.test.ts
@@ -1,0 +1,321 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import route from '../RouteCalculationFromTransition';
+import fetchMock from 'jest-fetch-mock';
+import projectConfig from '../../../config/projectConfig';
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    // Default value for transition URL
+    projectConfig.transitionApi = {
+        url: 'https://transition.url',
+        username: 'username',
+        password: 'password'
+    };
+});
+
+const bearerToken = 'tokenDataFromTransition';
+
+test('Get bearer token once', async () => {
+    // This first should call the token endpoint first and it will be set for the next calls
+    const params = {
+        origin: {
+            type: 'Point' as const,
+            coordinates: [0, 0]
+        },
+        destination: {
+            type: 'Point' as const,
+            coordinates: [1, 1]
+        },
+        departureSecondsSinceMidnight: 0,
+        departureDateString: '2022-01-01'
+    }
+    const defaultResponse = {
+        result: {
+            'walking': {
+                paths: [{
+                    distanceMeters: 100,
+                    travelTimeSeconds: 120
+                }]
+            }
+        }
+    }
+    
+    fetchMock.mockResponseOnce(bearerToken);
+    fetchMock.mockResponseOnce(JSON.stringify(defaultResponse));
+    await route(['walking'], params);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledWith(
+        'https://transition.url/token', 
+        expect.objectContaining({
+            method: 'POST',
+            body: JSON.stringify({ usernameOrEmail: 'username', password: 'password' })
+        })
+    );
+    expect(fetchMock).toHaveBeenCalledWith('https://transition.url/api/v1/route?withGeojson=false', expect.objectContaining({ 
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${bearerToken}`
+        }
+    }));
+});
+
+describe('Test various values for the Transition URL', () => {
+    const params = {
+        origin: {
+            type: 'Point' as const,
+            coordinates: [0, 0]
+        },
+        destination: {
+            type: 'Point' as const,
+            coordinates: [1, 1]
+        },
+        departureSecondsSinceMidnight: 0,
+        departureDateString: '2022-01-01'
+    }
+    const defaultResponse = {
+        result: {
+            'walking': {
+                paths: [{
+                    distanceMeters: 100,
+                    travelTimeSeconds: 120
+                }]
+            }
+        }
+    }
+
+    test('Undefined URL', async () => {
+        projectConfig.transitionApi = undefined;
+        await expect(route(['walking'], params))
+            .rejects
+            .toThrow('Transition URL not set in project config');
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    test('Complete URL', async () => {
+        projectConfig.transitionApi!.url = 'https://transition.url';
+        fetchMock.mockResponseOnce(JSON.stringify(defaultResponse));
+        await route(['walking'], params);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledWith('https://transition.url/api/v1/route?withGeojson=false', expect.objectContaining({ method: 'POST' }));
+
+    });
+
+    test('No HTTP', async () => {
+        projectConfig.transitionApi!.url = 'transition.url';
+        fetchMock.mockResponseOnce(JSON.stringify(defaultResponse));
+        await route(['walking'], params);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledWith('http://transition.url/api/v1/route?withGeojson=false', expect.objectContaining({ method: 'POST' }));
+    });
+
+    test('With port', async () => {
+        projectConfig.transitionApi!.url = 'https://localhost:8080';
+        fetchMock.mockResponseOnce(JSON.stringify(defaultResponse));
+        await route(['walking'], params);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledWith('https://localhost:8080/api/v1/route?withGeojson=false', expect.objectContaining({ method: 'POST' }));
+    });
+});
+
+describe('Test various Transition calls', () => {
+    const params = {
+        origin: {
+            type: 'Point' as const,
+            coordinates: [0, 0]
+        },
+        destination: {
+            type: 'Point' as const,
+            coordinates: [1, 1]
+        },
+        departureSecondsSinceMidnight: 0,
+        departureDateString: '2022-01-01'
+    }
+
+    test('fetch failing', async () => {
+        fetchMock.mockRejectedValueOnce(new Error('Failed to fetch'));
+        const result = await route(['walking'], params);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledWith(
+            'https://transition.url/api/v1/route?withGeojson=false',
+            expect.objectContaining({ 
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: `Bearer ${bearerToken}`
+                },
+                body: JSON.stringify({
+                    routingModes: ['walking'],
+                    originGeojson: params.origin,
+                    destinationGeojson: params.destination,
+                    departureTimeSecondsSinceMidnight: 0,
+                    scenarioId: undefined
+                })
+            })
+        );
+        expect(result).toEqual({
+            walking: { status: 'error', error: 'Error: Failed to fetch', source: 'transitionApi' }
+        });
+    });
+
+    test('Bad request response', async () => {
+        const badRequestMessage = 'Some parameter error';
+        fetchMock.mockResponseOnce(JSON.stringify(badRequestMessage), { status: 400 });
+        const result = await route(['walking'], params);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledWith(
+            'https://transition.url/api/v1/route?withGeojson=false',
+            expect.objectContaining({ 
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: `Bearer ${bearerToken}`
+                },
+                body: JSON.stringify({
+                    routingModes: ['walking'],
+                    originGeojson: params.origin,
+                    destinationGeojson: params.destination,
+                    departureTimeSecondsSinceMidnight: 0,
+                    scenarioId: undefined
+                })
+            })
+        );
+        expect(result).toEqual({
+            walking: { status: 'error', error: `Error: Unsuccessful response code from transition: 400`, source: 'transitionApi' }
+        });
+    });
+
+    test('Server error response', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify({}), { status: 500 });
+        const result = await route(['walking'], params);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledWith(
+            'https://transition.url/api/v1/route?withGeojson=false',
+            expect.objectContaining({ 
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: `Bearer ${bearerToken}`
+                },
+                body: JSON.stringify({
+                    routingModes: ['walking'],
+                    originGeojson: params.origin,
+                    destinationGeojson: params.destination,
+                    departureTimeSecondsSinceMidnight: 0,
+                    scenarioId: undefined
+                })
+            })
+        );
+        expect(result).toEqual({
+            walking: { status: 'error', error: `Error: Unsuccessful response code from transition: 500`, source: 'transitionApi' }
+        });
+    });
+
+    test('Correct response, but somes modes unresponded', async () => {
+        const response = {
+            result: {
+                'walking': {
+                    paths: [{
+                        distanceMeters: 100,
+                        travelTimeSeconds: 120
+                    }]
+                },
+                'cycling': {
+                    paths: [{
+                        distanceMeters: 105,
+                        travelTimeSeconds: 60
+                    }]
+                }
+            }
+        }
+
+        fetchMock.mockResponseOnce(JSON.stringify(response));
+        const result = await route(['walking', 'transit', 'cycling'], params);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledWith(
+            'https://transition.url/api/v1/route?withGeojson=false',
+            expect.objectContaining({ 
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: `Bearer ${bearerToken}`
+                },
+                body: JSON.stringify({
+                    routingModes: ['walking', 'transit', 'cycling'],
+                    originGeojson: params.origin,
+                    destinationGeojson: params.destination,
+                    departureTimeSecondsSinceMidnight: 0,
+                    scenarioId: undefined
+                })
+            })
+        );
+        expect(result).toEqual({
+            walking: { status: 'success', distanceM: 100, travelTimeS: 120, geojson: undefined, source: 'transitionApi' },
+            cycling: { status: 'success', distanceM: 105, travelTimeS: 60, geojson: undefined, source: 'transitionApi' },
+            transit: { status: 'no_routing_found', source: 'transitionApi' }
+        });
+    });
+
+    test('Correct and complete response', async () => {
+        const response = {
+            result: {
+                walking: {
+                    paths: [{
+                        distanceMeters: 100,
+                        travelTimeSeconds: 120
+                    }]
+                },
+                cycling: {
+                    paths: [{
+                        distanceMeters: 105,
+                        travelTimeSeconds: 60
+                    }]
+                },
+                transit: {
+                    paths: [{
+                        totalTravelTime: 300,
+                        totalDistance: 200,
+                        departureTime: 5
+                    }]
+                },
+                driving: {
+                    paths: []
+                }
+            }
+        }
+
+        fetchMock.mockResponseOnce(JSON.stringify(response));
+        const result = await route(['walking', 'transit', 'cycling', 'driving'], params);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledWith(
+            'https://transition.url/api/v1/route?withGeojson=false',
+            expect.objectContaining({ 
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: `Bearer ${bearerToken}`
+                },
+                body: JSON.stringify({
+                    routingModes: ['walking', 'transit', 'cycling', 'driving'],
+                    originGeojson: params.origin,
+                    destinationGeojson: params.destination,
+                    departureTimeSecondsSinceMidnight: 0,
+                    scenarioId: undefined
+                })
+            })
+        );
+        expect(result).toEqual({
+            walking: { status: 'success', distanceM: 100, travelTimeS: 120, source: 'transitionApi' },
+            cycling: { status: 'success', distanceM: 105, travelTimeS: 60, source: 'transitionApi' },
+            transit: { status: 'success', distanceM: 200, travelTimeS: 300, source: 'transitionApi' },
+            driving: { status: 'no_routing_found', source: 'transitionApi' }
+        });
+    });
+
+});
+

--- a/packages/evolution-backend/src/services/routing/index.ts
+++ b/packages/evolution-backend/src/services/routing/index.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+// This file contains route calculation utilities that can be used by the
+// survey.
+import moment from 'moment';
+import { RoutingOrTransitMode } from 'chaire-lib-common/lib/config/routingModes';
+import { getPointCoordinates } from 'chaire-lib-common/lib/services/geodata/GeoJSONUtils';
+import { RouteCalculationParameter, RoutingTimeDistanceResultByMode } from './types';
+import projectConfig from '../../config/projectConfig';
+import routeWithTransitionApi from './RouteCalculationFromTransition';
+
+/**
+ * Calculate the times and distances between 2 points for a list of modes
+ * @param modes The list of modes to calculate the routes for
+ * @param parameters The parameters for the route calculation
+ */
+export const calculateTimeDistanceByMode = async function (
+    modes: RoutingOrTransitMode[],
+    parameters: RouteCalculationParameter
+): Promise<RoutingTimeDistanceResultByMode> {
+    // Validate parameters first
+    const originCoordinates = getPointCoordinates(parameters.origin);
+    const destinationCoordinates = getPointCoordinates(parameters.destination);
+
+    if (!originCoordinates || !destinationCoordinates) {
+        throw new Error('Invalid origin or destination');
+    }
+    // Departure time since midnight should be between 0 and 28 hours, not 24 as
+    // transit days can be longer and it will be useful to determine the
+    // scenario to use
+    if (parameters.departureSecondsSinceMidnight < 0 || parameters.departureSecondsSinceMidnight >= 28 * 3600) {
+        throw new Error('Invalid departure time');
+    }
+    const tripDateMoment = moment(parameters.departureDateString, 'YYYY-MM-DD');
+    if (!tripDateMoment.isValid()) {
+        throw new Error('Invalid trip date');
+    }
+
+    if (modes.includes('transit') && parameters.transitScenario === undefined) {
+        throw new Error('Transit mode requested without a scenario');
+    }
+
+    // All parameters are valid, dispatch to the proper routing function. Only
+    // supporting transition public API for now, but we could have more
+    // eventually
+    if (projectConfig.transitionApi !== undefined) {
+        return routeWithTransitionApi(modes, parameters);
+    }
+    // TODO Implement other routing methods
+    // FIXME Should we fallback to turf and bird distance, with default speeds by mode if no routing found for a given mode?
+    throw new Error('No routing method available');
+};

--- a/packages/evolution-backend/src/services/routing/types.ts
+++ b/packages/evolution-backend/src/services/routing/types.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { RoutingOrTransitMode } from 'chaire-lib-common/lib/config/routingModes';
+
+export type RouteCalculationParameter = {
+    /**
+     * The origin of the route to calculate
+     */
+    origin: GeoJSON.Point | GeoJSON.Feature<GeoJSON.Point>;
+    /**
+     * The destination of the route to calculate
+     */
+    destination: GeoJSON.Point | GeoJSON.Feature<GeoJSON.Point>;
+    /**
+     * The time of the trip, in seconds since midnight
+     */
+    departureSecondsSinceMidnight: number;
+    /**
+     * The date of the trip, in the format 'YYYY-MM-DD'
+     */
+    departureDateString: string;
+    /**
+     * If `transit` mode is requested, the scenario to use for calculations
+     */
+    transitScenario?: string;
+};
+
+type RoutingTimeDistanceResult = {
+    // The source of the routing calculation. Can be used to identify the method
+    // called for this calculation
+    source: string;
+} & (
+    | {
+          status: 'no_routing_found';
+      }
+    | {
+          status: 'error';
+          error: string;
+      }
+    | {
+          status: 'success';
+          distanceM: number;
+          travelTimeS: number;
+      }
+);
+
+export type RoutingTimeDistanceResultByMode = {
+    [mode in RoutingOrTransitMode]?: RoutingTimeDistanceResult;
+};


### PR DESCRIPTION
This adds a function that requests route calculations from the Transition public API

It also adds a routing-function agnostic function that surveys can use for calculation.

Transiton URL and username/password can be set in the survey configuration at application startup.