### PR TITLE
Fix testing issue with google maps not being loaded.

### DIFF
--- a/packages/evolution-frontend/src/components/inputs/InputMapFindPlace.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputMapFindPlace.tsx
@@ -50,6 +50,7 @@ interface InputMapFindPlaceState {
      * need to match a map (for instance Google) */
     geocodingSpecificOptions: { [key: string]: unknown };
     displayMessage?: string;
+    renderGeoCodeButton: boolean;
 }
 
 /**
@@ -95,7 +96,8 @@ export class InputMapFindPlace extends React.Component<
             defaultCenter,
             places: [],
             searchPlaceButtonWasMouseDowned: false,
-            geocodingSpecificOptions: {}
+            geocodingSpecificOptions: {},
+            renderGeoCodeButton: false
         };
     }
 
@@ -155,6 +157,9 @@ export class InputMapFindPlace extends React.Component<
         /*if (!this.props.value) { // does not work because map is not yet loaded at this point
             this.geocodePlaces(bbox);
         }*/
+
+        // Do not render button until map is ready, to prevent flakiness when a test clicks the button too quickly.
+        this.setState({renderGeoCodeButton: true});
     };
 
     onBoundsChanged = (bbox?: [number, number, number, number]) => {
@@ -452,6 +457,7 @@ export class InputMapFindPlace extends React.Component<
                             onMouseUp={this.onSearchPlaceButtonMouseUp}
                             onKeyDown={this.onSearchPlaceButtonKeyDown}
                             ref={this.geocodeButtonRef}
+                            style={{display: this.state.renderGeoCodeButton ? 'inline' : 'none'}}
                         >
                             <FontAwesomeIcon icon={faMapMarkerAlt} className="faIconLeft" />
                             {surveyHelper.translateString(

--- a/packages/evolution-frontend/src/components/inputs/InputMapPoint.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputMapPoint.tsx
@@ -33,6 +33,7 @@ interface InputMapPointState {
     currentBounds?: [number, number, number, number];
     markers: MarkerData[];
     displayMessage?: string;
+    renderGeoCodeButton: boolean;
 }
 
 /**
@@ -72,6 +73,7 @@ export class InputMapPoint extends React.Component<InputMapPointProps & WithTran
         this.state = {
             defaultCenter,
             currentBounds: undefined,
+            renderGeoCodeButton: false,
             markers: this.props.value
                 ? [
                     {
@@ -103,7 +105,8 @@ export class InputMapPoint extends React.Component<InputMapPointProps & WithTran
     };
 
     onMapReady = (bbox?: [number, number, number, number]) => {
-        this.setState({ currentBounds: bbox });
+        // Do not render button until map is ready, to prevent flakiness when a test clicks the button too quickly.
+        this.setState({ currentBounds: bbox, renderGeoCodeButton: true });
         if (!this.props.value) {
             this.geocodeAddress(bbox);
         }
@@ -168,6 +171,7 @@ export class InputMapPoint extends React.Component<InputMapPointProps & WithTran
                         className="button refresh-geocode green large"
                         onClick={this.onGeocodeAddress}
                         ref={this.geocodeButtonRef}
+                        style={{display: this.state.renderGeoCodeButton ? 'inline' : 'none'}}
                     >
                         <FontAwesomeIcon icon={faMapMarkerAlt} className="faIconLeft" />
                         {surveyHelper.translateString(

--- a/packages/evolution-frontend/src/components/inputs/__tests__/__snapshots__/InputMapFindPlace.test.tsx.snap
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/__snapshots__/InputMapFindPlace.test.tsx.snap
@@ -27,6 +27,11 @@ exports[`Render InputMapPoint with various parameters Test with all parameters 1
       onKeyDown={[Function]}
       onMouseDown={[Function]}
       onMouseUp={[Function]}
+      style={
+        {
+          "display": "none",
+        }
+      }
       type="button"
     >
       <svg

--- a/packages/evolution-frontend/src/components/inputs/__tests__/__snapshots__/InputMapPoint.test.tsx.snap
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/__snapshots__/InputMapPoint.test.tsx.snap
@@ -15,6 +15,11 @@ exports[`Render InputMapPoint with various parameters Test with all parameters 1
     className="button refresh-geocode green large"
     id="test_refresh"
     onClick={[Function]}
+    style={
+      {
+        "display": "none",
+      }
+    }
     type="button"
   >
     <svg


### PR DESCRIPTION
Geocoder button will not render until the google map is finished loading, avoiding issues on some playwright tests where the button will be clicked too quickly on faster machines.

Fix: #621