### PR TITLE
mapFindPlace: Allow multiple geocoding query string and zooms

### DIFF
--- a/packages/evolution-common/src/services/widgets/WidgetConfig.ts
+++ b/packages/evolution-common/src/services/widgets/WidgetConfig.ts
@@ -206,7 +206,7 @@ export type InputDatePickerType = {
 
 type InputMapType = {
     defaultCenter: { lat: number; lon: number };
-    geocodingQueryString?: ParsingFunction<string | undefined>;
+    geocodingQueryString?: ParsingFunction<string | { queryString: string; zoom: number }[] | undefined>;
     refreshGeocodingLabel?: I18nData;
     afterRefreshButtonText?: I18nData;
     icon?: IconData;

--- a/packages/evolution-frontend/src/components/inputs/InputMapPoint.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputMapPoint.tsx
@@ -22,6 +22,10 @@ import InputMapGoogle from './maps/google/InputMapGoogle';
 import { geocodeSinglePoint } from './maps/google/GoogleGeocoder';
 import SurveyErrorMessage from '../survey/widgets/SurveyErrorMessage';
 
+// Default max zoom and zoom
+const defaultZoom = 13;
+const defaultMaxZoom = 18;
+
 export type InputMapPointProps = CommonInputProps & {
     value?: GeoJSON.Feature<GeoJSON.Point, FeatureGeocodedProperties>;
     inputRef?: React.LegacyRef<HTMLInputElement>;
@@ -129,9 +133,14 @@ export class InputMapPoint extends React.Component<InputMapPointProps & WithTran
 
     geocodeAddress = async (bbox?: [number, number, number, number]) => {
         const geocodingQueryString = this.getGeocodingQueryString();
-        if (geocodingQueryString) {
+        const geocodingQueryStringArray =
+            typeof geocodingQueryString === 'string'
+                ? [{ queryString: geocodingQueryString, zoom: defaultZoom }]
+                : geocodingQueryString;
+        if (geocodingQueryStringArray) {
             try {
-                const feature = await geocodeSinglePoint(geocodingQueryString, { bbox });
+                // FIXME We may want to adapt this to support multiple geocoding queries, like in the inputMapFindPlace widget
+                const feature = await geocodeSinglePoint(geocodingQueryStringArray[0].queryString, { bbox });
                 this.onValueChange(feature);
                 this.setState({ displayMessage: feature === undefined ? 'main:InputMapGeocodeNoResult' : undefined });
             } catch (error) {
@@ -142,7 +151,7 @@ export class InputMapPoint extends React.Component<InputMapPointProps & WithTran
     };
 
     render() {
-        const maxZoom = this.props.widgetConfig.maxZoom || 18;
+        const maxZoom = this.props.widgetConfig.maxZoom || defaultMaxZoom;
 
         const showSearchPlaceButton = this.props.widgetConfig.showSearchPlaceButton
             ? surveyHelper.parseBoolean(
@@ -191,7 +200,7 @@ export class InputMapPoint extends React.Component<InputMapPointProps & WithTran
                         defaultCenter={this.state.defaultCenter}
                         value={this.props.value}
                         onValueChange={this.onValueChange}
-                        defaultZoom={Math.min(this.props.widgetConfig.defaultZoom || 16, maxZoom)}
+                        defaultZoom={Math.min(this.props.widgetConfig.defaultZoom || defaultZoom, maxZoom)}
                         markers={this.state.markers}
                         onMapReady={this.onMapReady}
                         onBoundsChanged={this.onBoundsChanged}

--- a/packages/evolution-frontend/src/components/inputs/maps/google/InputMapGoogle.tsx
+++ b/packages/evolution-frontend/src/components/inputs/maps/google/InputMapGoogle.tsx
@@ -135,6 +135,15 @@ const InputMapGoogle: React.FunctionComponent<InputGoogleMapPointProps & WithTra
     }, [props.defaultCenter]);
 
     React.useEffect(() => {
+        if (!map || !props.defaultZoom) return;
+        // If the zoom is changed, we need to zoom to that level
+        const currentZoom = (map as google.maps.Map).getZoom();
+        if (currentZoom !== props.defaultZoom) {
+            (map as google.maps.Map).setZoom(props.defaultZoom);
+        }
+    }, [props.defaultZoom]);
+
+    React.useEffect(() => {
         if (map && props.markers.length >= 1) {
             const maxMapBounds = new google.maps.LatLngBounds();
             if (props.maxGeocodingResultsBounds !== undefined) {

--- a/packages/evolution-generator/src/types/inputTypes.ts
+++ b/packages/evolution-generator/src/types/inputTypes.ts
@@ -287,6 +287,7 @@ export type InputMapFindPlaceBase = {
     showSearchPlaceButton: (interview, path) => boolean;
     afterRefreshButtonText: TextKey;
     validations?: Validations;
+    invalidGeocodingResultTypes?: string[];
 };
 export type InputMapFindPlace = InputMapFindPlaceBase & {
     path: Path;


### PR DESCRIPTION
fixes #665

The `geocodingQueryString` function now returns either a string or an array of objects containing a `queryString` and a `zoom`. The first object is geocoded and if results are returned, they are used and the map zooms at the specified level. If no results are returned, the next query string object is geolocated, etc.