### PR TITLE
db: fix sequential tests

### DIFF
--- a/packages/evolution-backend/src/models/__tests__/interviews.db.test.ts
+++ b/packages/evolution-backend/src/models/__tests__/interviews.db.test.ts
@@ -758,25 +758,19 @@ describe('Queries with audits', () => {
             person: [
                 {
                     key: 'errorOne',
-                    cnt: '6',
-                    level: 'error',
-                    object_type: 'person'
+                    cnt: '6'
                 }
             ],
             interview: [
                 {
                     key: 'errorThree',
-                    cnt: '1',
-                    level: 'error',
-                    object_type: 'interview'
+                    cnt: '1'
                 }
             ],
             household: [
                 {
                     key: 'errorTwo',
-                    cnt: '1',
-                    level: 'error',
-                    object_type: 'household'
+                    cnt: '1'
                 }
             ]
         });
@@ -789,17 +783,13 @@ describe('Queries with audits', () => {
             person: [
                 {
                     key: 'errorOne',
-                    cnt: '3',
-                    level: 'error',
-                    object_type: 'person'
+                    cnt: '3'
                 }
             ],
             household: [
                 {
                     key: 'errorTwo',
-                    cnt: '1',
-                    level: 'error',
-                    object_type: 'household'
+                    cnt: '1'
                 }
             ]
         });


### PR DESCRIPTION
The level and objects are keys of the returned object and not returned as fields in the response.