### PR TITLE
Add a message when no auth method is there on the login page

### DIFF
--- a/locales/en/auth.json
+++ b/locales/en/auth.json
@@ -52,6 +52,7 @@
   "CheckMagicEmail": "Connection information has been sent to the email address you requested. If you do not see it, make sure it is not in the spam.",
   "UsePasswordLessAuthMethod": "Use authentication by email link",
   "UseLocalLoginAuthMethod": "Use authentication with password",
+  "UseNoLoginAuthMethod": "Currently, the only login method is through invitation. No other log in options are available at this time.",
   "WhyLoginInfo": "",
   "AnonymousLoginExplanation": "You will not be able to continue an incomplete survey if your session expires or if you change browsers.",
   "AuthAnonymousTitle": "Anonymously",

--- a/locales/fr/auth.json
+++ b/locales/fr/auth.json
@@ -52,6 +52,7 @@
   "CheckMagicEmail": "Les informations de connexion ont été envoyées à l'adresse courriel que vous avez entrée. Si vous ne les recevez pas, vérifiez vos pourriels.",
   "UsePasswordLessAuthMethod": "Utiliser l'authentification par lien courriel",
   "UseLocalLoginAuthMethod": "Utiliser l'authentification avec mot de passe",
+  "UseNoLoginAuthMethod": "Actuellement, la seule méthode de connexion est via une invitation. Aucune autre option de connexion n'est disponible pour le moment.",
   "WhyLoginInfo": "",
   "AnonymousLoginExplanation": "Vous ne pourrez continuer une entrevue incomplète si votre session expire ou si vous changez de navigateur.",
   "AuthAnonymousTitle": "Anonymement",

--- a/packages/evolution-frontend/src/components/pages/auth/AuthPageHOC.tsx
+++ b/packages/evolution-frontend/src/components/pages/auth/AuthPageHOC.tsx
@@ -72,6 +72,30 @@ const authPageHOC = <P extends AuthPageProps & WithTranslation>(WrappedComponent
             setCurrentAuthMethod(authMethod);
         };
 
+        // Check if there are no auth methods except directToken
+        const hasNoAuthMethodsExeptDirectToken = React.useMemo(() => {
+            // Check if there are no auth methods
+            const hasNoAuthMethods = authMethods?.length === 0;
+
+            // Check if there are no auth methods in the config
+            const hasNoConfigAuth = !Object.entries(config?.auth || {}).some(([key, value]) => {
+                // Handle key separately
+                if (key === 'directToken') {
+                    // 'directToken' is not considered a login method with a widget, so return false
+                    return false;
+                } else if (key === 'passwordless') {
+                    // 'passwordless' is considered a login method with a widget, so return true
+                    return true;
+                } else {
+                    // For other keys like 'anonymous', 'google', 'facebook', etc., check if the value is true
+                    return value === true;
+                }
+            });
+
+            // Make sure that there are no auth methods and no auth methods in the config
+            return hasNoAuthMethods && hasNoConfigAuth;
+        }, [authMethods, config.auth]); // Update when authMethods or config.auth change
+
         const { isAuthenticated, ...restProps } = props;
 
         return (
@@ -101,6 +125,11 @@ const authPageHOC = <P extends AuthPageProps & WithTranslation>(WrappedComponent
                                 isAuthenticated={isAuthenticated}
                             />
                             <div className="apptr__separator"></div>
+                            {/* Show a message only if there are no login methods available */}
+                            {hasNoAuthMethodsExeptDirectToken && (
+                                <div>{props.t(['survey:auth:UseNoLoginAuthMethod', 'auth:UseNoLoginAuthMethod'])}</div>
+                            )}
+
                             {currentAuthMethod !== 'passwordless' && authMethods.includes('passwordless') && (
                                 <div>
                                     <a


### PR DESCRIPTION
# Pull request

## Description
Add a message when no auth method is there on the login page 
Note: We add this message for surveys that can only be authenficate with an access token from an invitation, for example with Leo panel.

## Screenshot
Login page
![image](https://github.com/user-attachments/assets/ad0efa98-f5b1-4667-a3d2-8368177f3bed)
