### PR TITLE
admin: Fix the validation link callbacks

### DIFF
--- a/packages/evolution-frontend/src/actions/utils/WidgetOperation.ts
+++ b/packages/evolution-frontend/src/actions/utils/WidgetOperation.ts
@@ -357,7 +357,12 @@ export const prepareWidgets = function (
     const sectionWidgets = sectionConfig.widgets;
 
     if (sectionWidgets === undefined) {
-        return [interview, {}, false, false];
+        // FIXME Previously this code path was returning empty valuesByPath, but
+        // when in the validationOnePager section, there may not be widgets
+        // defined, but we want to keep the valuesByPath to update validity or
+        // completion.  Why was it returning empty valuesByPath instead of the
+        // original? See if it should be `valuesByPath` instead.
+        return [interview, sectionShortname === 'validationOnePager' ? valuesByPath : {}, false, false];
     }
     const widgetPrepData = {
         affectedPaths,

--- a/packages/evolution-legacy/src/components/admin/validation/InterviewSummary.js
+++ b/packages/evolution-legacy/src/components/admin/validation/InterviewSummary.js
@@ -26,7 +26,7 @@ class InterviewSummary extends React.Component {
     }
   }
 
-  refreshInterview() {
+  refreshInterview = () => {
     // FIXME was previously this line, but we are not using the interview from the global state, so we may just call the summary change again
     this.props.startSetValidateInterview(this.props.interview.uuid, (interview) => {
       this.setState({ loaded: true })
@@ -34,26 +34,26 @@ class InterviewSummary extends React.Component {
     this.props.handleInterviewSummaryChange(this.props.interview.uuid);
   }
 
-  resetInterview() {
+  resetInterview = () => {
     this.props.startResetValidateInterview(this.props.interview.uuid, (interview) => {
       this.props.handleInterviewSummaryChange(interview.uuid);
     });
   }
 
-  componentDidMount() {
+  componentDidMount = () => {
     this.refreshInterview();
 
     //this.forceUpdate();
   }
 
-  updateValuesByPath(valuesByPath, e) {
+  updateValuesByPath = (valuesByPath, e) => {
     if (e && e.preventDefault) {
         e.preventDefault();
     }
     this.props.startUpdateInterview(null, valuesByPath);
   }
 
-  render(){
+  render = () => {
 
     if (!(this.props.interview && this.state.loaded)) {
       surveyHelperNew.devLog('%c rendering empty survey', 'background: rgba(0,0,0,0.1);');


### PR DESCRIPTION
Return valuesByPath in widget preparation if there is no widget, but the section is validationOnePager

Use arrow functions in InterviewSummary, since it is javascript and not typescript.