### PR TITLE
Improve postal code verification.

### DIFF
--- a/example/demo_survey/src/survey/widgets/home.tsx
+++ b/example/demo_survey/src/survey/widgets/home.tsx
@@ -480,7 +480,11 @@ export const homePostalCode = {
         }
       },
       {
-        validation: !(/^[GHJKghjk][0-9][A-Za-z]( )?[0-9][A-Za-z][0-9]\s*$/).test(value),
+        // To be valid in Canada, the postal code cannot have the letters D, F, I, O, Q, or U.
+        // Here, we also use G, H, J, or K in the first letter to only accept Quebec and Eastern Ontario.
+        // See: https://en.wikipedia.org/wiki/Postal_codes_in_Canada#Number_of_possible_postal_codes and https://www150.statcan.gc.ca/n1/pub/92-153-g/2011002/tech-eng.htm
+        // TODO: Instead of directly writing the validation, make a function that takes the country/region as input and returns the right regex.
+        validation: !/^[ghjk][0-9][abceghj-nprstv-z]( )?[0-9][abceghj-nprstv-z][0-9]\s*$/i.test(value),
         errorMessage: {
           fr: `Le code postal est invalide. Vous devez résider au Québec pour compléter ce questionnaire`,
           en: `Postal code is invalid. You need to live in Quebec to fill this questionnaire.`

--- a/example/demo_survey/tests/test-input-validation.UI.spec.ts
+++ b/example/demo_survey/tests/test-input-validation.UI.spec.ts
@@ -25,15 +25,17 @@ surveyTestHelpers.startAndLoginAnonymously({ context, title: 'Démo', hasUser: t
 
 // Test the home page
 testHelpers.tryToContinueWithInvalidInputs({ context, text: 'Save and continue', currentPageUrl: '/survey/home' , nextPageUrl: '/survey/householdMembers' });
-testHelpers.inputInvalidStringValueTest({ context, path: 'household.carNumber', value: '14' });
-testHelpers.inputInvalidStringValueTest({ context, path: 'home.postalCode', value: 'H1S1V77' });
-testHelpers.inputInvalidStringValueTest({ context, path: 'home.postalCode', value: 'H1S1V' });
-testHelpers.inputInvalidStringValueTest({ context, path: 'home.postalCode', value: '1H1S7V' });
+testHelpers.inputStringInvalidValueTest({ context, path: 'household.carNumber', value: '14' });
+testHelpers.inputStringInvalidValueTest({ context, path: 'home.postalCode', value: 'H1S1V77' });
+testHelpers.inputStringInvalidValueTest({ context, path: 'home.postalCode', value: 'H1S1V' });
+testHelpers.inputStringInvalidValueTest({ context, path: 'home.postalCode', value: '1H1S7V' });
+testHelpers.inputStringInvalidValueTest({ context, path: 'home.postalCode', value: 'A1S1V7' });
+testHelpers.inputStringInvalidValueTest({ context, path: 'home.postalCode', value: 'H1D1F7' });
 
 onePersonTestHelpers.completeHomePage(context);
 
 // Test the household page
-testHelpers.inputInvalidStringTypeTest({ context, path: 'household.persons.${personId[0]}.age', value: testHelpers.nonNumericString });
+testHelpers.inputStringInvalidTypeTest({ context, path: 'household.persons.${personId[0]}.age', value: testHelpers.nonNumericString });
 testHelpers.inputStringTest({ context, path: 'household.persons.${personId[0]}.age', value: '15' });
 testHelpers.tryToContinueWithPopup({ context, text: 'Save and continue', currentPageUrl: '/survey/householdMembers' , nextPageUrl: '/survey/profile' });
 testHelpers.inputStringTest({ context, path: 'household.persons.${personId[0]}.age', value: '30' });

--- a/packages/evolution-generator/src/common/validations.tsx
+++ b/packages/evolution-generator/src/common/validations.tsx
@@ -259,7 +259,10 @@ export const postalCodeValidation: Validations = (value) => {
             }
         },
         {
-            validation: !/^[A-Za-z][0-9][A-Za-z]( )?[0-9][A-Za-z][0-9]\s*$/.test(String(value)),
+            // To be valid in Canada, the postal code cannot have the letters D, F, I, O, Q, or U. It also cannot have W or Z in the first character.
+            // See: https://en.wikipedia.org/wiki/Postal_codes_in_Canada#Number_of_possible_postal_codes
+            // TODO: Instead of directly writing the validation, make a function that takes the country/region as input and returns the right regex.
+            validation: !/^[abceghj-nprstvxy][0-9][abceghj-nprstv-z]( )?[0-9][abceghj-nprstv-z][0-9]\s*$/i.test(String(value)),
             errorMessage: {
                 fr: 'Le code postal est invalide. Vous devez résider au Canada pour compléter ce questionnaire.',
                 en: 'Postal code is invalid. You must live in Canada to fill this questionnaire.'


### PR DESCRIPTION
Change the regex for the postal code validation so that it doesn't accept letters not valid for canadian codes.
Also adds the case insensitive flag to shorten the regex and not repeat letters with different cases. 
Adds some more tests for the postal code to the input validation test. 
Fix: #663