### PR TITLE
Add summary call using the Transition API

### DIFF
--- a/packages/evolution-backend/src/services/routing/RouteCalculationFromTransition.ts
+++ b/packages/evolution-backend/src/services/routing/RouteCalculationFromTransition.ts
@@ -59,7 +59,7 @@ const getToken = async () => {
  * @param parameters The parameters for the route calculation
  * @param withGeojson Whether to include the GeoJSON in the response
  */
-export default async (
+export const getTimeAndDistanceFromTransitionApi = async (
     modes: RoutingOrTransitMode[],
     parameters: RouteCalculationParameter
 ): Promise<RoutingTimeDistanceResultByMode> => {

--- a/packages/evolution-backend/src/services/routing/__tests__/RouteCalculation.test.ts
+++ b/packages/evolution-backend/src/services/routing/__tests__/RouteCalculation.test.ts
@@ -7,11 +7,13 @@
 
 import { calculateTimeDistanceByMode } from '../';
 import each from 'jest-each';
-import routeFromTransition from '../RouteCalculationFromTransition';
+import { getTimeAndDistanceFromTransitionApi } from '../RouteCalculationFromTransition';
 import projectConfig from '../../../config/projectConfig';
 
-jest.mock('../RouteCalculationFromTransition', () => jest.fn());
-const mockedRouteFromTransition = routeFromTransition as jest.MockedFunction<typeof routeFromTransition>;
+jest.mock('../RouteCalculationFromTransition', () => ({
+    getTimeAndDistanceFromTransitionApi: jest.fn()
+}));
+const mockedRouteFromTransition = getTimeAndDistanceFromTransitionApi as jest.MockedFunction<typeof getTimeAndDistanceFromTransitionApi>;
 
 beforeEach(() => {
     jest.clearAllMocks();

--- a/packages/evolution-backend/src/services/routing/__tests__/RouteCalculationFromTransition.test.ts
+++ b/packages/evolution-backend/src/services/routing/__tests__/RouteCalculationFromTransition.test.ts
@@ -4,7 +4,7 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import route from '../RouteCalculationFromTransition';
+import { getTimeAndDistanceFromTransitionApi } from '../RouteCalculationFromTransition';
 import fetchMock from 'jest-fetch-mock';
 import projectConfig from '../../../config/projectConfig';
 
@@ -47,7 +47,7 @@ test('Get bearer token once', async () => {
     
     fetchMock.mockResponseOnce(bearerToken);
     fetchMock.mockResponseOnce(JSON.stringify(defaultResponse));
-    await route(['walking'], params);
+    await getTimeAndDistanceFromTransitionApi(['walking'], params);
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(fetchMock).toHaveBeenCalledWith(
         'https://transition.url/token', 
@@ -91,7 +91,7 @@ describe('Test various values for the Transition URL', () => {
 
     test('Undefined URL', async () => {
         projectConfig.transitionApi = undefined;
-        await expect(route(['walking'], params))
+        await expect(getTimeAndDistanceFromTransitionApi(['walking'], params))
             .rejects
             .toThrow('Transition URL not set in project config');
         expect(fetchMock).not.toHaveBeenCalled();
@@ -100,7 +100,7 @@ describe('Test various values for the Transition URL', () => {
     test('Complete URL', async () => {
         projectConfig.transitionApi!.url = 'https://transition.url';
         fetchMock.mockResponseOnce(JSON.stringify(defaultResponse));
-        await route(['walking'], params);
+        await getTimeAndDistanceFromTransitionApi(['walking'], params);
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(fetchMock).toHaveBeenCalledWith('https://transition.url/api/v1/route?withGeojson=false', expect.objectContaining({ method: 'POST' }));
 
@@ -109,7 +109,7 @@ describe('Test various values for the Transition URL', () => {
     test('No HTTP', async () => {
         projectConfig.transitionApi!.url = 'transition.url';
         fetchMock.mockResponseOnce(JSON.stringify(defaultResponse));
-        await route(['walking'], params);
+        await getTimeAndDistanceFromTransitionApi(['walking'], params);
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(fetchMock).toHaveBeenCalledWith('http://transition.url/api/v1/route?withGeojson=false', expect.objectContaining({ method: 'POST' }));
     });
@@ -117,7 +117,7 @@ describe('Test various values for the Transition URL', () => {
     test('With port', async () => {
         projectConfig.transitionApi!.url = 'https://localhost:8080';
         fetchMock.mockResponseOnce(JSON.stringify(defaultResponse));
-        await route(['walking'], params);
+        await getTimeAndDistanceFromTransitionApi(['walking'], params);
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(fetchMock).toHaveBeenCalledWith('https://localhost:8080/api/v1/route?withGeojson=false', expect.objectContaining({ method: 'POST' }));
     });
@@ -139,7 +139,7 @@ describe('Test various Transition calls', () => {
 
     test('fetch failing', async () => {
         fetchMock.mockRejectedValueOnce(new Error('Failed to fetch'));
-        const result = await route(['walking'], params);
+        const result = await getTimeAndDistanceFromTransitionApi(['walking'], params);
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(fetchMock).toHaveBeenCalledWith(
             'https://transition.url/api/v1/route?withGeojson=false',
@@ -166,7 +166,7 @@ describe('Test various Transition calls', () => {
     test('Bad request response', async () => {
         const badRequestMessage = 'Some parameter error';
         fetchMock.mockResponseOnce(JSON.stringify(badRequestMessage), { status: 400 });
-        const result = await route(['walking'], params);
+        const result = await getTimeAndDistanceFromTransitionApi(['walking'], params);
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(fetchMock).toHaveBeenCalledWith(
             'https://transition.url/api/v1/route?withGeojson=false',
@@ -192,7 +192,7 @@ describe('Test various Transition calls', () => {
 
     test('Server error response', async () => {
         fetchMock.mockResponseOnce(JSON.stringify({}), { status: 500 });
-        const result = await route(['walking'], params);
+        const result = await getTimeAndDistanceFromTransitionApi(['walking'], params);
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(fetchMock).toHaveBeenCalledWith(
             'https://transition.url/api/v1/route?withGeojson=false',
@@ -235,7 +235,7 @@ describe('Test various Transition calls', () => {
         }
 
         fetchMock.mockResponseOnce(JSON.stringify(response));
-        const result = await route(['walking', 'transit', 'cycling'], params);
+        const result = await getTimeAndDistanceFromTransitionApi(['walking', 'transit', 'cycling'], params);
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(fetchMock).toHaveBeenCalledWith(
             'https://transition.url/api/v1/route?withGeojson=false',
@@ -290,7 +290,7 @@ describe('Test various Transition calls', () => {
         }
 
         fetchMock.mockResponseOnce(JSON.stringify(response));
-        const result = await route(['walking', 'transit', 'cycling', 'driving'], params);
+        const result = await getTimeAndDistanceFromTransitionApi(['walking', 'transit', 'cycling', 'driving'], params);
         expect(fetchMock).toHaveBeenCalledTimes(1);
         expect(fetchMock).toHaveBeenCalledWith(
             'https://transition.url/api/v1/route?withGeojson=false',

--- a/packages/evolution-backend/src/services/routing/index.ts
+++ b/packages/evolution-backend/src/services/routing/index.ts
@@ -12,7 +12,7 @@ import { RoutingOrTransitMode } from 'chaire-lib-common/lib/config/routingModes'
 import { getPointCoordinates } from 'chaire-lib-common/lib/services/geodata/GeoJSONUtils';
 import { RouteCalculationParameter, RoutingTimeDistanceResultByMode } from './types';
 import projectConfig from '../../config/projectConfig';
-import routeWithTransitionApi from './RouteCalculationFromTransition';
+import { getTimeAndDistanceFromTransitionApi } from './RouteCalculationFromTransition';
 
 /**
  * Calculate the times and distances between 2 points for a list of modes
@@ -49,7 +49,7 @@ export const calculateTimeDistanceByMode = async function (
     // supporting transition public API for now, but we could have more
     // eventually
     if (projectConfig.transitionApi !== undefined) {
-        return routeWithTransitionApi(modes, parameters);
+        return getTimeAndDistanceFromTransitionApi(modes, parameters);
     }
     // TODO Implement other routing methods
     // FIXME Should we fallback to turf and bird distance, with default speeds by mode if no routing found for a given mode?

--- a/packages/evolution-backend/src/services/routing/types.ts
+++ b/packages/evolution-backend/src/services/routing/types.ts
@@ -5,6 +5,7 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import { RoutingOrTransitMode } from 'chaire-lib-common/lib/config/routingModes';
+import { SummaryResponse, SummarySuccessResult } from 'chaire-lib-common/lib/api/TrRouting/trRoutingApiV2';
 
 export type RouteCalculationParameter = {
     /**
@@ -51,3 +52,22 @@ type RoutingTimeDistanceResult = {
 export type RoutingTimeDistanceResultByMode = {
     [mode in RoutingOrTransitMode]?: RoutingTimeDistanceResult;
 };
+
+export type SummaryResult = {
+    // The source of the summary calculation. Can be used to identify the method
+    // called for this calculation
+    source: string;
+} & (
+    | {
+          status: 'no_routing_found';
+      }
+    | {
+          status: 'error';
+          error: string;
+      }
+    | {
+          status: 'success';
+          nbRoutes: number;
+          lines: SummarySuccessResult['result']['lines'];
+      }
+);


### PR DESCRIPTION
Renamed the default export for the time and distance from transition API to `getTimeAndDistanceFromTransitionApi`

Add a function to call the transition API's summary endpoint to retrieve summary for a trip

Expose this method as a `getTransitSummary` function in evolution-backend's `routing` service.