### PR TITLE
admin: Fix the validation links state when updated

### DIFF
--- a/packages/evolution-backend/src/api/survey.validation.routes.ts
+++ b/packages/evolution-backend/src/api/survey.validation.routes.ts
@@ -170,32 +170,6 @@ router.post('/validationList', async (req, res) => {
     }
 });
 
-router.get('/interviewSummary/:interviewUuid', async (req: Request, res: Response) => {
-    if (req.params.interviewUuid) {
-        try {
-            const response = await Interviews.getAllMatching({
-                pageIndex: 0,
-                pageSize: -1,
-                filter: { uuid: req.params.interviewUuid }
-            });
-            if (response.interviews.length === 1) {
-                return res.status(200).json({
-                    status: 'success',
-                    interview: response.interviews[0]
-                });
-            } else {
-                console.log('Not found, got response', response);
-                return res.status(404).json({ status: 'failed', interview: null });
-            }
-        } catch (error) {
-            console.error(`Error getting interview summary: ${error}`);
-            return res.status(500).json({ status: 'failed', interview: null, error: 'cannot fetch interview' });
-        }
-    } else {
-        return res.status(500).json({ status: 'failed', interview: null, error: 'wrong interview id' });
-    }
-});
-
 router.post('/validation/auditStats', async (req: Request, res: Response) => {
     try {
         const { ...filters } = req.body;

--- a/packages/evolution-frontend/src/components/pageParts/validations/InterviewList.tsx
+++ b/packages/evolution-frontend/src/components/pageParts/validations/InterviewList.tsx
@@ -17,6 +17,7 @@ import { faFolder } from '@fortawesome/free-solid-svg-icons/faFolder';
 import { faSortAmountDown } from '@fortawesome/free-solid-svg-icons/faSortAmountDown';
 import { faSortAmountDownAlt } from '@fortawesome/free-solid-svg-icons/faSortAmountDownAlt';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 
 interface UsersTableProps extends WithTranslation {
     columns: any[];
@@ -87,7 +88,7 @@ const InterviewList = (props: UsersTableProps) => {
             style={{
                 flexDirection: 'row',
                 flex: '0 0 auto',
-                display: props.showInterviewList || props.validationInterview === null ? 'block' : 'none'
+                display: props.showInterviewList || _isBlank(props.validationInterview) ? 'block' : 'none'
             }}
         >
             {props.validationInterview !== null && (

--- a/packages/evolution-legacy/src/actions/survey/survey.js
+++ b/packages/evolution-legacy/src/actions/survey/survey.js
@@ -420,6 +420,7 @@ export const startUpdateSurveyValidateInterview = function(sectionShortname, val
   };
 };
 
+// TODO: The difference with `startUpdateSurveyValidateInterview` is the sectionShortname that is here forced to validationOnePageSummary. These 2 functions should be merged.
 export const startUpdateValidateInterview = function(sectionShortname, valuesByPath = null, unsetPaths = null, interview = null, callback) {
   return {
     queue: 'UPDATE_INTERVIEW',

--- a/packages/evolution-legacy/src/components/admin/validation/InterviewSummary.js
+++ b/packages/evolution-legacy/src/components/admin/validation/InterviewSummary.js
@@ -21,29 +21,14 @@ class InterviewSummary extends React.Component {
   constructor(props) {
     super(props);
 
-    this.state = {
-      loaded: false
-    }
   }
 
   refreshInterview = () => {
-    // FIXME was previously this line, but we are not using the interview from the global state, so we may just call the summary change again
-    this.props.startSetValidateInterview(this.props.interview.uuid, (interview) => {
-      this.setState({ loaded: true })
-    });
-    this.props.handleInterviewSummaryChange(this.props.interview.uuid);
+    this.props.startSetValidateInterview(this.props.interview.uuid)
   }
 
   resetInterview = () => {
-    this.props.startResetValidateInterview(this.props.interview.uuid, (interview) => {
-      this.props.handleInterviewSummaryChange(interview.uuid);
-    });
-  }
-
-  componentDidMount = () => {
-    this.refreshInterview();
-
-    //this.forceUpdate();
+    this.props.startResetValidateInterview(this.props.interview.uuid);
   }
 
   updateValuesByPath = (valuesByPath, e) => {
@@ -54,8 +39,7 @@ class InterviewSummary extends React.Component {
   }
 
   render = () => {
-
-    if (!(this.props.interview && this.state.loaded)) {
+    if (!(this.props.interview)) {
       surveyHelperNew.devLog('%c rendering empty survey', 'background: rgba(0,0,0,0.1);');
       return (
         <div className="admin-widget-container"><LoadingPage /></div>
@@ -105,6 +89,7 @@ class InterviewSummary extends React.Component {
 
 const mapStateToProps = (state, props) => {
   return {
+      interview: state.survey.interview,
       errors: state.survey.errors,
       submitted: state.survey.submitted,
       user: state.auth.user,

--- a/packages/evolution-legacy/src/components/admin/validation/ValidationOnePageSummary.js
+++ b/packages/evolution-legacy/src/components/admin/validation/ValidationOnePageSummary.js
@@ -11,8 +11,6 @@ import _get from 'lodash/get';
 
 import appConfig from 'evolution-frontend/lib/config/application.config';
 import config from 'chaire-lib-common/lib/config/shared/project.config';
-import { InterviewContext } from 'evolution-frontend/lib/contexts/InterviewContext';
-import { withSurveyContext } from 'evolution-frontend/lib/components/hoc/WithSurveyContextHoc';
 import { startUpdateValidateInterview } from '../../../actions/survey/survey';
 import ValidationCommentForm from './ValidationCommentForm';
 import AdminErrorBoundary from 'evolution-frontend/lib/components/admin/AdminErrorBoundary';
@@ -30,7 +28,6 @@ if (InterviewMap === undefined) {
 }
 
 export const ValidationOnePageSummary = (props) => {
-    const { state, dispatch } = React.useContext(InterviewContext);
     const [activePlacePath, setActivePlacePath] = React.useState(null);
     const [activeTripUuid, setActiveTripUuid] = React.useState(null);
 
@@ -99,4 +96,4 @@ const mapDispatchToProps = (dispatch, props) => ({
 export default connect(
     mapStateToProps,
     mapDispatchToProps
-)(withTranslation()(withSurveyContext(ValidationOnePageSummary)));
+)(withTranslation()(ValidationOnePageSummary));


### PR DESCRIPTION
fixes #680

This also simplifies the interview loading from the validation list.

The `/interviewSummary` API path is not required anymore, as it is not the actual interview used in the map and stats pages.

The `Validation` component is now connected to the global state and gets its interview from there. Changing the interview now calls the `startSetValidateInterview` redux action and the `InterviewSummary` component does not need to load the interview separately.

Whenever the interview is updated by any of the components, it is re-rendered so validation/completion state changes are now visible as they happen.