### PR TITLE
survey: Add mechanism to report client side exceptions

### DIFF
--- a/packages/evolution-backend/src/api/survey.user.routes.ts
+++ b/packages/evolution-backend/src/api/survey.user.routes.ts
@@ -211,5 +211,28 @@ export default (authorizationMiddleware, loggingMiddleware: InterviewLoggingMidd
         }
     );
 
+    router.post('/survey/clientSideException/', async (req: Request, res: Response) => {
+        // Try/catch to avoid undocumented default behavior in case of an exception, even if we don't expect one
+        try {
+            // FIXME: Extract this to a function when we do more than just console.error
+            const content = req.body;
+            const interviewId = content.interviewId || -1;
+            if (content.exception) {
+                const exceptionString =
+                    typeof content.exception !== 'string' ? String(content.exception) : content.exception;
+                // Log up to 1000 characters of the exception to avoid spamming the logs
+                console.error(
+                    'Client-side exception in interview %d: %s',
+                    interviewId,
+                    exceptionString.substring(0, 1000)
+                );
+            }
+            return res.status(200);
+        } catch (error) {
+            console.error(`Error logging client side exception: ${error}`);
+            return res.status(500).json({ status: 'failed' });
+        }
+    });
+
     return router;
 };

--- a/packages/evolution-frontend/src/actions/Survey.ts
+++ b/packages/evolution-frontend/src/actions/Survey.ts
@@ -25,7 +25,7 @@ import { UserFrontendInterviewAttributes } from '../services/interviews/intervie
 import { incrementLoadingState, decrementLoadingState } from './LoadingState';
 import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
 import i18n from 'chaire-lib-frontend/lib/config/i18n.config';
-import { handleHttpOtherResponseCode } from '../services/errorManagement/errorHandling';
+import { handleClientError, handleHttpOtherResponseCode } from '../services/errorManagement/errorHandling';
 
 // called whenever an update occurs in interview responses or when section is switched to
 export const updateSection = (
@@ -248,7 +248,7 @@ const startUpdateInterviewCallback = async (
         // Loading state needs to be decremented, no matter the return value, otherwise the page won't get updated
         // TODO Put in the finally block if we are sure there are no side effect in the code path that returns before the fetch
         dispatch(decrementLoadingState());
-        await handleHttpOtherResponseCode(500, dispatch, history);
+        handleClientError(error instanceof Error ? error : new Error(String(error)), history);
     } finally {
         next();
     }

--- a/packages/evolution-frontend/src/actions/Survey.ts
+++ b/packages/evolution-frontend/src/actions/Survey.ts
@@ -248,7 +248,10 @@ const startUpdateInterviewCallback = async (
         // Loading state needs to be decremented, no matter the return value, otherwise the page won't get updated
         // TODO Put in the finally block if we are sure there are no side effect in the code path that returns before the fetch
         dispatch(decrementLoadingState());
-        handleClientError(error instanceof Error ? error : new Error(String(error)), history);
+        handleClientError(error instanceof Error ? error : new Error(String(error)), {
+            history,
+            interviewId: getState().survey.interview!.id
+        });
     } finally {
         next();
     }

--- a/packages/evolution-frontend/src/components/survey/ErrorBoundary.tsx
+++ b/packages/evolution-frontend/src/components/survey/ErrorBoundary.tsx
@@ -6,9 +6,13 @@
  */
 import React from 'react';
 import SurveyErrorPage from '../pages/SurveyErrorPage';
+import { connect } from 'react-redux';
+import { UserInterviewAttributes } from 'evolution-common/lib/services/interviews/interview';
+import { reportClientSideException } from '../../services/errorManagement/errorHandling';
 
 interface ErrorProps {
     // No props required
+    interview?: UserInterviewAttributes;
 }
 
 interface ErrorState {
@@ -29,6 +33,8 @@ export class ErrorBoundary extends React.Component<React.PropsWithChildren<Error
         // Display fallback UI
         this.setState({ hasError: true });
         console.log('An exception occurred in a react component', error, info);
+        // Send update responses to the server
+        reportClientSideException(error, this.props.interview?.id);
     }
 
     resetErrorBoundary = () => {
@@ -44,4 +50,10 @@ export class ErrorBoundary extends React.Component<React.PropsWithChildren<Error
     }
 }
 
-export default ErrorBoundary;
+const mapStateToProps = (state, props) => {
+    return {
+        interview: state.survey.interview
+    };
+};
+
+export default connect(mapStateToProps)(ErrorBoundary);

--- a/packages/evolution-frontend/src/components/survey/__tests__/ErrorBoundary.test.tsx
+++ b/packages/evolution-frontend/src/components/survey/__tests__/ErrorBoundary.test.tsx
@@ -6,24 +6,38 @@
  */
 import _cloneDeep from 'lodash/cloneDeep';
 import React from 'react';
+import thunk from 'redux-thunk';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
 import TestRenderer from 'react-test-renderer';
 import { mount } from 'enzyme';
 import { MemoryRouter } from 'react-router-dom';
 
 import ErrorBoundary from '../ErrorBoundary';
 
+const mockStore = configureStore([thunk]);
+let store;
 beforeEach(() => {
     jest.clearAllMocks();
+    store = mockStore({
+        survey: {
+            interview: {
+                id: 1
+            }
+        }
+    });
 });
 
 test('Render child widget if no error', () => {
     const NormalComponent = () => <div>Normal component</div>;
     const wrapper = TestRenderer.create(
-        <MemoryRouter>
-            <ErrorBoundary>
-                <NormalComponent />
-            </ErrorBoundary>
-        </MemoryRouter>
+        <Provider store={store}>
+            <MemoryRouter>
+                <ErrorBoundary>
+                    <NormalComponent />
+                </ErrorBoundary>
+            </MemoryRouter>
+        </Provider>
     );
     expect(wrapper).toMatchSnapshot();
 });
@@ -33,11 +47,13 @@ test('Render error page if widget has error', () => {
         throw new Error('Error component');
     };
     const wrapper = TestRenderer.create(
-        <MemoryRouter>
-            <ErrorBoundary>
-                <ErrorComponent />
-            </ErrorBoundary>
-        </MemoryRouter>
+        <Provider store={store}>
+            <MemoryRouter>
+                <ErrorBoundary>
+                    <ErrorComponent />
+                </ErrorBoundary>
+            </MemoryRouter>
+        </Provider>
     );
     expect(wrapper).toMatchSnapshot();
 });
@@ -53,11 +69,15 @@ test('Reset the error boundary when clicking', () => {
     };
 
     // Add initial keys for snapshots to work with enzyme without random keys (https://github.com/remix-run/react-router/issues/5579)
-    const surveyErrorPage = mount(<MemoryRouter initialEntries={[ { pathname: '/', key: 'testKey' } ]}>
-        <ErrorBoundary>
-            <ErrorComponent />
-        </ErrorBoundary>
-    </MemoryRouter>);
+    const surveyErrorPage = mount(
+        <Provider store={store}>
+            <MemoryRouter initialEntries={[ { pathname: '/', key: 'testKey' } ]}>
+                <ErrorBoundary>
+                    <ErrorComponent />
+                </ErrorBoundary>
+            </MemoryRouter>
+        </Provider>
+    );
 
     // This snapshot should be the error page
     expect(surveyErrorPage).toMatchSnapshot();

--- a/packages/evolution-frontend/src/components/survey/__tests__/__snapshots__/ErrorBoundary.test.tsx.snap
+++ b/packages/evolution-frontend/src/components/survey/__tests__/__snapshots__/ErrorBoundary.test.tsx.snap
@@ -76,264 +76,308 @@ exports[`Render error page if widget has error 1`] = `
 `;
 
 exports[`Reset the error boundary when clicking 1`] = `
-<MemoryRouter
-  initialEntries={
-    [
-      {
-        "key": "testKey",
-        "pathname": "/",
-      },
-    ]
+<Provider
+  store={
+    {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
   }
 >
-  <Router
-    history={
-      {
-        "action": "POP",
-        "block": [Function],
-        "canGo": [Function],
-        "createHref": [Function],
-        "entries": [
-          {
+  <MemoryRouter
+    initialEntries={
+      [
+        {
+          "key": "testKey",
+          "pathname": "/",
+        },
+      ]
+    }
+  >
+    <Router
+      history={
+        {
+          "action": "POP",
+          "block": [Function],
+          "canGo": [Function],
+          "createHref": [Function],
+          "entries": [
+            {
+              "hash": "",
+              "key": "testKey",
+              "pathname": "/",
+              "search": "",
+            },
+          ],
+          "go": [Function],
+          "goBack": [Function],
+          "goForward": [Function],
+          "index": 0,
+          "length": 1,
+          "listen": [Function],
+          "location": {
             "hash": "",
             "key": "testKey",
             "pathname": "/",
             "search": "",
           },
-        ],
-        "go": [Function],
-        "goBack": [Function],
-        "goForward": [Function],
-        "index": 0,
-        "length": 1,
-        "listen": [Function],
-        "location": {
-          "hash": "",
-          "key": "testKey",
-          "pathname": "/",
-          "search": "",
-        },
-        "push": [Function],
-        "replace": [Function],
+          "push": [Function],
+          "replace": [Function],
+        }
       }
-    }
-  >
-    <ErrorBoundary>
-      <withI18nextTranslation(SurveyErrorPage)
-        onRedirect={[Function]}
-      >
-        <SurveyErrorPage
-          i18n={
+    >
+      <Connect(ErrorBoundary)>
+        <ErrorBoundary
+          dispatch={[Function]}
+          interview={
             {
-              "language": "en",
-              "languages": [
-                "en",
-              ],
-              "options": {
-                "appendNamespaceToCIMode": false,
-                "appendNamespaceToMissingKey": false,
-                "contextSeparator": "_",
-                "debug": false,
-                "defaultNS": "translations",
-                "fallbackLng": [
-                  "en",
-                ],
-                "fallbackNS": false,
-                "ignoreJSONStructure": true,
-                "initImmediate": true,
-                "interpolation": {
-                  "escapeValue": false,
-                  "format": [Function],
-                  "formatSeparator": ",",
-                  "maxReplaces": 1000,
-                  "nestingOptionsSeparator": ",",
-                  "nestingPrefix": "$t(",
-                  "nestingSuffix": ")",
-                  "prefix": "{{",
-                  "skipOnVariables": true,
-                  "suffix": "}}",
-                  "unescapePrefix": "-",
-                },
-                "joinArrays": false,
-                "keySeparator": ".",
-                "lng": "en",
-                "load": "all",
-                "missingInterpolationHandler": false,
-                "missingKeyHandler": false,
-                "nonExplicitSupportedLngs": false,
-                "ns": [
-                  "translations",
-                ],
-                "nsSeparator": ":",
-                "overloadTranslationOptionHandler": [Function],
-                "parseMissingKeyHandler": false,
-                "partialBundledLanguages": false,
-                "pluralSeparator": "_",
-                "postProcess": false,
-                "postProcessPassResolved": false,
-                "preload": false,
-                "resources": {
-                  "en": {
-                    "translations": {},
-                  },
-                },
-                "returnEmptyString": true,
-                "returnNull": true,
-                "returnObjects": false,
-                "returnedObjectHandler": false,
-                "saveMissing": false,
-                "saveMissingPlurals": true,
-                "saveMissingTo": "fallback",
-                "simplifyPluralSuffix": true,
-                "supportedLngs": false,
-                "updateMissing": false,
-              },
-              "resolvedLanguage": undefined,
-              "store": {
-                "en": {
-                  "translations": {},
-                },
-              },
+              "id": 1,
             }
           }
-          onRedirect={[Function]}
-          t={[Function]}
-          tReady={true}
         >
-          <div
-            className="survey"
-            id="surveyErrorPage"
-            style={
-              {
-                "display": "block",
-              }
-            }
+          <withI18nextTranslation(SurveyErrorPage)
+            onRedirect={[Function]}
           >
-            <div
-              className="apptr__form"
+            <SurveyErrorPage
+              i18n={
+                {
+                  "language": "en",
+                  "languages": [
+                    "en",
+                  ],
+                  "options": {
+                    "appendNamespaceToCIMode": false,
+                    "appendNamespaceToMissingKey": false,
+                    "contextSeparator": "_",
+                    "debug": false,
+                    "defaultNS": "translations",
+                    "fallbackLng": [
+                      "en",
+                    ],
+                    "fallbackNS": false,
+                    "ignoreJSONStructure": true,
+                    "initImmediate": true,
+                    "interpolation": {
+                      "escapeValue": false,
+                      "format": [Function],
+                      "formatSeparator": ",",
+                      "maxReplaces": 1000,
+                      "nestingOptionsSeparator": ",",
+                      "nestingPrefix": "$t(",
+                      "nestingSuffix": ")",
+                      "prefix": "{{",
+                      "skipOnVariables": true,
+                      "suffix": "}}",
+                      "unescapePrefix": "-",
+                    },
+                    "joinArrays": false,
+                    "keySeparator": ".",
+                    "lng": "en",
+                    "load": "all",
+                    "missingInterpolationHandler": false,
+                    "missingKeyHandler": false,
+                    "nonExplicitSupportedLngs": false,
+                    "ns": [
+                      "translations",
+                    ],
+                    "nsSeparator": ":",
+                    "overloadTranslationOptionHandler": [Function],
+                    "parseMissingKeyHandler": false,
+                    "partialBundledLanguages": false,
+                    "pluralSeparator": "_",
+                    "postProcess": false,
+                    "postProcessPassResolved": false,
+                    "preload": false,
+                    "resources": {
+                      "en": {
+                        "translations": {},
+                      },
+                    },
+                    "returnEmptyString": true,
+                    "returnNull": true,
+                    "returnObjects": false,
+                    "returnedObjectHandler": false,
+                    "saveMissing": false,
+                    "saveMissingPlurals": true,
+                    "saveMissingTo": "fallback",
+                    "simplifyPluralSuffix": true,
+                    "supportedLngs": false,
+                    "updateMissing": false,
+                  },
+                  "resolvedLanguage": undefined,
+                  "store": {
+                    "en": {
+                      "translations": {},
+                    },
+                  },
+                }
+              }
+              onRedirect={[Function]}
+              t={[Function]}
+              tReady={true}
             >
-              <p
-                className="_large _strong _blue"
+              <div
+                className="survey"
+                id="surveyErrorPage"
+                style={
+                  {
+                    "display": "block",
+                  }
+                }
               >
                 <div
-                  dangerouslySetInnerHTML={
-                    {
-                      "__html": "AnErrorOccurred",
-                    }
-                  }
-                />
-              </p>
-            </div>
-            <div
-              className="apptr__separator"
-            />
-            <div
-              className="apptr__form"
-            >
-              <div
-                dangerouslySetInnerHTML={
-                  {
-                    "__html": "MakeSureReliableConnection",
-                  }
-                }
-              />
-            </div>
-            <div
-              className="apptr__separator"
-            />
-            <div
-              className="apptr__form"
-            >
-              <div
-                dangerouslySetInnerHTML={
-                  {
-                    "__html": "ErrorPersistsWhatToDo",
-                  }
-                }
-              />
-            </div>
-            <div
-              className="apptr__separator"
-            />
-            <div
-              className="apptr__form"
-            >
-              <Link
-                onClick={[Function]}
-                to="/survey"
-              >
-                <LinkAnchor
-                  href="/survey"
-                  navigate={[Function]}
-                  onClick={[Function]}
+                  className="apptr__form"
                 >
-                  <a
-                    href="/survey"
-                    onClick={[Function]}
+                  <p
+                    className="_large _strong _blue"
                   >
-                    BackToSurveyPage
-                  </a>
-                </LinkAnchor>
-              </Link>
-            </div>
-          </div>
-        </SurveyErrorPage>
-      </withI18nextTranslation(SurveyErrorPage)>
-    </ErrorBoundary>
-  </Router>
-</MemoryRouter>
+                    <div
+                      dangerouslySetInnerHTML={
+                        {
+                          "__html": "AnErrorOccurred",
+                        }
+                      }
+                    />
+                  </p>
+                </div>
+                <div
+                  className="apptr__separator"
+                />
+                <div
+                  className="apptr__form"
+                >
+                  <div
+                    dangerouslySetInnerHTML={
+                      {
+                        "__html": "MakeSureReliableConnection",
+                      }
+                    }
+                  />
+                </div>
+                <div
+                  className="apptr__separator"
+                />
+                <div
+                  className="apptr__form"
+                >
+                  <div
+                    dangerouslySetInnerHTML={
+                      {
+                        "__html": "ErrorPersistsWhatToDo",
+                      }
+                    }
+                  />
+                </div>
+                <div
+                  className="apptr__separator"
+                />
+                <div
+                  className="apptr__form"
+                >
+                  <Link
+                    onClick={[Function]}
+                    to="/survey"
+                  >
+                    <LinkAnchor
+                      href="/survey"
+                      navigate={[Function]}
+                      onClick={[Function]}
+                    >
+                      <a
+                        href="/survey"
+                        onClick={[Function]}
+                      >
+                        BackToSurveyPage
+                      </a>
+                    </LinkAnchor>
+                  </Link>
+                </div>
+              </div>
+            </SurveyErrorPage>
+          </withI18nextTranslation(SurveyErrorPage)>
+        </ErrorBoundary>
+      </Connect(ErrorBoundary)>
+    </Router>
+  </MemoryRouter>
+</Provider>
 `;
 
 exports[`Reset the error boundary when clicking 2`] = `
-<MemoryRouter
-  initialEntries={
-    [
-      {
-        "key": "testKey",
-        "pathname": "/",
-      },
-    ]
+<Provider
+  store={
+    {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
   }
 >
-  <Router
-    history={
-      {
-        "action": "POP",
-        "block": [Function],
-        "canGo": [Function],
-        "createHref": [Function],
-        "entries": [
-          {
+  <MemoryRouter
+    initialEntries={
+      [
+        {
+          "key": "testKey",
+          "pathname": "/",
+        },
+      ]
+    }
+  >
+    <Router
+      history={
+        {
+          "action": "POP",
+          "block": [Function],
+          "canGo": [Function],
+          "createHref": [Function],
+          "entries": [
+            {
+              "hash": "",
+              "key": "testKey",
+              "pathname": "/",
+              "search": "",
+            },
+          ],
+          "go": [Function],
+          "goBack": [Function],
+          "goForward": [Function],
+          "index": 0,
+          "length": 1,
+          "listen": [Function],
+          "location": {
             "hash": "",
             "key": "testKey",
             "pathname": "/",
             "search": "",
           },
-        ],
-        "go": [Function],
-        "goBack": [Function],
-        "goForward": [Function],
-        "index": 0,
-        "length": 1,
-        "listen": [Function],
-        "location": {
-          "hash": "",
-          "key": "testKey",
-          "pathname": "/",
-          "search": "",
-        },
-        "push": [Function],
-        "replace": [Function],
+          "push": [Function],
+          "replace": [Function],
+        }
       }
-    }
-  >
-    <ErrorBoundary>
-      <ErrorComponent>
-        <div>
-          Correct component
-        </div>
-      </ErrorComponent>
-    </ErrorBoundary>
-  </Router>
-</MemoryRouter>
+    >
+      <Connect(ErrorBoundary)>
+        <ErrorBoundary
+          dispatch={[Function]}
+          interview={
+            {
+              "id": 1,
+            }
+          }
+        >
+          <ErrorComponent>
+            <div>
+              Correct component
+            </div>
+          </ErrorComponent>
+        </ErrorBoundary>
+      </Connect(ErrorBoundary)>
+    </Router>
+  </MemoryRouter>
+</Provider>
 `;

--- a/packages/evolution-frontend/src/services/errorManagement/__tests__/errorHandling.test.ts
+++ b/packages/evolution-frontend/src/services/errorManagement/__tests__/errorHandling.test.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { reportClientSideException } from '../errorHandling';
+
+describe('reportClientSideException', () => {
+    test('should send a report of a client side exception to the server with interview', async () => {
+        const error = new Error('Test error');
+        const interviewId = 1;
+        const fetchSpy = jest.spyOn(window, 'fetch').mockResolvedValue({} as any);
+
+        await reportClientSideException(error, interviewId);
+
+        expect(fetchSpy).toHaveBeenCalledWith('/api/survey/clientSideException', {
+            headers: {
+                Accept: 'application/json',
+                'Content-Type': 'application/json'
+            },
+            method: 'POST',
+            credentials: 'include',
+            body: JSON.stringify({
+                exception: error.message,
+                interviewId
+            })
+        });
+    });
+
+    it('should send a report of a client side exception to the server without interview id', async () => {
+        const error = new Error('Test error');
+        const interviewId = 1;
+        const fetchSpy = jest.spyOn(window, 'fetch').mockResolvedValue({} as any);
+
+        await reportClientSideException(error, interviewId);
+
+        expect(fetchSpy).toHaveBeenCalledWith('/api/survey/clientSideException', {
+            headers: {
+                Accept: 'application/json',
+                'Content-Type': 'application/json'
+            },
+            method: 'POST',
+            credentials: 'include',
+            body: JSON.stringify({
+                exception: error.message,
+                interviewId
+            })
+        });
+    });
+});

--- a/packages/evolution-frontend/src/services/errorManagement/errorHandling.ts
+++ b/packages/evolution-frontend/src/services/errorManagement/errorHandling.ts
@@ -11,6 +11,38 @@ import verifyAuthentication from 'chaire-lib-frontend/lib/services/auth/verifyAu
 const unauthorizedPage = '/unauthorized';
 const errorPage = '/error';
 
+const redirectToErrorPage = (history?: History) => {
+    if (history) {
+        // History avoids reload the page to get to the error page, it keeps the
+        // current state of the interview.
+        history.push(errorPage);
+    } else {
+        // if history is not available, we still need to redirect to error page
+        window.location.href = errorPage;
+    }
+};
+
+/**
+ * Centralized function to handle any caught client exceptions. This function
+ * will redirect to the generic error page. Since this is for caught exceptions,
+ * callers should take any appropriate action concerning the exception (like
+ * logging) before calling this function.
+ * @param error The client error object
+ * @param history The browser history object, if available
+ */
+export const handleClientError = (error: Error, history?: History) => {
+    redirectToErrorPage(history);
+};
+
+/**
+ * Properly handles the response code received from the server. If the response
+ * is 'unauthorized', the user should be logged out and redirected to the
+ * unauthorized page. Other response codes will redirect to the generic error
+ * page.
+ * @param responseCode The response code received from the server
+ * @param dispatch The dispatch redux object
+ * @param history The browser history object, if available
+ */
 export const handleHttpOtherResponseCode = async (responseCode: number, dispatch: Dispatch, history?: History) => {
     if (responseCode === 401) {
         // Verify authentication, so that we get the new authentication status
@@ -24,12 +56,8 @@ export const handleHttpOtherResponseCode = async (responseCode: number, dispatch
         // the application, the proper flow of the application will redirect him
         // to the right page (login or unauthorized). We don't need to set href
         // to 'unauthorized' here.
-    } else if (history) {
-        // TODO Should there be other use cases that lead to other pages?
-        history.push(errorPage);
     } else {
-        // Error messages need proper handling, if history is not available, we
-        // still need to redirect to error page
-        window.location.href = errorPage;
+        // TODO Should there be other use cases that lead to other pages?
+        redirectToErrorPage(history);
     }
 };


### PR DESCRIPTION
fixes #704

* Add a server route to receive the exception and interview ID:
  `/survey/clientSideException/`. This route logs the error in server
  console
* Add an error handling utility function `reportClientSideException`
  that sends to the server the error message along with interview ID
* Let the ErrorBoundary call this error handling function when an
  exception is caught in a React component. This requires to connect the
  boundary component to the global state have access to the current interview
  to report the interview ID
* The `handleHttpOtherResponseCode` also calls the exception reporting
  function (this function is ill-named and can also be called on
  exceptions that are not related to request responses, so the server
  needs to be told).
