### PR TITLE
errorHandling: Make client-side exception reporting more robust

### DIFF
--- a/packages/evolution-backend/src/api/survey.user.routes.ts
+++ b/packages/evolution-backend/src/api/survey.user.routes.ts
@@ -216,8 +216,8 @@ export default (authorizationMiddleware, loggingMiddleware: InterviewLoggingMidd
         try {
             // FIXME: Extract this to a function when we do more than just console.error
             const content = req.body;
-            const interviewId = content.interviewId || -1;
-            if (content.exception) {
+            const interviewId = content?.interviewId || -1;
+            if (content?.exception) {
                 const exceptionString =
                     typeof content.exception !== 'string' ? String(content.exception) : content.exception;
                 // Log up to 1000 characters of the exception to avoid spamming the logs
@@ -225,6 +225,12 @@ export default (authorizationMiddleware, loggingMiddleware: InterviewLoggingMidd
                     'Client-side exception in interview %d: %s',
                     interviewId,
                     exceptionString.substring(0, 1000)
+                );
+            } else {
+                console.error(
+                    'Client-side exception in interview %d: missing exception but content was \'%s\'',
+                    interviewId,
+                    String(content).substring(0, 1000)
                 );
             }
             return res.status(200);

--- a/packages/evolution-frontend/src/services/errorManagement/errorHandling.ts
+++ b/packages/evolution-frontend/src/services/errorManagement/errorHandling.ts
@@ -35,7 +35,7 @@ const redirectToErrorPage = (history?: History) => {
  * available
  */
 export const handleClientError = (
-    error: Error,
+    error: unknown,
     { interviewId, history }: { interviewId?: number; history?: History }
 ) => {
     reportClientSideException(error, interviewId);
@@ -74,10 +74,16 @@ export const handleHttpOtherResponseCode = async (responseCode: number, dispatch
  * Send report of a client side exception to the server
  *
  * @param interviewId The numeric ID of the current interview
- * @param exception The Error object that was thrown
+ * @param exception The exception that was thrown
  * @returns
  */
-export const reportClientSideException = async (exception: Error, interviewId?: number) => {
+export const reportClientSideException = async (exception: unknown, interviewId?: number) => {
+    const exceptionMessage =
+        exception instanceof Error
+            ? exception.message
+            : typeof exception === 'object'
+                ? JSON.stringify(exception)
+                : String(exception);
     // We send the error message in the wild, not waiting for the answer as the
     // network might be down, in which point the server will not know about this
     // error anyway
@@ -89,7 +95,7 @@ export const reportClientSideException = async (exception: Error, interviewId?: 
         credentials: 'include',
         method: 'POST',
         body: JSON.stringify({
-            exception: exception.message,
+            exception: exceptionMessage,
             interviewId
         })
     });


### PR DESCRIPTION
Add a else clause in the express route in case the exception is not sent

In the frontend, let the exception be of unknown type and handle it properly.