### PR TITLE
inputMapGoogle: report client side load errors

### DIFF
--- a/packages/evolution-backend/src/services/logging/__tests__/messageLogging.test.ts
+++ b/packages/evolution-backend/src/services/logging/__tests__/messageLogging.test.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { logClientSide } from '../messageLogging';
+
+describe('logClientSide', () => {
+    let consoleErrorSpy: jest.SpyInstance;
+    let consoleWarnSpy: jest.SpyInstance;
+    let consoleInfoSpy: jest.SpyInstance;
+    let consoleLogSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+        consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('should log an error with message', () => {
+        logClientSide({ interviewId: 123, message: 'Test error', logLevel: 'error' });
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+            'Client-side %s in interview %d: %s',
+            'error',
+            123,
+            'Test error'
+        );
+    });
+
+    it('should log a warning with message', () => {
+        logClientSide({ interviewId: 123, message: 'Test warning', logLevel: 'warn' });
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+            'Client-side %s in interview %d: %s',
+            'warn',
+            123,
+            'Test warning'
+        );
+    });
+
+    it('should log info with message', () => {
+        logClientSide({ interviewId: 123, message: 'Test info', logLevel: 'info' });
+        expect(consoleInfoSpy).toHaveBeenCalledWith(
+            'Client-side %s in interview %d: %s',
+            'info',
+            123,
+            'Test info'
+        );
+    });
+
+    it('should log a log with message', () => {
+        logClientSide({ interviewId: 123, message: 'Test log', logLevel: 'log' });
+        expect(consoleLogSpy).toHaveBeenCalledWith(
+            'Client-side %s in interview %d: %s',
+            'log',
+            123,
+            'Test log'
+        );
+    });
+
+    it('should log an error when message is missing', () => {
+        logClientSide({ interviewId: 123 });
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+            'Client-side %s in interview %d: missing message data',
+            'error',
+            123
+        );
+    });
+
+    it('should truncate long messages to 1000 characters', () => {
+        const longException = 'a'.repeat(1500);
+        logClientSide({ interviewId: 123, message: longException, logLevel: 'error' });
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+            'Client-side %s in interview %d: %s',
+            'error',
+            123,
+            longException.substring(0, 1000)
+        );
+    });
+
+    it('should handle non-string messages', () => {
+        const messageObject = { message: 'Test object error' };
+        logClientSide({ interviewId: 123, message: messageObject, logLevel: 'error' });
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+            'Client-side %s in interview %d: %s',
+            'error',
+            123,
+            String(messageObject)
+        );
+    });
+
+    it('should log an error when empty parameters', () => {
+        logClientSide();
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+            'Client-side %s in interview %d: missing message data',
+            'error',
+            -1
+        );
+    });
+
+    it('should log an error with message', () => {
+        logClientSide({ interviewId: 123, message: 'Test error' });
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+            'Client-side %s in interview %d: %s',
+            'error',
+            123,
+            'Test error'
+        );
+    });
+});

--- a/packages/evolution-backend/src/services/logging/messageLogging.ts
+++ b/packages/evolution-backend/src/services/logging/messageLogging.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+/**
+ * Log a message coming from the client to the console with the appropriate log level
+ * @param args
+ * @param {number|undefined} args.interviewId The interview ID this message applies to
+ * @param {unknown|undefined} args.message The message to log
+ * @param {'error'|'warn'|'info'|'log'} args.logLevel The log level to use
+ */
+export const logClientSide = ({
+    interviewId = -1,
+    message,
+    logLevel = 'error'
+}: { interviewId?: number; message?: unknown; logLevel?: 'error' | 'warn' | 'info' | 'log' } = {}) => {
+    const logFct =
+        logLevel === 'error'
+            ? console.error
+            : logLevel === 'warn'
+                ? console.warn
+                : logLevel === 'info'
+                    ? console.info
+                    : console.log;
+    if (message) {
+        const messageString = typeof message !== 'string' ? String(message) : message;
+        // Log up to 1000 characters of the message to avoid spamming the logs
+        // TODO Add rate limit mechanism in case the same string comes very often
+        logFct('Client-side %s in interview %d: %s', logLevel, interviewId, messageString.substring(0, 1000));
+    } else {
+        console.error('Client-side %s in interview %d: missing message data', logLevel, interviewId);
+    }
+};

--- a/packages/evolution-frontend/src/components/inputs/maps/google/InputMapGoogle.tsx
+++ b/packages/evolution-frontend/src/components/inputs/maps/google/InputMapGoogle.tsx
@@ -16,6 +16,7 @@ import { getCurrentGoogleMapConfig } from '../../../../config/googleMaps.config'
 import InputLoading from '../../InputLoading';
 import { FeatureGeocodedProperties, MarkerData, InfoWindow } from '../InputMapTypes';
 import { geojson, toLatLng } from './GoogleMapUtils';
+import { reportClientSideException } from '../../../../services/errorManagement/errorHandling';
 
 export interface InputGoogleMapPointProps {
     defaultCenter: { lat: number; lon: number };
@@ -60,7 +61,12 @@ const InputMapGoogle: React.FunctionComponent<InputGoogleMapPointProps & WithTra
     // loaded (for language change for example). see
     // https://stackoverflow.com/questions/7065420/how-can-i-change-the-language-of-google-maps-on-the-run
     const googleMapConfig = React.useMemo(() => getCurrentGoogleMapConfig(props.i18n.language), []);
-    const { isLoaded } = useJsApiLoader(googleMapConfig);
+    const { isLoaded, loadError } = useJsApiLoader(googleMapConfig);
+    if (loadError !== undefined) {
+        const browserTechData = bowser.getParser(window.navigator.userAgent).parse();
+        const errorMessage = `Google Maps API could not be loaded. Browser: ${JSON.stringify(browserTechData)}, error: ${loadError.message}`;
+        reportClientSideException(errorMessage);
+    }
 
     const [map, setMap] = React.useState<google.maps.Map | null>(null);
     const [center, setCenter] = React.useState<{ lat: number; lng: number } | google.maps.LatLng>({

--- a/packages/evolution-frontend/src/components/inputs/maps/google/InputMapGoogle.tsx
+++ b/packages/evolution-frontend/src/components/inputs/maps/google/InputMapGoogle.tsx
@@ -16,7 +16,7 @@ import { getCurrentGoogleMapConfig } from '../../../../config/googleMaps.config'
 import InputLoading from '../../InputLoading';
 import { FeatureGeocodedProperties, MarkerData, InfoWindow } from '../InputMapTypes';
 import { geojson, toLatLng } from './GoogleMapUtils';
-import { reportClientSideException } from '../../../../services/errorManagement/errorHandling';
+import { logClientSideMessage } from '../../../../services/errorManagement/errorHandling';
 
 export interface InputGoogleMapPointProps {
     defaultCenter: { lat: number; lon: number };
@@ -65,7 +65,7 @@ const InputMapGoogle: React.FunctionComponent<InputGoogleMapPointProps & WithTra
     if (loadError !== undefined) {
         const browserTechData = bowser.getParser(window.navigator.userAgent).parse();
         const errorMessage = `Google Maps API could not be loaded. Browser: ${JSON.stringify(browserTechData)}, error: ${loadError.message}`;
-        reportClientSideException(errorMessage);
+        logClientSideMessage(errorMessage);
     }
 
     const [map, setMap] = React.useState<google.maps.Map | null>(null);

--- a/packages/evolution-frontend/src/components/survey/ErrorBoundary.tsx
+++ b/packages/evolution-frontend/src/components/survey/ErrorBoundary.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import SurveyErrorPage from '../pages/SurveyErrorPage';
 import { connect } from 'react-redux';
 import { UserInterviewAttributes } from 'evolution-common/lib/services/interviews/interview';
-import { reportClientSideException } from '../../services/errorManagement/errorHandling';
+import { logClientSideMessage } from '../../services/errorManagement/errorHandling';
 
 interface ErrorProps {
     // No props required
@@ -34,7 +34,7 @@ export class ErrorBoundary extends React.Component<React.PropsWithChildren<Error
         this.setState({ hasError: true });
         console.log('An exception occurred in a react component', error, info);
         // Send update responses to the server
-        reportClientSideException(error, this.props.interview?.id);
+        logClientSideMessage(error, { interviewId: this.props.interview?.id });
     }
 
     resetErrorBoundary = () => {

--- a/packages/evolution-frontend/src/services/errorManagement/__tests__/errorHandling.test.ts
+++ b/packages/evolution-frontend/src/services/errorManagement/__tests__/errorHandling.test.ts
@@ -4,46 +4,72 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import { reportClientSideException } from '../errorHandling';
+import * as ErrorHandlingFct from '../errorHandling';
 import each from 'jest-each';
 
-describe('reportClientSideException', () => {
+describe('logClientSideMessage', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
     })
 
     each([
-        ['Error object and interview id', new Error('Test error'), 1, {
-            exception: 'Test error',
-            interviewId: 1
+        ['Error object and interview id', new Error('Test error'), 1, undefined, {
+            message: 'Test error',
+            interviewId: 1,
+            logLevel: 'error'
         }],
-        ['Error object, no interview id', new Error('Test error'), undefined, {
-            exception: 'Test error',
-            interviewId: undefined
+        ['Error object, no interview id', new Error('Test error'), undefined, undefined, {
+            message: 'Test error',
+            interviewId: undefined,
+            logLevel: 'error'
         }],
-        ['String error and interview id', 'This is a string error', 1, {
-            exception: 'This is a string error',
-            interviewId: 1
+        ['String error and interview id', 'This is a string error', 1, undefined, {
+            message: 'This is a string error',
+            interviewId: 1,
+            logLevel: 'error'
         }],
-        ['Number error and interview id', 3, 1, {
-            exception: '3',
-            interviewId: 1
+        ['Number error and interview id', 3, 1, undefined, {
+            message: '3',
+            interviewId: 1,
+            logLevel: 'error'
         }],
-        ['Object error and interview id', { a: 'This is not an error!', b: 'Yes, this is', c: 'We accept you as you are' }, 1, {
-            exception: '{"a":"This is not an error!","b":"Yes, this is","c":"We accept you as you are"}',
-            interviewId: 1
+        ['Object error and interview id', { a: 'This is not an error!', b: 'Yes, this is', c: 'We accept you as you are' }, 1, undefined, {
+            message: '{"a":"This is not an error!","b":"Yes, this is","c":"We accept you as you are"}',
+            interviewId: 1,
+            logLevel: 'error'
         }],
-        ['Undefined error and interview id', undefined, 1, {
-            exception: 'undefined',
-            interviewId: 1
+        ['Array error and interview id', ['This is a log message', 'then another', { a: '2' }], 1, undefined, {
+            message: 'This is a log messagethen another[object Object]',
+            interviewId: 1,
+            logLevel: 'error'
         }],
-    ]).test('should send a report of a client side exception to the server: %s', async(_title, error, interviewId, expected) => {
+        ['Undefined error and interview id', undefined, 1, undefined, {
+            message: 'undefined',
+            interviewId: 1,
+            logLevel: 'error'
+        }],
+        ['Error object, interview id, log level error', new Error('Test error'), 1, 'error', {
+            message: 'Test error',
+            interviewId: 1,
+            logLevel: 'error'
+        }],
+        ['Undefined error, interview id, log level warn', new Error('Test error'), 1, 'warn', {
+            message: 'Test error',
+            interviewId: 1,
+            logLevel: 'warn'
+        }],
+        ['Undefined error, no interview id, log level log', new Error('Test error'), undefined, 'log', {
+            message: 'Test error',
+            interviewId: undefined,
+            logLevel: 'log'
+        }],
+    ]).test('should send a report of a client side exception to the server: %s', async(_title, error, interviewId, logLevel, expected) => {
         const fetchSpy = jest.spyOn(window, 'fetch').mockResolvedValue({} as any);
 
-        await reportClientSideException(error, interviewId);
+        await ErrorHandlingFct.logClientSideMessage(error, { interviewId, logLevel });
 
-        expect(fetchSpy).toHaveBeenCalledWith('/api/survey/clientSideException', {
+        expect(fetchSpy).toHaveBeenCalledWith('/api/survey/logClientSideMessage', {
             headers: {
                 Accept: 'application/json',
                 'Content-Type': 'application/json'
@@ -51,6 +77,26 @@ describe('reportClientSideException', () => {
             method: 'POST',
             credentials: 'include',
             body: JSON.stringify(expected)
+        });
+    });
+
+    test('With only one argument', async() => {
+        const fetchSpy = jest.spyOn(window, 'fetch').mockResolvedValue({} as any);
+
+        await ErrorHandlingFct.logClientSideMessage('This is an error');
+
+        expect(fetchSpy).toHaveBeenCalledWith('/api/survey/logClientSideMessage', {
+            headers: {
+                Accept: 'application/json',
+                'Content-Type': 'application/json'
+            },
+            method: 'POST',
+            credentials: 'include',
+            body: JSON.stringify({
+                message: 'This is an error',
+                interviewId: undefined,
+                logLevel: 'error'
+            })
         });
     });
 

--- a/packages/evolution-frontend/src/services/errorManagement/__tests__/errorHandling.test.ts
+++ b/packages/evolution-frontend/src/services/errorManagement/__tests__/errorHandling.test.ts
@@ -101,3 +101,72 @@ describe('logClientSideMessage', () => {
     });
 
 });
+
+describe('Console log overwriting', () => {
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        ErrorHandlingFct.restoreConsoleLogs();
+        jest.spyOn(ErrorHandlingFct, 'logClientSideMessage').mockResolvedValue(true as any);
+    })
+
+    test('should override console.log, console.warn and console.error', () => {
+        const logSpy = jest.spyOn(window.console, 'log').mockImplementation(() => {});
+        const warnSpy = jest.spyOn(window.console, 'warn').mockImplementation(() => {});
+        const errorSpy = jest.spyOn(window.console, 'error').mockImplementation(() => {});
+        const infoSpy = jest.spyOn(window.console, 'info').mockImplementation(() => {});
+
+        ErrorHandlingFct.overrideConsoleLogs({ getInterviewId: () => 1 });
+
+        expect(logSpy).not.toEqual(window.console.log);
+        expect(warnSpy).not.toEqual(window.console.warn);
+        expect(errorSpy).not.toEqual(window.console.error);
+        expect(infoSpy).not.toEqual(window.console.info);
+    });
+
+    test('Call to console.log should report client side exception', () => {
+        ErrorHandlingFct. overrideConsoleLogs({ getInterviewId: () => 1 });
+
+        window.console.log('This is a log message');
+
+        expect(ErrorHandlingFct.logClientSideMessage).toHaveBeenCalledWith('This is a log message', { interviewId: 1, logLevel: 'log' });
+    });
+
+    test('Call to console.warn should report client side exception, no interview id getter', () => {
+        ErrorHandlingFct. overrideConsoleLogs();
+
+        window.console.warn('This is a log message');
+
+        expect(ErrorHandlingFct.logClientSideMessage).toHaveBeenCalledWith('This is a log message', { interviewId: undefined, logLevel: 'warn' });
+    });
+
+    test('Call to console.info with multiple arguments should report client side exception, no interview id getter', () => {
+        ErrorHandlingFct. overrideConsoleLogs();
+
+        window.console.info('This is a log message', 'with other data', { a: '2', b: '3'});
+
+        expect(ErrorHandlingFct.logClientSideMessage).toHaveBeenCalledWith(['This is a log message', 'with other data', { a: '2', b: '3' }], { interviewId: undefined, logLevel: 'info' });
+    });
+
+    test('Call to console.info with multiple arguments should report client side exception, no interview id getter', () => {
+        ErrorHandlingFct. overrideConsoleLogs();
+
+        window.console.info('This is a log message', 'with other data', { a: '2', b: '3'});
+
+        expect(ErrorHandlingFct.logClientSideMessage).toHaveBeenCalledWith(['This is a log message', 'with other data', { a: '2', b: '3' }], { interviewId: undefined, logLevel: 'info' });
+    });
+
+    test('Restore console functions should not report client side exception anymore', () => {
+        ErrorHandlingFct. overrideConsoleLogs();
+
+        ErrorHandlingFct.restoreConsoleLogs();
+
+        window.console.log('Hello');
+        window.console.info('Hello');
+        window.console.warn('Hello');
+        window.console.error('Hello');
+
+        expect(ErrorHandlingFct.logClientSideMessage).not.toHaveBeenCalled();
+    });
+
+});

--- a/packages/evolution-legacy/src/components/survey/Survey.js
+++ b/packages/evolution-legacy/src/components/survey/Survey.js
@@ -21,6 +21,8 @@ import { validateAllWidgets } from 'evolution-frontend/lib/actions/utils';
 import { InterviewContext } from 'evolution-frontend/lib/contexts/InterviewContext';
 import { withSurveyContext } from 'evolution-frontend/lib/components/hoc/WithSurveyContextHoc';
 import { withPreferencesHOC } from 'evolution-frontend/lib/components/hoc/WithPreferencesHoc';
+import { overrideConsoleLogs } from 'evolution-frontend/lib/services/errorManagement/errorHandling';
+import { restoreConsoleLogs } from 'evolution-frontend/lib/services/errorManagement/errorHandling';
 
 export class Survey extends React.Component {
   static contextType = InterviewContext;
@@ -58,6 +60,14 @@ export class Survey extends React.Component {
     const pathSectionParentSection = pathSectionShortname && this.surveyContext.sections[pathSectionShortname] ? this.surveyContext.sections[pathSectionShortname].parentSection : null;
     const { state } = this.context;
     this.props.startSetInterview(existingActiveSection || pathSectionParentSection, surveyUuid, state.status === 'entering' && Object.keys(state.responses).length > 0 ? state.responses : undefined);
+
+    // Override the window.console functions to log errors and warnings to the server. It is here because it's the top most component with an interview to associate with
+    overrideConsoleLogs({ getInterviewId: () => this.props.interview ? this.props.interview.id : undefined });
+  }
+
+  componentWillUnmount() {
+    // Reset the console functions to their original values
+    restoreConsoleLogs();
   }
 
   onChangeSection(parentSection, activeSection, allWidgetsValid, e) {


### PR DESCRIPTION
This uses the `reportClientSideException` callback to report to the server any load error for the map. This adds browser data to the error log.