### PR TITLE
odSurvey: Let `getActivePerson` return `null` if no person found

### DIFF
--- a/packages/evolution-common/src/services/odSurvey/__tests__/helpers.test.ts
+++ b/packages/evolution-common/src/services/odSurvey/__tests__/helpers.test.ts
@@ -95,10 +95,10 @@ each([
     ['Person 1', interviewAttributesWithHh.responses, 'personId1', (interviewAttributesWithHh.responses as any).household.persons.personId1],
     ['Person 2', interviewAttributesWithHh.responses, 'personId2', (interviewAttributesWithHh.responses as any).household.persons.personId2],
     ['Undefined active person', interviewAttributesWithHh.responses, undefined, (interviewAttributesWithHh.responses as any).household.persons.personId1],
-    ['Empty persons', { household: { ...interviewAttributesWithHh.responses.household, persons: {} } }, 'personId1', {}],
-    ['Empty household', { household: {} }, undefined, {}],
-    ['Empty responses', {}, 'personId', {}]
-]).test('getCurrentPerson: %s', (_title, responses, currentPersonId, expected) => {
+    ['Empty persons', { household: { ...interviewAttributesWithHh.responses.household, persons: {} } }, 'personId1', null],
+    ['Empty household', { household: {} }, undefined, null],
+    ['Empty responses', {}, 'personId', null]
+]).test('getActivePerson: %s', (_title, responses, currentPersonId, expected) => {
     const interview = _cloneDeep(interviewAttributesWithHh);
     interview.responses = responses;
     interview.responses._activePersonId = currentPersonId;

--- a/packages/evolution-common/src/services/odSurvey/helpers.ts
+++ b/packages/evolution-common/src/services/odSurvey/helpers.ts
@@ -68,24 +68,21 @@ export const getHousehold = ({ interview }: { interview: UserInterviewAttributes
 /**
  * Get the currently active person, as defined in the interview responses. If
  * the active person is not set but there are persons defined, the first one
- * will be returned. If the person is not found, an empty object will be
- * returned.
+ * will be returned. If the person is not found, `null` will be returned
  *
  * @param {Object} options - The options object.
  * @param {UserInterviewAttributes} options.interview The interview object
- * @returns The current person object
+ * @returns The current person object or `null` if the person is not found
  */
-export const getActivePerson = ({ interview }: { interview: UserInterviewAttributes }): Partial<Person> => {
+export const getActivePerson = ({ interview }: { interview: UserInterviewAttributes }): Person | null => {
     const currentPerson = interview.responses._activePersonId;
     const hh = getHousehold({ interview });
     if (currentPerson !== undefined) {
-        return (hh.persons || {})[currentPerson] || {};
+        return (hh.persons || {})[currentPerson] || null;
     } else {
         // Get first person
-        const persons = Object.values(hh.persons || {});
-        // TODO: Fix this type, it should be a Person[] or {}
-        // but I need it like that for now because it's not working with Generator
-        return persons.length !== 0 ? (persons[0] as Partial<Person>) : ({} as Partial<Person>);
+        const persons = getPersonsArray({ interview });
+        return persons.length !== 0 ? persons[0] : null;
     }
 };
 


### PR DESCRIPTION
Instead of creating a new Person object that is in no way linked to the interview, if the active person is not defined, or if there are no persons in the household, then `null` is returned.