### PR TITLE
segments: Add helpers specific to the segment section

### DIFF
--- a/packages/evolution-common/src/services/odSurvey/types.ts
+++ b/packages/evolution-common/src/services/odSurvey/types.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+/**
+ * Activities that do not involve a destination
+ */
+export const loopActivities = ['workOnTheRoad', 'leisureStroll'];
+
+/**
+ * Simple modes, ie individual modes that involve no or private vehicles and are
+ * often used multiple times in a journey
+ */
+export const simpleModes = ['carDriver', 'walk', 'bicycle', 'bicycleElectric', 'scooterElectric'];

--- a/packages/evolution-frontend/src/services/sections/segments/__tests__/helpers.test.ts
+++ b/packages/evolution-frontend/src/services/sections/segments/__tests__/helpers.test.ts
@@ -1,0 +1,307 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import _cloneDeep from 'lodash/cloneDeep';
+import each from 'jest-each';
+import * as odHelpers from 'evolution-common/lib/services/odSurvey/helpers';
+import { interviewAttributesForTestCases } from 'evolution-common/lib/tests/surveys';
+import { setResponse } from 'evolution-common/lib/utils/helpers';
+import * as helpers from '../helpers';
+import { Journey, Person } from 'evolution-common/lib/services/interviews/interview';
+
+describe('getPreviousTripSingleSegment', () => {
+
+    test('No active trip', () => {
+        // Prepare test data
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        interview.responses._activePersonId = 'personId1';
+        interview.responses._activeJourneyId = 'journeyId1';
+        interview.responses._activeTripId = undefined;
+
+        // Get person and test the function
+        const person = odHelpers.getPerson({interview}) as Person;
+        expect(helpers.getPreviousTripSingleSegment({ interview, person })).toBeUndefined();
+    });
+
+    test('No active journey', () => {
+        // Prepare test data
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        interview.responses._activePersonId = 'personId1';
+        interview.responses._activeJourneyId = undefined;
+        interview.responses._activeTripId = 'tripId1P1';
+
+        // Get person and test the function
+        const person = odHelpers.getPerson({interview}) as Person;
+        expect(helpers.getPreviousTripSingleSegment({ interview, person })).toBeUndefined();
+    });
+
+    test('No previous trips', () => {
+        // Prepare test data
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        interview.responses._activePersonId = 'personId1';
+        interview.responses._activeJourneyId = 'journeyId1';
+        interview.responses._activeTripId = 'tripId1P1';
+
+        // Get person and test the function
+        const person = odHelpers.getPerson({interview}) as Person;
+        expect(helpers.getPreviousTripSingleSegment({ interview, person })).toBeUndefined();
+    });
+
+    test('Previous trip, but no segments', () => {
+        // Prepare test data
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        interview.responses._activePersonId = 'personId1';
+        interview.responses._activeJourneyId = 'journeyId1';
+        interview.responses._activeTripId = 'tripId2P1';
+
+        // Get person and test the function
+        const person = odHelpers.getPerson({interview}) as Person;
+        expect(helpers.getPreviousTripSingleSegment({ interview, person })).toBeUndefined();
+    });
+
+    test('Previous trip, one segment', () => {
+        // Prepare test data, trip 2 of person 2 as trip 1 has a single mode
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        interview.responses._activePersonId = 'personId2';
+        interview.responses._activeJourneyId = 'journeyId2';
+        interview.responses._activeTripId = 'tripId2P2';
+
+        // Get person and test the function
+        const person = odHelpers.getPerson({interview}) as Person;
+        expect(helpers.getPreviousTripSingleSegment({ interview, person })).toEqual(interview.responses.household!.persons!.personId2.journeys!.journeyId2.trips!.tripId1P2.segments!.segmentId1P2T1);
+    });
+
+    test('Previous trip, multiple segments', () => {
+        // Prepare test data, trip 3 of person 2 as trip 2 has 2 modes
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        interview.responses._activePersonId = 'personId2';
+        interview.responses._activeJourneyId = 'journeyId2';
+        interview.responses._activeTripId = 'tripId3P2';
+
+        // Get person and test the function
+        const person = odHelpers.getPerson({interview}) as Person;
+        expect(helpers.getPreviousTripSingleSegment({ interview, person })).toBeUndefined();
+    });
+});
+
+describe('isSimpleChainSingleModeReturnTrip', () => {
+
+    each([
+        ['origin', 'household.persons.personId3.journeys.journeyId3.trips.tripId2P3._originVisitedPlaceUuid'],
+        ['destination', 'household.persons.personId3.journeys.journeyId3.trips.tripId2P3._destinationVisitedPlaceUuid'],
+        ['previous origin', 'household.persons.personId3.journeys.journeyId3.trips.tripId1P3._originVisitedPlaceUuid'],
+        ['geography', 'home.geography'],
+    ]).test('undefined data for %s', (_field, pathOfValueToUndefine) => {
+        // Prepare test data, trip 2 of person 3 should be a simple chain
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        interview.responses._activePersonId = 'personId3';
+        interview.responses._activeJourneyId = 'journeyId3';
+        interview.responses._activeTripId = 'tripId2P3';
+        setResponse(interview, pathOfValueToUndefine, undefined);
+        const person = odHelpers.getPerson({interview}) as Person;
+        const journey = odHelpers.getActiveJourney({interview, person }) as Journey;
+
+        // Add a segment to trip1 to make sure it would return `true` if everything was right otherwise
+        journey.trips!.tripId1P3.segments = {
+            segmentId1P3T1: {
+                _uuid: 'segmentId1P3T1',
+                _sequence: 1,
+                _isNew: false,
+                mode: 'walk'
+            }
+        }
+
+        expect(helpers.isSimpleChainSingleModeReturnTrip({
+            interview,
+            journey,
+            person,
+            trip: journey.trips!.tripId2P3,
+            previousTrip: journey.trips!.tripId1P3
+        })).toEqual(false);
+    });
+
+    test('Previous trip is not a simple chain', () => {
+        // Prepare test data, trip 2 of person 2 is not a simple as it has other destinations
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        interview.responses._activePersonId = 'personId2';
+        interview.responses._activeJourneyId = 'journeyId2';
+        interview.responses._activeTripId = 'tripId2P2';
+        const person = odHelpers.getPerson({interview}) as Person;
+        const journey = odHelpers.getActiveJourney({interview, person }) as Journey;
+
+        // Add a segment to trip1 with simple mode
+        journey.trips!.tripId1P2.segments = {
+            segmentId1P2T1: {
+                _uuid: 'segmentId1P2T1',
+                _sequence: 1,
+                _isNew: false,
+                mode: 'walk'
+            }
+        }
+
+        expect(helpers.isSimpleChainSingleModeReturnTrip({
+            interview,
+            journey,
+            person,
+            trip: journey.trips!.tripId2P2,
+            previousTrip: journey.trips!.tripId1P2
+        })).toEqual(false);
+    });
+
+    test('Previous trip is simple chain and has single not simple mode', () => {
+        // Prepare test data, trip 2 of person 3 should be a simple chain
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        interview.responses._activePersonId = 'personId3';
+        interview.responses._activeJourneyId = 'journeyId3';
+        interview.responses._activeTripId = 'tripId2P3';
+        const person = odHelpers.getPerson({interview}) as Person;
+        const journey = odHelpers.getActiveJourney({interview, person }) as Journey;
+
+        // Add a segment to trip1 with not simle mode
+        journey.trips!.tripId1P3.segments = {
+            segmentId1P3T1: {
+                _uuid: 'segmentId1P3T1',
+                _sequence: 1,
+                _isNew: false,
+                mode: 'transitFerry'
+            }
+        }
+
+        expect(helpers.isSimpleChainSingleModeReturnTrip({
+            interview,
+            journey,
+            person,
+            trip: journey.trips!.tripId2P3,
+            previousTrip: journey.trips!.tripId1P3
+        })).toEqual(false);
+    });
+
+    test('Previous trip is simlpe chain and has 2 simple modes', () => {
+        // Prepare test data, trip 2 of person 3 should be a simple chain
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        interview.responses._activePersonId = 'personId3';
+        interview.responses._activeJourneyId = 'journeyId3';
+        interview.responses._activeTripId = 'tripId2P3';
+        const person = odHelpers.getPerson({interview}) as Person;
+        const journey = odHelpers.getActiveJourney({interview, person }) as Journey;
+
+        // Add 2 segments with simple modes to trip1 with not simle mode
+        journey.trips!.tripId1P3.segments = {
+            segmentId1P3T1: {
+                _uuid: 'segmentId1P3T1',
+                _sequence: 1,
+                _isNew: false,
+                mode: 'walk'
+            },
+            segmentId2P3T1: {
+                _uuid: 'segmentId2P3T1',
+                _sequence: 1,
+                _isNew: false,
+                mode: 'bicycle'
+            }
+        }
+
+        expect(helpers.isSimpleChainSingleModeReturnTrip({
+            interview,
+            journey,
+            person,
+            trip: journey.trips!.tripId2P3,
+            previousTrip: journey.trips!.tripId1P3
+        })).toEqual(false);
+    });
+
+    test('Previous trip is simple chain and has single simple mode', () => {
+        // Prepare test data, trip 2 of person 3 should be a simple chain
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        interview.responses._activePersonId = 'personId3';
+        interview.responses._activeJourneyId = 'journeyId3';
+        interview.responses._activeTripId = 'tripId2P3';
+        const person = odHelpers.getPerson({interview}) as Person;
+        const journey = odHelpers.getActiveJourney({interview, person }) as Journey;
+
+        // Add a segment to trip1 with single simple mode
+        journey.trips!.tripId1P3.segments = {
+            segmentId1P3T1: {
+                _uuid: 'segmentId1P3T1',
+                _sequence: 1,
+                _isNew: false,
+                mode: 'walk'
+            }
+        }
+
+        expect(helpers.isSimpleChainSingleModeReturnTrip({
+            interview,
+            journey,
+            person,
+            trip: journey.trips!.tripId2P3,
+            previousTrip: journey.trips!.tripId1P3
+        })).toEqual(true);
+    });
+
+    test('simple chain/simple mode, but moving activity at origin', () => {
+        // Prepare test data, trip 2 of person 3 should be a simple chain
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        interview.responses._activePersonId = 'personId3';
+        interview.responses._activeJourneyId = 'journeyId3';
+        interview.responses._activeTripId = 'tripId2P3';
+        const person = odHelpers.getPerson({interview}) as Person;
+        const journey = odHelpers.getActiveJourney({interview, person }) as Journey;
+
+        // Add a segment to trip1 with single simple mode
+        journey.trips!.tripId1P3.segments = {
+            segmentId1P3T1: {
+                _uuid: 'segmentId1P3T1',
+                _sequence: 1,
+                _isNew: false,
+                mode: 'walk'
+            }
+        }
+
+        // Change activity of origin to a moving one
+        journey.visitedPlaces!.schoolPlace1P3.activity = 'workOnTheRoad';
+
+        expect(helpers.isSimpleChainSingleModeReturnTrip({
+            interview,
+            journey,
+            person,
+            trip: journey.trips!.tripId2P3,
+            previousTrip: journey.trips!.tripId1P3
+        })).toEqual(false);
+    });
+
+    test('simple chain/simple mode, but moving activity at destination', () => {
+        // Prepare test data, trip 2 of person 3 should be a simple chain
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        interview.responses._activePersonId = 'personId3';
+        interview.responses._activeJourneyId = 'journeyId3';
+        interview.responses._activeTripId = 'tripId2P3';
+        const person = odHelpers.getPerson({interview}) as Person;
+        const journey = odHelpers.getActiveJourney({interview, person }) as Journey;
+
+        // Add a segment to trip1 with single simple mode
+        journey.trips!.tripId1P3.segments = {
+            segmentId1P3T1: {
+                _uuid: 'segmentId1P3T1',
+                _sequence: 1,
+                _isNew: false,
+                mode: 'walk'
+            }
+        }
+
+        // Change activity destinations to a moving one
+        journey.visitedPlaces!.homePlace1P3.activity = 'workOnTheRoad';
+        journey.visitedPlaces!.homePlace2P3.activity = 'workOnTheRoad';
+
+        expect(helpers.isSimpleChainSingleModeReturnTrip({
+            interview,
+            journey,
+            person,
+            trip: journey.trips!.tripId2P3,
+            previousTrip: journey.trips!.tripId1P3
+        })).toEqual(false);
+    })
+});
+

--- a/packages/evolution-frontend/src/services/sections/segments/helpers.ts
+++ b/packages/evolution-frontend/src/services/sections/segments/helpers.ts
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import _isEqual from 'lodash/isEqual';
+import {
+    Journey,
+    Person,
+    Segment,
+    Trip,
+    UserInterviewAttributes
+} from 'evolution-common/lib/services/interviews/interview';
+import * as helper from 'evolution-common/lib/services/odSurvey/helpers';
+import { loopActivities, simpleModes } from 'evolution-common/lib/services/odSurvey/types';
+import { Optional } from 'evolution-common/lib/types/Optional.type';
+
+/**
+ * Get the mode used in the single segment of the previous trip of the active
+ * one
+ *
+ * @param {Object} options - The options object.
+ * @param {Object} options.interview The interview object
+ * @param {Object} options.person The person these trips belong to
+ * @returns If there is a single mode in the previous trip, return it, otherwise
+ * undefined
+ */
+export const getPreviousTripSingleSegment = ({
+    interview,
+    person
+}: {
+    interview: UserInterviewAttributes;
+    person: Person;
+}): Optional<Segment> => {
+    const journey = helper.getActiveJourney({ interview, person });
+    const trip = helper.getActiveTrip({ interview, journey });
+    if (!journey || !trip) {
+        return undefined;
+    }
+    const previousTrip = helper.getPreviousTrip({ currentTrip: trip, journey });
+    if (previousTrip) {
+        const previousSegments = helper.getSegmentsArray({ trip: previousTrip });
+        if (previousSegments.length === 1) {
+            const previousSegment = previousSegments[0];
+            return previousSegment;
+        }
+    }
+    return undefined;
+};
+
+/**
+ * Return whether these 2 trips are part of a simple chain with a single mode,
+ * ie the origin of the previous trip is the same as the destination of the trip
+ * and there is only one segment in the previous trip that is one of the simple
+ * modes.
+ *
+ * @param {Object} options - The options object.
+ * @param {Trip} options.trip The potential return trip
+ * @param {Trip} options.previousTrip The previous trip that can be part of the
+ * chain
+ * @param {Object} options.journey The journey object that these trips are part
+ * of
+ * @param {Object} options.interview The interview object
+ * @param {Object} options.person The person these trips belong to
+ * @returns Whether the `trip` is the return trip of a simple chain with simple
+ * modes
+ */
+export const isSimpleChainSingleModeReturnTrip = ({
+    trip,
+    previousTrip,
+    journey,
+    interview,
+    person
+}: {
+    trip: Trip;
+    previousTrip: Trip;
+    journey: Journey;
+    interview: UserInterviewAttributes;
+    person: Person;
+}): boolean => {
+    const visitedPlaces = helper.getVisitedPlaces({ journey });
+    const origin = helper.getOrigin({ trip, visitedPlaces });
+    const destination = helper.getDestination({ trip, visitedPlaces });
+    const previousOrigin = helper.getOrigin({ trip: previousTrip, visitedPlaces });
+
+    // If origin or destination is not found, we cannot determine if it is a simple chain
+    if (!origin || !destination || !previousOrigin) {
+        return false;
+    }
+
+    // ignore loop/moving activities:
+    if (
+        (origin.activity && loopActivities.includes(origin.activity)) ||
+        (destination.activity && loopActivities.includes(destination.activity))
+    ) {
+        return false;
+    }
+    // If the trip already has more than one segment, it is not a simple chain
+    const segments = trip.segments || {};
+    const segmentsArray = Object.values(segments);
+    if (segmentsArray.length > 1) {
+        return false;
+    }
+
+    const previousTripOriginGeography = helper.getVisitedPlaceGeography({
+        visitedPlace: previousOrigin,
+        interview,
+        person
+    });
+    const tripDestinationGeography = helper.getVisitedPlaceGeography({ visitedPlace: destination, interview, person });
+    if (
+        previousTripOriginGeography &&
+        tripDestinationGeography &&
+        tripDestinationGeography.geometry &&
+        previousTripOriginGeography.geometry &&
+        _isEqual(previousTripOriginGeography.geometry.coordinates, tripDestinationGeography.geometry.coordinates)
+    ) {
+        const previousTripSegmentsAsArray = helper.getSegmentsArray({ trip: previousTrip });
+        if (
+            previousTripSegmentsAsArray.length === 1 &&
+            previousTripSegmentsAsArray[0].mode &&
+            simpleModes.includes(previousTripSegmentsAsArray[0].mode)
+        ) {
+            // we have a simple chain with single simple mode
+            return true;
+        }
+    }
+    return false;
+};


### PR DESCRIPTION
Add types for loopActivities and simple modes (ie individual/private modes that are often used for many trips).

Add helpers for survey time to check whether a trip is the return trip of a simple single chain, ie origin of first trip is same as the destination of second trip and the mode used is a simple mode. Another helper returns the unique segment of the previous trip of the chain.

Add unit tests for these functions.