### PR TITLE
Add `yarn build:admin:prod` to the workflow

### DIFF
--- a/.github/workflows/evolution.yml
+++ b/.github/workflows/evolution.yml
@@ -33,6 +33,8 @@ jobs:
       run: yarn compile
     - name: Build Client bundle
       run: yarn build:prod
+    - name: Build Admin bundle
+      run: yarn build:admin:prod
     - name: Unit Test
       run: yarn test
   


### PR DESCRIPTION
fixes #748

This step will detect any problem in the admin bundle compilation.