### PR TITLE
generator: Use types from evolution instead of defining them

### DIFF
--- a/packages/evolution-generator/src/common/defaultInputBase.tsx
+++ b/packages/evolution-generator/src/common/defaultInputBase.tsx
@@ -10,12 +10,24 @@ import config from 'chaire-lib-common/lib/config/shared/project.config';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import surveyHelper from 'evolution-legacy/lib/helpers/survey/survey';
 import * as surveyHelperNew from 'evolution-common/lib/utils/helpers';
-import * as inputTypes from '../types/inputTypes';
+import {
+    BaseQuestionType,
+    ButtonWidgetConfig,
+    InputCheckboxType,
+    InputMapFindPlaceType,
+    InputRadioNumberType,
+    InputRadioType,
+    InputRangeType,
+    InputSelectType,
+    InputStringType,
+    InputTextType,
+    TextWidgetConfig
+} from 'evolution-common/lib/services/widgets/WidgetConfig';
 
 // TODO: Make sure to add tests for these default inputs
 
 // Input Radio default params
-export const inputRadioBase: inputTypes.InputRadioBase = {
+export const inputRadioBase: Pick<BaseQuestionType & InputRadioType, 'type' | 'inputType' | 'datatype' | 'columns'> = {
     type: 'question',
     inputType: 'radio',
     datatype: 'string',
@@ -23,23 +35,28 @@ export const inputRadioBase: inputTypes.InputRadioBase = {
 };
 
 // Input Radio Number default params
-export const inputRadioNumberBase: inputTypes.InputRadioNumberBase = {
+export const inputRadioNumberBase: Pick<
+    BaseQuestionType & InputRadioNumberType,
+    'type' | 'inputType' | 'columns' | 'sameLine'
+> = {
     type: 'question',
     inputType: 'radioNumber',
-    datatype: 'integer',
     columns: 1,
     sameLine: true
 };
 
 // Input String default params
-export const inputStringBase: inputTypes.InputStringBase = {
+export const inputStringBase: Pick<BaseQuestionType & InputStringType, 'type' | 'inputType' | 'datatype'> = {
     type: 'question',
     inputType: 'string',
     datatype: 'string'
 };
 
 // Input Number default params
-export const inputNumberBase: inputTypes.InputStringBase = {
+export const inputNumberBase: Pick<
+    BaseQuestionType & InputStringType,
+    'type' | 'inputType' | 'datatype' | 'size' | 'inputFilter' | 'keyboardInputMode'
+> = {
     type: 'question',
     inputType: 'string',
     datatype: 'integer',
@@ -52,36 +69,39 @@ export const inputNumberBase: inputTypes.InputStringBase = {
 };
 
 // InfoText default params
-export const infoTextBase: inputTypes.InfoTextBase = {
+export const infoTextBase: Pick<TextWidgetConfig, 'type'> = {
     type: 'text'
 };
 
 // InputRange default params
-export const inputRangeBase: inputTypes.InputRangeBase = {
+export const inputRangeBase: Pick<BaseQuestionType & InputRangeType, 'type' | 'inputType'> = {
     type: 'question',
-    inputType: 'slider',
-    initValue: null
+    inputType: 'slider'
 };
 
 // Checkbox default params
-export const inputCheckboxBase: inputTypes.InputCheckboxBase = {
+export const inputCheckboxBase: Pick<
+    BaseQuestionType & InputCheckboxType,
+    'type' | 'inputType' | 'datatype' | 'columns'
+> = {
     type: 'question',
     inputType: 'checkbox',
     datatype: 'string',
-    multiple: true,
     columns: 1
 };
 
 // Select default params
-export const inputSelectBase: inputTypes.InputSelectBase = {
+export const inputSelectBase: Pick<BaseQuestionType & InputSelectType, 'type' | 'inputType' | 'datatype'> = {
     type: 'question',
     inputType: 'select',
-    datatype: 'string',
-    hasGroups: true
+    datatype: 'string'
 };
 
 // Next button default params
-export const buttonNextBase: inputTypes.InputButtonBase = {
+export const buttonNextBase: Pick<
+    ButtonWidgetConfig,
+    'type' | 'color' | 'hideWhenRefreshing' | 'icon' | 'align' | 'action'
+> = {
     type: 'button',
     color: 'green',
     hideWhenRefreshing: true,
@@ -92,17 +112,29 @@ export const buttonNextBase: inputTypes.InputButtonBase = {
 };
 
 // Text textarea default params
-export const textBase: inputTypes.TextBase = {
+export const textBase: Pick<BaseQuestionType & InputTextType, 'type' | 'inputType' | 'datatype'> = {
     type: 'question',
     inputType: 'text',
     datatype: 'text'
 };
 
 // Find map place default params
-export const inputMapFindPlaceBase: inputTypes.InputMapFindPlaceBase = {
+export const inputMapFindPlaceBase: Pick<
+    BaseQuestionType & InputMapFindPlaceType,
+    | 'type'
+    | 'inputType'
+    | 'height'
+    | 'containsHtml'
+    | 'autoConfirmIfSingleResult'
+    | 'placesIcon'
+    | 'defaultCenter'
+    | 'refreshGeocodingLabel'
+    | 'showSearchPlaceButton'
+    | 'afterRefreshButtonText'
+    | 'validations'
+> = {
     type: 'question',
     inputType: 'mapFindPlace',
-    datatype: 'geojson',
     height: '32rem',
     containsHtml: true,
     autoConfirmIfSingleResult: true,

--- a/packages/evolution-generator/src/common/validations.tsx
+++ b/packages/evolution-generator/src/common/validations.tsx
@@ -22,7 +22,7 @@ export const requiredValidation: Validations = (value) => {
 };
 
 // Optional question
-export const optionalValidation: Validations = () => [{ validation: false }];
+export const optionalValidation: Validations = () => [];
 
 // Make sure the InputRange is answered with a positive number
 export const inputRangeValidation: Validations = (value) => {

--- a/packages/evolution-generator/src/helpers/createConditionals.tsx
+++ b/packages/evolution-generator/src/helpers/createConditionals.tsx
@@ -23,7 +23,13 @@ type ConditionalsType = SingleConditionalsType[];
 
 // TODO: Make sure to add tests for this function
 // Check interview responses with conditions, returning the result and null.
-export const createConditionals = ({ interview, conditionals }: { interview; conditionals: ConditionalsType }) => {
+export const createConditionals = ({
+    interview,
+    conditionals
+}: {
+    interview;
+    conditionals: ConditionalsType;
+}): boolean | [boolean] | [boolean, unknown] => {
     let mathExpression = ''; // Construct the math expression to be evaluated
 
     // Iterate through the provided conditionals

--- a/packages/evolution-generator/src/types/inputTypes.ts
+++ b/packages/evolution-generator/src/types/inputTypes.ts
@@ -7,62 +7,39 @@
 
 // Note: This file includes types for all the different input and widgets types used in the evolution-generator
 
-import { UserInterviewAttributes } from 'evolution-common/lib/services/interviews/interview';
-import { InterviewUpdateCallbacks, ParsingFunctionWithCallbacks } from 'evolution-common/lib/utils/helpers';
-import { GroupConfig, InfoMapWidgetConfig } from 'evolution-common/lib/services/widgets/WidgetConfig';
-import { TFunction } from 'i18next';
+import {
+    BaseQuestionType,
+    ButtonWidgetConfig,
+    ChoiceType,
+    GroupConfig,
+    InfoMapWidgetConfig,
+    InputCheckboxType,
+    InputDatePickerType,
+    InputMapFindPlaceType,
+    InputMultiselectType,
+    InputRadioNumberType,
+    InputRadioType,
+    InputRangeType,
+    InputSelectType,
+    InputStringType,
+    InputTextType,
+    TextWidgetConfig,
+    ValidationFunction
+} from 'evolution-common/lib/services/widgets/WidgetConfig';
+import { I18nData, ParsingFunction } from 'evolution-common/lib/utils/helpers';
 
 /* Define types for all the different input types */
 type ContainsHtml = boolean;
-type TwoColumns = boolean;
-type AddCustom = boolean;
-type CustomPath = string;
-type CustomChoice = string;
-type Multiple = boolean;
-type Columns = 1 | 2;
-type Path = string;
-type Placeholder = string;
-type DefaultValue = string | ((interview, path) => string | void);
-type Align = 'left' | 'right' | 'center';
-type Size = 'small' | 'large';
-type Icon = {
-    url: string | ((interview: any, path?: Path) => string);
-    size: [number, number];
-};
-type DefaultCenter = { lat: number; lon: number } | ((interview: any, path?: Path) => { lat: number; lon: number });
 type Title = { fr: string | ((interview, path) => string); en: string | ((interview, path) => string) };
 export type InputFilter = (value) => string | number;
-type LabelFunction = (t: TFunction, interview, path) => string;
-type LabelNotFunction = { en: string | ((interview, path) => string); fr: string | ((interview, path) => string) };
-type Label = LabelFunction | LabelNotFunction;
-type TextKey = LabelFunction | LabelNotFunction;
+type Label = I18nData;
 export type Labels = {
     fr: string;
     en: string;
 }[];
-type Choice = {
-    value: string | number | boolean;
-    label: Label;
-    internalId?: number;
-    iconPath?: string;
-    conditional?: Conditional;
-};
-type ChoiceFunction = (interview, path?: Path) => Choice[];
-export type Choices = Choice[] | ChoiceFunction;
-export type Conditional = (interview: any, path?: Path) => boolean | (boolean | null)[];
-export type Validations = (
-    value: number | string,
-    customValue: number | string,
-    interview: any,
-    path: Path,
-    customPath: Path
-) => {
-    validation: boolean;
-    errorMessage?: {
-        fr: string;
-        en: string;
-    };
-}[];
+export type Choices = ChoiceType[] | ParsingFunction<ChoiceType[]>;
+export type Conditional = ParsingFunction<boolean | [boolean] | [boolean, unknown]>;
+export type Validations = ValidationFunction;
 export type NameFunction = (groupedObject, sequence, interview) => string;
 export type HelpPopup = {
     containsHtml?: ContainsHtml;
@@ -73,255 +50,47 @@ export type HelpPopup = {
 // TODO: Add some missing types for the different input types
 
 /* InputRadio widgetConfig Type */
-export type InputRadioBase = {
-    type: 'question';
-    inputType: 'radio';
-    datatype: 'string' | 'integer' | 'boolean';
-    columns: Columns;
-};
-export type InputRadio = InputRadioBase & {
-    path: Path;
-    label: Label;
-    helpPopup?: HelpPopup;
-    choices: Choices;
-    conditional: Conditional;
-    validations?: Validations;
-    addCustom?: AddCustom;
-    customPath?: CustomPath;
-    customChoice?: CustomChoice;
-    containsHtml: ContainsHtml;
-    twoColumns: TwoColumns;
-};
+export type InputRadio = BaseQuestionType & InputRadioType;
 
 /* InputRadioNumber widgetConfig Type */
-export type InputRadioNumberBase = {
-    type: 'question';
-    inputType: 'radioNumber';
-    datatype: 'integer';
-    columns: Columns;
-    sameLine?: boolean;
-};
-export type InputRadioNumber = InputRadioNumberBase & {
-    path: Path;
-    label: Label;
-    valueRange: {
-        min: number;
-        max: number;
-    };
-    overMaxAllowed: boolean;
-    helpPopup?: HelpPopup;
-    conditional: Conditional;
-    validations?: Validations;
-    containsHtml: ContainsHtml;
-    twoColumns: TwoColumns;
-};
+export type InputRadioNumber = BaseQuestionType & InputRadioNumberType;
 
 /* InputString widgetConfig Type */
-export type InputStringBase = {
-    type: 'question';
-    inputType: 'string';
-    datatype: 'string' | 'integer';
-    size?: Size;
-    inputFilter?: InputFilter;
-    keyboardInputMode?: 'none' | 'text' | 'numeric' | 'decimal' | 'tel' | 'search' | 'email' | 'url';
-    maxLength?: number;
-    placeholder?: Placeholder;
-};
-export type InputString = InputStringBase & {
-    path: Path;
-    label: Label;
-    helpPopup?: HelpPopup;
-    conditional: Conditional;
-    validations?: Validations;
-    textTransform?: 'uppercase' | 'lowercase' | 'capitalize';
-    defaultValue?: DefaultValue;
-    containsHtml: ContainsHtml;
-    twoColumns: TwoColumns;
-};
+export type InputString = BaseQuestionType & InputStringType;
 
 /* Text widgetConfig Type */
-export type InfoTextBase = {
-    type: 'text';
-    align?: Align;
-};
-export type InfoText = InfoTextBase & {
-    path?: Path; // Note: The 'path' is required to resolve ${relativePath} in conditional expressions.
-    text: TextKey;
-    conditional: Conditional;
-    containsHtml: ContainsHtml;
-};
+export type InfoText = TextWidgetConfig;
 
 /* InputRange widgetConfig Type */
-export type InputRangeBase = {
-    type: 'question';
-    inputType: 'slider';
-    initValue: null;
-};
-export type InputRangeConfig = {
-    labels: Labels;
-    minValue?: number;
-    maxValue?: number;
-    formatLabel?: (value: number, lang: string) => string;
-    trackClassName: 'input-slider-blue' | 'input-slider-red-yellow-green' | 'input-slider-green-yellow-red';
-};
-export type InputRange = InputRangeBase &
-    InputRangeConfig & {
-        path: Path;
-        label: Label;
-        conditional: Conditional;
-        containsHtml: ContainsHtml;
-        twoColumns: TwoColumns;
-        validations?: Validations;
-        includeNotApplicable?: boolean;
-    };
+export type InputRangeConfig = Pick<
+    InputRangeType,
+    'labels' | 'minValue' | 'maxValue' | 'formatLabel' | 'trackClassName'
+>;
+export type InputRange = BaseQuestionType & InputRangeType;
 
 /* InputCheckbox widgetConfig Type */
-export type InputCheckboxBase = {
-    type: 'question';
-    inputType: 'checkbox';
-    datatype: 'string' | 'integer';
-    multiple: Multiple;
-    columns: Columns;
-};
-export type InputCheckbox = InputCheckboxBase & {
-    path: Path;
-    label: Label;
-    choices: Choices;
-    helpPopup?: HelpPopup;
-    conditional: Conditional;
-    validations?: Validations;
-    addCustom?: AddCustom;
-    containsHtml: ContainsHtml;
-    twoColumns: TwoColumns;
-};
+export type InputCheckbox = BaseQuestionType & InputCheckboxType;
 
 /* InputSelect widgetConfig Type */
-export type InputSelectBase = {
-    type: 'question';
-    inputType: 'select';
-    datatype: 'string';
-    hasGroups: boolean;
-};
-export type InputSelect = InputSelectBase & {
-    path: Path;
-    label: Label;
-    choices: Choices;
-    conditional: Conditional;
-    validations?: Validations;
-    twoColumns: TwoColumns;
-    containsHtml: ContainsHtml;
-};
+export type InputSelect = BaseQuestionType & InputSelectType;
 
 /* InputMultiselect widgetConfig Type */
-export type InputMultiselect = {
-    type: 'question';
-    path: Path;
-    inputType: 'multiselect';
-    multiple: Multiple;
-    datatype: 'string';
-    twoColumns: TwoColumns;
-    containsHtml: ContainsHtml;
-    choices: Choices;
-    label: Label;
-    conditional: Conditional;
-    validations?: Validations;
-};
+export type InputMultiselect = BaseQuestionType & InputMultiselectType;
 
 /* InputButton widgetConfig Type */
-export type InputButtonBase = {
-    type: 'button';
-    color: 'green' | 'red' | 'blue' | 'grey';
-    hideWhenRefreshing: boolean;
-    icon: any;
-    // icon: IconProp | IconDefinition;
-    // icon: IconDefinition;
-    align: Align;
-    action: (
-        callbacks: InterviewUpdateCallbacks,
-        interview: UserInterviewAttributes,
-        path: string,
-        section,
-        sections,
-        saveCallback: ParsingFunctionWithCallbacks<void>
-    ) => void;
-};
-export type InputButton = InputButtonBase & {
-    path: Path;
-    label: Label;
-    confirmPopup?: {
-        shortname: string;
-        content: Label;
-        showConfirmButton?: boolean;
-        cancelButtonColor?: 'green' | 'red' | 'blue' | 'grey';
-        cancelButtonLabel?: Label;
-        conditional?: Conditional;
-    };
-    size?: Size;
-    saveCallback?: ParsingFunctionWithCallbacks<void>;
-    conditional?: Conditional;
-};
+export type InputButton = ButtonWidgetConfig;
 
 /* InputText widgetConfig Type */
-export type TextBase = {
-    type: 'question';
-    inputType: 'text';
-    datatype: 'text';
-};
-export type Text = TextBase & {
-    path: Path;
-    label: Label;
-    conditional: Conditional;
-    validations?: Validations;
-    containsHtml?: ContainsHtml;
-    twoColumns: false;
-};
+export type Text = BaseQuestionType & InputTextType;
 
 /* Group type */
 export type Group = GroupConfig;
 
 /* InputMapFindPlace widgetConfig Type */
-export type InputMapFindPlaceBase = {
-    type: 'question';
-    inputType: 'mapFindPlace';
-    datatype: 'geojson';
-    height: string;
-    containsHtml: ContainsHtml;
-    autoConfirmIfSingleResult: boolean;
-    placesIcon: Icon;
-    defaultValue?: DefaultValue;
-    defaultCenter: DefaultCenter;
-    defaultZoom?: number;
-    refreshGeocodingLabel: Label;
-    showSearchPlaceButton: (interview, path) => boolean;
-    afterRefreshButtonText: TextKey;
-    validations?: Validations;
-    invalidGeocodingResultTypes?: string[];
-};
-export type InputMapFindPlace = InputMapFindPlaceBase & {
-    path: Path;
-    label: Label;
-    icon: Icon;
-    geocodingQueryString: (interview, path?) => void;
-    conditional: Conditional;
-};
+export type InputMapFindPlace = BaseQuestionType & InputMapFindPlaceType;
 
 /* InfoMap widgetConfig Type */
 export type InfoMap = InfoMapWidgetConfig;
 
 /* InputDatePicker widgetConfig Type */
-export type InputDatePicker = {
-    type: 'question';
-    inputType: 'datePicker';
-    path: Path;
-    label: Label;
-    datatype: 'number';
-    containsHtml: ContainsHtml;
-    twoColumns: TwoColumns;
-    showTimeSelect: boolean;
-    placeholderText: Title;
-    locale: { fr: string; en: string };
-    maxDate: (interview, path) => Date;
-    minDate: (interview, path) => Date;
-    conditional: Conditional;
-    validations: Validations;
-};
+export type InputDatePicker = BaseQuestionType & InputDatePickerType;


### PR DESCRIPTION
This makes sure the widget types are as expected and defined in evolution. It removes unused fields in some default inputs for some types.

Tested with generated survey, it may cause compilation errors, easy to fix, on custom widgets.