### PR TITLE
survey: The `startSetInterview` prop type does nto include the `history`

### DIFF
--- a/packages/evolution-frontend/src/components/pages/Survey.tsx
+++ b/packages/evolution-frontend/src/components/pages/Survey.tsx
@@ -50,7 +50,6 @@ export type SurveyProps = {
     startSetInterview: (
         activeSection: string | null,
         surveyUuid: string | undefined,
-        history: History | undefined,
         preFilledResponses: { [key: string]: unknown } | undefined
     ) => void;
     startUpdateInterview: StartUpdateInterview;
@@ -105,7 +104,6 @@ export class Survey extends React.Component<SurveyProps, SurveyState> {
         this.props.startSetInterview(
             existingActiveSection || pathSectionParentSection,
             surveyUuid,
-            this.props.history,
             state.status === 'entering' && Object.keys(state.responses).length > 0 ? state.responses : undefined
         );
 


### PR DESCRIPTION
fixes #758

The `startSetInterview` function received in the props receives only 3 parameters that do not include the `History` object. This one is automatically added by the `dispatch` call. This added the History data to the survey instead of the prefilled answers, so we have a lot of un-necessary fields in the interviews.