### PR TITLE
adminExport: Handle null or undefined values_by_path in log export

### DIFF
--- a/packages/evolution-backend/src/services/adminExport/exportInterviewLogs.ts
+++ b/packages/evolution-backend/src/services/adminExport/exportInterviewLogs.ts
@@ -25,16 +25,17 @@ const filterLogData = (
     logData: { values_by_path: { [key: string]: any }; unset_paths: string[] },
     participantResponsesOnly: boolean
 ) => {
+    const valuesByPath = logData.values_by_path || {};
     if (participantResponsesOnly === false) {
         return {
-            filteredValuesByPath: logData.values_by_path,
+            filteredValuesByPath: valuesByPath,
             filteredUnsetPaths: logData.unset_paths
         };
     }
-    const filteredValuesByPath = Object.keys(logData.values_by_path)
+    const filteredValuesByPath = Object.keys(valuesByPath)
         .filter((key) => key.startsWith('responses.'))
         .reduce((acc, key) => {
-            acc[key] = logData.values_by_path[key];
+            acc[key] = valuesByPath[key];
             return acc;
         }, {});
     const filteredUnsetPaths = (logData.unset_paths || []).filter((path) => path.startsWith('responses.'));


### PR DESCRIPTION
Some older surveys potentially had log statements without the valuesByPath set, so this fixes exception when handling those records.