### PR TITLE
sections: Extract widget component from Section and others

### DIFF
--- a/example/demo_survey/src/survey/templates/SegmentsSection.tsx
+++ b/example/demo_survey/src/survey/templates/SegmentsSection.tsx
@@ -20,11 +20,8 @@ import { createBrowserHistory } from 'history';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import  { secondsSinceMidnightToTimeStr } from 'chaire-lib-common/lib/utils/DateTimeUtils';
 import { withSurveyContext } from 'evolution-frontend/lib/components/hoc/WithSurveyContextHoc';
-import Text            from 'evolution-frontend/lib/components/survey/Text';
-import InfoMap         from 'evolution-frontend/lib/components/survey/InfoMap';
-import Button          from 'evolution-frontend/lib/components/survey/Button';
-import Question        from 'evolution-frontend/lib/components/survey/Question';
-import { Group, GroupedObject } from 'evolution-frontend/lib/components/survey/GroupWidgets';
+import { GroupedObject } from 'evolution-frontend/lib/components/survey/GroupWidgets';
+import { Widget } from 'evolution-frontend/lib/components/survey/Widget';
 import * as surveyHelper from 'evolution-common/lib/utils/helpers';
 import LoadingPage from 'chaire-lib-frontend/lib/components/pages/LoadingPage';
 import helper          from '../helper';
@@ -122,38 +119,23 @@ export class SegmentsSection extends React.Component<any, any> {
 
     for (let i = 0, count = this.props.widgets.length; i < count; i++)
     {
-      const widgetShortname = this.props.widgets[i];
-      const widgetConfig = this.props.surveyContext.widgets[widgetShortname];
-      const widgetStatus    = _get(this.props.interview, `widgets.${widgetShortname}`, {});
-      const path            = surveyHelper.interpolatePath(this.props.interview, (widgetConfig.path || `${this.props.shortname}.${widgetShortname}`));
-      const customPath      = surveyHelper.interpolatePath(this.props.interview, widgetConfig.customPath);
-      let   component;
-      const defaultProps = {
-        path                           : path,
-        customPath                     : customPath,
-        key                            : path,
-        shortname                      : widgetShortname,
-        loadingState                   : this.props.loadingState,
-        widgetConfig                   : widgetConfig,
-        widgetStatus                   : widgetStatus,
-        section                        : this.props.shortname,
-        interview                      : this.props.interview,
-        user                           : this.props.user,
-        startUpdateInterview           : this.props.startUpdateInterview,
-        startAddGroupedObjects         : this.props.startAddGroupedObjects,
-        startRemoveGroupedObjects      : this.props.startRemoveGroupedObjects
-      };
-      switch(widgetConfig.type)
-      {
-        case 'text':     component = <Text     {...defaultProps} />; break;
-        case 'infoMap':  component = <InfoMap  {...defaultProps} />; break;
-        case 'button':   component = <Button   {...defaultProps} />; break;
-        case 'question': component = <Question {...defaultProps} />; break;
-        case 'group':    component = <Group    {...defaultProps}
-          parentObjectIds = {{}}
-        />;
-      }
-      widgetsComponentsByShortname[widgetShortname] = component;
+        const widgetShortname = this.props.widgets[i];
+
+        widgetsComponentsByShortname[widgetShortname] = (
+            <Widget
+                key={widgetShortname}
+                currentWidgetShortname={widgetShortname}
+                nextWidgetShortname={this.props.widgets[i + 1]}
+                sectionName={this.props.shortname}
+                interview={this.props.interview}
+                errors={this.props.errors}
+                user={this.props.user}
+                loadingState={this.props.loadingState}
+                startUpdateInterview={this.props.startUpdateInterview}
+                startAddGroupedObjects={this.props.startAddGroupedObjects}
+                startRemoveGroupedObjects={this.props.startRemoveGroupedObjects}
+            />
+        );
     }
     
     for (let i = 0, count = Object.keys(trips).length; i < count; i++)
@@ -254,6 +236,7 @@ export class SegmentsSection extends React.Component<any, any> {
               section                     = {'segments'}
               interview                   = {this.props.interview}
               user                        = {this.props.user}
+              errors                      = {this.props.errors}
               startUpdateInterview        = {this.props.startUpdateInterview}
               startAddGroupedObjects      = {this.props.startAddGroupedObjects}
               startRemoveGroupedObjects   = {this.props.startRemoveGroupedObjects}

--- a/example/demo_survey/src/survey/templates/VisitedPlacesSection.tsx
+++ b/example/demo_survey/src/survey/templates/VisitedPlacesSection.tsx
@@ -28,11 +28,8 @@ import { createBrowserHistory } from 'history';
 
 import  { secondsSinceMidnightToTimeStr } from 'chaire-lib-common/lib/utils/DateTimeUtils';
 import { withSurveyContext } from 'evolution-frontend/lib/components/hoc/WithSurveyContextHoc';
-import Text            from 'evolution-frontend/lib/components/survey/Text';
-import InfoMap         from 'evolution-frontend/lib/components/survey/InfoMap';
-import Button          from 'evolution-frontend/lib/components/survey/Button';
-import Question        from 'evolution-frontend/lib/components/survey/Question';
-import { Group, GroupedObject } from 'evolution-frontend/lib/components/survey/GroupWidgets';
+import { GroupedObject } from 'evolution-frontend/lib/components/survey/GroupWidgets';
+import { Widget } from 'evolution-frontend/lib/components/survey/Widget';
 import * as surveyHelper from 'evolution-common/lib/utils/helpers';
 import * as odSurveyHelper from 'evolution-common/lib/services/odSurvey/helpers';
 import helper          from '../helper';
@@ -237,37 +234,23 @@ export class VisitedPlacesSection extends React.Component<any, any> {
 
     for (let i = 0, count = this.props.widgets.length; i < count; i++)
     {
-      const widgetShortname = this.props.widgets[i];
-      const widgetStatus    = _get(this.props.interview, `widgets.${widgetShortname}`, {});
-      const path            = surveyHelper.interpolatePath(this.props.interview, (this.props.surveyContext.widgets[widgetShortname].path || `${this.props.shortname}.${widgetShortname}`));
-      const customPath      = this.props.surveyContext.widgets[widgetShortname].customPath ? surveyHelper.interpolatePath(this.props.interview, this.props.surveyContext.widgets[widgetShortname].customPath) : null;
-      let   component;
-      const defaultProps = {
-        path                           : path,
-        customPath                     : customPath,
-        key                            : path,
-        shortname                      : widgetShortname,
-        loadingState                   : this.props.loadingState,
-        widgetConfig                   : this.props.surveyContext.widgets[widgetShortname],
-        widgetStatus                   : widgetStatus,
-        section                        : this.props.shortname,
-        interview                      : this.props.interview,
-        user                           : this.props.user,
-        startUpdateInterview           : this.props.startUpdateInterview,
-        startAddGroupedObjects         : this.props.startAddGroupedObjects,
-        startRemoveGroupedObjects      : this.props.startRemoveGroupedObjects
-      };
-      switch(this.props.surveyContext.widgets[widgetShortname].type)
-      {
-        case 'text':     component = <Text     {...defaultProps} />; break;
-        case 'infoMap':  component = <InfoMap  {...defaultProps} />; break;
-        case 'button':   component = <Button   {...defaultProps} />; break;
-        case 'question': component = <Question {...defaultProps} />; break;
-        case 'group':    component = <Group    {...defaultProps}
-          parentObjectIds = {{}}
-        />;
-      }
-      widgetsComponentsByShortname[widgetShortname] = component;
+        const widgetShortname = this.props.widgets[i];
+
+        widgetsComponentsByShortname[widgetShortname] = (
+            <Widget
+                key={widgetShortname}
+                currentWidgetShortname={widgetShortname}
+                nextWidgetShortname={this.props.widgets[i + 1]}
+                sectionName={this.props.shortname}
+                interview={this.props.interview}
+                errors={this.props.errors}
+                user={this.props.user}
+                loadingState={this.props.loadingState}
+                startUpdateInterview={this.props.startUpdateInterview}
+                startAddGroupedObjects={this.props.startAddGroupedObjects}
+                startRemoveGroupedObjects={this.props.startRemoveGroupedObjects}
+            />
+        );
     }
 
     // setup visited places:
@@ -364,6 +347,7 @@ export class VisitedPlacesSection extends React.Component<any, any> {
               section                     = {'visitedPlaces'}
               interview                   = {this.props.interview}
               user                        = {this.props.user}
+              errors                      = {this.props.errors}
               startUpdateInterview        = {this.props.startUpdateInterview}
               startAddGroupedObjects      = {this.props.startAddGroupedObjects}
               startRemoveGroupedObjects   = {this.props.startRemoveGroupedObjects}

--- a/packages/evolution-frontend/src/actions/Survey.ts
+++ b/packages/evolution-frontend/src/actions/Survey.ts
@@ -418,21 +418,9 @@ export const startSetInterview = (
                             const interview = body.interview;
                             if (!activeSection) {
                                 for (const sectionShortname in applicationConfiguration.sections) {
-                                    if (config.isPartTwo === true) {
-                                        if (
-                                            applicationConfiguration.sections[sectionShortname]
-                                                .isPartTwoFirstSection === true
-                                        ) {
-                                            activeSection = sectionShortname;
-                                            break;
-                                        }
-                                    } else {
-                                        if (
-                                            applicationConfiguration.sections[sectionShortname].previousSection === null
-                                        ) {
-                                            activeSection = sectionShortname;
-                                            break;
-                                        }
+                                    if (applicationConfiguration.sections[sectionShortname].previousSection === null) {
+                                        activeSection = sectionShortname;
+                                        break;
                                     }
                                 }
                             }

--- a/packages/evolution-frontend/src/components/pageParts/Section.tsx
+++ b/packages/evolution-frontend/src/components/pageParts/Section.tsx
@@ -15,42 +15,27 @@ import { withSurveyContext, WithSurveyContextProps } from '../hoc/WithSurveyCont
 import { Widget } from '../survey/Widget';
 import LoadingPage from 'chaire-lib-frontend/lib/components/pages/LoadingPage';
 import { getPathForSection } from '../../services/url';
-import { UserFrontendInterviewAttributes } from '../../services/interviews/interview';
+import { SectionConfig, UserFrontendInterviewAttributes } from '../../services/interviews/interview';
 import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
-import {
-    StartUpdateInterview,
-    StartAddGroupedObjects,
-    StartRemoveGroupedObjects,
-    InterviewUpdateCallbacks
-} from 'evolution-common/lib/utils/helpers';
+import { InterviewUpdateCallbacks } from 'evolution-common/lib/utils/helpers';
 
 export type SectionProps = {
     shortname: string;
-    widgets: string[];
+    sectionConfig: SectionConfig;
     interview: UserFrontendInterviewAttributes;
     errors: { [path: string]: string };
     user: CliUser;
-    preload: (
-        interview: UserFrontendInterviewAttributes,
-        startUpdateInterview: StartUpdateInterview,
-        startAddGroupedObjects: StartAddGroupedObjects,
-        startRemoveGroupedObjects: StartRemoveGroupedObjects,
-        callback: (interview: UserFrontendInterviewAttributes) => void,
-        user: CliUser
-    ) => void;
     allWidgetsValid?: boolean;
     submitted?: boolean;
     loadingState: number;
-} & WithTranslation &
-    InterviewUpdateCallbacks &
-    WithSurveyContextProps;
+} & InterviewUpdateCallbacks;
 
 export type SectionState = {
     preloaded: boolean;
     sortedWidgetShortnames: string[];
 };
 
-export class Section extends React.Component<SectionProps, SectionState> {
+export class Section extends React.Component<SectionProps & WithTranslation & WithSurveyContextProps, SectionState> {
     constructor(props) {
         super(props);
         this.state = {
@@ -63,8 +48,8 @@ export class Section extends React.Component<SectionProps, SectionState> {
 
     componentDidMount() {
         const sortedWidgetShortnames = this.getSortedWidgetShortnames();
-        if (typeof this.props.preload === 'function') {
-            this.props.preload.call(
+        if (typeof this.props.sectionConfig.preload === 'function') {
+            this.props.sectionConfig.preload.call(
                 this,
                 this.props.interview,
                 this.props.startUpdateInterview,
@@ -116,12 +101,12 @@ export class Section extends React.Component<SectionProps, SectionState> {
         const randomGroupsIndexes: { [key: string]: number[] } = {};
         const randomGroupsStartIndexes: { [key: string]: number } = {};
         const sortedShortnames: string[] = [];
-        const countWidgets = this.props.widgets.length;
+        const countWidgets = this.props.sectionConfig.widgets.length;
         const unsortedWidgetShortnames: string[] = [];
 
         // shuffle random groups indexes:
         for (let i = 0; i < countWidgets; i++) {
-            const widgetShortname = this.props.widgets[i];
+            const widgetShortname = this.props.sectionConfig.widgets[i];
             const widgetConfig = this.props.surveyContext.widgets[widgetShortname];
             unsortedWidgetShortnames.push(widgetShortname);
             if (widgetConfig === undefined) {
@@ -169,14 +154,14 @@ export class Section extends React.Component<SectionProps, SectionState> {
         const widgetsComponentByShortname: { [key: string]: React.ReactNode } = {};
 
         surveyHelper.devLog('%c rendering section ' + this.props.shortname, 'background: rgba(0,0,255,0.1);');
-        for (let i = 0, count = this.props.widgets.length; i < count; i++) {
-            const widgetShortname = this.props.widgets[i];
+        for (let i = 0, count = this.props.sectionConfig.widgets.length; i < count; i++) {
+            const widgetShortname = this.props.sectionConfig.widgets[i];
 
             widgetsComponentByShortname[widgetShortname] = (
                 <Widget
                     key={widgetShortname}
                     currentWidgetShortname={widgetShortname}
-                    nextWidgetShortname={this.props.widgets[i + 1]}
+                    nextWidgetShortname={this.props.sectionConfig.widgets[i + 1]}
                     sectionName={this.props.shortname}
                     interview={this.props.interview}
                     errors={this.props.errors}

--- a/packages/evolution-frontend/src/components/pages/Survey.tsx
+++ b/packages/evolution-frontend/src/components/pages/Survey.tsx
@@ -173,8 +173,8 @@ export class Survey extends React.Component<SurveyProps, SurveyState> {
         const sectionShortname = activeSection;
         const sectionConfig = this.props.surveyContext.sections[sectionShortname];
         // TODO: type template components:
-        const SectionComponent: React.ComponentType<any> = sectionConfig.template
-            ? (sectionConfig.template as React.ComponentType<any>)
+        const SectionComponent: React.ComponentType<SectionProps> = sectionConfig.template
+            ? (sectionConfig.template as React.ComponentType<SectionProps>)
             : (Section as React.ComponentType<SectionProps>);
         let navActiveSection: string | null = activeSection;
 
@@ -246,17 +246,13 @@ export class Survey extends React.Component<SurveyProps, SurveyState> {
                             key={sectionShortname}
                             loadingState={this.props.loadingState}
                             shortname={sectionShortname}
-                            previousSection={sectionConfig.previousSection}
-                            nextSection={sectionConfig.nextSection}
-                            widgets={sectionConfig.widgets}
-                            preload={sectionConfig.preload}
+                            sectionConfig={sectionConfig}
                             interview={this.props.interview}
                             errors={this.props.errors}
                             user={this.props.user}
                             startUpdateInterview={this.props.startUpdateInterview}
                             startAddGroupedObjects={this.props.startAddGroupedObjects}
                             startRemoveGroupedObjects={this.props.startRemoveGroupedObjects}
-                            location={this.props.location}
                             submitted={this.props.submitted}
                         />
                     </form>

--- a/packages/evolution-frontend/src/components/survey/Widget.tsx
+++ b/packages/evolution-frontend/src/components/survey/Widget.tsx
@@ -156,7 +156,7 @@ const BaseSingleWidget: React.FC<
         return <InfoMap {...widgetProps} />;
     case 'button':
         return <Button {...widgetProps} />;
-    case 'question':
+    case 'question': {
         // check for joined widgets:
         const nextWidgetConfig = props.nextWidgetShortname
             ? props.surveyContext.widgets[props.nextWidgetShortname]
@@ -170,6 +170,7 @@ const BaseSingleWidget: React.FC<
                     (widgetConfig.joinWith === props.nextWidgetShortname && nextWidgetStatus.isVisible));
         widgetProps.join = join;
         return <Question {...widgetProps} />;
+    }
     case 'group':
         return (
             <Group

--- a/packages/evolution-frontend/src/components/survey/Widget.tsx
+++ b/packages/evolution-frontend/src/components/survey/Widget.tsx
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { withTranslation, WithTranslation } from 'react-i18next';
+import React from 'react';
+import _get from 'lodash/get';
+
+import * as surveyHelper from 'evolution-common/lib/utils/helpers';
+import Text from '../survey/Text';
+import InfoMap from '../survey/InfoMap';
+import Button from '../survey/Button';
+import Question from '../survey/Question';
+import { Group } from '../survey/GroupWidgets';
+import { withSurveyContext, WithSurveyContextProps } from '../hoc/WithSurveyContextHoc';
+import { UserFrontendInterviewAttributes, WidgetStatus } from '../../services/interviews/interview';
+import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
+import { InterviewUpdateCallbacks } from 'evolution-common/lib/utils/helpers';
+import { WidgetConfig } from 'evolution-common/lib/services/widgets';
+
+export type WidgetProps = {
+    currentWidgetShortname: string;
+    nextWidgetShortname?: string;
+    sectionName: string;
+    interview: UserFrontendInterviewAttributes;
+    errors?: { [path: string]: string };
+    user: CliUser;
+    loadingState: number;
+};
+
+export type InGroupWidgetProps = WidgetProps & {
+    /** The path where to get the widget status for this widget. Defaults to `widgets`, but can be other in case the widget is for a group */
+    widgetStatusPath: string;
+    /** Path to prepend to the widget path, for example in groups */
+    pathPrefix: string;
+    groupedObjectId: string;
+    parentObjectIds: { [shortname: string]: string };
+};
+
+type SingleWidgetProps = WidgetProps & {
+    path?: string;
+    customPath?: string;
+    widgetStatus: WidgetStatus;
+    groupedObjectId: string;
+    parentObjectIds: { [shortname: string]: string };
+};
+
+// BaseWidget is a wrapper around the SingleWidget component that is responsible
+// for setting the default values of some fields when the widget is not part of
+// a group
+const BaseWidget: React.FC<WidgetProps & WithTranslation & InterviewUpdateCallbacks & WithSurveyContextProps> = (
+    props: WidgetProps & WithTranslation & InterviewUpdateCallbacks & WithSurveyContextProps
+) => {
+    const widgetConfig = props.surveyContext.widgets[props.currentWidgetShortname] as WidgetConfig;
+    const widgetStatus = _get(props.interview, `widgets.${props.currentWidgetShortname}`, {}) as WidgetStatus;
+    return (
+        <SingleWidget
+            {...props}
+            path={widgetConfig?.path}
+            customPath={(widgetConfig as any)?.customPath}
+            widgetStatus={widgetStatus}
+            groupedObjectId=""
+            parentObjectIds={{}}
+        />
+    );
+};
+
+// BaseInGroupWidget is a wrapper around the SingleWidget component that is
+// responsible for setting the default values of some fields when the widget is
+// part of a group
+const BaseInGroupWidget: React.FC<
+    InGroupWidgetProps & WithTranslation & InterviewUpdateCallbacks & WithSurveyContextProps
+> = (props: InGroupWidgetProps & WithTranslation & InterviewUpdateCallbacks & WithSurveyContextProps) => {
+    const widgetConfig = props.surveyContext.widgets[props.currentWidgetShortname] as WidgetConfig;
+    const widgetStatus = _get(
+        props.interview,
+        `${props.widgetStatusPath}.${props.currentWidgetShortname}`,
+        {}
+    ) as WidgetStatus;
+    // Get the paths with prefix if it exists
+    const widgetPath = props.pathPrefix && widgetConfig?.path ? `${props.pathPrefix}.${widgetConfig.path}` : undefined;
+    const widgetCustomPath =
+        props.pathPrefix && (widgetConfig as any)?.customPath
+            ? `${props.pathPrefix}.${(widgetConfig as any).customPath}`
+            : undefined;
+    return (
+        <SingleWidget
+            {...props}
+            path={widgetPath}
+            customPath={widgetCustomPath}
+            widgetStatus={widgetStatus}
+            groupedObjectId={props.groupedObjectId}
+            parentObjectIds={props.parentObjectIds}
+        />
+    );
+};
+
+/**
+ * This is a single widget with all necessary properties to render it.
+ */
+const BaseSingleWidget: React.FC<
+    SingleWidgetProps & WithTranslation & InterviewUpdateCallbacks & WithSurveyContextProps
+> = (props: SingleWidgetProps & WithTranslation & InterviewUpdateCallbacks & WithSurveyContextProps) => {
+    const widgetShortname = props.currentWidgetShortname;
+    surveyHelper.devLog('%c rendering widget ' + widgetShortname, 'background: rgba(0,255,0,0.1);');
+    const widgetConfig = props.surveyContext.widgets[widgetShortname] as WidgetConfig;
+    if (widgetConfig === undefined) {
+        console.error(`Widget is undefined: ${widgetShortname}`);
+        if (props.surveyContext.devMode) {
+            return (
+                <div className="apptr__form-container two-columns question-invalid">{`Widget is undefined: ${widgetShortname}`}</div>
+            );
+        }
+        return null;
+    }
+
+    const path = props.path
+        ? surveyHelper.interpolatePath(props.interview, props.path)
+        : `${props.sectionName}.${widgetShortname}`;
+    const customPath = props.customPath ? surveyHelper.interpolatePath(props.interview, props.customPath) : undefined;
+    // FIXME This should be typed and correctly got from the interview
+    // FIXME 2 This component should be responsible to check the isVisible status and return null instead of each widget individually
+    const widgetStatus = props.widgetStatus;
+    const [isServerValid, serverErrorMessage] =
+        props.errors && props.errors[path] ? [false, props.errors[path]] : [true, undefined];
+    // Overwrite widget status with server validation data if invalid
+    if (!isServerValid) {
+        widgetStatus.isValid = false;
+        widgetStatus.errorMessage = widgetStatus.errorMessage || serverErrorMessage;
+    }
+
+    const widgetProps: any = {
+        // TODO: type default props
+        path: path,
+        customPath: customPath,
+        key: path,
+        shortname: widgetShortname,
+        loadingState: props.loadingState,
+        groupedObjectId: props.groupedObjectId,
+        widgetConfig: widgetConfig,
+        widgetStatus: widgetStatus,
+        section: props.sectionName,
+        interview: props.interview,
+        user: props.user,
+        startUpdateInterview: props.startUpdateInterview,
+        startAddGroupedObjects: props.startAddGroupedObjects,
+        startRemoveGroupedObjects: props.startRemoveGroupedObjects
+    };
+
+    switch (widgetConfig.type) {
+    case 'text':
+        return <Text {...widgetProps} />;
+    case 'infoMap':
+        return <InfoMap {...widgetProps} />;
+    case 'button':
+        return <Button {...widgetProps} />;
+    case 'question':
+        // check for joined widgets:
+        const nextWidgetConfig = props.nextWidgetShortname
+            ? props.surveyContext.widgets[props.nextWidgetShortname]
+            : undefined;
+        const nextWidgetStatus = nextWidgetConfig
+            ? (_get(props.interview, `widgets.${props.nextWidgetShortname}`, {}) as any)
+            : undefined;
+        const join =
+                nextWidgetStatus &&
+                ((nextWidgetConfig.joinWith === widgetShortname && nextWidgetStatus.isVisible) ||
+                    (widgetConfig.joinWith === props.nextWidgetShortname && nextWidgetStatus.isVisible));
+        widgetProps.join = join;
+        return <Question {...widgetProps} />;
+    case 'group':
+        return (
+            <Group
+                {...widgetProps}
+                parentObjectIds={props.parentObjectIds}
+                shortname={widgetShortname}
+                errors={props.errors}
+            />
+        );
+    }
+};
+
+export const Widget = withTranslation()(withSurveyContext(BaseWidget));
+
+export const InGroupWidget = withTranslation()(withSurveyContext(BaseInGroupWidget));
+
+const SingleWidget = withTranslation()(withSurveyContext(BaseSingleWidget));

--- a/packages/evolution-frontend/src/components/survey/__tests__/GroupWidgets.test.tsx
+++ b/packages/evolution-frontend/src/components/survey/__tests__/GroupWidgets.test.tsx
@@ -14,6 +14,7 @@ expect.extend(toHaveNoViolations);
 import { Group, GroupedObject } from '../GroupWidgets';
 import each from 'jest-each';
 import { interviewAttributes } from '../../inputs/__tests__/interviewData.test';
+import { UserFrontendInterviewAttributes } from '../../../services/interviews/interview';
 
 // Mock react-markdown and remark-gfm as they use syntax not supported by jest
 jest.mock('react-markdown', () => 'Markdown');
@@ -88,7 +89,7 @@ const startAddGroupedObjectsMock = jest.fn();
 const startRemoveGroupedObjectsMock = jest.fn();
 
 // Add some grouped object data in the interview
-const interview = _cloneDeep(interviewAttributes);
+const interview = _cloneDeep(interviewAttributes) as UserFrontendInterviewAttributes;
 const groupedObjectIds = [ 'obj0Uuid', 'obj1Uuid', 'obj2Uuid' ];
 interview.responses.myGroups = {
     [groupedObjectIds[0]]: {
@@ -229,7 +230,7 @@ describe('Group', () => {
     });
 
     test('Nested groups, should display widgets with right path', () => {
-        const interviewWithNested = _cloneDeep(interviewAttributes);
+        const interviewWithNested = _cloneDeep(interviewAttributes) as UserFrontendInterviewAttributes;
         const groupedObjectIds = [ 'obj0Uuid', 'obj1Uuid', 'obj2Uuid' ];
         const nestedGroupObjectIds = [ 'nestedObj0Uuid', 'nestedObj1Uuid' ];
         interviewWithNested.responses.myGroups = {

--- a/packages/evolution-frontend/src/components/survey/__tests__/Widget.test.tsx
+++ b/packages/evolution-frontend/src/components/survey/__tests__/Widget.test.tsx
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import _cloneDeep from 'lodash/cloneDeep';
+import React from 'react';
+import TestRenderer from 'react-test-renderer';
+import each from 'jest-each';
+
+import { interviewAttributes } from '../../inputs/__tests__/interviewData.test';
+import { Widget, InGroupWidget } from '../Widget';
+import { WidgetStatus } from '../../../services/interviews/interview';
+
+// Mock react-markdown and remark-gfm as they use syntax not supported by jest
+jest.mock('react-markdown', () => 'Markdown');
+jest.mock('remark-gfm', () => 'remark-gfm');
+
+// Mock the react-datepicker files to avoid jest compilation errors in imported files
+jest.mock('react-datepicker/dist/react-datepicker.css', () => {});
+// Mock the react-input-range files to avoid jest compilation errors in imported files
+jest.mock('react-input-range/src/js/input-range/default-class-names', () => ({
+    activeTrack: 'input-range__track input-range__track--active',
+    disabledInputRange: 'input-range input-range--disabled',
+    inputRange: 'input-range',
+    labelContainer: 'input-range__label-container',
+    maxLabel: 'input-range__label input-range__label--max',
+    minLabel: 'input-range__label input-range__label--min',
+    slider: 'input-range__slider',
+    sliderContainer: 'input-range__slider-container',
+    track: 'input-range__track input-range__track--background',
+    valueLabel: 'input-range__label input-range__label--value',
+}));
+jest.mock('react-input-range/lib/css/index.css', () => {});
+
+const testWidgetShortname = 'test';
+const testNextWidgetShortname = 'testNext';
+const commonWidgetConfig = {
+    type: 'question' as const,
+    twoColumns: true,
+    path: 'myTestPath',
+    containsHtml: true,
+    label: {
+        fr: 'Texte en français',
+        en: 'English text'
+    }
+};
+const mockedContext = { sections: {}, widgets: { [testWidgetShortname]: {}, [testNextWidgetShortname]: commonWidgetConfig }, devMode: false, dispath: jest.fn()};
+jest.mock('../../hoc/WithSurveyContextHoc', () => ({
+    withSurveyContext: (Component) => (props) => <Component {...props} surveyContext={mockedContext}/> 
+}));
+
+const mockComponent = (props, name) => (
+    <div>
+        Mocked {name} Widget: 
+        path: {props.path}
+        customPath: {props.customPath}
+        section: {props.section}
+        loadingState: {props.loadingState}
+        widgetConfig: {JSON.stringify(props.widgetConfig)}
+        widgetStatus: {JSON.stringify(props.widgetStatus)}
+        join: {props.join === true ? 'true' : 'false'}
+        {name === 'Group' && (
+            <>
+                shortname: {props.shortname}
+                parentObjectIds: {JSON.stringify(props.parentObjectIds)}
+                errors: {props.errors ? JSON.stringify(props.errors) : undefined}
+            </>
+        )}
+    </div>
+);
+
+// Mock the Question component
+jest.mock('../Question', () => jest.fn((props) => mockComponent(props, 'Question')));
+
+// Mock the Text component
+jest.mock('../Text', () => jest.fn((props) => mockComponent(props, 'Text')));
+
+// Mock the Button component
+jest.mock('../Button', () => jest.fn((props) => mockComponent(props, 'Button')));
+
+// Mock the InfoMap component
+jest.mock('../InfoMap', () => jest.fn((props) => mockComponent(props, 'InfoMap')));
+
+// Mock the Group component
+jest.mock('../GroupWidgets', () => ({
+    Group: jest.fn((props) => mockComponent(props, 'Group'))
+}));
+
+const userAttributes = {
+    id: 1,
+    username: 'foo',
+    preferences: {  },
+    serializedPermissions: [],
+    isAuthorized: () => true,
+    is_admin: false,
+    pages: [],
+    showUserInfo: true
+};
+
+const defaultWidgetStatus: WidgetStatus = {
+    path: commonWidgetConfig.path,
+    isVisible: true,
+    modalIsOpen: false,
+    isDisabled: false,
+    isCollapsed: false,
+    isEmpty: false,
+    isCustomEmpty: false,
+    isValid: true,
+    isResponded: true,
+    isCustomResponded: false,
+    errorMessage: undefined,
+    currentUpdateKey: 1,
+    value: null
+};
+
+const groupWidgetStatus: WidgetStatus = {
+    ..._cloneDeep(defaultWidgetStatus),
+    path: 'myGroupPath'
+};
+
+const frontendInterviewAttributes = {
+    ...interviewAttributes,
+    previousWidgets: {},
+    previousGroups: {},
+    widgets: {
+        [testWidgetShortname]: _cloneDeep(defaultWidgetStatus),
+        [testNextWidgetShortname]: _cloneDeep(defaultWidgetStatus)
+    },
+    groups: {
+        myGroup: {
+            myGroupId: {
+                [testWidgetShortname]: _cloneDeep(groupWidgetStatus),
+                [testNextWidgetShortname]: _cloneDeep(groupWidgetStatus)
+            }
+        }
+    },
+    visibleWidgets: [],
+    allWidgetsValid: true
+};
+
+each([
+    ['Text', { type: 'text', text: 'test text' }],
+    ['InfoMap', { type: 'infoMap', title: 'info map title', geojsons: () => {} }],
+    ['Button', { type: 'button', action: jest.fn(), label: 'test button label' }],
+    ['Question', { type: 'question', path: 'test', label: 'test question', inputType: 'string' }],
+    ['Question with custom path', { type: 'question', path: 'test', customPath: 'test.custom', label: 'test question', inputType: 'string' }],
+    ['Question with join', { type: 'question', path: 'test', label: 'test question', inputType: 'string', joinWith: testNextWidgetShortname }],
+    ['Group', { type: 'group', path: 'test', widgets: [testNextWidgetShortname] }],
+    ['undefined', undefined]
+]).describe('Widget of type %s', (_widget, widgetConfig) => {
+
+    test('Render widget', () => {
+        // Set the widget config in the context. Has to be in the test, since
+        // it's a shared variable and otherwise it's racy with other tests
+        mockedContext.widgets[testWidgetShortname] = widgetConfig;
+
+        // What to check in snapshots
+        // Expected path: should be the one specified in the widget, otherwise prefixed with "Test."
+        // Expected section: Test
+        // Expected widget status: should be the one with path as "myTestPath"
+        // For groups, the additional parameters should be present but empty
+
+        const wrapper = TestRenderer.create(
+            <Widget
+                currentWidgetShortname={testWidgetShortname}
+                nextWidgetShortname={testNextWidgetShortname}
+                sectionName='Test'
+                interview={frontendInterviewAttributes}
+                loadingState={0}
+                errors={{}}
+                user={userAttributes}
+                startUpdateInterview={jest.fn()}
+                startAddGroupedObjects={jest.fn()}
+                startRemoveGroupedObjects={jest.fn()}
+            />
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('Render in group widget', () => {
+        // Set the widget config in the context. Has to be in the test, since
+        // it's a shared variable and otherwise it's racy with other tests
+        mockedContext.widgets[testWidgetShortname] = widgetConfig;
+        const groupedShortname = 'myGroupName';
+
+        // What to check in snapshots
+        // Expected path: should be prefixed with groupPath.uuid.groupName for widgets with a path specified, otherwise prefixed with "myGroupName."
+        // Expected section: myGroupName
+        // Expected widget status: should be the one with path as "myGroupPath"
+        // For groups, the additional parameters should match what is sent here
+
+        const wrapper = TestRenderer.create(
+            <InGroupWidget
+                currentWidgetShortname={testWidgetShortname}
+                nextWidgetShortname={testNextWidgetShortname}
+                sectionName={groupedShortname}
+                interview={frontendInterviewAttributes}
+                loadingState={0}
+                errors={{}}
+                user={userAttributes}
+                startUpdateInterview={jest.fn()}
+                startAddGroupedObjects={jest.fn()}
+                startRemoveGroupedObjects={jest.fn()}
+                widgetStatusPath='groups.myGroup.myGroupId'
+                pathPrefix='groupPath.uuid.groupName'
+                groupedObjectId='myGroupId'
+                parentObjectIds={{[groupedShortname]: 'myGroupId'}}
+            />
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+});
+
+describe('With server errors', () => {
+
+    test('Render Question with server error', () => {
+        // In the snapshot, expect the widget status to have the extra server error in it
+        const questionWidgetConfig = {
+            type: 'question',
+            path: 'test',
+            label: 'test question',
+            inputType: 'string'
+        };
+        mockedContext.widgets[testWidgetShortname] = questionWidgetConfig;
+
+        const wrapper = TestRenderer.create(
+            <Widget
+                currentWidgetShortname={testWidgetShortname}
+                nextWidgetShortname={testNextWidgetShortname}
+                sectionName='Test'
+                interview={frontendInterviewAttributes}
+                loadingState={0}
+                errors={{
+                    [testWidgetShortname]: 'Server error message'
+                }}
+                user={userAttributes}
+                startUpdateInterview={jest.fn()}
+                startAddGroupedObjects={jest.fn()}
+                startRemoveGroupedObjects={jest.fn()}
+            />
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('Render Group with server error, shoud be passed along', () => {
+        // In the snapshot, expect the widget status to have the extra server
+        // error in it. The errors prop should also be passed along to the Group
+        // widget
+        const questionWidgetConfig = { type: 'group', path: 'test', widgets: [testNextWidgetShortname] };
+        mockedContext.widgets[testWidgetShortname] = questionWidgetConfig;
+
+        const wrapper = TestRenderer.create(
+            <Widget
+                currentWidgetShortname={testWidgetShortname}
+                nextWidgetShortname={testNextWidgetShortname}
+                sectionName='Test'
+                interview={frontendInterviewAttributes}
+                loadingState={0}
+                errors={{
+                    [testWidgetShortname]: 'Server error message'
+                }}
+                user={userAttributes}
+                startUpdateInterview={jest.fn()}
+                startAddGroupedObjects={jest.fn()}
+                startRemoveGroupedObjects={jest.fn()}
+            />
+        );
+        expect(wrapper).toMatchSnapshot();
+
+    })
+
+});

--- a/packages/evolution-frontend/src/components/survey/__tests__/__snapshots__/Widget.test.tsx.snap
+++ b/packages/evolution-frontend/src/components/survey/__tests__/__snapshots__/Widget.test.tsx.snap
@@ -1,0 +1,345 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Widget of type Button Render in group widget 1`] = `
+<div>
+  Mocked 
+  Button
+   Widget: path: 
+  myGroupName.test
+  customPath: 
+  section: 
+  myGroupName
+  loadingState: 
+  0
+  widgetConfig: 
+  {"type":"button","label":"test button label"}
+  widgetStatus: 
+  {"path":"myGroupPath","isVisible":true,"modalIsOpen":false,"isDisabled":false,"isCollapsed":false,"isEmpty":false,"isCustomEmpty":false,"isValid":true,"isResponded":true,"isCustomResponded":false,"currentUpdateKey":1,"value":null}
+  join: 
+  false
+</div>
+`;
+
+exports[`Widget of type Button Render widget 1`] = `
+<div>
+  Mocked 
+  Button
+   Widget: path: 
+  Test.test
+  customPath: 
+  section: 
+  Test
+  loadingState: 
+  0
+  widgetConfig: 
+  {"type":"button","label":"test button label"}
+  widgetStatus: 
+  {"path":"myTestPath","isVisible":true,"modalIsOpen":false,"isDisabled":false,"isCollapsed":false,"isEmpty":false,"isCustomEmpty":false,"isValid":true,"isResponded":true,"isCustomResponded":false,"currentUpdateKey":1,"value":null}
+  join: 
+  false
+</div>
+`;
+
+exports[`Widget of type Group Render in group widget 1`] = `
+<div>
+  Mocked 
+  Group
+   Widget: path: 
+  groupPath.uuid.groupName.test
+  customPath: 
+  section: 
+  myGroupName
+  loadingState: 
+  0
+  widgetConfig: 
+  {"type":"group","path":"test","widgets":["testNext"]}
+  widgetStatus: 
+  {"path":"myGroupPath","isVisible":true,"modalIsOpen":false,"isDisabled":false,"isCollapsed":false,"isEmpty":false,"isCustomEmpty":false,"isValid":true,"isResponded":true,"isCustomResponded":false,"currentUpdateKey":1,"value":null}
+  join: 
+  false
+  shortname: 
+  test
+  parentObjectIds: 
+  {"myGroupName":"myGroupId"}
+  errors: 
+  {}
+</div>
+`;
+
+exports[`Widget of type Group Render widget 1`] = `
+<div>
+  Mocked 
+  Group
+   Widget: path: 
+  test
+  customPath: 
+  section: 
+  Test
+  loadingState: 
+  0
+  widgetConfig: 
+  {"type":"group","path":"test","widgets":["testNext"]}
+  widgetStatus: 
+  {"path":"myTestPath","isVisible":true,"modalIsOpen":false,"isDisabled":false,"isCollapsed":false,"isEmpty":false,"isCustomEmpty":false,"isValid":true,"isResponded":true,"isCustomResponded":false,"currentUpdateKey":1,"value":null}
+  join: 
+  false
+  shortname: 
+  test
+  parentObjectIds: 
+  {}
+  errors: 
+  {}
+</div>
+`;
+
+exports[`Widget of type InfoMap Render in group widget 1`] = `
+<div>
+  Mocked 
+  InfoMap
+   Widget: path: 
+  myGroupName.test
+  customPath: 
+  section: 
+  myGroupName
+  loadingState: 
+  0
+  widgetConfig: 
+  {"type":"infoMap","title":"info map title"}
+  widgetStatus: 
+  {"path":"myGroupPath","isVisible":true,"modalIsOpen":false,"isDisabled":false,"isCollapsed":false,"isEmpty":false,"isCustomEmpty":false,"isValid":true,"isResponded":true,"isCustomResponded":false,"currentUpdateKey":1,"value":null}
+  join: 
+  false
+</div>
+`;
+
+exports[`Widget of type InfoMap Render widget 1`] = `
+<div>
+  Mocked 
+  InfoMap
+   Widget: path: 
+  Test.test
+  customPath: 
+  section: 
+  Test
+  loadingState: 
+  0
+  widgetConfig: 
+  {"type":"infoMap","title":"info map title"}
+  widgetStatus: 
+  {"path":"myTestPath","isVisible":true,"modalIsOpen":false,"isDisabled":false,"isCollapsed":false,"isEmpty":false,"isCustomEmpty":false,"isValid":true,"isResponded":true,"isCustomResponded":false,"currentUpdateKey":1,"value":null}
+  join: 
+  false
+</div>
+`;
+
+exports[`Widget of type Question Render in group widget 1`] = `
+<div>
+  Mocked 
+  Question
+   Widget: path: 
+  groupPath.uuid.groupName.test
+  customPath: 
+  section: 
+  myGroupName
+  loadingState: 
+  0
+  widgetConfig: 
+  {"type":"question","path":"test","label":"test question","inputType":"string"}
+  widgetStatus: 
+  {"path":"myGroupPath","isVisible":true,"modalIsOpen":false,"isDisabled":false,"isCollapsed":false,"isEmpty":false,"isCustomEmpty":false,"isValid":true,"isResponded":true,"isCustomResponded":false,"currentUpdateKey":1,"value":null}
+  join: 
+  false
+</div>
+`;
+
+exports[`Widget of type Question Render widget 1`] = `
+<div>
+  Mocked 
+  Question
+   Widget: path: 
+  test
+  customPath: 
+  section: 
+  Test
+  loadingState: 
+  0
+  widgetConfig: 
+  {"type":"question","path":"test","label":"test question","inputType":"string"}
+  widgetStatus: 
+  {"path":"myTestPath","isVisible":true,"modalIsOpen":false,"isDisabled":false,"isCollapsed":false,"isEmpty":false,"isCustomEmpty":false,"isValid":true,"isResponded":true,"isCustomResponded":false,"currentUpdateKey":1,"value":null}
+  join: 
+  false
+</div>
+`;
+
+exports[`Widget of type Question with custom path Render in group widget 1`] = `
+<div>
+  Mocked 
+  Question
+   Widget: path: 
+  groupPath.uuid.groupName.test
+  customPath: 
+  groupPath.uuid.groupName.test.custom
+  section: 
+  myGroupName
+  loadingState: 
+  0
+  widgetConfig: 
+  {"type":"question","path":"test","customPath":"test.custom","label":"test question","inputType":"string"}
+  widgetStatus: 
+  {"path":"myGroupPath","isVisible":true,"modalIsOpen":false,"isDisabled":false,"isCollapsed":false,"isEmpty":false,"isCustomEmpty":false,"isValid":true,"isResponded":true,"isCustomResponded":false,"currentUpdateKey":1,"value":null}
+  join: 
+  false
+</div>
+`;
+
+exports[`Widget of type Question with custom path Render widget 1`] = `
+<div>
+  Mocked 
+  Question
+   Widget: path: 
+  test
+  customPath: 
+  test.custom
+  section: 
+  Test
+  loadingState: 
+  0
+  widgetConfig: 
+  {"type":"question","path":"test","customPath":"test.custom","label":"test question","inputType":"string"}
+  widgetStatus: 
+  {"path":"myTestPath","isVisible":true,"modalIsOpen":false,"isDisabled":false,"isCollapsed":false,"isEmpty":false,"isCustomEmpty":false,"isValid":true,"isResponded":true,"isCustomResponded":false,"currentUpdateKey":1,"value":null}
+  join: 
+  false
+</div>
+`;
+
+exports[`Widget of type Question with join Render in group widget 1`] = `
+<div>
+  Mocked 
+  Question
+   Widget: path: 
+  groupPath.uuid.groupName.test
+  customPath: 
+  section: 
+  myGroupName
+  loadingState: 
+  0
+  widgetConfig: 
+  {"type":"question","path":"test","label":"test question","inputType":"string","joinWith":"testNext"}
+  widgetStatus: 
+  {"path":"myGroupPath","isVisible":true,"modalIsOpen":false,"isDisabled":false,"isCollapsed":false,"isEmpty":false,"isCustomEmpty":false,"isValid":true,"isResponded":true,"isCustomResponded":false,"currentUpdateKey":1,"value":null}
+  join: 
+  true
+</div>
+`;
+
+exports[`Widget of type Question with join Render widget 1`] = `
+<div>
+  Mocked 
+  Question
+   Widget: path: 
+  test
+  customPath: 
+  section: 
+  Test
+  loadingState: 
+  0
+  widgetConfig: 
+  {"type":"question","path":"test","label":"test question","inputType":"string","joinWith":"testNext"}
+  widgetStatus: 
+  {"path":"myTestPath","isVisible":true,"modalIsOpen":false,"isDisabled":false,"isCollapsed":false,"isEmpty":false,"isCustomEmpty":false,"isValid":true,"isResponded":true,"isCustomResponded":false,"currentUpdateKey":1,"value":null}
+  join: 
+  true
+</div>
+`;
+
+exports[`Widget of type Text Render in group widget 1`] = `
+<div>
+  Mocked 
+  Text
+   Widget: path: 
+  myGroupName.test
+  customPath: 
+  section: 
+  myGroupName
+  loadingState: 
+  0
+  widgetConfig: 
+  {"type":"text","text":"test text"}
+  widgetStatus: 
+  {"path":"myGroupPath","isVisible":true,"modalIsOpen":false,"isDisabled":false,"isCollapsed":false,"isEmpty":false,"isCustomEmpty":false,"isValid":true,"isResponded":true,"isCustomResponded":false,"currentUpdateKey":1,"value":null}
+  join: 
+  false
+</div>
+`;
+
+exports[`Widget of type Text Render widget 1`] = `
+<div>
+  Mocked 
+  Text
+   Widget: path: 
+  Test.test
+  customPath: 
+  section: 
+  Test
+  loadingState: 
+  0
+  widgetConfig: 
+  {"type":"text","text":"test text"}
+  widgetStatus: 
+  {"path":"myTestPath","isVisible":true,"modalIsOpen":false,"isDisabled":false,"isCollapsed":false,"isEmpty":false,"isCustomEmpty":false,"isValid":true,"isResponded":true,"isCustomResponded":false,"currentUpdateKey":1,"value":null}
+  join: 
+  false
+</div>
+`;
+
+exports[`Widget of type undefined Render in group widget 1`] = `null`;
+
+exports[`Widget of type undefined Render widget 1`] = `null`;
+
+exports[`With server errors Render Group with server error, shoud be passed along 1`] = `
+<div>
+  Mocked 
+  Group
+   Widget: path: 
+  test
+  customPath: 
+  section: 
+  Test
+  loadingState: 
+  0
+  widgetConfig: 
+  {"type":"group","path":"test","widgets":["testNext"]}
+  widgetStatus: 
+  {"path":"myTestPath","isVisible":true,"modalIsOpen":false,"isDisabled":false,"isCollapsed":false,"isEmpty":false,"isCustomEmpty":false,"isValid":false,"isResponded":true,"isCustomResponded":false,"errorMessage":"Server error message","currentUpdateKey":1,"value":null}
+  join: 
+  false
+  shortname: 
+  test
+  parentObjectIds: 
+  {}
+  errors: 
+  {"test":"Server error message"}
+</div>
+`;
+
+exports[`With server errors Render Question with server error 1`] = `
+<div>
+  Mocked 
+  Question
+   Widget: path: 
+  test
+  customPath: 
+  section: 
+  Test
+  loadingState: 
+  0
+  widgetConfig: 
+  {"type":"question","path":"test","label":"test question","inputType":"string"}
+  widgetStatus: 
+  {"path":"myTestPath","isVisible":true,"modalIsOpen":false,"isDisabled":false,"isCollapsed":false,"isEmpty":false,"isCustomEmpty":false,"isValid":false,"isResponded":true,"isCustomResponded":false,"errorMessage":"Server error message","currentUpdateKey":1,"value":null}
+  join: 
+  false
+</div>
+`;

--- a/packages/evolution-frontend/src/services/interviews/interview.ts
+++ b/packages/evolution-frontend/src/services/interviews/interview.ts
@@ -5,9 +5,15 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 
+import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
 import { UserInterviewAttributes } from 'evolution-common/lib/services/interviews/interview';
 import { WidgetConfig } from 'evolution-common/lib/services/widgets';
-import { I18nData, ParsingFunction } from 'evolution-common/lib/utils/helpers';
+import {
+    I18nData,
+    StartAddGroupedObjects,
+    StartRemoveGroupedObjects,
+    StartUpdateInterview
+} from 'evolution-common/lib/utils/helpers';
 
 export type WidgetStatus = {
     path: string;
@@ -63,12 +69,26 @@ export type FrontendInterviewAttributes = {
 
 export type UserFrontendInterviewAttributes = FrontendInterviewAttributes & UserInterviewAttributes;
 
-// TODO Properly type this
-export type SurveySection = {
+export type SectionConfig = {
     widgets: string[];
-    [key: string]: unknown;
+    previousSection?: string;
+    nextSection?: string;
+    // FIXME: change for a single named option argument instead of 6 arguments
+    preload?: (
+        interview: UserFrontendInterviewAttributes,
+        startUpdateInterview: StartUpdateInterview,
+        startAddGroupedObjects: StartAddGroupedObjects,
+        startRemoveGroupedObjects: StartRemoveGroupedObjects,
+        callback: (interview: UserFrontendInterviewAttributes) => void,
+        user: CliUser
+    ) => void;
+    template?: React.ComponentType;
+    hiddenInNav?: boolean;
+    parentSection?: string;
+    // FIXME Type this
+    customStyle?: any;
 };
-export type SurveySections = { [sectionName: string]: SurveySection };
+export type SurveySections = { [sectionName: string]: SectionConfig };
 export type SurveyWidgets = {
     [widgetName: string]: WidgetConfig;
 };

--- a/packages/evolution-legacy/src/components/admin/ValidateSurvey.js
+++ b/packages/evolution-legacy/src/components/admin/ValidateSurvey.js
@@ -152,10 +152,7 @@ export class ValidateSurvey extends React.Component {
                   key                         = {sectionShortname}
                   loadingState                = {this.props.loadingState}
                   shortname                   = {sectionShortname}
-                  previousSection             = {sectionConfig.previousSection}
-                  nextSection                 = {sectionConfig.nextSection}
-                  widgets                     = {sectionConfig.widgets}
-                  preload                     = {sectionConfig.preload}
+                  sectionConfig               = {sectionConfig}
                   interview                   = {this.props.interview}
                   errors                      = {this.props.errors}
                   user                        = {this.props.user}


### PR DESCRIPTION
To ensure that widget generation is always handled the same way and new features are not added in a single code path, a `Widget` component is added to display the high level widget (Text, Group, Button, InfoMap or Question). There is one version for end components (`Widget`) and one for widgets that are part of a grouped object (`InGroupWidget`), with additional pathPrefix and different widgetStatus location. 

Section templates in `demo_survey` are updated to use this new component.

Also type the SectionConfig and pass the sectionConfig to the Section widget instead of individual fields. This is a **breaking change** for surveys as section templates will also need to be updated to match the Section's props. See commit message for details.