### PR TITLE
Type the section `preload`'s call and other fixes

### DIFF
--- a/example/demo_survey/src/admin/parsers/madasare2018.ts
+++ b/example/demo_survey/src/admin/parsers/madasare2018.ts
@@ -499,7 +499,7 @@ export default {
         return person._sequence;
       },
       [`${prefix}glo_pers.permis`]: function(user, interview, responses, household, home, personsById, personsArray, person) {
-        const internalId = getInternalId('personDrivingLicenseOwner', interview, person.drivingLicenseOwner, 0);
+        const internalId = getInternalId('personDrivingLicenseOwner', interview, person.drivingLicenseOwnership, 0);
         if (internalId)
         {
           return internalId;
@@ -614,7 +614,7 @@ export default {
         return 10;
       },
       [`${prefix}glo_pers.abon_ap`]: function(user, interview, responses, household, home, personsById, personsArray, person) {
-        if (person.age < 16 || person.drivingLicenseOwner !== 'yes')
+        if (person.age < 16 || person.drivingLicenseOwnership !== 'yes')
         {
           return 4;
         }

--- a/example/demo_survey/src/admin/validations.ts
+++ b/example/demo_survey/src/admin/validations.ts
@@ -510,7 +510,7 @@ const validations =  {
       },
       errorCode: "P_M_DRIVINGLICENSEOWNER",
       isValid: function(user, interview, responses, household, home, personsById, personsArray, person) {
-        const isValid = !(person.age >= 5 && sharedHelper.isBlank(person.drivingLicenseOwner));
+        const isValid = !(person.age >= 5 && sharedHelper.isBlank(person.drivingLicenseOwnership));
         if (interview.is_completed && !isValid)
         {
           console.log('P_M_DRIVINGLICENSEOWNER', responses.accessCode);
@@ -525,7 +525,7 @@ const validations =  {
       },
       errorCode: "P_I_DRIVINGLICENSEOWNERTOOYOUNG",
       isValid: function(user, interview, responses, household, home, personsById, personsArray, person) {
-        const isValid = !(person.age < 16 && person.drivingLicenseOwner === 'yes');
+        const isValid = !(person.age < 16 && person.drivingLicenseOwnership === 'yes');
         if (interview.is_completed && !isValid)
         {
           console.log('P_I_DRIVINGLICENSEOWNERTOOYOUNG', responses.accessCode);
@@ -540,7 +540,7 @@ const validations =  {
       },
       errorCode: "P_I_DRIVINGLICENSEOWNEREMPTY",
       isValid: function(user, interview, responses, household, home, personsById, personsArray, person) {
-        const isValid = !(person.age >= 16 && sharedHelper.isBlank(person.drivingLicenseOwner));
+        const isValid = !(person.age >= 16 && sharedHelper.isBlank(person.drivingLicenseOwnership));
         if (interview.is_completed && !isValid)
         {
           console.log('P_I_DRIVINGLICENSEOWNEREMPTY', responses.accessCode);
@@ -1404,7 +1404,7 @@ const validations =  {
       },
       errorCode: "S_I_MODECARDRIVERWITHOUTLICENSE",
       isValid: function(user, interview, responses, household, home, personsById, personsArray, person, visitedPlacesById, visitedPlacesArray, tripsById, tripsArray, trip, segmentsById, segmentsArray, segment) {
-        const isValid = !(segment.mode === 'carDriver' && person.drivingLicenseOwner !== 'yes');
+        const isValid = !(segment.mode === 'carDriver' && person.drivingLicenseOwnership !== 'yes');
         if (interview.is_completed && !isValid)
         {
           console.log('S_I_MODECARDRIVERWITHOUTLICENSE', responses.accessCode);
@@ -1452,7 +1452,7 @@ const validations =  {
         if (segment.mode === 'carPassenger' && uuidValidate(segment.driver) && !sharedHelper.isBlank(personsById[segment.driver]))
         {
           const driver = personsById[segment.driver];
-          if (driver.drivingLicenseOwner !== 'yes')
+          if (driver.drivingLicenseOwnership !== 'yes')
           {
             if (interview.is_completed)
             {

--- a/example/demo_survey/src/routes/admin/admin.routes.ts
+++ b/example/demo_survey/src/routes/admin/admin.routes.ts
@@ -163,7 +163,7 @@ export default function(router) {
               gender              : person.gender,
               occupation          : person.occupation,
               numberOfTrips       : tripIds.length,
-              drivingLicenseOwner : person.drivingLicenseOwner,
+              drivingLicenseOwnership : person.drivingLicenseOwnership,
               transitPassOwner    : person.transitPassOwner,
               carsharingMember    : person.carsharingMember,
               bikesharingMember   : person.bikesharingMember,

--- a/example/demo_survey/src/survey/sections.ts
+++ b/example/demo_survey/src/survey/sections.ts
@@ -105,7 +105,7 @@ export default {
       ...homeWidgets,
       'buttonSaveNextSection'
     ],
-    preload: function (interview, startUpdateInterview, startAddGroupedObjects, startRemoveGroupedObjects, callback) {
+    preload: function (interview, { startUpdateInterview, callback }) {
       if (!getResponse(interview, 'tripsDate')) {
         startUpdateInterview('home', {
           'responses.tripsDate': moment().prevBusinessDay().format('YYYY-MM-DD'),
@@ -137,7 +137,7 @@ export default {
       'householdMembers',
       'buttonSaveNextSectionHouseholdMembers'
     ],
-    preload: function(interview, startUpdateInterview, startAddGroupedObjects, startRemoveGroupedObjects, callback) {
+    preload: function(interview, { startAddGroupedObjects, startRemoveGroupedObjects, callback }) {
       const groupedObjects       = getResponse(interview, 'household.persons');
       const groupedObjectIds     = groupedObjects ? Object.keys(groupedObjects) : [];
       const countGroupedObjects  = groupedObjectIds.length;
@@ -194,7 +194,7 @@ export default {
       'partTwoIntroText',
       'partOneConfirmed'
     ],
-    preload: function (interview, startUpdateInterview, startAddGroupedObjects, startRemoveGroupedObjects, callback) {
+    preload: function (interview, {startUpdateInterview, callback}) {
       const updateValuesByPath = {};
       if (_isBlank(getResponse(interview, 'tripsDate', null)))
       {
@@ -233,7 +233,7 @@ export default {
       'selectPerson',
       'buttonSelectPersonConfirm'
     ],
-    preload: function(interview, startUpdateInterview, startAddGroupedObjects, startRemoveGroupedObjects, callback) {
+    preload: function(interview, { startUpdateInterview, callback }) {
       const personsCount = helper.countPersons(interview);
       if (personsCount === 1)
       {
@@ -270,7 +270,7 @@ export default {
     },
     hiddenInNav: true,
     widgets: profileWidgets,
-    preload: function (interview, startUpdateInterview, startAddGroupedObjects, startRemoveGroupedObjects, callback) {
+    preload: function (interview, { startUpdateInterview, callback }) {
       if (config.isPartTwo === true)
       {
         callback();
@@ -324,7 +324,7 @@ export default {
       'buttonContinueNextSection',
       'visitedPlacesOutro'
     ],
-    preload: function (interview, startUpdateInterview, startAddGroupedObjects, startRemoveGroupedObjects, callback) {
+    preload: function (interview, { startUpdateInterview, callback }) {
       const person = helper.getPerson(interview);
       if ((person.didTripsOnTripsDate !== 'yes' && person.didTripsOnTripsDate !== true) || person.didTripsOnTripsDateKnowTrips === 'no') // if no trip, go to next no trip section
       {
@@ -405,7 +405,7 @@ export default {
       //'personLastVisitedPlaceNotHome',
       'buttonVisitedPlacesConfirmNextSection'
     ],
-    preload: function (interview, startUpdateInterview, startAddGroupedObjects, startRemoveGroupedObjects, callback) {
+    preload: function (interview, { startUpdateInterview, callback }) {
       
       const person = helper.getPerson(interview);
       if ((person.didTripsOnTripsDate !== 'yes' && person.didTripsOnTripsDate !== true) || person.didTripsOnTripsDateKnowTrips === 'no') // if no trip, go to next no trip section
@@ -489,7 +489,7 @@ export default {
       'personVisitedPlacesMap',
       'buttonConfirmNextSection'
     ],
-    preload: function (interview, startUpdateInterview, startAddGroupedObjects, startRemoveGroupedObjects, callback) {
+    preload: function (interview, { startUpdateInterview, callback }) {
       
       const person = helper.getPerson(interview);
       if ((person.didTripsOnTripsDate !== 'yes' && person.didTripsOnTripsDate !== true) || person.didTripsOnTripsDateKnowTrips === 'no') // if no trip, go to next no trip section
@@ -595,7 +595,7 @@ export default {
       'personWhoAnsweredForThisPerson',
       'buttonContinueNextSection'
     ],
-    preload: function (interview, startUpdateInterview, startAddGroupedObjects, startRemoveGroupedObjects, callback) {
+    preload: function (interview, { startUpdateInterview,callback }) {
       const person = helper.getPerson(interview);
       if (interview.visibleWidgets.indexOf(`household.persons.${person._uuid}.noSchoolTripReason`) <= -1 && interview.visibleWidgets.indexOf(`household.persons.${person._uuid}.noWorkTripReason`) <= -1 && interview.visibleWidgets.indexOf(`household.persons.${person._uuid}.whoAnsweredForThisPerson`) <= -1)
       {
@@ -641,7 +641,7 @@ export default {
       'householdCommentsOnSurvey',
       'buttonCompleteInterview'
     ],
-    preload: function (interview, startUpdateInterview, startAddGroupedObjects, startRemoveGroupedObjects, callback) {
+    preload: function (interview, { startUpdateInterview, callback }) {
       
       const persons = helper.getPersons(interview);
       for (let personId in persons)
@@ -694,13 +694,12 @@ export default {
     widgets: [
       'completedText'
     ],
-    preload: function (interview, startUpdateInterview, startAddGroupedObjects, startRemoveGroupedObjects, callback) {
+    preload: function (interview, { startUpdateInterview, callback, user }) {
       if (config.isPartTwo === true)
       {
-        if (!this.props.user || (this.props.user && this.props.user.is_admin !== true))
+        if (!user || (user && user.is_admin !== true))
         {
           startUpdateInterview('end', {
-            'responses._language'   : this.props.i18n.language,
             'responses._partTwoCompletedAt': moment().unix(),
             'responses._partTwoIsCompleted': true,
             'responses._completedAt': moment().unix(),
@@ -710,10 +709,9 @@ export default {
       }
       else
       {
-        if (!this.props.user || (this.props.user && this.props.user.is_admin !== true))
+        if (!user || (user && user.is_admin !== true))
         {
           startUpdateInterview('end', {
-            'responses._language'   : this.props.i18n.language,
             'responses._completedAt': moment().unix(),
             'responses._isCompleted': true
           }, null, null, callback);
@@ -804,7 +802,7 @@ export default {
         ]
       }
     },
-    preload: function(interview, startUpdateInterview, startAddGroupedObjects, startRemoveGroupedObjects, callback) {
+    preload: function(interview, { startUpdateInterview, startAddGroupedObjects, startRemoveGroupedObjects, callback }) {
       if (!getResponse(interview, 'tripsDate')) {
         startUpdateInterview('home', {
           'responses.tripsDate': moment().prevBusinessDay().format('YYYY-MM-DD'),

--- a/example/demo_survey/src/survey/widgets/householdMembers.tsx
+++ b/example/demo_survey/src/survey/widgets/householdMembers.tsx
@@ -733,16 +733,16 @@ export const personCarsharingMember = {
     }
   },
   conditional: function(interview, path) {
-    const drivingLicenseOwner = surveyHelperNew.getResponse(interview, path, null, '../drivingLicenseOwner');
-    if (_isBlank(drivingLicenseOwner)) { return [false, null]; }
-    if (!_isBlank(drivingLicenseOwner) && drivingLicenseOwner !== 'yes') { return [false, 'nonApplicable']; }
+    const drivingLicenseOwnership = surveyHelperNew.getResponse(interview, path, null, '../drivingLicenseOwnership');
+    if (_isBlank(drivingLicenseOwnership)) { return [false, null]; }
+    if (!_isBlank(drivingLicenseOwnership) && drivingLicenseOwnership !== 'yes') { return [false, 'nonApplicable']; }
     return [true, null];
   },
   validations: function(value, customValue, interview, path, customPath) {
-    const drivingLicenseOwner = surveyHelperNew.getResponse(interview, path, null, '../drivingLicenseOwner');
+    const drivingLicenseOwnership = surveyHelperNew.getResponse(interview, path, null, '../drivingLicenseOwnership');
     return [
       {
-        validation: _isBlank(value) && drivingLicenseOwner == 'yes',
+        validation: _isBlank(value) && drivingLicenseOwnership === 'yes',
         errorMessage: {
           fr: `Cette réponse est requise.`,
           en: `This field is required.`

--- a/example/demo_survey/tests/test-one-person-helpers.ts
+++ b/example/demo_survey/tests/test-one-person-helpers.ts
@@ -21,7 +21,7 @@ export function completeHouseholdPage(context) {
     testHelpers.inputStringTest({ context, path: 'household.persons.${personId[0]}.age', value: '30' });
     testHelpers.inputRadioTest({ context, path: 'household.persons.${personId[0]}.gender', value: 'male' });
     testHelpers.inputSelectTest({ context, path: 'household.persons.${personId[0]}.occupation', value: 'fullTimeWorker' });
-    testHelpers.inputRadioTest({ context, path: 'household.persons.${personId[0]}.drivingLicenseOwner', value: 'no' });
+    testHelpers.inputRadioTest({ context, path: 'household.persons.${personId[0]}.drivingLicenseOwnership', value: 'no' });
     testHelpers.inputRadioTest({ context, path: 'household.persons.${personId[0]}.transitPassOwner', value: 'no' });
     testHelpers.inputRadioTest({ context, path: 'household.persons.${personId[0]}.bikesharingMember', value: 'yes' });
     testHelpers.inputRadioTest({ context, path: 'household.persons.${personId[0]}.hasDisability', value: 'no' });

--- a/example/demo_survey/tests/test-two-adults-no-trips.UI.spec.ts
+++ b/example/demo_survey/tests/test-two-adults-no-trips.UI.spec.ts
@@ -40,7 +40,7 @@ testHelpers.inputStringTest({ context, path: 'household.persons.${personId[0]}.n
 testHelpers.inputStringTest({ context, path: 'household.persons.${personId[0]}.age', value: '30' });
 testHelpers.inputRadioTest({ context, path: 'household.persons.${personId[0]}.gender', value: 'male' });
 testHelpers.inputSelectTest({ context, path: 'household.persons.${personId[0]}.occupation', value: 'fullTimeWorker' });
-testHelpers.inputRadioTest({ context, path: 'household.persons.${personId[0]}.drivingLicenseOwner', value: 'no' });
+testHelpers.inputRadioTest({ context, path: 'household.persons.${personId[0]}.drivingLicenseOwnership', value: 'no' });
 testHelpers.inputRadioTest({ context, path: 'household.persons.${personId[0]}.transitPassOwner', value: 'no' });
 testHelpers.inputRadioTest({ context, path: 'household.persons.${personId[0]}.bikesharingMember', value: 'yes' });
 testHelpers.inputRadioTest({ context, path: 'household.persons.${personId[0]}.hasDisability', value: 'no' });
@@ -52,7 +52,7 @@ testHelpers.inputStringTest({ context, path: 'household.persons.${personId[1]}.n
 testHelpers.inputStringTest({ context, path: 'household.persons.${personId[1]}.age', value: '60' });
 testHelpers.inputRadioTest({ context, path: 'household.persons.${personId[1]}.gender', value: 'female' });
 testHelpers.inputSelectTest({ context, path: 'household.persons.${personId[1]}.occupation', value: 'fullTimeWorker' });
-testHelpers.inputRadioTest({ context, path: 'household.persons.${personId[1]}.drivingLicenseOwner', value: 'yes' });
+testHelpers.inputRadioTest({ context, path: 'household.persons.${personId[1]}.drivingLicenseOwnership', value: 'yes' });
 testHelpers.inputRadioTest({ context, path: 'household.persons.${personId[1]}.carsharingMember', value: 'yes' });
 testHelpers.inputRadioTest({ context, path: 'household.persons.${personId[1]}.transitPassOwner', value: 'no' });
 testHelpers.inputRadioTest({ context, path: 'household.persons.${personId[1]}.bikesharingMember', value: 'yes' });

--- a/locales/en/segments.yml
+++ b/locales/en/segments.yml
@@ -58,39 +58,38 @@ mode:
         bicycle: Bicycle
         bicycleElectric: E-Bike
         scooterElectric: E-Scooter
-        bicycleBikeSharing: BIXI
-        bicycleBikeSharingElectric: BIXI E-Bike
-        bus: Bus
-        transitHeavy: Metro, REM or train
-        transitBus: Transit bus
-        intercityBus: Intercity bus
-        schoolBus: Yellow school bus
-        integratedSchoolLines: Integrated school lines
-        busOther: Chartered or private bus
-        transitTram: Tramway
-        transitSubway: Metro (subway)
-        transitREM: REM
-        transitRail: Commuter train
-        intercityRail: Intercity train
-        personalCar: Car driver with personal car
+        bicyclePassenger: Passenger on bike
         carDriver: Car driver
         carPassenger: Car passenger
-        carDriverCarsharing: Carsharing
-        carDriverCarsharingStationBased: Station-based carsharing
-        carDriverCarsharingFreeFloating: Free floating carsharing
-        rentalCar: Rental car
-        transitTaxi: Taxibus / On-demand
+        transitBus: Transit bus
+        transitBRT: Bus rapid transit
+        transitSchoolBus: School service operated by transit agency
+        transitStreetCar: Tramway on street
+        transitFerry: River shuttle or ferry without vehicle
+        transitGondola: Gondola
+        transitMonorail: Monorail
+        transitRRT: Rapid rail transit, category A
+        transitLRT: Light rail transit, category B
+        transitLRRT: Light Rail Rapid Transit, category A
+        transitHSR: High speed rail
+        transitRegionalRail: Regional train
+        transitOnDemand: On-demand transport
+        transitTaxi: Taxibus
+        intercityBus: Intercity bus
+        intercityTrain: Intercity train
+        schoolBus: School bus
+        otherBus: Chartered or private bus
         taxi: Taxi
         paratransit: Paratransit
+        wheelchair: Wheelchair
+        mobilityScooter: Mobility scooter
+        motorcycle: Motorcycle or motorized scooter/moped
+        ferryWithCar: Ferry with vehicle
         plane: Airplane
         otherActiveModes: Other active mode
-        motorcycle: Motorcycle or motorized scooter/moped
-        ferryNoCar: River shuttle or ferry without vehicle
-        ferryWithCar: Ferry with vehicle
         other: Other
-        unknown: Unknown
         dontKnow: Don't know
-        preferNotToAnswer: Prefer not to answer
+        preferNotToAnswer: Prefer not to answer    
 ModeFirst: Which mode of transport was used first?
 ModeFirst_cati: >-
     Which mode of transport was used first to go from {{originName}} to

--- a/locales/fr/segments.yml
+++ b/locales/fr/segments.yml
@@ -57,15 +57,9 @@ mode:
         walk: Marche
         bicycle: Vélo
         bicycleElectric: Vélo électrique
-        bicycleBikesharing: Vélo partage
-        bicycleBikesharingElectric: Vélo partage électrique
-        bicyclePassenger: Vélo passager
         scooterElectric: Trottinette électrique
-        carDriverPersonal: Auto conducteur avec voiture personnelle
-        carDriverRental: Auto conducteur avec voiture de location
-        carDriverCarsharingStationBased: Autopartage basé station
-        carDriverCarsharingFreeFloating: Autopartage en libre service
-        carDriverCarsharingUnspecified: Autopartage
+        bicyclePassenger: Vélo passager
+        carDriver: Auto conducteur
         carPassenger: Auto passager
         transitBus: Bus
         transitBRT: Service rapide par bus

--- a/packages/evolution-frontend/src/components/hooks/__tests__/useSectionTemplate.test.ts
+++ b/packages/evolution-frontend/src/components/hooks/__tests__/useSectionTemplate.test.ts
@@ -45,12 +45,13 @@ describe('useSectionTemplate', () => {
     it('should call preload function on mount', () => {
         renderHook(() => useSectionTemplate(props));
         expect(props.sectionConfig.preload).toHaveBeenCalledWith(
-            props.interview,
-            props.startUpdateInterview,
-            props.startAddGroupedObjects,
-            props.startRemoveGroupedObjects,
-            expect.any(Function),
-            props.user
+            props.interview, {
+                startUpdateInterview: props.startUpdateInterview,
+                startAddGroupedObjects: props.startAddGroupedObjects,
+                startRemoveGroupedObjects: props.startRemoveGroupedObjects,
+                callback: expect.any(Function),
+                user: props.user
+            }
         );
     });
 

--- a/packages/evolution-frontend/src/components/hooks/useSectionTemplate.ts
+++ b/packages/evolution-frontend/src/components/hooks/useSectionTemplate.ts
@@ -29,15 +29,13 @@ export function useSectionTemplate(props: SectionProps) {
     // Call preload upon the first mount of the component
     useEffect(() => {
         if (typeof props.sectionConfig.preload === 'function') {
-            props.sectionConfig.preload.call(
-                null,
-                props.interview,
-                props.startUpdateInterview,
-                props.startAddGroupedObjects,
-                props.startRemoveGroupedObjects,
-                () => setPreloaded(true),
-                props.user
-            );
+            props.sectionConfig.preload(props.interview, {
+                startUpdateInterview: props.startUpdateInterview,
+                startAddGroupedObjects: props.startAddGroupedObjects,
+                startRemoveGroupedObjects: props.startRemoveGroupedObjects,
+                callback: () => setPreloaded(true),
+                user: props.user
+            });
         } else {
             setPreloaded(true);
         }

--- a/packages/evolution-frontend/src/services/interviews/interview.ts
+++ b/packages/evolution-frontend/src/services/interviews/interview.ts
@@ -69,19 +69,22 @@ export type FrontendInterviewAttributes = {
 
 export type UserFrontendInterviewAttributes = FrontendInterviewAttributes & UserInterviewAttributes;
 
+export type SectionPreload = (
+    interview: UserInterviewAttributes,
+    args: {
+        startUpdateInterview: StartUpdateInterview;
+        startAddGroupedObjects: StartAddGroupedObjects;
+        startRemoveGroupedObjects: StartRemoveGroupedObjects;
+        callback: (interview: UserInterviewAttributes) => void;
+        user: CliUser;
+    }
+) => void;
+
 export type SectionConfig = {
     widgets: string[];
     previousSection?: string;
     nextSection?: string;
-    // FIXME: change for a single named option argument instead of 6 arguments
-    preload?: (
-        interview: UserFrontendInterviewAttributes,
-        startUpdateInterview: StartUpdateInterview,
-        startAddGroupedObjects: StartAddGroupedObjects,
-        startRemoveGroupedObjects: StartRemoveGroupedObjects,
-        callback: (interview: UserFrontendInterviewAttributes) => void,
-        user: CliUser
-    ) => void;
+    preload?: SectionPreload;
     template?: React.ComponentType;
     hiddenInNav?: boolean;
     parentSection?: string;


### PR DESCRIPTION
* Type the section`preload`'s call and change the second and more arguments to a single named argument, to make it simpler for implementations to use use only the required values without worrying about positioning.
* Fix short mode labels
* Fix UI tests after renaming the `driverLicenseOwnership` widget.