### PR TITLE
Admin export: Add interviewer count and created to exported interview csv file

### DIFF
--- a/packages/evolution-backend/src/services/adminExport/exportAllToCsvByObject.ts
+++ b/packages/evolution-backend/src/services/adminExport/exportAllToCsvByObject.ts
@@ -17,6 +17,7 @@ import { execJob } from '../../tasks/serverWorkerPool';
 import * as surveyHelperNew from 'evolution-common/lib/utils/helpers';
 import { fileManager } from 'chaire-lib-backend/lib/utils/filesystem/fileManager';
 import interviewsDbQueries from '../../models/interviews.db.queries';
+import config from 'evolution-common/lib/config/project.config';
 
 export const filePathOnServer = 'exports/interviewData';
 
@@ -285,8 +286,7 @@ export const exportAllToCsvByObjectTask = async function (
     const csvFilePaths: string[] = [];
     const fileNamePrefix = options.responseType === 'validatedIfAvailable' ? 'validated' : 'participant';
     for (const objectPath in pathsByObject) {
-        const csvFilePath =
-            `${filePathOnServer}/${fileNamePrefix}_` + objectPath.replaceAll('._.', '_').replaceAll('.', '_') + '.csv';
+        const csvFilePath = `${filePathOnServer}/${fileNamePrefix}_${objectPath.replaceAll('._.', '_').replaceAll('.', '_')}_${config.projectShortname}.csv`;
         const csvStream = fs.createWriteStream(fileManager.getAbsolutePath(csvFilePath));
         csvStream.on('error', console.error);
         csvFilePathByObjectPath[objectPath] = csvStream;

--- a/packages/evolution-common/src/services/interviews/interview.ts
+++ b/packages/evolution-common/src/services/interviews/interview.ts
@@ -16,6 +16,12 @@ import { Optional } from '../../types/Optional.type';
 import { SegmentAttributes } from '../baseObjects/Segment';
 import { HouseholdAttributes } from '../baseObjects/Household';
 
+/**
+ * Prefix used for the username of the participants created for a
+ * computer-aided telephone interview (CATI)
+ * */
+export const INTERVIEWER_PARTICIPANT_PREFIX = 'telephone';
+
 type Required<T> = { [P in keyof T]-?: T[P] };
 // This recursive generic type is taken from this stack overflow question:
 // https://stackoverflow.com/questions/65332597/typescript-is-there-a-recursive-keyof

--- a/packages/evolution-frontend/src/components/admin/interviews/InterviewSearchList.tsx
+++ b/packages/evolution-frontend/src/components/admin/interviews/InterviewSearchList.tsx
@@ -11,6 +11,7 @@ import Interview from './InterviewSearchResult';
 import { InterviewContext } from '../../../contexts/InterviewContext';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import InterviewsCreateLink from './InterviewsCreateLink';
+import { INTERVIEWER_PARTICIPANT_PREFIX } from 'evolution-common/lib/services/interviews/interview';
 
 type InterviewSearchListProps = {
     autoCreateIfNoData: boolean;
@@ -55,7 +56,7 @@ const InterviewSearchList: React.FunctionComponent<InterviewSearchListProps & Wi
                             // automatically create new interview with this access code
                             dispatch({
                                 type: 'createNew',
-                                username: `telephone_${(Math.ceil(Math.random() * 8999) + 1000).toString()}`,
+                                username: `${INTERVIEWER_PARTICIPANT_PREFIX}_${(Math.ceil(Math.random() * 8999) + 1000).toString()}`,
                                 queryData: props.queryData
                             });
                         }

--- a/packages/evolution-frontend/src/components/admin/interviews/InterviewsCreateLink.tsx
+++ b/packages/evolution-frontend/src/components/admin/interviews/InterviewsCreateLink.tsx
@@ -9,6 +9,7 @@ import { WithTranslation, withTranslation } from 'react-i18next';
 import InterviewsCreateNew from './InterviewsCreateNew';
 import { InterviewContext } from '../../../contexts/InterviewContext';
 import { URLSearchParams } from 'url';
+import { INTERVIEWER_PARTICIPANT_PREFIX } from 'evolution-common/lib/services/interviews/interview';
 
 type InterviewCreateLinkProps = {
     queryData: URLSearchParams;
@@ -30,7 +31,7 @@ const InterviewCreateLink: React.FunctionComponent<WithTranslation & InterviewCr
                     e.preventDefault();
                     dispatch({
                         type: 'createNew',
-                        username: `telephone_${(Math.ceil(Math.random() * 8999) + 1000).toString()}`,
+                        username: `${INTERVIEWER_PARTICIPANT_PREFIX}_${(Math.ceil(Math.random() * 8999) + 1000).toString()}`,
                         queryData: props.queryData
                     });
                 }}


### PR DESCRIPTION
Add the `includeInterviewerData` option to the interviews stream query. If set to `true`, it will return whether the interview was created by an interviewer and the number of interviewer who touched this interview.

This adds the `_interviewer_count` and `_interviewer_created` columns to
the exported interviews' csv file.

Also add the project shortname to the exported file names.