### PR TITLE
survey: Add an appContext to the SurveyContext type for generic local…

### DIFF
--- a/packages/evolution-frontend/src/components/pageParts/ConsentAndStartForm.tsx
+++ b/packages/evolution-frontend/src/components/pageParts/ConsentAndStartForm.tsx
@@ -12,6 +12,7 @@ import { WithTranslation, withTranslation } from 'react-i18next';
 import config from 'chaire-lib-common/lib/config/shared/project.config';
 import FormErrors from 'chaire-lib-frontend/lib/components/pageParts/FormErrors';
 import { addConsent } from '../../actions/Survey';
+import { SurveyContext } from '../../contexts/SurveyContext';
 
 export type ConsentAndStartFormProps = {
     hasConsented: boolean;
@@ -60,8 +61,10 @@ const AgreementCheckbox = (props: AgreementCheckboxProps) => {
 
 const ConsentAndStartForm = (props: ConsentAndStartFormProps & WithTranslation) => {
     const [showError, setShowError] = React.useState(false);
+    const { appContext } = React.useContext(SurveyContext);
+
     const color = config.startButtonColor ? config.startButtonColor : 'green';
-    const agreementText = props.t(['survey:homepage:AgreementText', 'main:AgreementText']);
+    const agreementText = props.t(['survey:homepage:AgreementText', 'main:AgreementText'], { context: appContext });
     React.useEffect(() => {
         if (_isBlank(agreementText)) {
             props.addConsent(true);
@@ -89,7 +92,9 @@ const ConsentAndStartForm = (props: ConsentAndStartFormProps & WithTranslation) 
             )}
             {showError && (
                 <FormErrors
-                    errors={[props.t(['survey:homepage:ErrorNotAgreed', 'main:ErrorNotAgreed'])]}
+                    errors={[
+                        props.t(['survey:homepage:ErrorNotAgreed', 'main:ErrorNotAgreed'], { context: appContext })
+                    ]}
                     errorType="Error"
                 />
             )}
@@ -99,7 +104,7 @@ const ConsentAndStartForm = (props: ConsentAndStartFormProps & WithTranslation) 
                     className={`survey-section__button button ${color} large`}
                     onClick={onButtonClicked}
                 >
-                    {props.t(['survey:homepage:start', 'auth:Start'])}
+                    {props.t(['survey:homepage:start', 'auth:Start'], { context: appContext })}
                 </button>
             </div>
         </div>

--- a/packages/evolution-frontend/src/components/pages/HomePage.tsx
+++ b/packages/evolution-frontend/src/components/pages/HomePage.tsx
@@ -16,6 +16,7 @@ import { startRegister } from '../../actions/Auth';
 import config from 'evolution-common/lib/config/project.config';
 import ConsentAndStartForm from '../pageParts/ConsentAndStartForm';
 import { InterviewContext } from '../../contexts/InterviewContext';
+import { SurveyContext } from '../../contexts/SurveyContext';
 import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
 import { AnyAction } from 'redux';
 
@@ -25,88 +26,73 @@ type HomePageProps = {
     history: History;
     location: Location;
     dispatch: Dispatch<AnyAction>;
-} & WithTranslation;
+};
 
-class HomePage extends React.Component<HomePageProps> {
-    static contextType = InterviewContext;
+const HomePage: React.FunctionComponent<HomePageProps & WithTranslation> = (props: HomePageProps & WithTranslation) => {
+    const { state, dispatch } = React.useContext(InterviewContext);
+    const { appContext } = React.useContext(SurveyContext);
 
-    constructor(props) {
-        super(props);
-
-        if (this.props.isAuthenticated === true) {
-            const goToPage = this.props.user && this.props.user.homePage ? this.props.user.homePage : '/survey';
+    React.useEffect(() => {
+        if (props.isAuthenticated === true) {
+            const goToPage = props.user && props.user.homePage ? props.user.homePage : '/survey';
             // Avoid infinite loops
-            this.props.history.push(goToPage === '' || goToPage === '/' ? '/survey' : goToPage);
+            props.history.push(goToPage === '' || goToPage === '/' ? '/survey' : goToPage);
         }
-    }
-
-    componentDidMount() {
         // If there is a query string, add to the responses
-        if (this.props.location.search && this.props.location.search !== '') {
-            const { state, dispatch } = this.context;
+        if (props.location.search && props.location.search !== '') {
             if (state.status !== 'entering') {
-                dispatch({ type: 'enter', queryData: new URLSearchParams(this.props.location.search) });
+                dispatch({ type: 'enter', queryData: new URLSearchParams(props.location.search) });
             }
         }
-    }
+    }, []);
 
-    afterClick = () => this.props.history.push({ pathname: '/login', search: this.props.location.search });
+    const afterClick = () => props.history.push({ pathname: '/login', search: props.location.search });
 
-    render = () => (
+    return (
         <div className="survey">
             <div style={{ width: '100%', margin: '0 auto', maxWidth: '60em' }}>
                 {config.introBanner && config.bannerPaths && (
                     <div className="main-logo center">
-                        <img
-                            src={config.bannerPaths[this.props.i18n.language]}
-                            style={{ width: '100%' }}
-                            alt="Banner"
-                        />
+                        <img src={config.bannerPaths[props.i18n.language]} style={{ width: '100%' }} alt="Banner" />
                     </div>
                 )}
                 <div style={{ width: '100%', margin: '0 auto', maxWidth: '30em', padding: '0 1rem' }}>
                     <form className="apptr__form" id="survey_form">
                         {!config.introLogoAfterStartButton && config.logoPaths && (
                             <div className="main-logo center">
-                                <img
-                                    src={config.logoPaths[this.props.i18n.language]}
-                                    style={{ width: '100%' }}
-                                    alt="Logo"
-                                />
+                                <img src={config.logoPaths[props.i18n.language]} style={{ width: '100%' }} alt="Logo" />
                             </div>
                         )}
-                        <div dangerouslySetInnerHTML={{ __html: this.props.t('survey:homepage:introduction') }} />
-                        {config.hideStartButtonOnHomePage !== true && (
-                            <ConsentAndStartForm afterClicked={this.afterClick} />
-                        )}
+                        <div
+                            dangerouslySetInnerHTML={{
+                                __html: props.t('survey:homepage:introduction', { context: appContext })
+                            }}
+                        />
+                        {config.hideStartButtonOnHomePage !== true && <ConsentAndStartForm afterClicked={afterClick} />}
                         {config.introLogoAfterStartButton && config.logoPaths && (
                             <div className="main-logo center">
-                                <img
-                                    src={config.logoPaths[this.props.i18n.language]}
-                                    style={{ width: '100%' }}
-                                    alt="Logo"
-                                />
+                                <img src={config.logoPaths[props.i18n.language]} style={{ width: '100%' }} alt="Logo" />
                             </div>
                         )}
                         {config.introductionTwoParagraph && (
                             <div
                                 dangerouslySetInnerHTML={{
-                                    __html: this.props.t('survey:homepage:introductionParagraphTwo')
+                                    __html: props.t('survey:homepage:introductionParagraphTwo', { context: appContext })
                                 }}
                             />
                         )}
                         <div className="center">
                             {config.languages.map((language) => {
                                 // TODO: make sure it would work with more than two langages (css and formatting)
-                                return this.props.i18n.language !== language ? (
+                                return props.i18n.language !== language ? (
                                     <a
                                         href="#"
                                         className="em"
                                         key={`header__nav-language-${language}`}
                                         onClick={(e) => {
                                             e.preventDefault();
-                                            this.props.i18n.changeLanguage(language);
-                                            moment.locale(this.props.i18n.language);
+                                            props.i18n.changeLanguage(language);
+                                            moment.locale(props.i18n.language);
                                         }}
                                     >
                                         {config.languageNames[language]}
@@ -121,7 +107,7 @@ class HomePage extends React.Component<HomePageProps> {
             </div>
         </div>
     );
-}
+};
 
 const mapStateToProps = (state, _props) => {
     return {

--- a/packages/evolution-frontend/src/contexts/SurveyContext.ts
+++ b/packages/evolution-frontend/src/contexts/SurveyContext.ts
@@ -14,6 +14,11 @@ export type SurveyContextType = {
     sections: SurveySections;
     widgets: SurveyWidgets;
     devMode: boolean;
+    /**
+     * Additional app context, that can be used as context in translations
+     * strings of core components
+     */
+    appContext?: string;
     dispatch: React.Dispatch<SurveyAction>;
 };
 

--- a/packages/evolution-legacy/src/apps/participant/client/index.js
+++ b/packages/evolution-legacy/src/apps/participant/client/index.js
@@ -25,7 +25,15 @@ import verifyAuthentication from 'chaire-lib-frontend/lib/services/auth/verifyAu
   
 setApplicationConfiguration({ homePage: '/survey' });
 
-export default () => {
+/*
+type AppProps = {
+  // Additional app context, that can be used as context in basic translations strings
+  appContext: string;
+};
+ */
+
+// Type of props AppProps
+export default (props = {}) => {
     document.title = config.title[i18n.language];
 
     const history = createBrowserHistory();
@@ -35,7 +43,7 @@ export default () => {
       const [state, dispatch] = React.useReducer(interviewReducer, initialState);
       const [devMode, dispatchSurvey] = React.useReducer(surveyReducer, { devMode: false });
       return(
-        <SurveyContext.Provider value={{ sections: appConfig.sections, widgets: appConfig.widgets, ...devMode, dispatch: dispatchSurvey }}>
+        <SurveyContext.Provider value={{ sections: appConfig.sections, widgets: appConfig.widgets, ...devMode, appContext: props.appContext, dispatch: dispatchSurvey }}>
         <InterviewContext.Provider value={{ state, dispatch }}>
           <Provider store={store}>
             <I18nextProvider i18n={ i18n }>


### PR DESCRIPTION
…es context

The `appContext` value is passed as prop to the `runClientApp` function and set in the `SurveyContext`. The `HomePage` widget uses this as a context for the i18n string translations, so it is possible to fine-tune these named translation strings to specific "context". This value is `undefined` by default and can be anything, either coming from the url, or specific to an instance, etc. It is only used to personnalize translation strings to this "context".

The `HomePage` widget is turned to a function component instead of a class to allow the use the multiple react contexts.