### PR TITLE
segments: add a group widget for the segments

### DIFF
--- a/example/demo_survey/src/survey/widgets/segments.tsx
+++ b/example/demo_survey/src/survey/widgets/segments.tsx
@@ -23,6 +23,7 @@ import { getModePreWidgetConfig } from 'evolution-common/lib/services/sections/s
 import { getModeWidgetConfig } from 'evolution-common/lib/services/sections/segments/widgetSegmentMode';
 import { getSameAsReverseTripWidgetConfig } from 'evolution-common/lib/services/sections/segments/widgetSameAsReverseTrip';
 import { getSegmentHasNextModeWidgetConfig } from 'evolution-common/lib/services/sections/segments/widgetSegmentHasNextMode';
+import { getSegmentsModeConfig } from 'evolution-common/lib/services/sections/segments/groupSegments';
 
 export const personTrips: GroupConfig = {
   type: "group",
@@ -65,59 +66,10 @@ export const personTrips: GroupConfig = {
   ]
 };
 
-export const segments: GroupConfig = {
-  type: "group",
-  path: "segments",
-  title: {
-    fr: "Modes",
-    en: "Modes"
-  },
-  name: {
-    fr: (groupedObject, sequence, interview, path) => (`Mode de transport ${sequence}`),
-    en: (groupedObject, sequence, interview, path) => (`Mode of transport ${sequence}`)
-  },
-  showTitle: false,
-  showGroupedObjectDeleteButton: function(interview, path) {
-    const segment = surveyHelperNew.getResponse(interview, path, {});
-    return (segment && segment['_sequence'] > 1);
-  },
-  showGroupedObjectAddButton: function(interview, path) {
-    const segments      = surveyHelperNew.getResponse(interview, path, {});
-    const segmentsArray = Object.values(segments).sort((segmentA, segmentB) => {
-      return segmentA['_sequence'] - segmentB['_sequence'];
-    });
-    const segmentsCount = segmentsArray.length;
-    const lastSegment   = segmentsArray[segmentsCount - 1];
-    return segmentsCount === 0 || (lastSegment  && lastSegment.hasNextMode === true);
-  },
-  groupedObjectAddButtonLabel: {
-    fr: function(interview, path) {
-      const segments      = surveyHelperNew.getResponse(interview, path, {});
-      const segmentsCount = Object.keys(segments).length;
-      if (segmentsCount === 0)
-      {
-        return 'Sélectionner le premier (ou le seul) mode de transport utilisé pour ce déplacement';
-      }
-      else
-      {
-        return 'Sélectionner le mode de transport suivant';
-      }
-    },
-    en: function(interview, path) {
-      const segments = surveyHelperNew.getResponse(interview, path, {});
-      const segmentsCount = Object.keys(segments).length;
-      if (segmentsCount === 0)
-      {
-        return 'Select the first mode of transport used during this trip';
-      }
-      else
-      {
-        return 'Select the next mode of transport';
-      }
-    }
-  },
-  addButtonLocation: 'bottom' as const,
-  widgets: [
+export const segments: GroupConfig = getSegmentsModeConfig();
+/*
+TODO These were the original widgets for the group, as well as some from other surveys, that should eventually be configurable
+widgets: [
     'segmentSameModeAsReverseTrip',
     'segmentModePre',
     'segmentMode',
@@ -134,10 +86,15 @@ export const segments: GroupConfig = {
     'segmentSubwayTransferStations',
     'segmentTrainStationStart',
     'segmentTrainStationEnd',
+    'segmentHowToBus',
     'segmentBusLines',
+    'segmentBusLinesWarning',
+    'segmentOnDemandType',
+    'tripJunctionQueryString',
+    'tripJunctionGeography',
     'segmentHasNextMode'
   ]
-}
+    */
 
 export const segmentIntro = {
   type: "text",

--- a/locales/en/segments.yml
+++ b/locales/en/segments.yml
@@ -1,3 +1,5 @@
+GroupTitle: Modes
+GroupName: Mode of transport {{sequence}}
 ModeIsRequired: Mode of transport is required.
 modePre:
     CarDriver: <strong>Driver</strong> (car/moto/scooter/truck)
@@ -105,3 +107,5 @@ SegmentSameModeReturn: >-
     Was it the same mode of transport used as the previous trip ({{previousMode}})?
 SegmentHasNextModeLoop: Other mode of transport used to complete {{thisTrip}}?
 SegmentHasNextMode: Other mode of transport used to complete {{thisTrip}}?
+AddButtonLabel_zero: Select the first (or only) mode of transport used during this trip
+AddButtonLabel: Select the next mode of transport

--- a/locales/fr/segments.yml
+++ b/locales/fr/segments.yml
@@ -1,3 +1,5 @@
+GroupTitle: Modes
+GroupName: Mode de transport {{sequence}}
 ModeIsRequired: Le mode de transport est requis.
 modePre:
     CarDriver: <strong>Conducteur</strong> (voiture/moto/scooter/camion)
@@ -106,3 +108,5 @@ SegmentSameModeReturn: >-
 SegmentHasNextModeLoop: Autre mode utilisé pour compléter {{thisTrip}}
     avant l'arrivée?
 SegmentHasNextMode: Autre mode utilisé pour compléter {{thisTrip}} avant l'arrivée?
+AddButtonLabel_zero: Sélectionner le premier (ou le seul) mode de transport utilisé pour ce déplacement
+AddButtonLabel: Sélectionner le mode de transport suivant

--- a/packages/evolution-common/src/services/sections/segments/__tests__/groupSegments.test.ts
+++ b/packages/evolution-common/src/services/sections/segments/__tests__/groupSegments.test.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import _cloneDeep from 'lodash/cloneDeep';
+
+import { getSegmentsModeConfig } from '../groupSegments';
+import { interviewAttributesForTestCases } from '../../../../tests/surveys';
+import * as utilHelpers from '../../../../utils/helpers';
+
+describe('getSegmentsModeConfig', () => {
+
+    test('should return the correct widget config', () => {
+        const widgetConfig = getSegmentsModeConfig();
+        expect(widgetConfig).toEqual({
+            type: 'group',
+            path: 'segments',
+            title: expect.any(Function),
+            name: expect.any(Function),
+            showTitle: false,
+            showGroupedObjectDeleteButton: expect.any(Function),
+            showGroupedObjectAddButton: expect.any(Function),
+            groupedObjectAddButtonLabel: expect.any(Function),
+            addButtonLocation: 'bottom' as const,
+            widgets: [
+                'segmentSameModeAsReverseTrip',
+                'segmentModePre',
+                'segmentMode',
+                'segmentHasNextMode'
+            ]
+        });
+    });
+
+});
+
+describe('getSegmentsModeConfig labels', () => {
+    const widgetConfig = getSegmentsModeConfig({});
+
+    test('should return the right label for title', () => {
+        const mockedT = jest.fn();
+        const title = widgetConfig.title;
+        expect(title).toBeDefined();
+        utilHelpers.translateString(title, { t: mockedT } as any, interviewAttributesForTestCases, 'path');
+        expect(mockedT).toHaveBeenCalledWith(['customSurvey:segments:GroupTitle', 'segments:GroupTitle']);
+    });
+
+    test('should return the right label for group name', () => {
+        const mockedT = jest.fn();
+        const name = widgetConfig.name;
+        expect(name).toBeDefined();
+        (name as any)(mockedT, {}, 2);
+        expect(mockedT).toHaveBeenCalledWith(['customSurvey:segments:GroupName', 'segments:GroupName'], { sequence: 2 });
+    });
+
+    test('should return the right label for add button', () => {
+        const mockedT = jest.fn();
+        const addButtonLabel = widgetConfig.groupedObjectAddButtonLabel;
+        expect(addButtonLabel).toBeDefined();
+
+        // Call the function with a path with no segments
+        jest.spyOn(utilHelpers, 'getResponse').mockReturnValue({});
+        utilHelpers.translateString(addButtonLabel, { t: mockedT } as any, interviewAttributesForTestCases, 'path');
+        expect(mockedT).toHaveBeenCalledWith(['customSurvey:segments:AddButtonLabel', 'segments:AddButtonLabel'], { count: 0 });
+
+        // Call the function with a path with segments
+        jest.spyOn(utilHelpers, 'getResponse').mockReturnValue({ segment1: { _uuid: 'segment1', _sequence: 1}});
+        utilHelpers.translateString(addButtonLabel, { t: mockedT } as any, interviewAttributesForTestCases, 'path');
+        expect(mockedT).toHaveBeenCalledWith(['customSurvey:segments:AddButtonLabel', 'segments:AddButtonLabel'], { count: 1 });
+    });
+
+    test('should return the right label for delete button', () => {
+        const deleteButtonLabel = widgetConfig.groupedObjectDeleteButtonLabel;
+        expect(deleteButtonLabel).toBeUndefined();
+    });
+});
+
+describe('getSegmentsModeConfig show add button', () => {
+    const widgetConfig = getSegmentsModeConfig({});
+
+    jest.spyOn(utilHelpers, 'getResponse').mockReturnValue({});
+    const mockedGetResponse = utilHelpers.getResponse as jest.MockedFunction<typeof utilHelpers.getResponse>;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('should show the add button if no segments yet', () => {
+        mockedGetResponse.mockReturnValue({});
+        const showAddButton = widgetConfig.showGroupedObjectAddButton;
+        expect(showAddButton).toBeDefined();
+        expect((showAddButton as any)(interviewAttributesForTestCases, 'path')).toBe(true);
+        expect(mockedGetResponse).toHaveBeenCalledWith(interviewAttributesForTestCases, 'path', {});
+    });
+
+    test('shoud show the add button if the last segment has next mode', () => {
+        mockedGetResponse.mockReturnValue({ segment1: { _uuid: 'segment1', _sequence: 1, hasNextMode: true }, segment2: { _uuid: 'segment2', _sequence: 2, hasNextMode: true }});
+        const showAddButton = widgetConfig.showGroupedObjectAddButton;
+        expect(showAddButton).toBeDefined();
+        expect((showAddButton as any)(interviewAttributesForTestCases, 'path')).toBe(true);
+        expect(mockedGetResponse).toHaveBeenCalledWith(interviewAttributesForTestCases, 'path', {});
+    });
+
+    test('shoud not show add button if the last segment has no next mode', () => {
+        mockedGetResponse.mockReturnValue({ segment1: { _uuid: 'segment1', _sequence: 1, hasNextMode: false }});
+        const showAddButton = widgetConfig.showGroupedObjectAddButton;
+        expect(showAddButton).toBeDefined();
+        expect((showAddButton as any)(interviewAttributesForTestCases, 'path')).toBe(false);
+        expect(mockedGetResponse).toHaveBeenCalledWith(interviewAttributesForTestCases, 'path', {});
+    });
+
+    test('shoud not show add button if the last segment has next mode not set', () => {
+        mockedGetResponse.mockReturnValue({ segment1: { _uuid: 'segment1', _sequence: 1 }});
+        const showAddButton = widgetConfig.showGroupedObjectAddButton;
+        expect(showAddButton).toBeDefined();
+        expect((showAddButton as any)(interviewAttributesForTestCases, 'path')).toBe(false);
+        expect(mockedGetResponse).toHaveBeenCalledWith(interviewAttributesForTestCases, 'path', {});
+    });
+
+});
+
+describe('getSegmentsModeConfig show delete button', () => {
+    const widgetConfig = getSegmentsModeConfig({});
+
+    jest.spyOn(utilHelpers, 'getResponse').mockReturnValue({});
+    const mockedGetResponse = utilHelpers.getResponse as jest.MockedFunction<typeof utilHelpers.getResponse>;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('should show the delete button if segment is not first', () => {
+        mockedGetResponse.mockReturnValue({ _uuid: 'segment2', _sequence: 2 });
+        const showDeleteButton = widgetConfig.showGroupedObjectDeleteButton;
+        expect(showDeleteButton).toBeDefined();
+        expect((showDeleteButton as any)(interviewAttributesForTestCases, 'path')).toBe(true);
+        expect(mockedGetResponse).toHaveBeenCalledWith(interviewAttributesForTestCases, 'path', null);
+    });
+
+    test('shoud not show the delete button if segment is first', () => {
+        mockedGetResponse.mockReturnValue({ _uuid: 'segment2', _sequence: 1 });
+        const showDeleteButton = widgetConfig.showGroupedObjectDeleteButton;
+        expect(showDeleteButton).toBeDefined();
+        expect((showDeleteButton as any)(interviewAttributesForTestCases, 'path')).toBe(false);
+        expect(mockedGetResponse).toHaveBeenCalledWith(interviewAttributesForTestCases, 'path', null);
+    });
+
+    test('shoud not show delete button if segment does not exist', () => {
+        mockedGetResponse.mockReturnValue(null);
+        const showDeleteButton = widgetConfig.showGroupedObjectDeleteButton;
+        expect(showDeleteButton).toBeDefined();
+        expect((showDeleteButton as any)(interviewAttributesForTestCases, 'path')).toBe(false);
+        expect(mockedGetResponse).toHaveBeenCalledWith(interviewAttributesForTestCases, 'path', null);
+    });
+
+});

--- a/packages/evolution-common/src/services/sections/segments/groupSegments.ts
+++ b/packages/evolution-common/src/services/sections/segments/groupSegments.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { GroupConfig } from '../../widgets';
+import { Segment } from '../../interviews/interview';
+import { getResponse } from '../../../utils/helpers';
+import { TFunction } from 'i18next';
+
+export const getSegmentsModeConfig = (
+    // FIXME: Type this when there is a few more widgets implemented
+    options: { context?: () => string } = {}
+): GroupConfig => {
+    // TODO These should be some configuration receive here to fine-tune the section's content
+    return {
+        type: 'group',
+        path: 'segments',
+        title: (t: TFunction) => t(['customSurvey:segments:GroupTitle', 'segments:GroupTitle']),
+        name: (t: TFunction, _groupedObject, sequence) =>
+            t(['customSurvey:segments:GroupName', 'segments:GroupName'], { sequence }),
+        showTitle: false,
+        showGroupedObjectDeleteButton: function (interview, path) {
+            const segment = getResponse(interview, path, null) as Segment | null;
+            return segment !== null && segment['_sequence'] > 1;
+        },
+        showGroupedObjectAddButton: function (interview, path) {
+            const segments = getResponse(interview, path, {}) as { [segmentId: string]: Segment };
+            const segmentsArray = Object.values(segments).sort((segmentA, segmentB) => {
+                return segmentA['_sequence'] - segmentB['_sequence'];
+            });
+            const segmentsCount = segmentsArray.length;
+            const lastSegment = segmentsArray[segmentsCount - 1];
+            return segmentsCount === 0 || (lastSegment && lastSegment.hasNextMode === true);
+        },
+        groupedObjectAddButtonLabel: (t: TFunction, interview, path) => {
+            const segments = getResponse(interview, path, {}) as { [segmentId: string]: Segment };
+            const segmentsCount = Object.keys(segments).length;
+            return t(['customSurvey:segments:AddButtonLabel', 'segments:AddButtonLabel'], { count: segmentsCount });
+        },
+        addButtonLocation: 'bottom' as const,
+        widgets: [
+            // TODO Those widget names do not link to anything! They should accompany their actual widgets somewhere
+            // Hard-coded, mandatory questions
+            'segmentSameModeAsReverseTrip',
+            'segmentModePre',
+            'segmentMode',
+            'segmentHasNextMode'
+            // TODO Add more configurable widgets here, either custom or depending on the segments section configuration
+        ]
+    };
+};

--- a/packages/evolution-common/src/services/widgets/WidgetConfig.ts
+++ b/packages/evolution-common/src/services/widgets/WidgetConfig.ts
@@ -418,8 +418,19 @@ export type GroupConfig = {
      * FIXME: Is this redundant with filter?
      */
     groupedObjectConditional?: boolean | ParsingFunction<boolean>;
+    /**
+     * This function is called for the whole group and must return whether to
+     * show the add button. The path received in the parsing function is the
+     * path to the current group and not one of the individual element of the
+     * group.
+     */
     showGroupedObjectAddButton?: boolean | ParsingFunction<boolean>;
     groupedObjectAddButtonLabel?: I18nData;
+    /**
+     * This function is called for each individual group object and must return
+     * whether to show the delete button for the current object. The path
+     * received in the parsing function is the path to the current object.
+     */
     showGroupedObjectDeleteButton?: boolean | ParsingFunction<boolean>;
     groupedObjectDeleteButtonLabel?: I18nData;
     deleteConfirmPopup?: {

--- a/packages/evolution-frontend/src/components/survey/GroupWidgets.tsx
+++ b/packages/evolution-frontend/src/components/survey/GroupWidgets.tsx
@@ -220,14 +220,8 @@ const BaseGroup: FunctionComponent<GroupProps & WithTranslation & WithSurveyCont
         props.loadingState === 0 &&
         parseBoolean(props.widgetConfig.showGroupedObjectAddButton, props.interview, props.path, props.user);
     const addButtonLabel =
-        parseString(
-            props.widgetConfig.groupedObjectAddButtonLabel
-                ? props.widgetConfig.groupedObjectAddButtonLabel[props.i18n.language] ||
-                      props.widgetConfig.groupedObjectAddButtonLabel
-                : null,
-            props.interview,
-            props.path
-        ) || props.t(`survey:${props.shortname}:addGroupedObject`);
+        translateString(props.widgetConfig.groupedObjectAddButtonLabel, props.i18n, props.interview, props.path) ||
+        props.t(`survey:${props.shortname}:addGroupedObject`);
     const addButtonLocation = props.widgetConfig.addButtonLocation || 'bottom';
     const addButtonSize = props.widgetConfig.addButtonSize || 'large';
 


### PR DESCRIPTION
This group is the main group for the `segments` object of the survey. It contains the button labels, as well as the segment widgets.

The demo_survey now uses this group widget instead of the main one.

TODO The group or its widgets is not yet configurable