### PR TITLE
trips: move necessary widgets and helper functions for the trips group

### DIFF
--- a/example/demo_survey/src/survey/widgets/segments.tsx
+++ b/example/demo_survey/src/survey/widgets/segments.tsx
@@ -23,7 +23,7 @@ import { getModePreWidgetConfig } from 'evolution-common/lib/services/sections/s
 import { getModeWidgetConfig } from 'evolution-common/lib/services/sections/segments/widgetSegmentMode';
 import { getSameAsReverseTripWidgetConfig } from 'evolution-common/lib/services/sections/segments/widgetSameAsReverseTrip';
 import { getSegmentHasNextModeWidgetConfig } from 'evolution-common/lib/services/sections/segments/widgetSegmentHasNextMode';
-import { getSegmentsModeConfig } from 'evolution-common/lib/services/sections/segments/groupSegments';
+import { getSegmentsGroupConfig } from 'evolution-common/lib/services/sections/segments/groupSegments';
 import { getTripSegmentsIntro } from 'evolution-common/lib/services/sections/segments/widgetTripSegmentsIntro';
 import { getButtonSaveTripSegmentsConfig } from 'evolution-common/lib/services/sections/segments/buttonSaveTripSegments';
 
@@ -68,7 +68,7 @@ export const personTrips: GroupConfig = {
   ]
 };
 
-export const segments: GroupConfig = getSegmentsModeConfig();
+export const segments: GroupConfig = getSegmentsGroupConfig();
 /*
 TODO These were the original widgets for the group, as well as some from other surveys, that should eventually be configurable
 widgets: [

--- a/example/demo_survey/src/survey/widgets/segments.tsx
+++ b/example/demo_survey/src/survey/widgets/segments.tsx
@@ -24,6 +24,7 @@ import { getModeWidgetConfig } from 'evolution-common/lib/services/sections/segm
 import { getSameAsReverseTripWidgetConfig } from 'evolution-common/lib/services/sections/segments/widgetSameAsReverseTrip';
 import { getSegmentHasNextModeWidgetConfig } from 'evolution-common/lib/services/sections/segments/widgetSegmentHasNextMode';
 import { getSegmentsModeConfig } from 'evolution-common/lib/services/sections/segments/groupSegments';
+import { getTripSegmentsIntro } from 'evolution-common/lib/services/sections/segments/widgetTripSegmentsIntro';
 
 export const personTrips: GroupConfig = {
   type: "group",
@@ -96,17 +97,7 @@ widgets: [
   ]
     */
 
-export const segmentIntro = {
-  type: "text",
-  text: {
-    fr: function(interview, path) {
-      return `Veuillez sélectionner **tous** les modes de transport utilisés pour effectuer ce déplacement, **dans l'ordre chronologique**:`;
-    },
-    en: function(interview, path) {
-      return `Please select **all** modes of transport used for this trip, **in chronological order**:`;
-    }
-  }
-};
+export const segmentIntro = getTripSegmentsIntro();;
 
 export const segmentSameModeAsReverseTrip = getSameAsReverseTripWidgetConfig();
 

--- a/example/demo_survey/src/survey/widgets/segments.tsx
+++ b/example/demo_survey/src/survey/widgets/segments.tsx
@@ -25,6 +25,7 @@ import { getSameAsReverseTripWidgetConfig } from 'evolution-common/lib/services/
 import { getSegmentHasNextModeWidgetConfig } from 'evolution-common/lib/services/sections/segments/widgetSegmentHasNextMode';
 import { getSegmentsModeConfig } from 'evolution-common/lib/services/sections/segments/groupSegments';
 import { getTripSegmentsIntro } from 'evolution-common/lib/services/sections/segments/widgetTripSegmentsIntro';
+import { getButtonSaveTripSegmentsConfig } from 'evolution-common/lib/services/sections/segments/buttonSaveTripSegments';
 
 export const personTrips: GroupConfig = {
   type: "group",
@@ -2528,29 +2529,8 @@ export const introButtonSaveTrip = {
   }
 };
 
-export const buttonSaveTrip = {
-  type: "button",
-  color: "green",
-  label: {
-    fr: "Confirmer ce déplacement",
-    en: "Confirm this trip"
-  },
-  hideWhenRefreshing: true,
-  path: "buttonSaveTrip",
-  icon: faCheckCircle,
-  align: 'center',
-  action: surveyHelper.validateButtonAction,
-  saveCallback: function(callbacks: surveyHelperNew.InterviewUpdateCallbacks) {
-    callbacks.startUpdateInterview("segments", {
-      'responses._activeTripId': null
-    });
-  },
-  conditional: function(interview, path) {
-    const segments      = surveyHelperNew.getResponse(interview, path, {}, '../segments');
-    const segmentsArray = Object.values(segments).sort((segmentA, segmentB) => {
-      return segmentA['_sequence'] - segmentB['_sequence'];
-    });
-    const lastSegment   = segmentsArray[segmentsArray.length - 1];
-    return [lastSegment && lastSegment.hasNextMode === false, undefined];
-  }
-};
+// FIXME The options should be in a config somewhere for frontend mapping
+export const buttonSaveTrip = getButtonSaveTripSegmentsConfig({
+    iconMapper: { 'check-circle': faCheckCircle },
+    buttonActions: { validateButtonAction: surveyHelper.validateButtonAction },
+});

--- a/example/demo_survey/src/survey/widgets/segments.tsx
+++ b/example/demo_survey/src/survey/widgets/segments.tsx
@@ -26,47 +26,9 @@ import { getSegmentHasNextModeWidgetConfig } from 'evolution-common/lib/services
 import { getSegmentsGroupConfig } from 'evolution-common/lib/services/sections/segments/groupSegments';
 import { getTripSegmentsIntro } from 'evolution-common/lib/services/sections/segments/widgetTripSegmentsIntro';
 import { getButtonSaveTripSegmentsConfig } from 'evolution-common/lib/services/sections/segments/buttonSaveTripSegments';
+import { getPersonsTripsGroupConfig } from 'evolution-common/lib/services/sections/segments/groupPersonTrips'
 
-export const personTrips: GroupConfig = {
-  type: "group",
-  path: "household.persons.{_activePersonId}.journeys.{_activeJourneyId}.trips",
-  title: {
-    fr: "Déplacements",
-    en: "Trips"
-  },
-  filter: function(interview, groupedObjects) {
-    const activeTripId = surveyHelperNew.getResponse(interview, '_activeTripId', null);
-    if (activeTripId)
-    {
-      const filteredGroupedObject = {};
-      for (const groupedObjectId in groupedObjects)
-      {
-        if (groupedObjectId === activeTripId)
-        {
-          filteredGroupedObject[groupedObjectId] = groupedObjects[groupedObjectId];
-        }
-      }
-      return filteredGroupedObject;
-    }
-    else
-    {
-      return {};
-    }
-  },
-  name: {
-    fr: "",
-    en: ""
-  },
-  showGroupedObjectDeleteButton: false,
-  showGroupedObjectAddButton: false,
-  widgets: [
-    'segmentIntro',
-    'segments',
-    'tripJunctionGeography',
-    //'introButtonSaveTrip',
-    'buttonSaveTrip'
-  ]
-};
+export const personTrips: GroupConfig = getPersonsTripsGroupConfig();
 
 export const segments: GroupConfig = getSegmentsGroupConfig();
 /*

--- a/locales/en/segments.yml
+++ b/locales/en/segments.yml
@@ -118,3 +118,4 @@ CurrentTripSegmentsIntro_workOnTheRoad: >-
 CurrentTripSegmentsIntro_leisureStroll: >-
     Please indicate all modes of transport used to complete the stroll, in chronological
     order:
+SaveTripLabel: Confirm this trip

--- a/locales/en/segments.yml
+++ b/locales/en/segments.yml
@@ -1,3 +1,4 @@
+TripsTitle: Trips
 GroupTitle: Modes
 GroupName: Mode of transport {{sequence}}
 ModeIsRequired: Mode of transport is required.

--- a/locales/en/segments.yml
+++ b/locales/en/segments.yml
@@ -109,3 +109,12 @@ SegmentHasNextModeLoop: Other mode of transport used to complete {{thisTrip}}?
 SegmentHasNextMode: Other mode of transport used to complete {{thisTrip}}?
 AddButtonLabel_zero: Select the first (or only) mode of transport used during this trip
 AddButtonLabel: Select the next mode of transport
+CurrentTripSegmentsIntro: >-
+    Please indicate all modes of transport used for this trip (from {{originName}}
+    to {{destinationName}}), in chronological order:
+CurrentTripSegmentsIntro_workOnTheRoad: >-
+    Please indicate all modes of transport used to complete work trip on the road,
+    in chronological order:
+CurrentTripSegmentsIntro_leisureStroll: >-
+    Please indicate all modes of transport used to complete the stroll, in chronological
+    order:

--- a/locales/fr/segments.yml
+++ b/locales/fr/segments.yml
@@ -1,3 +1,4 @@
+TripsTitle: Déplacements
 GroupTitle: Modes
 GroupName: Mode de transport {{sequence}}
 ModeIsRequired: Le mode de transport est requis.

--- a/locales/fr/segments.yml
+++ b/locales/fr/segments.yml
@@ -110,3 +110,12 @@ SegmentHasNextModeLoop: Autre mode utilisé pour compléter {{thisTrip}}
 SegmentHasNextMode: Autre mode utilisé pour compléter {{thisTrip}} avant l'arrivée?
 AddButtonLabel_zero: Sélectionner le premier (ou le seul) mode de transport utilisé pour ce déplacement
 AddButtonLabel: Sélectionner le mode de transport suivant
+CurrentTripSegmentsIntro: >-
+    Veuillez indiquer tous les modes de transport utilisés pour effectuer ce déplacement
+    (de {{originName}} à {{destinationName}}), dans l'ordre chronologique:
+CurrentTripSegmentsIntro_workOnTheRoad: >-
+    Veuillez indiquer tous les modes de transport utilisés pour effectuer les déplacements
+    sur la route, dans l'ordre chronologique:
+CurrentTripSegmentsIntro_leisureStroll: >-
+    Veuillez indiquer tous les modes de transport utilisés pour effectuer la promenade,
+    dans l'ordre chronologique:

--- a/locales/fr/segments.yml
+++ b/locales/fr/segments.yml
@@ -119,3 +119,4 @@ CurrentTripSegmentsIntro_workOnTheRoad: >-
 CurrentTripSegmentsIntro_leisureStroll: >-
     Veuillez indiquer tous les modes de transport utilisés pour effectuer la promenade,
     dans l'ordre chronologique:
+SaveTripLabel: Confirmer ce déplacement

--- a/packages/evolution-common/src/services/odSurvey/__tests__/helpers.test.ts
+++ b/packages/evolution-common/src/services/odSurvey/__tests__/helpers.test.ts
@@ -972,6 +972,50 @@ describe('getTrips', () => {
 
 });
 
+describe('selectNextIncompleteTrip', () => {
+
+    const segments = {
+        segment1: { _uuid: 'segment1', _sequence: 1, mode: 'carDriver' as const, hasNextMode: true, _isNew: false },
+        segment2: { _uuid: 'segment1', _sequence: 1, mode: 'carDriver' as const, hasNextMode: false, _isNew: false }
+    };
+
+    const trips = {
+        trip1: { _uuid: 'trip1', _sequence: 1, segments },
+        trip2: { _uuid: 'trip2', _sequence: 2 }
+    };
+
+    const journey: Journey = { _uuid: 'arbitraryJourney', _sequence: 1, trips };
+
+    test('should select trip with no segment', () => {
+        const attributes = _cloneDeep(journey);
+        expect(Helpers.selectNextIncompleteTrip({ journey: attributes })).toEqual(attributes.trips!.trip2);
+    });
+
+    test('should select trip where one segment does not have a mode', () => {
+        const attributes = _cloneDeep(journey);
+        delete attributes.trips!.trip1.segments!.segment2.mode;
+        expect(Helpers.selectNextIncompleteTrip({ journey: attributes })).toEqual(attributes.trips!.trip1);
+    });
+
+    test('should select trip with segment with hasNextMode not set or true', () => {
+        const attributes = _cloneDeep(journey);
+        // Set hasNextMode to false to last segment
+        attributes.trips!.trip1.segments!.segment2.hasNextMode = true;
+        expect(Helpers.selectNextIncompleteTrip({ journey: attributes })).toEqual(attributes.trips!.trip1);
+
+        // Delete hasNextMode in last segment
+        delete attributes.trips!.trip1.segments!.segment2.hasNextMode;
+        expect(Helpers.selectNextIncompleteTrip({ journey: attributes })).toEqual(attributes.trips!.trip1);
+    });
+
+    test('should return null if all trips complete', () => {
+        const attributes = _cloneDeep(journey);
+        // segments of trip2
+        attributes.trips!.trip2.segments = segments;
+        expect(Helpers.selectNextIncompleteTrip({ journey: attributes })).toEqual(null);
+    });
+})
+
 describe('getOrigin/getDestination', () => {
 
     test('getOrigin, existing', () => {

--- a/packages/evolution-common/src/services/sections/segments/__tests__/buttonSaveTripSegments.test.ts
+++ b/packages/evolution-common/src/services/sections/segments/__tests__/buttonSaveTripSegments.test.ts
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import _cloneDeep from 'lodash/cloneDeep';
+
+import { getButtonSaveTripSegmentsConfig } from '../buttonSaveTripSegments';
+import { interviewAttributesForTestCases } from '../../../../tests/surveys';
+import * as utilHelpers from '../../../../utils/helpers';
+import * as odHelpers from '../../../odSurvey/helpers';
+
+jest.mock('../../../odSurvey/helpers', () => ({
+    getPerson: jest.fn().mockReturnValue({}),
+    getActiveJourney: jest.fn().mockReturnValue({}),
+    selectNextIncompleteTrip: jest.fn().mockReturnValue(null)
+}));
+const mockedGetPerson = odHelpers.getPerson as jest.MockedFunction<typeof odHelpers.getPerson>;
+const mockedGetActiveJourney = odHelpers.getActiveJourney as jest.MockedFunction<typeof odHelpers.getActiveJourney>;
+const mockedSelectNextIncompleteTrip = odHelpers.selectNextIncompleteTrip as jest.MockedFunction<typeof odHelpers.selectNextIncompleteTrip>;
+
+// Prepare configuration options
+const mockButtonValidate = jest.fn();
+const options = {
+    buttonActions: { validateButtonAction: mockButtonValidate },
+    iconMapper: { 'check-circle': 'check-circle' as any }
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+})
+
+describe('getButtonSaveTripSegmentsConfig', () => {
+
+    test('should return the correct widget config', () => {
+        const widgetConfig = getButtonSaveTripSegmentsConfig(options);
+        expect(widgetConfig).toEqual({
+            type: 'button',
+            color: 'green',
+            label: expect.any(Function),
+            hideWhenRefreshing: true,
+            path: 'buttonSaveTrip',
+            icon: 'check-circle',
+            align: 'center',
+            action: mockButtonValidate,
+            saveCallback: expect.any(Function),
+            conditional: expect.any(Function)
+        });
+    });
+
+});
+
+describe('getButtonSaveTripSegmentsConfig labels', () => {
+    const widgetConfig = getButtonSaveTripSegmentsConfig(options);
+
+    test('should return the right label for title', () => {
+        const mockedT = jest.fn();
+        const title = widgetConfig.label;
+        expect(title).toBeDefined();
+        utilHelpers.translateString(title, { t: mockedT } as any, interviewAttributesForTestCases, 'path');
+        expect(mockedT).toHaveBeenCalledWith(['customSurvey:segments:SaveTripLabel', 'segments:SaveTripLabel']);
+    });
+
+});
+
+describe('getButtonSaveTripSegmentsConfig conditional', () => {
+    const widgetConfig = getButtonSaveTripSegmentsConfig(options);
+
+    jest.spyOn(utilHelpers, 'getResponse').mockReturnValue({});
+    const mockedGetResponse = utilHelpers.getResponse as jest.MockedFunction<typeof utilHelpers.getResponse>;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('should return `false` if no segments', () => {
+        mockedGetResponse.mockReturnValue({});
+        const conditional = widgetConfig.conditional;
+        expect(conditional).toBeDefined();
+        expect((conditional as any)(interviewAttributesForTestCases, 'path')).toEqual([false, undefined]);
+        expect(mockedGetResponse).toHaveBeenCalledWith(interviewAttributesForTestCases, 'path', {}, '../segments');
+    });
+
+    test('shoud return `false` if the last segment has next mode', () => {
+        mockedGetResponse.mockReturnValue({ segment1: { _uuid: 'segment1', _sequence: 1, hasNextMode: true }, segment2: { _uuid: 'segment2', _sequence: 2, hasNextMode: true }});
+        const conditional = widgetConfig.conditional;
+        expect(conditional).toBeDefined();
+        expect((conditional as any)(interviewAttributesForTestCases, 'path')).toEqual([false, undefined]);
+        expect(mockedGetResponse).toHaveBeenCalledWith(interviewAttributesForTestCases, 'path', {}, '../segments');
+    });
+
+    test('shoud return `false` if the last segment has next mode is not set', () => {
+        mockedGetResponse.mockReturnValue({ segment1: { _uuid: 'segment1', _sequence: 1 }});
+        const conditional = widgetConfig.conditional;
+        expect(conditional).toBeDefined();
+        expect((conditional as any)(interviewAttributesForTestCases, 'path')).toEqual([false, undefined]);
+        expect(mockedGetResponse).toHaveBeenCalledWith(interviewAttributesForTestCases, 'path', {}, '../segments');
+    });
+
+    test('shoud return `true` if the last segment does not have nex mode', () => {
+        mockedGetResponse.mockReturnValue({ segment1: { _uuid: 'segment1', _sequence: 1, hasNextMode: false }});
+        const conditional = widgetConfig.conditional;
+        expect(conditional).toBeDefined();
+        expect((conditional as any)(interviewAttributesForTestCases, 'path')).toEqual([true, undefined]);
+        expect(mockedGetResponse).toHaveBeenCalledWith(interviewAttributesForTestCases, 'path', {}, '../segments');
+    });
+
+});
+
+describe('getButtonSaveTripSegmentsConfig button action', () => {
+    const widgetConfig = getButtonSaveTripSegmentsConfig(options);
+
+    test('test button action', () => {
+        expect(mockButtonValidate).not.toHaveBeenCalled();
+        const action = widgetConfig.action;
+        action({ startUpdateInterview: jest.fn(), startAddGroupedObjects: jest.fn(), startRemoveGroupedObjects: jest.fn() }, interviewAttributesForTestCases, 'path', 'segments', {});
+        expect(mockButtonValidate).toHaveBeenCalled();
+    })
+});
+
+describe('getButtonSaveTripSegmentsConfig save callback', () => {
+    const widgetConfig = getButtonSaveTripSegmentsConfig(options);
+
+    jest.spyOn(utilHelpers, 'getResponse').mockReturnValue({});
+    const mockedGetResponse = utilHelpers.getResponse as jest.MockedFunction<typeof utilHelpers.getResponse>;
+
+    const buttonPath = 'path.to.trip.buttonAction';
+    const saveCallback = widgetConfig.saveCallback;
+    const updateCallbacks =
+        { startUpdateInterview: jest.fn(), startAddGroupedObjects: jest.fn(), startRemoveGroupedObjects: jest.fn() }
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('should set all _isNew to `false` and select next incomplete trip', () => {
+        // Mock function responses: 2 segments, active journey and incomplete trip
+        const journey = { _uuid: 'journey', _sequence: 1 };
+        const incompleteTrip = { _uuid: 'trip1', _sequence: 1 };
+        mockedGetResponse.mockReturnValueOnce({ segment1: { _uuid: 'segment1', _sequence: 1 }, segment2: { _uuid: 'segment2', _sequence: 2 } });
+        mockedGetActiveJourney.mockReturnValueOnce(journey);
+        mockedSelectNextIncompleteTrip.mockReturnValueOnce(incompleteTrip);
+
+        // Call the save callback
+        saveCallback!(updateCallbacks, interviewAttributesForTestCases, buttonPath);
+
+        // Test function calls
+        expect(mockedGetResponse).toHaveBeenCalledWith(interviewAttributesForTestCases, 'path.to.trip.segments', {});
+        expect(mockedGetActiveJourney).toHaveBeenCalledWith({ interview: interviewAttributesForTestCases });
+        expect(mockedSelectNextIncompleteTrip).toHaveBeenCalledWith({ journey });
+        expect(updateCallbacks.startUpdateInterview).toHaveBeenCalledWith('segments', {
+            'responses.path.to.trip.segments.segment1._isNew': false,
+            'responses.path.to.trip.segments.segment2._isNew': false,
+            'responses._activeTripId': 'trip1'
+        });
+    });
+
+    test('should set all _isNew to `false` and select no trip if no active journey', () => {
+        // Mock function responses: 2 segments no active journey
+        mockedGetResponse.mockReturnValueOnce({ segment1: { _uuid: 'segment1', _sequence: 1 }, segment2: { _uuid: 'segment2', _sequence: 2 } });
+        mockedGetActiveJourney.mockReturnValueOnce(null);
+
+        // Call the save callback
+        saveCallback!(updateCallbacks, interviewAttributesForTestCases, buttonPath);
+
+        // Test function calls
+        expect(mockedGetResponse).toHaveBeenCalledWith(interviewAttributesForTestCases, 'path.to.trip.segments', {});
+        expect(mockedGetActiveJourney).toHaveBeenCalledWith({ interview: interviewAttributesForTestCases });
+        expect(mockedSelectNextIncompleteTrip).not.toHaveBeenCalled();
+        expect(updateCallbacks.startUpdateInterview).toHaveBeenCalledWith('segments', {
+            'responses.path.to.trip.segments.segment1._isNew': false,
+            'responses.path.to.trip.segments.segment2._isNew': false,
+            'responses._activeTripId': null
+        });
+    });
+
+    test('should set all _isNew to `false` and select no trip if no incomplete trip', () => {
+        // Mock function responses: 2 segments, active journey and incomplete trip
+        const journey = { _uuid: 'journey', _sequence: 1 };
+        mockedGetResponse.mockReturnValueOnce({ segment1: { _uuid: 'segment1', _sequence: 1 }, segment2: { _uuid: 'segment2', _sequence: 2 } });
+        mockedGetActiveJourney.mockReturnValueOnce(journey);
+        mockedSelectNextIncompleteTrip.mockReturnValueOnce(null);
+
+        // Call the save callback
+        saveCallback!(updateCallbacks, interviewAttributesForTestCases, buttonPath);
+
+        // Test function calls
+        expect(mockedGetResponse).toHaveBeenCalledWith(interviewAttributesForTestCases, 'path.to.trip.segments', {});
+        expect(mockedGetActiveJourney).toHaveBeenCalledWith({ interview: interviewAttributesForTestCases });
+        expect(mockedSelectNextIncompleteTrip).toHaveBeenCalledWith({ journey });
+        expect(updateCallbacks.startUpdateInterview).toHaveBeenCalledWith('segments', {
+            'responses.path.to.trip.segments.segment1._isNew': false,
+            'responses.path.to.trip.segments.segment2._isNew': false,
+            'responses._activeTripId': null
+        });
+    });
+
+    test('should just set next incomplete trip is no segments', () => {
+        // Mock function responses: 2 segments, active journey and incomplete trip
+        const journey = { _uuid: 'journey', _sequence: 1 };
+        const incompleteTrip = { _uuid: 'trip1', _sequence: 1 };
+        mockedGetResponse.mockReturnValueOnce({ });
+        mockedGetActiveJourney.mockReturnValueOnce(journey);
+        mockedSelectNextIncompleteTrip.mockReturnValueOnce(incompleteTrip);
+
+        // Call the save callback
+        saveCallback!(updateCallbacks, interviewAttributesForTestCases, buttonPath);
+
+        // Test function calls
+        expect(mockedGetResponse).toHaveBeenCalledWith(interviewAttributesForTestCases, 'path.to.trip.segments', {});
+        expect(mockedGetActiveJourney).toHaveBeenCalledWith({ interview: interviewAttributesForTestCases });
+        expect(mockedSelectNextIncompleteTrip).toHaveBeenCalledWith({ journey });
+        expect(updateCallbacks.startUpdateInterview).toHaveBeenCalledWith('segments', {
+            'responses._activeTripId': 'trip1'
+        });
+    });
+
+});

--- a/packages/evolution-common/src/services/sections/segments/__tests__/groupPersonTrips.test.ts
+++ b/packages/evolution-common/src/services/sections/segments/__tests__/groupPersonTrips.test.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import _cloneDeep from 'lodash/cloneDeep';
+
+import { getPersonsTripsGroupConfig } from '../groupPersonTrips';
+import { interviewAttributesForTestCases } from '../../../../tests/surveys';
+import * as utilHelpers from '../../../../utils/helpers';
+import { t } from 'i18next';
+
+describe('getPersonsTripsGroupConfig', () => {
+
+    test('should return the correct widget config', () => {
+        const widgetConfig = getPersonsTripsGroupConfig();
+        expect(widgetConfig).toEqual({
+            type: 'group',
+            path: 'household.persons.{_activePersonId}.journeys.{_activeJourneyId}.trips',
+            title: expect.any(Function),
+            filter: expect.any(Function),
+            showTitle: false,
+            showGroupedObjectDeleteButton: false,
+            showGroupedObjectAddButton: false,
+            widgets: [
+                'segmentIntro',
+                'segments',
+                'buttonSaveTrip'
+            ]
+        });
+    });
+
+});
+
+describe('getPersonsTripsGroupConfig labels', () => {
+    const widgetConfig = getPersonsTripsGroupConfig({});
+
+    test('should return the right label for title', () => {
+        const mockedT = jest.fn();
+        const title = widgetConfig.title;
+        expect(title).toBeDefined();
+        utilHelpers.translateString(title, { t: mockedT } as any, interviewAttributesForTestCases, 'path');
+        expect(mockedT).toHaveBeenCalledWith(['customSurvey:segments:TripsTitle', 'segments:TripsTitle']);
+    });
+
+});
+
+describe('getPersonsTripsGroupConfig filter', () => {
+    const widgetConfig = getPersonsTripsGroupConfig({});
+
+    jest.spyOn(utilHelpers, 'getResponse').mockReturnValue({});
+    const mockedGetResponse = utilHelpers.getResponse as jest.MockedFunction<typeof utilHelpers.getResponse>;
+    
+    const filter = widgetConfig.filter;
+
+    const groupedObjects = {
+        trip1: { _uuid: 'trip1', _sequence: 1 },
+        trip2: { _uuid: 'trip2', _sequence: 2 }
+    }
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('should return empty element is no active trip ID', () => {
+        mockedGetResponse.mockReturnValue(null);
+        expect(filter!(interviewAttributesForTestCases, groupedObjects)).toEqual({})
+        expect(mockedGetResponse).toHaveBeenCalledWith(interviewAttributesForTestCases, '_activeTripId', null);
+    });
+
+    test('should return empty object if active trip ID does not exist in group objects', () => {
+        mockedGetResponse.mockReturnValue(null);
+        expect(filter!(interviewAttributesForTestCases, groupedObjects)).toEqual({})
+        expect(mockedGetResponse).toHaveBeenCalledWith(interviewAttributesForTestCases, '_activeTripId', null);
+    });
+
+    test('should return only the active trip if active trip ID exists', () => {
+        mockedGetResponse.mockReturnValue('trip1');
+        expect(filter!(interviewAttributesForTestCases, groupedObjects)).toEqual({ trip1: groupedObjects.trip1 });
+        expect(mockedGetResponse).toHaveBeenCalledWith(interviewAttributesForTestCases, '_activeTripId', null);
+    });
+
+});

--- a/packages/evolution-common/src/services/sections/segments/__tests__/groupSegments.test.ts
+++ b/packages/evolution-common/src/services/sections/segments/__tests__/groupSegments.test.ts
@@ -6,14 +6,14 @@
  */
 import _cloneDeep from 'lodash/cloneDeep';
 
-import { getSegmentsModeConfig } from '../groupSegments';
+import { getSegmentsGroupConfig } from '../groupSegments';
 import { interviewAttributesForTestCases } from '../../../../tests/surveys';
 import * as utilHelpers from '../../../../utils/helpers';
 
-describe('getSegmentsModeConfig', () => {
+describe('getSegmentsGroupConfig', () => {
 
     test('should return the correct widget config', () => {
-        const widgetConfig = getSegmentsModeConfig();
+        const widgetConfig = getSegmentsGroupConfig();
         expect(widgetConfig).toEqual({
             type: 'group',
             path: 'segments',
@@ -35,8 +35,8 @@ describe('getSegmentsModeConfig', () => {
 
 });
 
-describe('getSegmentsModeConfig labels', () => {
-    const widgetConfig = getSegmentsModeConfig({});
+describe('getSegmentsGroupConfig labels', () => {
+    const widgetConfig = getSegmentsGroupConfig({});
 
     test('should return the right label for title', () => {
         const mockedT = jest.fn();
@@ -76,8 +76,8 @@ describe('getSegmentsModeConfig labels', () => {
     });
 });
 
-describe('getSegmentsModeConfig show add button', () => {
-    const widgetConfig = getSegmentsModeConfig({});
+describe('getSegmentsGroupConfig show add button', () => {
+    const widgetConfig = getSegmentsGroupConfig({});
 
     jest.spyOn(utilHelpers, 'getResponse').mockReturnValue({});
     const mockedGetResponse = utilHelpers.getResponse as jest.MockedFunction<typeof utilHelpers.getResponse>;
@@ -120,8 +120,8 @@ describe('getSegmentsModeConfig show add button', () => {
 
 });
 
-describe('getSegmentsModeConfig show delete button', () => {
-    const widgetConfig = getSegmentsModeConfig({});
+describe('getSegmentsGroupConfig show delete button', () => {
+    const widgetConfig = getSegmentsGroupConfig({});
 
     jest.spyOn(utilHelpers, 'getResponse').mockReturnValue({});
     const mockedGetResponse = utilHelpers.getResponse as jest.MockedFunction<typeof utilHelpers.getResponse>;

--- a/packages/evolution-common/src/services/sections/segments/__tests__/widgetTripSegmentsIntro.test.ts
+++ b/packages/evolution-common/src/services/sections/segments/__tests__/widgetTripSegmentsIntro.test.ts
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import _cloneDeep from 'lodash/cloneDeep';
+import { getTripSegmentsIntro } from '../widgetTripSegmentsIntro';
+import { interviewAttributesForTestCases } from '../../../../tests/surveys';
+import * as odHelpers from '../../../odSurvey/helpers';
+
+jest.mock('../../../odSurvey/helpers', () => ({
+    getPerson: jest.fn().mockReturnValue({}),
+    getActiveJourney: jest.fn().mockReturnValue({}),
+    getActiveTrip: jest.fn().mockReturnValue({}),
+    getVisitedPlaces: jest.fn().mockReturnValue({}),
+    getOrigin: jest.fn().mockReturnValue({ activity: 'home', _uuid: 'originuuid', _sequence: 1 }),
+    getDestination: jest.fn().mockReturnValue({ activity: 'work', _uuid: 'originuuid', _sequence: 2 }),
+    getVisitedPlaceName: jest.fn().mockReturnValue('visitedPlaceName'),
+    getCountOrSelfDeclared: jest.fn().mockReturnValue(1)
+}));
+const mockedGetPerson = odHelpers.getPerson as jest.MockedFunction<typeof odHelpers.getPerson>;
+const mockedGetActiveJourney = odHelpers.getActiveJourney as jest.MockedFunction<typeof odHelpers.getActiveJourney>;
+const mockedGetActiveTrip = odHelpers.getActiveTrip as jest.MockedFunction<typeof odHelpers.getActiveTrip>;
+const mockedGetVisitedPlaces = odHelpers.getVisitedPlaces as jest.MockedFunction<typeof odHelpers.getVisitedPlaces>;
+const mockedGetOrigin = odHelpers.getOrigin as jest.MockedFunction<typeof odHelpers.getOrigin>;
+const mockedGetDestination = odHelpers.getDestination as jest.MockedFunction<typeof odHelpers.getDestination>;
+const mockedGetVisitedPlaceName = odHelpers.getVisitedPlaceName as jest.MockedFunction<typeof odHelpers.getVisitedPlaceName>;
+const mockedGetCountOrSelfDeclared = odHelpers.getCountOrSelfDeclared as jest.MockedFunction<typeof odHelpers.getCountOrSelfDeclared>;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+})
+
+describe('getTripSegmentsIntro', () => {
+    it('should return the correct widget config', () => {
+
+        const options = {
+            context: jest.fn()
+        };
+
+        const widgetConfig = getTripSegmentsIntro(options);
+
+        expect(widgetConfig).toEqual({
+            type: 'text',
+            text: expect.any(Function)
+        });
+    });
+});
+
+describe('tripSegmentsIntro text', () => {
+
+    const options = {
+        context: jest.fn()
+    };
+
+    const widgetText = getTripSegmentsIntro(options).text as any;
+    const mockedT = jest.fn().mockReturnValue('translatedString');
+   
+    test('should return empty if no person', () => {
+        mockedGetPerson.mockReturnValueOnce(null);
+        expect(widgetText(mockedT, interviewAttributesForTestCases, 'path')).toEqual('');
+        expect(mockedGetVisitedPlaceName).not.toHaveBeenCalled();
+        expect(mockedGetVisitedPlaces).not.toHaveBeenCalled();
+        expect(mockedT).not.toHaveBeenCalled();
+    });
+
+    test('should return empty if no active journey', () => {
+        mockedGetActiveJourney.mockReturnValueOnce(null);
+        expect(widgetText(mockedT, interviewAttributesForTestCases, 'path')).toEqual('');
+        expect(mockedGetVisitedPlaceName).not.toHaveBeenCalled();
+        expect(mockedGetVisitedPlaces).not.toHaveBeenCalled();
+        expect(mockedT).not.toHaveBeenCalled();
+    });
+
+    test('should return empty if no active trip', () => {
+        mockedGetActiveTrip.mockReturnValueOnce(null);
+        expect(widgetText(mockedT, interviewAttributesForTestCases, 'path')).toEqual('');
+        expect(mockedGetVisitedPlaceName).not.toHaveBeenCalled();
+        expect(mockedGetVisitedPlaces).not.toHaveBeenCalled();
+        expect(mockedT).not.toHaveBeenCalled();
+    });
+
+    test('should return empty if no origin', () => {
+        mockedGetOrigin.mockReturnValueOnce(null);
+        expect(widgetText(mockedT, interviewAttributesForTestCases, 'path')).toEqual('');
+        expect(mockedGetVisitedPlaceName).not.toHaveBeenCalled();
+        expect(mockedGetVisitedPlaces).toHaveBeenCalled();
+        expect(mockedT).not.toHaveBeenCalled();
+    });
+
+    test('should return empty if no destination', () => {
+        mockedGetDestination.mockReturnValueOnce(null);
+        expect(widgetText(mockedT, interviewAttributesForTestCases, 'path')).toEqual('');
+        expect(mockedGetVisitedPlaceName).not.toHaveBeenCalled();
+        expect(mockedGetVisitedPlaces).toHaveBeenCalled();
+        expect(mockedT).not.toHaveBeenCalled();
+    });
+
+    test('should return correct string with normal activities', () => {
+        mockedGetVisitedPlaceName.mockReturnValueOnce('originName').mockReturnValueOnce('destinationName');
+        expect(widgetText(mockedT, interviewAttributesForTestCases, 'path')).toEqual('translatedString');
+        expect(mockedGetVisitedPlaceName).toHaveBeenCalledTimes(2);
+        expect(mockedGetVisitedPlaces).toHaveBeenCalled();
+        expect(mockedT).toHaveBeenCalledWith(['customSurvey:segments:CurrentTripSegmentsIntro', 'segments:CurrentTripSegmentsIntro'], {
+            context: 'work',
+            count: 1,
+            originName: 'originName',
+            destinationName: 'destinationName'
+        });
+        expect(options.context).toHaveBeenCalledWith('work');
+    });
+
+    test('should return correct string with loop activity at origin', () => {
+        mockedGetOrigin.mockReturnValueOnce({ activity: 'leisureStroll', _uuid: 'originuuid', _sequence: 1 });
+        mockedGetVisitedPlaceName.mockReturnValueOnce('originName').mockReturnValueOnce('destinationName');
+        expect(widgetText(mockedT, interviewAttributesForTestCases, 'path')).toEqual('translatedString');
+        expect(mockedGetVisitedPlaceName).toHaveBeenCalledTimes(2);
+        expect(mockedGetVisitedPlaces).toHaveBeenCalled();
+        expect(mockedT).toHaveBeenCalledWith(['customSurvey:segments:CurrentTripSegmentsIntro', 'segments:CurrentTripSegmentsIntro'], {
+            context: 'leisureStroll',
+            count: 1,
+            originName: 'originName',
+            destinationName: 'destinationName'
+        });
+        expect(options.context).toHaveBeenCalledWith('leisureStroll');
+    });
+
+    test('should return correct string with normal activities and no context function', () => {
+        const widgetText = getTripSegmentsIntro().text as any;
+        mockedGetOrigin.mockReturnValueOnce({ activity: 'leisureStroll', _uuid: 'originuuid', _sequence: 1 });
+        mockedGetVisitedPlaceName.mockReturnValueOnce('originName').mockReturnValueOnce('destinationName');
+        expect(widgetText(mockedT, interviewAttributesForTestCases, 'path')).toEqual('translatedString');
+        expect(mockedGetVisitedPlaceName).toHaveBeenCalledTimes(2);
+        expect(mockedGetVisitedPlaces).toHaveBeenCalled();
+        expect(mockedT).toHaveBeenCalledWith(['customSurvey:segments:CurrentTripSegmentsIntro', 'segments:CurrentTripSegmentsIntro'], {
+            context: 'leisureStroll',
+            count: 1,
+            originName: 'originName',
+            destinationName: 'destinationName'
+        });
+    });
+
+    test('should return correct string with normal activities, context and person count', () => {
+        const context = 'context';
+        const count = 3;
+        options.context.mockReturnValueOnce('context');
+        mockedGetCountOrSelfDeclared.mockReturnValueOnce(count);
+
+        mockedGetVisitedPlaceName.mockReturnValueOnce('originName').mockReturnValueOnce('destinationName');
+        expect(widgetText(mockedT, interviewAttributesForTestCases, 'path')).toEqual('translatedString');
+        expect(mockedGetVisitedPlaceName).toHaveBeenCalledTimes(2);
+        expect(mockedGetVisitedPlaces).toHaveBeenCalled();
+        expect(mockedT).toHaveBeenCalledWith(['customSurvey:segments:CurrentTripSegmentsIntro', 'segments:CurrentTripSegmentsIntro'], {
+            context,
+            count,
+            originName: 'originName',
+            destinationName: 'destinationName'
+        });
+        expect(options.context).toHaveBeenCalledWith('work');
+    });
+
+});

--- a/packages/evolution-common/src/services/sections/segments/buttonSaveTripSegments.ts
+++ b/packages/evolution-common/src/services/sections/segments/buttonSaveTripSegments.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { ButtonWidgetConfig } from '../../widgets';
+import { Segment, UserInterviewAttributes } from '../../interviews/interview';
+import { ButtonAction, getPath, getResponse, InterviewUpdateCallbacks } from '../../../utils/helpers';
+import * as odHelpers from '../../odSurvey/helpers';
+import { TFunction } from 'i18next';
+import { IconProp } from '@fortawesome/fontawesome-svg-core';
+
+export const getButtonSaveTripSegmentsConfig = (
+    // FIXME: Type this when there is a few more widgets implemented
+    options: {
+        context?: () => string;
+        buttonActions: { validateButtonAction: ButtonAction };
+        iconMapper: { [iconName: string]: IconProp };
+    }
+): ButtonWidgetConfig => {
+    // TODO These should be some configuration receive here to fine-tune the section's content
+    return {
+        type: 'button',
+        color: 'green',
+        label: (t: TFunction) => t(['customSurvey:segments:SaveTripLabel', 'segments:SaveTripLabel']),
+        hideWhenRefreshing: true,
+        path: 'buttonSaveTrip',
+        // FIXME This requires dependencies
+        icon: options.iconMapper['check-circle'],
+        align: 'center',
+        action: options.buttonActions.validateButtonAction,
+        saveCallback: (callbacks: InterviewUpdateCallbacks, interview: UserInterviewAttributes, path: string) => {
+            // Set all segments' _isNew to false and select the next trip ID as the active one
+            const updateValuesbyPath = {};
+            const segmentsPath = getPath(path, '../segments') as string;
+            const segments = getResponse(interview, segmentsPath, {}) as any;
+            // set segments as not new:
+            for (const segmentUuid in segments) {
+                const segment = segments[segmentUuid];
+                segment._isNew = false;
+                const segmentPath = `${segmentsPath}.${segmentUuid}`;
+                updateValuesbyPath[`responses.${segmentPath}._isNew`] = false;
+            }
+            const journey = odHelpers.getActiveJourney({ interview });
+            const nextTrip = journey !== null ? odHelpers.selectNextIncompleteTrip({ journey }) : null;
+            updateValuesbyPath['responses._activeTripId'] = nextTrip ? nextTrip._uuid : null;
+            callbacks.startUpdateInterview('segments', updateValuesbyPath);
+        },
+        conditional: function (interview, path) {
+            const segments = getResponse(interview, path, {}, '../segments') as { [segmentId: string]: Segment };
+            const segmentsArray = Object.values(segments).sort((segmentA, segmentB) => {
+                return segmentA['_sequence'] - segmentB['_sequence'];
+            });
+            const lastSegment = segmentsArray[segmentsArray.length - 1];
+            return [lastSegment !== undefined && lastSegment.hasNextMode === false, undefined];
+        }
+    };
+};

--- a/packages/evolution-common/src/services/sections/segments/groupPersonTrips.ts
+++ b/packages/evolution-common/src/services/sections/segments/groupPersonTrips.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { GroupConfig } from '../../widgets';
+import { getResponse } from '../../../utils/helpers';
+import { TFunction } from 'i18next';
+
+export const getPersonsTripsGroupConfig = (
+    // FIXME: Type this when there is a few more widgets implemented
+    options: { context?: () => string } = {}
+): GroupConfig => {
+    // TODO These should be some configuration receive here to fine-tune the section's content
+    return {
+        type: 'group',
+        // FIXME Why do we have the full path here, but a relative path in the segments group? This should be consistent, but it's probably how evolution is structured
+        path: 'household.persons.{_activePersonId}.journeys.{_activeJourneyId}.trips',
+        title: (t: TFunction) => t(['customSurvey:segments:TripsTitle', 'segments:TripsTitle']),
+        filter: function (interview, groupedObjects) {
+            // Only the active trip should be shown with its widgets, if no active trip, return an empty object
+            const activeTripId = getResponse(interview, '_activeTripId', null);
+            if (typeof activeTripId === 'string' && groupedObjects[activeTripId]) {
+                return { [activeTripId]: groupedObjects[activeTripId] };
+            }
+            return {};
+        },
+        showTitle: false,
+        showGroupedObjectDeleteButton: false,
+        showGroupedObjectAddButton: false,
+        widgets: [
+            // TODO Those widget names do not link to anything! They should accompany their actual widgets somewhere
+            // Hard-coded, mandatory questions
+            'segmentIntro',
+            'segments',
+            'buttonSaveTrip'
+            // TODO Add more configurable widgets here, either custom or depending on the segments section configuration
+        ]
+    };
+};

--- a/packages/evolution-common/src/services/sections/segments/groupSegments.ts
+++ b/packages/evolution-common/src/services/sections/segments/groupSegments.ts
@@ -10,7 +10,7 @@ import { Segment } from '../../interviews/interview';
 import { getResponse } from '../../../utils/helpers';
 import { TFunction } from 'i18next';
 
-export const getSegmentsModeConfig = (
+export const getSegmentsGroupConfig = (
     // FIXME: Type this when there is a few more widgets implemented
     options: { context?: () => string } = {}
 ): GroupConfig => {

--- a/packages/evolution-common/src/services/sections/segments/widgetTripSegmentsIntro.ts
+++ b/packages/evolution-common/src/services/sections/segments/widgetTripSegmentsIntro.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { TextWidgetConfig } from '../../widgets';
+import * as odHelpers from '../../odSurvey/helpers';
+import { TFunction } from 'i18next';
+import { loopActivities } from '../../odSurvey/types';
+
+export const getTripSegmentsIntro = (
+    // FIXME: Type this when there is a few more widgets implemented
+    options: { context?: (additionalContext?: string) => string } = {}
+): TextWidgetConfig => ({
+    type: 'text',
+    text: (t: TFunction, interview, path) => {
+        const person = odHelpers.getPerson({ interview });
+        const journey = odHelpers.getActiveJourney({ interview, person });
+        const trip = odHelpers.getActiveTrip({ interview, journey });
+        if (!trip || !journey || !person) {
+            console.error('trip segments intro: trip, journey or person not found');
+            return '';
+        }
+        const visitedPlaces = odHelpers.getVisitedPlaces({ journey });
+        const origin = odHelpers.getOrigin({ trip, visitedPlaces });
+        const destination = odHelpers.getDestination({ trip, visitedPlaces });
+        if (!origin || !destination) {
+            console.error('trip segments intro: origin or destination not found, trip is invalid');
+            return '';
+        }
+        const originName = origin ? odHelpers.getVisitedPlaceName({ visitedPlace: origin, t, interview }) : '';
+        const destinationName = destination
+            ? odHelpers.getVisitedPlaceName({ visitedPlace: destination, t, interview })
+            : '';
+        // If origin or destination is a loopActivity, use this activity as context, otherwise, it's the destination
+        const activityContext =
+            origin.activity && loopActivities.includes(origin.activity) ? origin.activity : destination.activity;
+        return t(['customSurvey:segments:CurrentTripSegmentsIntro', 'segments:CurrentTripSegmentsIntro'], {
+            context: options.context?.(activityContext) || activityContext,
+            count: odHelpers.getCountOrSelfDeclared({ interview, person }),
+            originName,
+            destinationName
+        });
+    }
+});

--- a/packages/evolution-common/src/services/widgets/WidgetConfig.ts
+++ b/packages/evolution-common/src/services/widgets/WidgetConfig.ts
@@ -8,7 +8,13 @@
 
 import { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { UserInterviewAttributes, InterviewResponsePath, InterviewResponses } from '../interviews/interview';
-import { ParsingFunction, I18nData, InterviewUpdateCallbacks, ParsingFunctionWithCallbacks } from '../../utils/helpers';
+import {
+    ParsingFunction,
+    I18nData,
+    InterviewUpdateCallbacks,
+    ParsingFunctionWithCallbacks,
+    ButtonAction
+} from '../../utils/helpers';
 import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
 import { TFunction } from 'i18next';
 
@@ -320,15 +326,7 @@ export type ButtonWidgetConfig = {
     icon?: IconProp;
     iconPath?: string;
     align?: WidgetDirectionAlign;
-    // FIXME: Type the sections parameters
-    action: (
-        callbacks: InterviewUpdateCallbacks,
-        interview: UserInterviewAttributes,
-        path: string,
-        section: string,
-        sections: { [key: string]: any },
-        saveCallback?: ParsingFunctionWithCallbacks<void>
-    ) => void;
+    action: ButtonAction;
     saveCallback?: ParsingFunctionWithCallbacks<void>;
     confirmPopup?: {
         title?: I18nData;

--- a/packages/evolution-common/src/utils/helpers.ts
+++ b/packages/evolution-common/src/utils/helpers.ts
@@ -90,6 +90,15 @@ export type ParsingFunctionWithCallbacks<T> = (
     user?: CliUser
 ) => T;
 
+export type ButtonAction = (
+    callbacks: InterviewUpdateCallbacks,
+    interview: UserInterviewAttributes,
+    path: string,
+    section: string,
+    sections: { [key: string]: any },
+    saveCallback?: ParsingFunctionWithCallbacks<void>
+) => void;
+
 export const translateString = (
     i18nData: I18nData | undefined,
     i18nObj: i18n,

--- a/packages/evolution-frontend/src/services/display/frontendHelper.ts
+++ b/packages/evolution-frontend/src/services/display/frontendHelper.ts
@@ -10,6 +10,7 @@ import moment from 'moment';
 import i18n from '../../config/i18n.config';
 import { Person } from 'evolution-common/lib/services/interviews/interview';
 import { secondsSinceMidnightToTimeStr } from 'chaire-lib-common/lib/utils/DateTimeUtils';
+import { ButtonAction } from 'evolution-common/lib/utils/helpers';
 
 type GenderedData = {
     [gender: string]: {
@@ -117,4 +118,20 @@ export const secondsSinceMidnightToTimeStrWithSuffix = function (
     } else {
         return `${secondsSinceMidnightToTimeStr(secondsSinceMidnight)}`;
     }
+};
+
+export const validateButtonAction: ButtonAction = (callbacks, interview, path, section, sections, saveCallback) => {
+    callbacks.startUpdateInterview(section, { _all: true }, undefined, interview, (updatedInterview) => {
+        if ((updatedInterview as any).allWidgetsValid) {
+            if (typeof saveCallback === 'function') {
+                saveCallback(callbacks, updatedInterview, path);
+            } // go to next section
+            else {
+                window.scrollTo(0, 0);
+                callbacks.startUpdateInterview(section, {
+                    'responses._activeSection': sections[section].nextSection
+                });
+            }
+        }
+    });
 };

--- a/packages/evolution-legacy/src/helpers/survey/survey.js
+++ b/packages/evolution-legacy/src/helpers/survey/survey.js
@@ -11,6 +11,7 @@ import * as Helpers from 'evolution-common/lib/utils/helpers';
 import * as LE from 'chaire-lib-common/lib/utils/LodashExtensions';
 import * as DateTimeUtils from 'chaire-lib-common/lib/utils/DateTimeUtils';
 import { getPerson } from 'evolution-common/lib/services/odSurvey/helpers';
+import { validateButtonAction } from 'evolution-frontend/lib/services/display/frontendHelper';
 
 export default {
   
@@ -108,30 +109,7 @@ export default {
 
   removeGroupedObjects: Helpers.removeGroupedObjects,
 
-  validateButtonAction: function(callbacks, _interview, path, section, sections, saveCallback) {
-    callbacks.startUpdateInterview(section, { '_all': true }, null, null, (interview) => {
-      if (interview.allWidgetsValid)
-      {
-        if (typeof saveCallback === 'function')
-        {
-          saveCallback(callbacks, interview, path);
-        }
-        else // go to next section
-        {
-          window.scrollTo(0, 0);
-          callbacks.startUpdateInterview(section, {
-            'responses._activeSection': sections[section].nextSection
-          });
-        }
-      }
-      else
-      {
-        //this.props.startUpdateInterview(section, { '_all': true }, null, null, null);
-      }
-    });
-
-    
-  },
+  validateButtonAction: validateButtonAction,
 
   validateButtonActionWithCompleteSection: function(callbacks, _interview, path, section, sections, saveCallback) {
     callbacks.startUpdateInterview(section, { '_all': true }, null, null, (interview) => {


### PR DESCRIPTION
As part of the "15-minutes survey" segment section configuration, the personTrips group and the widgets it contains are moved to evolution and unit tested.

They are also used in demo_survey.

The widgets content was taken and adapted from the od_nationale_2024 survey when it was different from the demo_survey widgets. They are mostly taken as is, with FIXMEs where additional configuration, or some thought, would be required.