### PR TITLE
inputRadioNumber: Fix check when value is 0 and resolves to `false`

### DIFF
--- a/packages/evolution-frontend/src/components/inputs/InputRadioNumber.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputRadioNumber.tsx
@@ -56,7 +56,7 @@ export const InputRadioNumber = ({
         // pass (because events are being re-used and validating its content
         // later does not work as it has been changed).
         onValueChange({ target: { value: newCurrentValue } });
-        newCurrentValue && newCurrentValue <= maxValue ? setIsOverMax(false) : setIsOverMax(true);
+        newCurrentValue !== undefined && newCurrentValue > maxValue ? setIsOverMax(true) : setIsOverMax(false);
     };
 
     // TODO: The three functions below are copied from InputRadio.tsx.

--- a/packages/evolution-frontend/src/components/inputs/__tests__/InputRadioNumber.test.tsx
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/InputRadioNumber.test.tsx
@@ -84,7 +84,7 @@ describe('Render InputRadioNumber', () => {
 describe('InputRadioNumber onChange', () => {
     const widgetConfig = {
         inputType: 'radioNumber' as const,
-        valueRange: { min: 1, max: 3 },
+        valueRange: { min: 0, max: 3 },
         overMaxAllowed: true
     };
 
@@ -112,7 +112,7 @@ describe('InputRadioNumber onChange', () => {
 
     test('Test entering the max option', () => {
         const mockOnValueChange = jest.fn();
-        const { queryByText, getByLabelText } = render(
+        const { queryByText, queryByLabelText } = render(
             <InputRadioNumber
                 id={'test'}
                 onValueChange={mockOnValueChange}
@@ -132,7 +132,7 @@ describe('InputRadioNumber onChange', () => {
         expect(mockOnValueChange).toHaveBeenCalledWith(expect.objectContaining({ target: { value: 4 }}));
 
         // Find the text input
-        const input = getByLabelText("SpecifyAboveLimit:");
+        const input = queryByLabelText("SpecifyAboveLimit:");
         expect(input).toBeTruthy();
 
         // Enter a value in the input
@@ -147,5 +147,37 @@ describe('InputRadioNumber onChange', () => {
         expect(mockOnValueChange).toHaveBeenCalledTimes(3);
         expect(mockOnValueChange).toHaveBeenCalledWith(expect.objectContaining({ target: { value: undefined }}));
 
+        // Find the text input
+        const inputAfterReset = queryByLabelText("SpecifyAboveLimit:");
+        expect(inputAfterReset).toBeFalsy();
+
     });
+
+    test('Test entering the 0 option', () => {
+        const mockOnValueChange = jest.fn();
+        const { queryByText, queryByLabelText } = render(
+            <InputRadioNumber
+                id={'test'}
+                onValueChange={mockOnValueChange}
+                widgetConfig={widgetConfig}
+                value={3}
+                interview={interview} path={''} user={user}
+            />
+        );
+
+        // Find the "0" option
+        const option0 = queryByText("0");
+        expect(option0).toBeTruthy();
+    
+        // Click on the option 0
+        fireEvent.click(option0 as any);
+        expect(mockOnValueChange).toHaveBeenCalledTimes(1);
+        expect(mockOnValueChange).toHaveBeenCalledWith(expect.objectContaining({ target: { value: 0 }}));
+
+        // Find the text input
+        const input = queryByLabelText("SpecifyAboveLimit:");
+        expect(input).toBeFalsy();
+
+    });
+
 });


### PR DESCRIPTION
Fixes #781

The `Specify` widget should only be shown if the value is set and it is above the max.