### PR TITLE
admin: Drop the "reset interview" features

### DIFF
--- a/locales/en/menu.json
+++ b/locales/en/menu.json
@@ -2,7 +2,6 @@
     "home":"Home",
     "login":"Login",
     "logout":"Logout",
-    "resetInterview":"Reset interview",
     "setDevModeOn": "Survey development mode",
     "setDevModeOff": "Normal mode",
     "User":"Connected",

--- a/locales/fr/menu.json
+++ b/locales/fr/menu.json
@@ -2,7 +2,6 @@
     "home":"Accueil",
     "login":"Se connecter",
     "logout":"Quitter",
-    "resetInterview": "Réinitialiser l'entrevue",
     "setDevModeOn": "Mode développement d'enquête",
     "setDevModeOff": "Mode normal",
     "User":"Connecté",

--- a/packages/evolution-frontend/src/components/pageParts/SectionNav.tsx
+++ b/packages/evolution-frontend/src/components/pageParts/SectionNav.tsx
@@ -115,25 +115,6 @@ const SectionNav = function ({
                     <button
                         type="button"
                         className="menu-button _oblique _red"
-                        key={'header__nav-reset'}
-                        onClick={() =>
-                            startUpdateInterview(
-                                activeSection,
-                                { responses: {}, validations: {} },
-                                undefined,
-                                undefined,
-                                () => {
-                                    startUpdateInterview(null, { 'responses._activeSection': firstSectionShortname });
-                                }
-                            )
-                        }
-                    >
-                        {t('menu:resetInterview')}
-                    </button>{' '}
-                    •{' '}
-                    <button
-                        type="button"
-                        className="menu-button _oblique _red"
                         key={'header__nav-devMode'}
                         onClick={() => dispatch({ type: 'setDevMode', value: !devMode })}
                     >


### PR DESCRIPTION
This is a dangerous feature that can erase an interview data and should not be available for any reason. If the feature should at any point come back, it should be documented and implemented correctlyt o avoid mistakes with production data.