### PR TITLE
conditional: type and clean the Conditional file

### DIFF
--- a/packages/evolution-frontend/src/actions/utils/Conditional.ts
+++ b/packages/evolution-frontend/src/actions/utils/Conditional.ts
@@ -123,8 +123,8 @@ export const checkChoiceConditional = (
  * @param path The path of the value to conditionally test
  * @param user The current user
  * @returns An array, where the first value is whether all selected choices are
- * still visible. The second element is the value to set to this field if the
- * condition fails.
+ * still visible. The second element is the value to set to this field if any of
+ * the conditional are now `false`.
  */
 export const checkChoicesConditional = (
     value: unknown,

--- a/packages/evolution-frontend/src/actions/utils/WidgetOperation.ts
+++ b/packages/evolution-frontend/src/actions/utils/WidgetOperation.ts
@@ -95,7 +95,7 @@ const prepareSimpleWidget = (
         widgetConfig.conditional,
         data.interview,
         path,
-        customPath
+        data.user
     );
     let assignedValue = invisibleValue;
     const customAssignedValue = customInvisibleValue;

--- a/packages/evolution-frontend/src/actions/utils/__tests__/Conditional.test.ts
+++ b/packages/evolution-frontend/src/actions/utils/__tests__/Conditional.test.ts
@@ -83,10 +83,10 @@ each([
     ['legacy return value', jest.fn().mockReturnValue(null), [false, undefined, undefined]],
     ['function with error', jest.fn().mockImplementation(() => { throw 'error' }), [false, undefined, undefined]],
 ]).test('Test check conditional %s', (_title, conditional, expectedResult) => {
-    expect(checkConditional(conditional, interviewAttributes, 'path', 'customPath', userAttributes)).toEqual(expectedResult);
+    expect(checkConditional(conditional, interviewAttributes, 'path', userAttributes)).toEqual(expectedResult);
     if (typeof conditional === 'function') {
         expect(conditional).toHaveBeenCalledTimes(1);
-        expect(conditional).toHaveBeenCalledWith(interviewAttributes, 'path', 'customPath', userAttributes);
+        expect(conditional).toHaveBeenCalledWith(interviewAttributes, 'path', userAttributes);
     }
 });
 

--- a/packages/evolution-frontend/src/components/survey/GroupWidgets.tsx
+++ b/packages/evolution-frontend/src/components/survey/GroupWidgets.tsx
@@ -162,7 +162,7 @@ const BaseGroup: FunctionComponent<GroupProps & WithTranslation & WithSurveyCont
             parseBoolean(props.widgetConfig.conditional, props.interview, props.path),
             props.interview,
             props.path,
-            props.customPath
+            props.user
         )[0]
     ) {
         return null;


### PR DESCRIPTION
The conditional function received in the `checkConditional` function is indeed
a `ParsingFunction`, as defined in the `WidgetConfig` type. This
function does not expect a customPath as third parameter, but a user, so
we fix the call parameters. Also, the calls of the `checkConditional`
effectively send the `user` parameter, which was not the case before.

Also

Update comments and test names for choice conditional
    
This confirms the fix #55
