### PR TITLE
Remove Lint warnings from evolution-backend

### DIFF
--- a/packages/evolution-backend/jest.config.js
+++ b/packages/evolution-backend/jest.config.js
@@ -5,6 +5,8 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 /* eslint-disable n/no-unpublished-require */
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports */
 const baseConfig = require('../../tests/jest.config.base');
 
 module.exports = {

--- a/packages/evolution-backend/jest.sequential.config.js
+++ b/packages/evolution-backend/jest.sequential.config.js
@@ -5,6 +5,8 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 /* eslint-disable n/no-unpublished-require */
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports */
 const baseConfig = require('../../tests/jest.config.base');
 
 // Ignore db.queries.test files

--- a/packages/evolution-backend/src/api/admin.routes.ts
+++ b/packages/evolution-backend/src/api/admin.routes.ts
@@ -13,7 +13,7 @@ import { addExportRoutes } from './admin/exports.routes';
 
 addExportRoutes();
 
-router.all('/data/widgets/:widget/', (req, res, next) => {
+router.all('/data/widgets/:widget/', (req, res, _next) => {
     const widgetName = req.params.widget;
 
     if (!widgetName) {

--- a/packages/evolution-backend/src/api/admin/exports.routes.ts
+++ b/packages/evolution-backend/src/api/admin/exports.routes.ts
@@ -19,7 +19,7 @@ import router from 'chaire-lib-backend/lib/api/admin.routes';
 
 export const addExportRoutes = () => {
     // Get a specific export file per object
-    router.get('/data/exportcsv/exports/:filePath', (req, res, next) => {
+    router.get('/data/exportcsv/exports/:filePath', (req, res, _next) => {
         console.log('requesting csv file from path', req.params.filePath);
         const projectRelativeFilePath = `${filePathOnServer}/${req.params.filePath}`;
         const fileExists = fileManager.fileExists(projectRelativeFilePath);
@@ -37,7 +37,7 @@ export const addExportRoutes = () => {
     });
 
     // Route to get the status of the export task and the list of files
-    router.get('/data/getExportTaskResults', (req, res, next) => {
+    router.get('/data/getExportTaskResults', (_req, res, _next) => {
         console.log('getting csv export files...');
         try {
             if (isExportRunning()) {
@@ -52,7 +52,7 @@ export const addExportRoutes = () => {
     });
 
     // Route to prepare the csv files to export
-    router.get('/data/prepareCsvFileForExportByObject', (req, res, next) => {
+    router.get('/data/prepareCsvFileForExportByObject', (req, res, _next) => {
         console.log('preparing csv export files...');
         try {
             const validatedResponses = req.query.responseType !== 'participant';

--- a/packages/evolution-backend/src/api/express-session.d.ts
+++ b/packages/evolution-backend/src/api/express-session.d.ts
@@ -4,9 +4,12 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import session from 'express-session';
 
-// Custom type declaraction merging for express-session's SessionData type, as suggested in the express-session documentation
+// This import is required for the declaration merging to work.
+import session from 'express-session'; /* eslint-disable-line @typescript-eslint/no-unused-vars */
+
+// Custom type declaraction merging for express-session's SessionData type, as suggested in the express-session documentation: https://expressjs.com/
+// TODO: Find which page exactly.
 declare module 'express-session' {
     interface SessionData {
         // Additional values by path to send to the client upon next request

--- a/packages/evolution-backend/src/api/survey.validation.routes.ts
+++ b/packages/evolution-backend/src/api/survey.validation.routes.ts
@@ -194,7 +194,7 @@ router.post('/validation/auditStats', async (req: Request, res: Response) => {
     }
 });
 
-router.post('/validation/updateAudits/:uuid', async (req, res, next) => {
+router.post('/validation/updateAudits/:uuid', async (req, res, _next) => {
     try {
         const audits = req.body.audits;
         const interview = await Interviews.getInterviewByUuid(req.params.uuid);

--- a/packages/evolution-backend/src/models/interviews.db.queries.ts
+++ b/packages/evolution-backend/src/models/interviews.db.queries.ts
@@ -375,7 +375,7 @@ const getRawWhereClause = (
     // TODO Once the individual surveys are typed and the expected
     // responses are known in advance, try to completely type the responses
     // object and make sure the field here matches an actual path
-    const dotSeparatedStringRegex = /^[\w\.]*$/g;
+    const dotSeparatedStringRegex = /^[\w.]*$/g;
     const match = field.match(dotSeparatedStringRegex);
     if (match === null) {
         throw new TrError(

--- a/packages/evolution-backend/src/models/migrations/20230921100001_setInterviewSurvey.ts
+++ b/packages/evolution-backend/src/models/migrations/20230921100001_setInterviewSurvey.ts
@@ -4,7 +4,6 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { Knex } from 'knex';
 import { SurveyAttributes } from '../../services/surveys/survey';
 import config from 'chaire-lib-common/lib/config/shared/project.config';

--- a/packages/evolution-backend/src/models/participants.db.queries.ts
+++ b/packages/evolution-backend/src/models/participants.db.queries.ts
@@ -5,7 +5,6 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import knex from 'chaire-lib-backend/lib/config/shared/db.config';
-import _cloneDeep from 'lodash/cloneDeep';
 
 import TrError from 'chaire-lib-common/lib/utils/TrError';
 
@@ -100,7 +99,7 @@ const update = async (id: number, attributes: Partial<ParticipantAttributes>): P
         if (Object.keys(attributes).length === 0) {
             return false;
         }
-        const returningArray = await knex(tableName).update(attributes).where('id', id);
+        await knex(tableName).update(attributes).where('id', id);
         return true;
     } catch (error) {
         throw new TrError(

--- a/packages/evolution-backend/src/services/accessCode.ts
+++ b/packages/evolution-backend/src/services/accessCode.ts
@@ -23,7 +23,7 @@ export const registerAccessCodeValidationFunction = (isAccessCodeValid: (accessC
 export const validateAccessCode = (accessCode: string): boolean => {
     try {
         return accessCodeValidationFunction(accessCode);
-    } catch (e) {
+    } catch {
         return false;
     }
 };

--- a/packages/evolution-backend/src/services/adminExport/exportAllToCsvByObject.ts
+++ b/packages/evolution-backend/src/services/adminExport/exportAllToCsvByObject.ts
@@ -13,6 +13,7 @@ import _cloneDeep from 'lodash/cloneDeep';
 import { unparse } from 'papaparse';
 import isString from 'lodash/isString';
 
+import { ExportOptions } from './types';
 import { execJob } from '../../tasks/serverWorkerPool';
 import * as surveyHelperNew from 'evolution-common/lib/utils/helpers';
 import { fileManager } from 'chaire-lib-backend/lib/utils/filesystem/fileManager';

--- a/packages/evolution-backend/src/services/adminExport/types.ts
+++ b/packages/evolution-backend/src/services/adminExport/types.ts
@@ -5,7 +5,7 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 
-type ExportOptions = {
+export type ExportOptions = {
     /** Specifies which set of responses should be exported. 'validated' means
      * it exports the validated data if available, 'participant' is the original
      * participant responses */

--- a/packages/evolution-backend/src/services/auth/roleDefinition.ts
+++ b/packages/evolution-backend/src/services/auth/roleDefinition.ts
@@ -26,7 +26,7 @@ const defineDefaultRoles = function (): void {
     addRole(DEFAULT_ROLE_NAME, addDefaultPermissions);
 
     // Add an interviewer role
-    addRole(VALIDATOR_LVL1_ROLE, ({ can }, user) => {
+    addRole(VALIDATOR_LVL1_ROLE, ({ can }, _user) => {
         addDefaultPermissions();
         // Required permissions to list interviews to validate
         can(['read', 'validate'], InterviewsSubject);
@@ -35,7 +35,7 @@ const defineDefaultRoles = function (): void {
     });
 
     // Add an interviewer role
-    addRole(VALIDATOR_LVL2_ROLE, ({ can }, user) => {
+    addRole(VALIDATOR_LVL2_ROLE, ({ can }, _user) => {
         addDefaultPermissions();
         // Required permissions to list interviews to validate and confirm
         can(['read', 'validate', 'confirm'], InterviewsSubject);

--- a/packages/evolution-backend/src/services/interviews/interviews.ts
+++ b/packages/evolution-backend/src/services/interviews/interviews.ts
@@ -204,7 +204,7 @@ export default class Interviews {
                         copyResponsesToValidatedData(interview)
                             .then(
                                 () =>
-                                    new Promise((res1, rej1) => {
+                                    new Promise((res1, _rej1) => {
                                         Audits.runAndSaveInterviewAudits(interview)
                                             .then(() => {
                                                 res1(true);

--- a/packages/evolution-backend/src/services/routing/types.ts
+++ b/packages/evolution-backend/src/services/routing/types.ts
@@ -5,7 +5,7 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import { RoutingOrTransitMode } from 'chaire-lib-common/lib/config/routingModes';
-import { SummaryResponse, SummarySuccessResult } from 'chaire-lib-common/lib/api/TrRouting/trRoutingApiV2';
+import { SummarySuccessResult } from 'chaire-lib-common/lib/api/TrRouting/trRoutingApiV2';
 
 export type RouteCalculationParameter = {
     /**

--- a/packages/evolution-backend/src/services/validations/serverValidation.ts
+++ b/packages/evolution-backend/src/services/validations/serverValidation.ts
@@ -27,15 +27,16 @@ export type ServerValidation =
  * the invalid field.
  *
  * @param {{ [key: string]: any }} valuesByPath
- * @param {string[]} unsetValues
+ * @param {string[]} _unsetValues
  * @return {*}  {Promise<{ [key: string]: { [key: string]: string } } |
  * boolean>}
  */
+//TODO: Add functionality to the _unsetValues argument, or remove it.
 const validate = async (
     interview: InterviewAttributes,
     serverValidations: ServerValidation,
     valuesByPath: { [key: string]: any },
-    unsetValues: string[]
+    _unsetValues: string[]
 ): Promise<{ [key: string]: { [key: string]: string } } | true> => {
     if (!serverValidations) {
         return true;

--- a/packages/evolution-backend/src/tasks/exportInterviewsJson.task.ts
+++ b/packages/evolution-backend/src/tasks/exportInterviewsJson.task.ts
@@ -36,7 +36,7 @@ const exportInterviews = function (exportJsonFileDirectory) {
 };
 
 class ExportInterviewsJSON {
-    async run(argv) {
+    async run(_argv) {
         // TODO Support options from the command line
         await exportInterviews(exportJsonFileDirectory);
 


### PR DESCRIPTION
The lint warnings from evolution-backend (other than "unexpected any") have been removed.

22 warnings got removed (55 to 33).