### PR TITLE
Fix bug where parsing null value with type geojson would throw an error.

### DIFF
--- a/packages/evolution-common/src/utils/__tests__/helpers.test.ts
+++ b/packages/evolution-common/src/utils/__tests__/helpers.test.ts
@@ -153,6 +153,7 @@ each([
     [{ type: 'Feature', geometry: 'not a geometry' }, 'geojson', null],
     [3, 'geojson', null],
     ['not a feature', 'geojson', null],
+    [null, 'geojson', null],
     [[3, 4], undefined, [3, 4]],
     [{ test: 3 }, undefined, { test: 3 }],
     // TODO What about other data types? They are simply converted to string, should something else be done?

--- a/packages/evolution-common/src/utils/helpers.ts
+++ b/packages/evolution-common/src/utils/helpers.ts
@@ -253,7 +253,7 @@ export const parseValue = function (
     }
     if (datatype === 'geojson') {
         // Add the properties to the value if it is an object and it does not have properties
-        if (typeof value === 'object' && value['properties'] === undefined) {
+        if (value !== null && typeof value === 'object' && value['properties'] === undefined) {
             value.properties = {};
         }
         // For geojson, we only accept valid geojson objects


### PR DESCRIPTION
Because the type of null is considered an object in javascript, the function would then try to read one of its properties, throwing an error. Also adds a test to make sure the bug is not reproduced.