### PR TITLE
Remove Lint warnings from evolution-common

### DIFF
--- a/packages/evolution-common/jest.config.js
+++ b/packages/evolution-common/jest.config.js
@@ -5,6 +5,8 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 /* eslint-disable n/no-unpublished-require */
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports */
 const baseConfig = require('../../tests/jest.config.base');
 
 module.exports = {

--- a/packages/evolution-common/src/services/baseObjects/BaseOrganization.ts
+++ b/packages/evolution-common/src/services/baseObjects/BaseOrganization.ts
@@ -12,7 +12,6 @@
 
 import { Optional } from '../../types/Optional.type';
 import { IValidatable } from './IValidatable';
-import { BasePlace } from './BasePlace';
 import { Weightable, Weight, validateWeights } from './Weight';
 import * as OAttr from './attributeTypes/OrganizationAttributes';
 import { Uuidable } from './Uuidable';

--- a/packages/evolution-common/src/services/baseObjects/BaseSegment.ts
+++ b/packages/evolution-common/src/services/baseObjects/BaseSegment.ts
@@ -10,7 +10,6 @@
  */
 
 import { Optional } from '../../types/Optional.type';
-import { BaseVehicle, BaseVehicleAttributes, ExtendedVehicleAttributes } from './BaseVehicle';
 import { Uuidable } from './Uuidable';
 import { IValidatable } from './IValidatable';
 import * as SAttr from './attributeTypes/SegmentAttributes';

--- a/packages/evolution-common/src/services/baseObjects/BaseVehicle.ts
+++ b/packages/evolution-common/src/services/baseObjects/BaseVehicle.ts
@@ -12,7 +12,7 @@
 import { Optional } from '../../types/Optional.type';
 import { Uuidable } from './Uuidable';
 import { IValidatable } from './IValidatable';
-import { Weightable, Weight, validateWeights } from './Weight';
+import { Weightable, Weight } from './Weight';
 import * as VAttr from './attributeTypes/VehicleAttributes';
 
 export type BaseVehicleAttributes = {

--- a/packages/evolution-common/src/services/baseObjects/Trip.ts
+++ b/packages/evolution-common/src/services/baseObjects/Trip.ts
@@ -6,7 +6,6 @@
  */
 
 import _uniq from 'lodash/uniq';
-import { distance as turfDistance } from '@turf/turf';
 import { Optional } from '../../types/Optional.type';
 import { IValidatable, ValidatebleAttributes } from './IValidatable';
 import { WeightableAttributes, Weight, validateWeights } from './Weight';

--- a/packages/evolution-common/src/services/baseObjects/VisitedPlace.ts
+++ b/packages/evolution-common/src/services/baseObjects/VisitedPlace.ts
@@ -9,7 +9,6 @@ import { Optional } from '../../types/Optional.type';
 import { IValidatable } from './IValidatable';
 import { Place, PlaceAttributes, placeAttributes } from './Place';
 import * as VPAttr from './attributeTypes/VisitedPlaceAttributes';
-import * as JAttr from './attributeTypes/JourneyAttributes';
 import { ParamsValidatorUtils } from '../../utils/ParamsValidatorUtils';
 import { Result, createErrors, createOk } from '../../types/Result.type';
 import { StartEndable, startEndDateAndTimesAttributes, StartEndDateAndTimesAttributes } from './StartEndable';

--- a/packages/evolution-common/src/services/baseObjects/attributeTypes/TripChainAttributes.ts
+++ b/packages/evolution-common/src/services/baseObjects/attributeTypes/TripChainAttributes.ts
@@ -5,4 +5,4 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 
-export type TripChainCategory = string; // TODO: use normalized trip chain categories, simple | complex | open
+export type TripChainCategory = string; // TODO: use normalized trip chain categories, simple | complex | open

--- a/packages/evolution-common/src/services/baseObjects/interview/InterviewParadata.ts
+++ b/packages/evolution-common/src/services/baseObjects/interview/InterviewParadata.ts
@@ -82,7 +82,7 @@ export class InterviewParadata {
     constructor(params: InterviewParadataAttributes) {
         this._attributes = {} as InterviewParadataAttributes;
 
-        const { attributes, customAttributes } = ConstructorUtils.initializeAttributes(
+        const { attributes } = ConstructorUtils.initializeAttributes(
             params,
             interviewParadataAttributes,
             interviewParadataAttributesWithComposedAttributes

--- a/packages/evolution-common/src/services/odSurvey/helpers.ts
+++ b/packages/evolution-common/src/services/odSurvey/helpers.ts
@@ -6,7 +6,6 @@
  */
 
 import _get from 'lodash/get';
-import _isEmpty from 'lodash/isEmpty';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { getResponse } from '../../utils/helpers';
 import {

--- a/packages/evolution-common/src/services/questionnaire/sections/common/widgetsSwitchPerson.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/common/widgetsSwitchPerson.ts
@@ -18,7 +18,7 @@ const activePersonTitle: TextWidgetConfig = {
     align: 'center',
     containsHtml: true,
     classes: '',
-    text: (t: TFunction, interview: UserInterviewAttributes, path: string) => {
+    text: (t: TFunction, interview: UserInterviewAttributes, _path: string) => {
         const activePerson = odHelpers.getActivePerson({ interview });
         if (activePerson === null) {
             return '';
@@ -49,14 +49,14 @@ const buttonSwitchPerson: ButtonWidgetConfig = {
         cancelButtonColor: 'blue',
         cancelButtonLabel: (t: TFunction) => t('main:OK')
     },
-    conditional: (interview, path) => [hasMoreThanOneInterviewablePerson(interview), undefined],
+    conditional: (interview, _path) => [hasMoreThanOneInterviewablePerson(interview), undefined],
     action: function (
         callbacks: InterviewUpdateCallbacks,
-        interview: UserInterviewAttributes,
-        path: string,
+        _interview: UserInterviewAttributes,
+        _path: string,
         section,
-        sections,
-        saveCallback
+        _sections,
+        _saveCallback
     ) {
         // FIXME: We navigate to the selectPerson section... That means this widget should be part of a feature that contains this section
         callbacks.startUpdateInterview(section, {
@@ -73,7 +73,7 @@ const buttonSwitchPerson: ButtonWidgetConfig = {
  */
 export const getSwitchPersonWidgets = (
     // FIXME: Type this when there is a few more widgets implemented
-    options: { context?: () => string } = {}
+    _options: { context?: () => string } = {}
 ): { activePersonTitle: TextWidgetConfig; buttonSwitchPerson: ButtonWidgetConfig } => {
     // TODO These should be some configuration receive here to fine-tune the section's content
     return {

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/groupPersonTrips.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/groupPersonTrips.ts
@@ -11,7 +11,7 @@ import { TFunction } from 'i18next';
 
 export const getPersonsTripsGroupConfig = (
     // FIXME: Type this when there is a few more widgets implemented
-    options: { context?: () => string } = {}
+    _options: { context?: () => string } = {}
 ): GroupConfig => {
     // TODO These should be some configuration receive here to fine-tune the section's content
     return {

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/groupSegments.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/groupSegments.ts
@@ -12,7 +12,7 @@ import { Segment } from '../../types';
 
 export const getSegmentsGroupConfig = (
     // FIXME: Type this when there is a few more widgets implemented
-    options: { context?: () => string } = {}
+    _options: { context?: () => string } = {}
 ): GroupConfig => {
     // TODO These should be some configuration receive here to fine-tune the section's content
     return {

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/sectionSegments.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/sectionSegments.ts
@@ -18,7 +18,7 @@ export const getSegmentsSectionConfig = (
     // should return some other type than the SectionConfig, which will be
     // transformed to a SectionConfig by a higher level handler questionnaire
     // handler
-    options: { context?: (context?: string) => string }
+    _options: { context?: (context?: string) => string }
 ): SectionConfig => {
     const sectionShortname = 'segments';
     return {

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/widgetPersonTripsTitle.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/widgetPersonTripsTitle.ts
@@ -19,7 +19,7 @@ export const getPersonsTripsTitleWidgetConfig = (
     return {
         type: 'text',
         align: 'left',
-        text: (t: TFunction, interview: UserInterviewAttributes, path: string) => {
+        text: (t: TFunction, interview: UserInterviewAttributes, _path: string) => {
             const person = odHelpers.getActivePerson({ interview });
             const journey = odHelpers.getActiveJourney({ interview });
             // FIXME Write a function somewhere to get the journey's or dateToString function, once we move to objects

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/widgetSameAsReverseTrip.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/widgetSameAsReverseTrip.ts
@@ -4,7 +4,6 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import _upperFirst from 'lodash/upperFirst';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { WidgetConfig } from '../../../questionnaire/types';
 import { getResponse } from '../../../../utils/helpers';
@@ -23,7 +22,7 @@ export const getSameAsReverseTripWidgetConfig = (
         inputType: 'radio',
         twoColumns: false,
         datatype: 'boolean',
-        label: (t: TFunction, interview, path) => {
+        label: (t: TFunction, interview, _path) => {
             const person = odHelpers.getPerson({ interview }) as Person;
             const previousSegment = getPreviousTripSingleSegment({ interview, person });
             const journey = odHelpers.getActiveJourney({ interview, person }) as Journey;

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/widgetSegmentHasNextMode.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/widgetSegmentHasNextMode.ts
@@ -4,7 +4,6 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import _upperFirst from 'lodash/upperFirst';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { WidgetConfig } from '../../../questionnaire/types';
 import { getResponse } from '../../../../utils/helpers';

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/widgetSegmentModePre.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/widgetSegmentModePre.ts
@@ -19,7 +19,7 @@ const getModePreChoices = () => [
     {
         value: 'carDriver',
         label: (t: TFunction) => t(['customSurvey:segments:modePre:CarDriver', 'segments:modePre:CarDriver']),
-        conditional: function (interview, path) {
+        conditional: function (interview, _path) {
             const person = odHelpers.getActivePerson({ interview });
             if (person === null) {
                 return true;

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/widgetTripSegmentsIntro.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/widgetTripSegmentsIntro.ts
@@ -15,7 +15,7 @@ export const getTripSegmentsIntro = (
     options: { context?: (additionalContext?: string) => string } = {}
 ): TextWidgetConfig => ({
     type: 'text',
-    text: (t: TFunction, interview, path) => {
+    text: (t: TFunction, interview, _path) => {
         const person = odHelpers.getPerson({ interview });
         const journey = odHelpers.getActiveJourney({ interview, person });
         const trip = odHelpers.getActiveTrip({ interview, journey });


### PR DESCRIPTION
The lint warnings from evolution-common (other than "unexpected any") have been removed.

26 warnings got removed (104 to 78).