### PR TITLE
Remove Lint warnings from evolution-interviewer

### DIFF
--- a/packages/evolution-interviewer/jest.config.js
+++ b/packages/evolution-interviewer/jest.config.js
@@ -5,6 +5,8 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 /* eslint-disable n/no-unpublished-require */
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports */
 const baseConfig = require('../../tests/jest.config.base');
 
 module.exports = {

--- a/packages/evolution-interviewer/jest.sequential.config.js
+++ b/packages/evolution-interviewer/jest.sequential.config.js
@@ -5,6 +5,8 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 /* eslint-disable n/no-unpublished-require */
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports */
 const baseConfig = require('../../tests/jest.config.base');
 
 // Ignore db.queries.test files

--- a/packages/evolution-interviewer/src/client/components/monitoring/RefreshInterviewerCache.tsx
+++ b/packages/evolution-interviewer/src/client/components/monitoring/RefreshInterviewerCache.tsx
@@ -36,7 +36,7 @@ export const RefreshInterviewerCache = (props: WithTranslation) => {
             } else {
                 setError(props.t(['survey:admin:interviewer:error', 'admin:interviewer:error']));
             }
-        } catch (error) {
+        } catch {
             setError(props.t(['survey:admin:interviewer:error', 'admin:interviewer:error']));
         } finally {
             setLoading(false);
@@ -64,7 +64,7 @@ export const RefreshInterviewerCache = (props: WithTranslation) => {
                         'admin:interviewer:refreshInterviewerCache'
                     ]) as string
                 }
-                onClick={(e) => onRefreshMonitoringData()}
+                onClick={(_e) => onRefreshMonitoringData()}
                 color="blue"
                 disabled={!loading}
             />

--- a/packages/evolution-interviewer/src/server/routes/interviewer.routes.ts
+++ b/packages/evolution-interviewer/src/server/routes/interviewer.routes.ts
@@ -113,7 +113,7 @@ export default function (interviewDataFct: {
         }
     });
 
-    router.get('/monitoring/get_interviewer_data', (req, res, next) => {
+    router.get('/monitoring/get_interviewer_data', (req, res, _next) => {
         try {
             if (!(req as any).user) {
                 throw 'Request user is not defined, an interview cannot be created for the user';


### PR DESCRIPTION
The lint warnings from evolution-interviewer (other than "unexpected any") have been removed.

7 warnings got removed (18 to 11).