### PR TITLE
Remove Lint warnings from evolution-interviewer

### DIFF
--- a/packages/evolution-frontend/jest.config.js
+++ b/packages/evolution-frontend/jest.config.js
@@ -5,6 +5,8 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 /* eslint-disable n/no-unpublished-require */
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports */
 const baseConfig = require('../../tests/jest.config.base');
 
 module.exports = {

--- a/packages/evolution-frontend/src/actions/Auth.ts
+++ b/packages/evolution-frontend/src/actions/Auth.ts
@@ -48,7 +48,7 @@ export const startDirectTokenLogin = (history: History, location: Location, call
 
 // TODO: Is commented in chaire-lib-frontend
 export const startRegister = (data: any, history: History) => {
-    return (dispatch, getState) => {
+    return (dispatch, _getState) => {
         return fetch('/register', {
             method: 'POST',
             body: JSON.stringify(data),

--- a/packages/evolution-frontend/src/components/admin/interviews/InterviewSearchList.tsx
+++ b/packages/evolution-frontend/src/components/admin/interviews/InterviewSearchList.tsx
@@ -22,7 +22,6 @@ const InterviewSearchList: React.FunctionComponent<InterviewSearchListProps & Wi
     props: InterviewSearchListProps & WithTranslation
 ) => {
     const [data, setData] = React.useState<{ [key: string]: any }[]>([]);
-    const [loading, setLoading] = React.useState(false);
     const { state, dispatch } = React.useContext(InterviewContext);
     const fetchIdRef = React.useRef(0);
 
@@ -32,11 +31,7 @@ const InterviewSearchList: React.FunctionComponent<InterviewSearchListProps & Wi
             // Give this fetch an ID
             const fetchId = ++fetchIdRef.current;
 
-            // Set the loading state
-            setLoading(true);
-
             // Make a query string from the filters
-
             try {
                 const response = await fetch(`/api/interviews/interviewByCode?accessCode=${accessCode}`);
                 if (fetchId !== fetchIdRef.current) {
@@ -67,10 +62,6 @@ const InterviewSearchList: React.FunctionComponent<InterviewSearchListProps & Wi
             } catch (error) {
                 console.error(`Error fetching user data from server: ${error}`);
                 setData([]);
-            } finally {
-                if (fetchId === fetchIdRef.current) {
-                    setLoading(false);
-                }
             }
         },
         [state.status]

--- a/packages/evolution-frontend/src/components/admin/monitoring/StartedAndCompletedInterviewByDay.tsx
+++ b/packages/evolution-frontend/src/components/admin/monitoring/StartedAndCompletedInterviewByDay.tsx
@@ -196,6 +196,8 @@ class StartedAndCompletedInterviewsByDay extends React.Component<
                 ? this.state.data.completedCount / this.state.data.startedCount
                 : null;
 
+        const reactHighchartsRef = 'highchart-started-and-completed-interviews-by-day';
+
         return (
             <div
                 className="admin-widget-container"
@@ -205,7 +207,7 @@ class StartedAndCompletedInterviewsByDay extends React.Component<
                     config={chartOptions}
                     domProps={{ id: 'highchartStartedAndCompletedInterviewsByDay' }}
                     callback={null}
-                    ref={'highchart-started-and-completed-interviews-by-day'}
+                    ref={reactHighchartsRef}
                 ></ReactHighcharts>
                 <p className="no-bottom-margin">
                     {this.state.data.startedCount && (

--- a/packages/evolution-frontend/src/components/admin/validations/InterviewByCodeFilter.tsx
+++ b/packages/evolution-frontend/src/components/admin/validations/InterviewByCodeFilter.tsx
@@ -7,7 +7,6 @@
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { FilterProps } from 'react-table';
-import _isEqual from 'lodash/isEqual';
 import { faCheckCircle } from '@fortawesome/free-solid-svg-icons/faCheckCircle';
 
 import InputString from 'chaire-lib-frontend/lib/components/input/InputString';

--- a/packages/evolution-frontend/src/components/admin/validations/InterviewByDateFilter.tsx
+++ b/packages/evolution-frontend/src/components/admin/validations/InterviewByDateFilter.tsx
@@ -7,7 +7,6 @@
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { FilterProps } from 'react-table';
-import _isEqual from 'lodash/isEqual';
 
 import { InterviewListAttributes } from 'evolution-common/lib/services/questionnaire/types';
 import DatePicker from 'react-datepicker';

--- a/packages/evolution-frontend/src/components/admin/validations/InterviewByHomeGeographyFilter.tsx
+++ b/packages/evolution-frontend/src/components/admin/validations/InterviewByHomeGeographyFilter.tsx
@@ -7,7 +7,6 @@
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { FilterProps } from 'react-table';
-import _isEqual from 'lodash/isEqual';
 import { faCheckCircle } from '@fortawesome/free-solid-svg-icons/faCheckCircle';
 
 import { InterviewListAttributes } from 'evolution-common/lib/services/questionnaire/types';
@@ -43,7 +42,7 @@ export const InterviewByCodeFilter = ({
                 setHasError(true);
                 setCurrentValue(undefined);
             }
-        } catch (error) {
+        } catch {
             setHasError(true);
             setCurrentValue(undefined);
         }

--- a/packages/evolution-frontend/src/components/admin/validations/InterviewCompletedFilter.tsx
+++ b/packages/evolution-frontend/src/components/admin/validations/InterviewCompletedFilter.tsx
@@ -34,7 +34,7 @@ export const InterviewCompletedFilter = ({
                     setFilter(options[e.target.value] || undefined);
                 }}
             >
-                {Object.keys(options).map((key, i) => (
+                {Object.keys(options).map((key, _i) => (
                     <option key={`interviewCompleted_${key}`} value={key}>
                         {t(`admin:interviewCompletedFilter:${key}`)}
                     </option>

--- a/packages/evolution-frontend/src/components/admin/validations/InterviewListComponent.tsx
+++ b/packages/evolution-frontend/src/components/admin/validations/InterviewListComponent.tsx
@@ -32,6 +32,12 @@ interface InterviewListComponentProps extends WithTranslation {
     dispatch: Dispatch;
 }
 
+type CellArgs = {
+    value: any;
+    data?: any;
+    row?: any;
+};
+
 const InterviewListComponent: React.FunctionComponent<InterviewListComponentProps> = (
     props: InterviewListComponentProps
 ) => {
@@ -120,12 +126,13 @@ const InterviewListComponent: React.FunctionComponent<InterviewListComponentProp
         }
     }, []);
 
+    // TODO: Turn cells into proper components instead of just making them inline.
     const columns = React.useMemo(() => {
         const columns = [
             {
                 accessor: 'id',
                 label: props.t('admin:InterviewId'),
-                Cell: ({ value }) => `#${value}`,
+                Cell: ({ value }: CellArgs) => `#${value}`,
                 enableSortBy: true
             },
             {
@@ -140,7 +147,7 @@ const InterviewListComponent: React.FunctionComponent<InterviewListComponentProp
                 id: 'created_at',
                 accessor: 'created_at',
                 label: props.t('admin:interviewByDateFilter:title'),
-                Cell: ({ value }) =>
+                Cell: ({ value }: CellArgs) =>
                     !_isBlank(value) ? new Date(value).toISOString().split('T')[0].replace('/', '-') : '?', // Converts to YYYY-MM-DD format
                 Filter: InterviewByDateFilter,
                 enableSortBy: true
@@ -149,13 +156,13 @@ const InterviewListComponent: React.FunctionComponent<InterviewListComponentProp
                 accessor: 'responses._isCompleted',
                 Filter: InterviewCompletedFilter,
                 enableSortBy: false,
-                Cell: ({ value }) =>
+                Cell: ({ value }: CellArgs) =>
                     value ? props.t('admin:CompletedFemSingular') : props.t('admin:NotCompletedFemSingular')
             },
             {
                 accessor: 'is_valid',
                 Filter: ValidityColumnFilter,
-                Cell: ({ value }) =>
+                Cell: ({ value }: CellArgs) =>
                     value
                         ? props.t('admin:Valid')
                         : value === false
@@ -164,12 +171,13 @@ const InterviewListComponent: React.FunctionComponent<InterviewListComponentProp
             },
             {
                 accessor: 'responses.household.size',
-                Cell: ({ value }) => (
+                Cell: ({ value }: CellArgs) => (
                     <React.Fragment>
                         {value || '?'}
                         <FontAwesomeIcon
                             icon={faUserCircle}
                             className="faIconNoMargin"
+                            /* eslint-disable-next-line react/prop-types */
                             title={props.t('admin:persons')}
                         />
                     </React.Fragment>
@@ -179,7 +187,7 @@ const InterviewListComponent: React.FunctionComponent<InterviewListComponentProp
             },
             {
                 accessor: 'audits',
-                Cell: ({ value }) =>
+                Cell: ({ value }: CellArgs) =>
                     !value || Object.keys(value).length === 0 ? (
                         ''
                     ) : (
@@ -187,6 +195,7 @@ const InterviewListComponent: React.FunctionComponent<InterviewListComponentProp
                             icon={faExclamationTriangle}
                             className="faIconNoMargin _error _red"
                             title={Object.keys(value)
+                                /* eslint-disable-next-line react/prop-types */
                                 .map((error: any) => props.t([`survey:validations:${error}`, `surveyAdmin:${error}`]))
                                 .join('\n')}
                         />
@@ -195,7 +204,7 @@ const InterviewListComponent: React.FunctionComponent<InterviewListComponentProp
             },
             {
                 accessor: 'uuid',
-                Cell: ({ data, row, value }) => {
+                Cell: ({ data, row, value }: CellArgs) => {
                     // TODO Do we want to continue navigating beyond the current page? If so, implement it
                     const prevUuid = row.index > 0 ? data[row.index - 1].uuid : '';
                     const nextUuid = row.index < data.length - 1 ? data[row.index + 1].uuid : '';
@@ -208,14 +217,14 @@ const InterviewListComponent: React.FunctionComponent<InterviewListComponentProp
                             data-next-uuid={nextUuid}
                             onClick={handleInterviewSummaryChange}
                         >
-                            {props.t('admin:Validate')}
+                            {props.t('admin:Validate') /* eslint-disable-line react/prop-types */}
                         </a>
                     );
                 }
             },
             {
                 accessor: 'responses._validationComment',
-                Cell: ({ value }) =>
+                Cell: ({ value }: CellArgs) =>
                     _isBlank(value) ? (
                         ''
                     ) : (
@@ -250,7 +259,7 @@ const InterviewListComponent: React.FunctionComponent<InterviewListComponentProp
     );
 };
 
-const mapDispatchToProps = (dispatch, props: Omit<InterviewListComponentProps, 'dispatch'>) => ({
+const mapDispatchToProps = (dispatch, _props: Omit<InterviewListComponentProps, 'dispatch'>) => ({
     dispatch
 });
 

--- a/packages/evolution-frontend/src/components/admin/validations/InterviewMap.tsx
+++ b/packages/evolution-frontend/src/components/admin/validations/InterviewMap.tsx
@@ -66,14 +66,14 @@ const InterviewMap: React.FunctionComponent<InterviewMapProps> = (props: Intervi
         minZoom: 0,
         tileSize: 256,
         opacity: 0.5,
-        renderSubLayers: (props) => {
-            const { boundingBox } = props.tile;
+        renderSubLayers: (subLayerProps) => {
+            const { boundingBox } = subLayerProps.tile;
 
             return new BitmapLayer(
-                props as any,
+                subLayerProps as any,
                 {
                     data: null,
-                    image: props.data,
+                    image: subLayerProps.data,
                     bounds: [boundingBox[0][0], boundingBox[0][1], boundingBox[1][0], boundingBox[1][1]]
                 } as any
             );

--- a/packages/evolution-frontend/src/components/admin/validations/ValidationAuditFilter.tsx
+++ b/packages/evolution-frontend/src/components/admin/validations/ValidationAuditFilter.tsx
@@ -134,7 +134,7 @@ export const ValidationAuditFilter = ({
                 </label>
                 <Select
                     styles={{
-                        option: (baseStyles, state) => ({
+                        option: (baseStyles, _state) => ({
                             ...baseStyles,
                             paddingTop: 0,
                             paddingBottom: 0

--- a/packages/evolution-frontend/src/components/admin/validations/ValidityColumnFilter.tsx
+++ b/packages/evolution-frontend/src/components/admin/validations/ValidityColumnFilter.tsx
@@ -33,7 +33,7 @@ export const ValidityColumnFilter = ({
                     setFilter(e.target.value || undefined);
                 }}
             >
-                {options.map((key, i) => (
+                {options.map((key, _i) => (
                     <option key={`validitySeletion_${key}`} value={key}>
                         {t(`admin:validationFilters:${key}`)}
                     </option>

--- a/packages/evolution-frontend/src/components/admin/validations/react-table-config.d.ts
+++ b/packages/evolution-frontend/src/components/admin/validations/react-table-config.d.ts
@@ -122,6 +122,8 @@ declare module 'react-table' {
             UseResizeColumnsColumnProps<D>,
             UseSortByColumnProps<D> {}
 
+    // TODO: Is the V really necessary? Why is it the only interface here that has it?
+    /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
     export interface Cell<D extends Record<string, unknown> = Record<string, unknown>, V = any>
         extends UseGroupByCellProps<D>,
             UseRowStateCellProps<D> {}

--- a/packages/evolution-frontend/src/components/hoc/WithSurveyContextHoc.tsx
+++ b/packages/evolution-frontend/src/components/hoc/WithSurveyContextHoc.tsx
@@ -13,6 +13,7 @@ export interface WithSurveyContextProps {
 
 export const withSurveyContext =
     <T extends WithSurveyContextProps = WithSurveyContextProps>(WrappedComponent: React.ComponentType<T>) =>
+    /* eslint-disable-next-line react/display-name */
         (props: Omit<T, keyof WithSurveyContextProps>) => (
             <SurveyContext.Consumer>
                 {(context) => <WrappedComponent {...(props as T)} surveyContext={context} />}

--- a/packages/evolution-frontend/src/components/inputs/InputButton.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputButton.tsx
@@ -6,7 +6,6 @@
  */
 import React from 'react';
 
-import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { ChoiceType, InputButtonType } from 'evolution-common/lib/services/questionnaire/types';
 import * as surveyHelper from 'evolution-common/lib/utils/helpers';
 import { UserInterviewAttributes } from 'evolution-common/lib/services/questionnaire/types';

--- a/packages/evolution-frontend/src/components/inputs/InputDatePicker.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputDatePicker.tsx
@@ -12,7 +12,6 @@ import fr from 'date-fns/locale/fr';
 import enCA from 'date-fns/locale/en-CA';
 import 'react-datepicker/dist/react-datepicker.css';
 
-import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { InputDatePickerType } from 'evolution-common/lib/services/questionnaire/types';
 import * as surveyHelper from 'evolution-common/lib/utils/helpers';
 import { CommonInputProps } from './CommonInputProps';

--- a/packages/evolution-frontend/src/components/inputs/InputMapFindPlace.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputMapFindPlace.tsx
@@ -12,7 +12,6 @@ import { faCheckCircle } from '@fortawesome/free-solid-svg-icons/faCheckCircle';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
-import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import projectConfig from 'chaire-lib-common/lib/config/shared/project.config';
 import { InputMapFindPlaceType } from 'evolution-common/lib/services/questionnaire/types';
 import * as surveyHelper from 'evolution-common/lib/utils/helpers';
@@ -120,7 +119,7 @@ export class InputMapFindPlace extends React.Component<
         }
     }
 
-    onSearchPlaceButtonMouseDown(e) {
+    onSearchPlaceButtonMouseDown(_e) {
         //e.preventDefault();
         // preventing default would ignore active input blur
         this.setState({ searchPlaceButtonWasMouseDowned: true });

--- a/packages/evolution-frontend/src/components/inputs/InputMapPoint.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputMapPoint.tsx
@@ -9,7 +9,6 @@ import GeoJSON from 'geojson';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faMapMarkerAlt } from '@fortawesome/free-solid-svg-icons/faMapMarkerAlt';
 
-import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import projectConfig from 'evolution-common/lib/config/project.config';
 import { InputMapPointType } from 'evolution-common/lib/services/questionnaire/types';
 import * as surveyHelper from 'evolution-common/lib/utils/helpers';
@@ -143,7 +142,7 @@ export class InputMapPoint extends React.Component<InputMapPointProps & WithTran
                 const feature = await geocodeSinglePoint(geocodingQueryStringArray[0].queryString, { bbox });
                 this.onValueChange(feature);
                 this.setState({ displayMessage: feature === undefined ? 'main:InputMapGeocodeNoResult' : undefined });
-            } catch (error) {
+            } catch {
                 this.onValueChange(undefined);
                 this.setState({ displayMessage: 'main:InputMapGeocodeError' });
             }

--- a/packages/evolution-frontend/src/components/inputs/InputMultiselect.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputMultiselect.tsx
@@ -166,11 +166,11 @@ export class InputMultiselect extends React.Component<InputMultiselectProps & Wi
         }
 
         const customStyles = {
-            option: (base, state) => ({
+            option: (base, _state) => ({
                 ...base,
                 padding: '0.25rem 0.5rem'
             }),
-            menu: (base, state) => ({
+            menu: (base, _state) => ({
                 ...base,
                 marginTop: '0'
             })

--- a/packages/evolution-frontend/src/components/inputs/maps/google/InputMapGoogle.tsx
+++ b/packages/evolution-frontend/src/components/inputs/maps/google/InputMapGoogle.tsx
@@ -11,7 +11,6 @@ import { GoogleMap, useJsApiLoader, Marker } from '@react-google-maps/api';
 import GeoJSON from 'geojson';
 import bowser from 'bowser';
 
-import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { getCurrentGoogleMapConfig } from '../../../../config/googleMaps.config';
 import InputLoading from '../../InputLoading';
 import { FeatureGeocodedProperties, MarkerData, InfoWindow } from '../InputMapTypes';

--- a/packages/evolution-frontend/src/components/pageParts/Section.tsx
+++ b/packages/evolution-frontend/src/components/pageParts/Section.tsx
@@ -6,15 +6,12 @@
  */
 import { withTranslation, WithTranslation } from 'react-i18next';
 import React from 'react';
-import _get from 'lodash/get';
 import _shuffle from 'lodash/shuffle';
 
 import * as surveyHelper from 'evolution-common/lib/utils/helpers';
 import { withSurveyContext, WithSurveyContextProps } from '../hoc/WithSurveyContextHoc';
 import { Widget } from '../survey/Widget';
 import LoadingPage from 'chaire-lib-frontend/lib/components/pages/LoadingPage';
-import { SectionConfig, UserRuntimeInterviewAttributes } from 'evolution-common/lib/services/questionnaire/types';
-import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
 import { SectionProps, useSectionTemplate } from '../hooks/useSectionTemplate';
 
 export const Section: React.FC<SectionProps & WithTranslation & WithSurveyContextProps> = (

--- a/packages/evolution-frontend/src/components/pageParts/SectionNav.tsx
+++ b/packages/evolution-frontend/src/components/pageParts/SectionNav.tsx
@@ -9,7 +9,6 @@ import { withTranslation, WithTranslation } from 'react-i18next';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faAngleRight } from '@fortawesome/free-solid-svg-icons/faAngleRight';
 
-import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { SurveyContext } from '../../contexts/SurveyContext';
 import { SectionConfig, UserRuntimeInterviewAttributes } from 'evolution-common/lib/services/questionnaire/types';
 import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
@@ -28,7 +27,7 @@ type SectionNavProps = {
     interview: UserRuntimeInterviewAttributes;
     allWidgetsValid: boolean;
     loadingState: number;
-    startUpdateInterview: StartUpdateInterview;
+    _startUpdateInterview: StartUpdateInterview; //TODO: Add functionality to the _startUpdateInterview, or remove it.
     user: CliUser;
 } & WithTranslation;
 
@@ -41,7 +40,7 @@ const SectionNav = function ({
     interview,
     allWidgetsValid,
     loadingState,
-    startUpdateInterview,
+    _startUpdateInterview,
     user
 }: SectionNavProps) {
     const { devMode, dispatch } = React.useContext(SurveyContext);

--- a/packages/evolution-frontend/src/components/pages/Survey.tsx
+++ b/packages/evolution-frontend/src/components/pages/Survey.tsx
@@ -183,16 +183,17 @@ export class Survey extends React.Component<SurveyProps, SurveyState> {
                 console.error(`Template ${sectionConfig.template} not found in appConfig.templateMapping`);
             }
         }
-        let navActiveSection: string | null = activeSection;
+
+        //let navActiveSection: string | null = activeSection;
 
         // use parent section name as active section if active section is set to be hidden in navigation:
-        // Right now this is ignored. TODO/FIXME: implement? Find what it should do?
-        if (
-            this.props.surveyContext.sections[activeSection] &&
-            this.props.surveyContext.sections[activeSection].parentSection !== undefined
-        ) {
-            navActiveSection = this.props.surveyContext.sections[activeSection].parentSection as string;
-        }
+        // Right now this is ignored and commented. TODO/FIXME: implement? Find what it should do?
+        // if (
+        //     this.props.surveyContext.sections[activeSection] &&
+        //     this.props.surveyContext.sections[activeSection].parentSection !== undefined
+        // ) {
+        //     navActiveSection = this.props.surveyContext.sections[activeSection].parentSection as string;
+        // }
 
         let customStyle: React.CSSProperties = {};
 
@@ -224,7 +225,7 @@ export class Survey extends React.Component<SurveyProps, SurveyState> {
                         interview={this.props.interview}
                         allWidgetsValid={config.allowChangeSectionWithoutValidation ? true : allWidgetsValid}
                         loadingState={this.props.loadingState}
-                        startUpdateInterview={this.props.startUpdateInterview}
+                        _startUpdateInterview={this.props.startUpdateInterview}
                         user={this.props.user}
                     />
                     {this.state.confirmCompleteBeforeSwitchingOpened && (

--- a/packages/evolution-frontend/src/components/routers/ConsentedRoute.tsx
+++ b/packages/evolution-frontend/src/components/routers/ConsentedRoute.tsx
@@ -10,7 +10,19 @@ import { Route, Redirect } from 'react-router-dom';
 
 import { Header } from 'chaire-lib-frontend/lib/components/pageParts';
 
-export const ConsentedRoute = ({ isAuthenticated, hasConsented, component: Component, config, ...rest }) => (
+type ConsentedRouteProps = {
+    isAuthenticated: boolean;
+    hasConsented: boolean;
+    component: any;
+} & any;
+
+// TODO: Refactor this component so it doesn't need to use `...rest` in its props.
+export const ConsentedRoute = ({
+    isAuthenticated,
+    hasConsented,
+    component: Component,
+    ...rest
+}: ConsentedRouteProps) => (
     <Route
         {...rest}
         component={(props) => {

--- a/packages/evolution-frontend/src/components/survey/ErrorBoundary.tsx
+++ b/packages/evolution-frontend/src/components/survey/ErrorBoundary.tsx
@@ -50,7 +50,7 @@ export class ErrorBoundary extends React.Component<React.PropsWithChildren<Error
     }
 }
 
-const mapStateToProps = (state, props) => {
+const mapStateToProps = (state, _props) => {
     return {
         interview: state.survey.interview
     };

--- a/packages/evolution-frontend/src/components/survey/GroupWidgets.tsx
+++ b/packages/evolution-frontend/src/components/survey/GroupWidgets.tsx
@@ -171,7 +171,7 @@ const BaseGroup: FunctionComponent<GroupProps & WithTranslation & WithSurveyCont
     const widgetsComponents: JSX.Element[] = [];
     const parentObjectIds = _cloneDeep(props.parentObjectIds) || {};
     // FIXME Type the groupedObject
-    groupedObjects().forEach((groupedObject: any, index) => {
+    groupedObjects().forEach((groupedObject: any, _index) => {
         // FIXME What are we doing here exactly? Why?
         parentObjectIds[props.shortname] = groupedObject._uuid;
         const path = `${props.path}.${groupedObject._uuid}`;

--- a/packages/evolution-frontend/src/components/survey/InfoMap.tsx
+++ b/packages/evolution-frontend/src/components/survey/InfoMap.tsx
@@ -4,7 +4,7 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { withTranslation, WithTranslation } from 'react-i18next';
 import { GoogleMap, useJsApiLoader, Marker, Polyline, Polygon, MarkerProps } from '@react-google-maps/api';
 import Markdown from 'react-markdown';

--- a/packages/evolution-frontend/src/components/survey/Question.tsx
+++ b/packages/evolution-frontend/src/components/survey/Question.tsx
@@ -91,7 +91,7 @@ export class Question extends React.Component<QuestionProps & WithSurveyContextP
         const value = e.target ? e.target.value : e; //InputDatePicker call onValueChange with e=value
         const parsedValue = surveyHelper.parseValue(value, (widgetConfig as any).datatype);
         const parsedCustomValue = surveyHelper.parseValue(customValue, (widgetConfig as any).customDatatype);
-        const [isValid, errorMessage] = checkValidations(
+        const [isValid] = checkValidations(
             widgetConfig.validations,
             parsedValue,
             parsedCustomValue,
@@ -133,7 +133,7 @@ export class Question extends React.Component<QuestionProps & WithSurveyContextP
         }
     };
 
-    shouldComponentUpdate(nextProps, nextState) {
+    shouldComponentUpdate(nextProps, _nextState) {
         // we need to re-render whenever loading state changes for widgets with buttons, like mapFindPlace:
         // TODO: find all buttons inside questions to make sure they are correctly re-render before click event is triggered.
         // See Button.js for more comments about this issue
@@ -142,7 +142,6 @@ export class Question extends React.Component<QuestionProps & WithSurveyContextP
 
     render() {
         const widgetStatus = this.props.widgetStatus;
-        const wc = this.props.widgetConfig as any;
 
         if (!widgetStatus.isVisible && !this.props.surveyContext.devMode) {
             return null;

--- a/packages/evolution-frontend/src/components/survey/sectionTemplates/TripsAndSegmentsSection.tsx
+++ b/packages/evolution-frontend/src/components/survey/sectionTemplates/TripsAndSegmentsSection.tsx
@@ -17,8 +17,6 @@ import { GroupedObject } from '../GroupWidgets';
 import LoadingPage from 'chaire-lib-frontend/lib/components/pages/LoadingPage';
 import { withSurveyContext, WithSurveyContextProps } from '../../hoc/WithSurveyContextHoc';
 import { getResponse } from 'evolution-common/lib/utils/helpers';
-import { SectionConfig, UserRuntimeInterviewAttributes } from 'evolution-common/lib/services/questionnaire/types';
-import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
 import { SectionProps, useSectionTemplate } from '../../hooks/useSectionTemplate';
 import * as odSurveyHelper from 'evolution-common/lib/services/odSurvey/helpers';
 import * as helpers from 'evolution-common/lib/utils/helpers';

--- a/packages/evolution-frontend/src/components/survey/widgets/SurveyErrorMessage.tsx
+++ b/packages/evolution-frontend/src/components/survey/widgets/SurveyErrorMessage.tsx
@@ -5,10 +5,6 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import React from 'react';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons/faQuestionCircle';
-
-import SimpleModal from '../../modal/SimpleModal';
 
 interface SurveyErrorMessageProps {
     containsHtml: boolean;
@@ -17,7 +13,6 @@ interface SurveyErrorMessageProps {
 }
 
 export const SurveyErrorMessage = (props: SurveyErrorMessageProps) => {
-    const [modalIsOpened, setModalIsOpened] = React.useState(false);
     return (
         <p className="apptr__form-error-message">
             {props.containsHtml ? (

--- a/packages/evolution-frontend/src/config/i18n.config.ts
+++ b/packages/evolution-frontend/src/config/i18n.config.ts
@@ -44,7 +44,7 @@ i18n.use(LanguageDetector)
                 //useSuspense: false
             }
         },
-        (err, t) => {
+        (err, _t) => {
             if (err) {
                 console.log(err);
             }

--- a/packages/evolution-frontend/src/services/display/frontendHelper.ts
+++ b/packages/evolution-frontend/src/services/display/frontendHelper.ts
@@ -124,8 +124,8 @@ export const validateButtonAction: ButtonAction = (callbacks, interview, path, s
         if ((updatedInterview as any).allWidgetsValid) {
             if (typeof saveCallback === 'function') {
                 saveCallback(callbacks, updatedInterview, path);
-            } // go to next section
-            else {
+            } else {
+                // go to next section
                 window.scrollTo(0, 0);
                 callbacks.startUpdateInterview(section, {
                     'responses._activeSection': sections[section].nextSection


### PR DESCRIPTION
The lint warnings from evolution-frontend (other than "unexpected any" and a few require() related ones) have been removed.

70 warnings got removed (204 to 134).