### PR TITLE
Fix title header overflow

### DIFF
--- a/packages/evolution-legacy/src/styles/survey/_admin.scss
+++ b/packages/evolution-legacy/src/styles/survey/_admin.scss
@@ -347,3 +347,10 @@ table {
   width: 100%;
   height: 100%;
 }
+
+// Show the user name in the top header
+header {
+  #item-nav-user {
+    display: block;
+  }
+}

--- a/packages/evolution-legacy/src/styles/survey/_header.scss
+++ b/packages/evolution-legacy/src/styles/survey/_header.scss
@@ -3,25 +3,38 @@ header {
   height: 1.8em;
   border-bottom: 1px solid $black-pale;
 
-
   .header__content {
     font-size: $font-size-small;
     align-items: flex-end;
     display: flex;
     justify-content: space-between;
     padding: $xxs-size;
+
+    // Ensures the title text in the top navigation bar doesn't overflow
     h1 {
       opacity: 0.6;
       margin: 0;
+      width: 100%;
+      max-width: 180px;
       font-size: $font-size-small;
       font-weight: 300;
+      white-space: nowrap; /* Prevents the text from wrapping to the next line */
+      overflow: hidden; /* Hides the overflow text */
+      text-overflow: ellipsis; /* Adds an ellipsis to indicate hidden text */
+
+      // Adjusts on larger screens
+      @media (min-width: 600px) {
+        max-width: 300px; 
+      }
     }
+
     ul {
       padding: 0;
       list-style: none;
       display: flex;
       margin: 0;
     }
+
     li {
       display: flex;
     }
@@ -43,5 +56,8 @@ header {
     z-index: 1000;
   }
 
+  // Hide the user name in the top header
+  #item-nav-user {
+    display: none;
+  }
 }
-


### PR DESCRIPTION
It's a cherry-pick from c41dbac13ca2daad8c5d3fbd5804d8adbe1e6049 of the main.

Make header H1 show big on big screen and small on small screen so the header doesn't break Remove the user name for survey but show on admin
fixes #574 fixes #448