### PR TITLE
widgetOperation: Refactor and document unit tests

### DIFF
--- a/packages/evolution-frontend/src/actions/utils/WidgetOperation.ts
+++ b/packages/evolution-frontend/src/actions/utils/WidgetOperation.ts
@@ -148,6 +148,7 @@ const prepareSimpleWidget = (
     customValue = surveyHelper.parseValue(customValue, widgetConfig.customDatatype);
 
     let isResponded = value !== undefined || data.affectedPaths['_all'] === true;
+    // FIXME Why do we set to true if _all is affected, even if there is no custom value?
     let isCustomResponded = customValue !== undefined || data.affectedPaths['_all'] === true;
 
     const isMapPoint =


### PR DESCRIPTION
The unit tests are complex enough as it is and were using some globally defined variable, so it was hard to follow what was being done. Now tests each control the values that they use and more comments are added above each code block.

Tests are renamed to actually represent what they do, as there was confusion between validation and conditionals.

Also, each test now calls the `prepareSectionWidgets` function once, but rather set their previous status instead of relying on a previous call to set the statuses.