### PR TITLE
tests: fix UI tests with anonym user hidden

### DIFF
--- a/example/demo_survey/tests/test-input-validation.UI.spec.ts
+++ b/example/demo_survey/tests/test-input-validation.UI.spec.ts
@@ -21,7 +21,7 @@ test.beforeAll(async ({ browser }) => {
 });
 
 /* Test the survey's input widget to make sure that they accept only the right data and will not continue until then. */
-surveyTestHelpers.startAndLoginAnonymously({ context, title: 'Démo', hasUser: true });
+surveyTestHelpers.startAndLoginAnonymously({ context, title: 'Démo', hasUser: false });
 
 // Test the home page
 testHelpers.tryToContinueWithInvalidInputs({ context, text: 'Save and continue', currentPageUrl: '/survey/home' , nextPageUrl: '/survey/householdMembers' });

--- a/example/demo_survey/tests/test-navigation-bar.UI.spec.ts
+++ b/example/demo_survey/tests/test-navigation-bar.UI.spec.ts
@@ -20,7 +20,7 @@ test.beforeAll(async ({ browser }) => {
 });
 
 /* Test the survey with a one-person household */
-surveyTestHelpers.startAndLoginAnonymously({ context, title: 'Démo', hasUser: true });
+surveyTestHelpers.startAndLoginAnonymously({ context, title: 'Démo', hasUser: false });
 
 // Verify that the buttons have the expected class/colors and are disabled if we haven't been to the corresponding page yet.
 testHelpers.verifyNavBarButtonStatus({ context, buttonText: 'Home', buttonStatus: 'active', isDisabled: false });

--- a/example/demo_survey/tests/test-one-person-no-trips.UI.spec.ts
+++ b/example/demo_survey/tests/test-one-person-no-trips.UI.spec.ts
@@ -20,7 +20,7 @@ test.beforeAll(async ({ browser }) => {
 });
 
 /* Test the survey with a one-person household */
-surveyTestHelpers.startAndLoginAnonymously({ context, title: 'Démo', hasUser: true });
+surveyTestHelpers.startAndLoginAnonymously({ context, title: 'Démo', hasUser: false });
 
 // Test the home page
 onePersonTestHelpers.completeHomePage(context);

--- a/example/demo_survey/tests/test-two-adults-no-trips.UI.spec.ts
+++ b/example/demo_survey/tests/test-two-adults-no-trips.UI.spec.ts
@@ -18,7 +18,7 @@ test.beforeAll(async ({ browser }) => {
     context.page = await testHelpers.initializeTestPage(browser, context.objectDetector);
 });
 /* Test the survey with a one-person household */
-surveyTestHelpers.startAndLoginAnonymously({ context, title: 'Démo', hasUser: true });
+surveyTestHelpers.startAndLoginAnonymously({ context, title: 'Démo', hasUser: false });
 
 // Test the home page
 testHelpers.inputStringTest({ context, path: 'accessCode', value: '1111-2222' });


### PR DESCRIPTION
A recent commit removed by default the username in the header for the participant app. UI tests were failing as it looked for the name.