### PR TITLE
dep: drop the redux-async-queue package

### DIFF
--- a/packages/evolution-frontend/package.json
+++ b/packages/evolution-frontend/package.json
@@ -66,7 +66,6 @@
     "react-spinners": "^0.14.1",
     "react-table": "^7.8.0",
     "redux": "^4.2.1",
-    "redux-async-queue": "^1.0.0",
     "redux-thunk": "^2.4.2",
     "remark-gfm": "^3.0.1",
     "typescript": "^5.7.2"

--- a/packages/evolution-frontend/src/actions/Survey.ts
+++ b/packages/evolution-frontend/src/actions/Survey.ts
@@ -71,7 +71,6 @@ export const updateSection = (
 };
 
 const startUpdateInterviewCallback = async (
-    next,
     dispatch,
     getState,
     requestedSectionShortname: string | null,
@@ -266,8 +265,6 @@ const startUpdateInterviewCallback = async (
             history,
             interviewId: getState().survey.interview!.id
         });
-    } finally {
-        next();
     }
 };
 
@@ -300,29 +297,27 @@ export const updateInterview = (
  * @returns The dispatched action
  */
 // TODO: unit test
-export const startUpdateInterview = (
-    sectionShortname: string | null,
-    valuesByPath?: { [path: string]: unknown },
-    unsetPaths?: string[],
-    interview?: UserRuntimeInterviewAttributes,
-    callback?: (interview: UserRuntimeInterviewAttributes) => void,
-    history?: History
-) => ({
-    queue: 'UPDATE_INTERVIEW',
-    callback: async (next, dispatch, getState) => {
-        await startUpdateInterviewCallback(
-            next,
-            dispatch,
-            getState,
-            sectionShortname,
-            valuesByPath,
-            unsetPaths,
-            interview,
-            callback,
-            history
-        );
-    }
-});
+export const startUpdateInterview =
+    (
+        sectionShortname: string | null,
+        valuesByPath?: { [path: string]: unknown },
+        unsetPaths?: string[],
+        interview?: UserRuntimeInterviewAttributes,
+        callback?: (interview: UserRuntimeInterviewAttributes) => void,
+        history?: History
+    ) =>
+        async (dispatch, getState) => {
+            return await startUpdateInterviewCallback(
+                dispatch,
+                getState,
+                sectionShortname,
+                valuesByPath,
+                unsetPaths,
+                interview,
+                callback,
+                history
+            );
+        };
 
 export const addConsent = (consented: boolean) => ({
     type: 'ADD_CONSENT',

--- a/packages/evolution-frontend/src/actions/SurveyAdmin.ts
+++ b/packages/evolution-frontend/src/actions/SurveyAdmin.ts
@@ -38,149 +38,144 @@ export const startUpdateSurveyValidateInterview = function (
     interview: UserRuntimeInterviewAttributes | null = null,
     callback: (interview: UserRuntimeInterviewAttributes) => void
 ) {
-    return {
-        queue: 'UPDATE_INTERVIEW',
-        callback: async function (next, dispatch, getState) {
-            //surveyHelper.devLog(`Update interview and section with values by path`, valuesByPath);
-            try {
-                if (interview === null) {
-                    interview = _cloneDeep(getState().survey.interview);
-                }
+    return async (dispatch, getState) => {
+        //surveyHelper.devLog(`Update interview and section with values by path`, valuesByPath);
+        try {
+            if (interview === null) {
+                interview = _cloneDeep(getState().survey.interview);
+            }
 
-                //interview.sectionLoaded = null;
+            //interview.sectionLoaded = null;
 
-                dispatch(incrementLoadingState());
+            dispatch(incrementLoadingState());
 
-                if (valuesByPath && Object.keys(valuesByPath).length > 0) {
-                    surveyHelper.devLog(
-                        'Update interview and section with values by path',
-                        JSON.parse(JSON.stringify(valuesByPath))
-                    );
-                }
-
-                //const oldInterview = _cloneDeep(interview);
-                //const previousSection = surveyHelper.getResponse(interview, '_activeSection', null);
-
-                const affectedPaths = {};
-
-                if (Array.isArray(unsetPaths)) {
-                    // unsetPaths if array (each path in array has to be deleted)
-                    for (let i = 0, count = unsetPaths.length; i < count; i++) {
-                        const path = unsetPaths[i];
-                        affectedPaths[path] = true;
-                        _unset(interview, path);
-                    }
-                } else {
-                    unsetPaths = [];
-                }
-
-                // update language if needed:
-                //const oldLanguage    = _get(interview, 'responses._language', null);
-                //const actualLanguage = null;//i18n.language;
-                //if (oldLanguage !== actualLanguage)
-                //{
-                //   valuesByPath['responses._language'] = actualLanguage;
-                //}
-
-                if (valuesByPath) {
-                    if (valuesByPath['_all'] === true) {
-                        affectedPaths['_all'] = true;
-                    }
-                    for (const path in valuesByPath) {
-                        affectedPaths[path] = true;
-                        if (interview) {
-                            _set(interview, path, valuesByPath[path]);
-                        }
-                    }
-                }
-
-                // TODO: update this so it works well with validationOnePager (admin). Should we force this? Anyway this code should be replaced/updated completely in the next version.
-                sectionShortname =
-                    sectionShortname === 'validationOnePager'
-                        ? 'validationOnePager'
-                        : (surveyHelper.getResponse(
-                              interview as UserRuntimeInterviewAttributes,
-                              '_activeSection',
-                              sectionShortname
-                        ) as string);
-                //if (sectionShortname !== previousSection) // need to update all widgets if new section
-                //{
-                //  affectedPaths['_all'] = true;
-                //}
-                const updatedInterviewAndValuesByPath = updateSection(
-                    sectionShortname,
-                    interview as UserRuntimeInterviewAttributes,
-                    affectedPaths,
-                    valuesByPath as { [path: string]: unknown }
+            if (valuesByPath && Object.keys(valuesByPath).length > 0) {
+                surveyHelper.devLog(
+                    'Update interview and section with values by path',
+                    JSON.parse(JSON.stringify(valuesByPath))
                 );
-                interview = updatedInterviewAndValuesByPath[0];
-                valuesByPath = updatedInterviewAndValuesByPath[1];
+            }
 
-                if (!interview.sectionLoaded || interview.sectionLoaded !== sectionShortname) {
-                    valuesByPath['sectionLoaded'] = sectionShortname;
-                    interview.sectionLoaded = sectionShortname;
+            //const oldInterview = _cloneDeep(interview);
+            //const previousSection = surveyHelper.getResponse(interview, '_activeSection', null);
+
+            const affectedPaths = {};
+
+            if (Array.isArray(unsetPaths)) {
+                // unsetPaths if array (each path in array has to be deleted)
+                for (let i = 0, count = unsetPaths.length; i < count; i++) {
+                    const path = unsetPaths[i];
+                    affectedPaths[path] = true;
+                    _unset(interview, path);
                 }
+            } else {
+                unsetPaths = [];
+            }
 
-                // convert undefined values to unset (delete) because stringify will remove undefined values:
+            // update language if needed:
+            //const oldLanguage    = _get(interview, 'responses._language', null);
+            //const actualLanguage = null;//i18n.language;
+            //if (oldLanguage !== actualLanguage)
+            //{
+            //   valuesByPath['responses._language'] = actualLanguage;
+            //}
+
+            if (valuesByPath) {
+                if (valuesByPath['_all'] === true) {
+                    affectedPaths['_all'] = true;
+                }
                 for (const path in valuesByPath) {
-                    if (valuesByPath[path] === undefined) {
-                        unsetPaths.push(path);
+                    affectedPaths[path] = true;
+                    if (interview) {
+                        _set(interview, path, valuesByPath[path]);
                     }
                 }
+            }
 
-                if (isEqual(valuesByPath, { _all: true }) && _isBlank(unsetPaths)) {
+            // TODO: update this so it works well with validationOnePager (admin). Should we force this? Anyway this code should be replaced/updated completely in the next version.
+            sectionShortname =
+                sectionShortname === 'validationOnePager'
+                    ? 'validationOnePager'
+                    : (surveyHelper.getResponse(
+                          interview as UserRuntimeInterviewAttributes,
+                          '_activeSection',
+                          sectionShortname
+                    ) as string);
+            //if (sectionShortname !== previousSection) // need to update all widgets if new section
+            //{
+            //  affectedPaths['_all'] = true;
+            //}
+            const updatedInterviewAndValuesByPath = updateSection(
+                sectionShortname,
+                interview as UserRuntimeInterviewAttributes,
+                affectedPaths,
+                valuesByPath as { [path: string]: unknown }
+            );
+            interview = updatedInterviewAndValuesByPath[0];
+            valuesByPath = updatedInterviewAndValuesByPath[1];
+
+            if (!interview.sectionLoaded || interview.sectionLoaded !== sectionShortname) {
+                valuesByPath['sectionLoaded'] = sectionShortname;
+                interview.sectionLoaded = sectionShortname;
+            }
+
+            // convert undefined values to unset (delete) because stringify will remove undefined values:
+            for (const path in valuesByPath) {
+                if (valuesByPath[path] === undefined) {
+                    unsetPaths.push(path);
+                }
+            }
+
+            if (isEqual(valuesByPath, { _all: true }) && _isBlank(unsetPaths)) {
+                dispatch(updateInterview(_cloneDeep(interview)));
+                dispatch(decrementLoadingState());
+                if (typeof callback === 'function') {
+                    callback(interview);
+                }
+                return null;
+            }
+
+            //const differences = surveyHelper.differences(interview.responses, oldInterview.responses);
+            const response = await fetch(`/api/survey/updateValidateInterview/${interview.uuid}`, {
+                headers: {
+                    Accept: 'application/json',
+                    'Content-Type': 'application/json'
+                },
+                credentials: 'include',
+                method: 'POST',
+                body: JSON.stringify({
+                    id: interview.id,
+                    participant_id: interview.participant_id,
+                    valuesByPath: valuesByPath,
+                    unsetPaths: unsetPaths
+                    //responses  : interview.responses,
+                    //validations: interview.validations
+                })
+            });
+            if (response.status === 200) {
+                const body = await response.json();
+                if (body.status === 'success' && body.interviewId === interview.uuid) {
+                    //surveyHelper.devLog('Interview saved to db');
+                    //setTimeout(function() {
                     dispatch(updateInterview(_cloneDeep(interview)));
-                    dispatch(decrementLoadingState());
                     if (typeof callback === 'function') {
                         callback(interview);
                     }
-                    return null;
-                }
-
-                //const differences = surveyHelper.differences(interview.responses, oldInterview.responses);
-                const response = await fetch(`/api/survey/updateValidateInterview/${interview.uuid}`, {
-                    headers: {
-                        Accept: 'application/json',
-                        'Content-Type': 'application/json'
-                    },
-                    credentials: 'include',
-                    method: 'POST',
-                    body: JSON.stringify({
-                        id: interview.id,
-                        participant_id: interview.participant_id,
-                        valuesByPath: valuesByPath,
-                        unsetPaths: unsetPaths
-                        //responses  : interview.responses,
-                        //validations: interview.validations
-                    })
-                });
-                if (response.status === 200) {
-                    const body = await response.json();
-                    if (body.status === 'success' && body.interviewId === interview.uuid) {
-                        //surveyHelper.devLog('Interview saved to db');
-                        //setTimeout(function() {
-                        dispatch(updateInterview(_cloneDeep(interview)));
-                        if (typeof callback === 'function') {
-                            callback(interview);
-                        }
-                        //}, 500, 'That was really slow!');
-                    } else {
-                        // we need to do something if no interview is returned (error)
-                    }
+                    //}, 500, 'That was really slow!');
                 } else {
-                    console.log(`startUpdateSurveyValidateInterview: wrong responses status: ${response.status}`);
-                    handleHttpOtherResponseCode(response.status, dispatch);
+                    // we need to do something if no interview is returned (error)
                 }
-                // Loading state needs to be decremented, no matter the return value, otherwise the page won't get updated
-                dispatch(decrementLoadingState());
-            } catch (error) {
-                console.log('Error updating interview', error);
-                // Loading state needs to be decremented, no matter the return value, otherwise the page won't get updated
-                // TODO Put in the finally block if we are sure there are no side effect in the code path that returns before the fetch
-                dispatch(decrementLoadingState());
-            } finally {
-                next();
+            } else {
+                console.log(`startUpdateSurveyValidateInterview: wrong responses status: ${response.status}`);
+                handleHttpOtherResponseCode(response.status, dispatch);
             }
+            // Loading state needs to be decremented, no matter the return value, otherwise the page won't get updated
+            dispatch(decrementLoadingState());
+        } catch (error) {
+            console.log('Error updating interview', error);
+            // Loading state needs to be decremented, no matter the return value, otherwise the page won't get updated
+            // TODO Put in the finally block if we are sure there are no side effect in the code path that returns before the fetch
+            dispatch(decrementLoadingState());
         }
     };
 };

--- a/packages/evolution-frontend/src/actions/__tests__/Survey.test.ts
+++ b/packages/evolution-frontend/src/actions/__tests__/Survey.test.ts
@@ -91,7 +91,6 @@ jest.mock('../utils', () => ({
 }));
 const mockDispatch = jest.fn();
 const mockPrepareSectionWidgets = prepareSectionWidgets as jest.MockedFunction<typeof prepareSectionWidgets>;
-const mockNext = jest.fn();
 const mockGetState = jest.fn().mockReturnValue({
     survey: {
         interview: interviewAttributes,
@@ -121,8 +120,8 @@ describe('Update interview', () => {
         expectedInterviewAsState.sectionLoaded = 'section';
         
         // Do the actual test
-        const { callback } = SurveyActions.startUpdateInterview('section', _cloneDeep(valuesByPath), undefined, _cloneDeep(interviewAttributes), updateCallback);
-        await callback(mockNext, mockDispatch, mockGetState);
+        const callback = SurveyActions.startUpdateInterview('section', _cloneDeep(valuesByPath), undefined, _cloneDeep(interviewAttributes), updateCallback);
+        await callback(mockDispatch, mockGetState);
 
         // Verifications
         expect(mockPrepareSectionWidgets).toHaveBeenCalledTimes(1);
@@ -153,7 +152,6 @@ describe('Update interview', () => {
             type: 'DECREMENT_LOADING_STATE'
         });
         expect(updateCallback).toHaveBeenCalledWith(expectedInterviewAsState);
-        expect(mockNext).toHaveBeenCalledTimes(1);
     });
 
     test('Call with an interview, with validation and unset path', async () => {
@@ -175,8 +173,8 @@ describe('Update interview', () => {
         (expectedInterviewAsState.validations as any).section1.q2 = true;
         
         // Do the actual test
-        const { callback } = SurveyActions.startUpdateInterview('section', _cloneDeep(valuesByPath), unsetPaths, _cloneDeep(interviewAttributes), updateCallback);
-        await callback(mockNext, mockDispatch, mockGetState);
+        const callback = SurveyActions.startUpdateInterview('section', _cloneDeep(valuesByPath), unsetPaths, _cloneDeep(interviewAttributes), updateCallback);
+        await callback(mockDispatch, mockGetState);
 
         // Verifications
         expect(mockPrepareSectionWidgets).toHaveBeenCalledTimes(1);
@@ -207,7 +205,6 @@ describe('Update interview', () => {
             type: 'DECREMENT_LOADING_STATE'
         });
         expect(updateCallback).toHaveBeenCalledWith(expectedInterviewAsState);
-        expect(mockNext).toHaveBeenCalledTimes(1);
     });
 
     test('Test with previous and new server errors', async () => {
@@ -224,8 +221,8 @@ describe('Update interview', () => {
         expectedInterviewAsState.sectionLoaded = 'section';
         
         // Do the actual test
-        const { callback } = SurveyActions.startUpdateInterview('section', _cloneDeep(valuesByPath), undefined, _cloneDeep(interviewAttributes), updateCallback);
-        await callback(mockNext, mockDispatch, mockLocalGetState);
+        const callback = SurveyActions.startUpdateInterview('section', _cloneDeep(valuesByPath), undefined, _cloneDeep(interviewAttributes), updateCallback);
+        await callback(mockDispatch, mockLocalGetState);
 
         // Verifications
         expect(mockPrepareSectionWidgets).toHaveBeenCalledTimes(1);
@@ -256,7 +253,6 @@ describe('Update interview', () => {
             type: 'DECREMENT_LOADING_STATE'
         });
         expect(updateCallback).toHaveBeenCalledWith(expectedInterviewAsState);
-        expect(mockNext).toHaveBeenCalledTimes(1);
     });
 
     test('Test with server updated values', async () => {
@@ -275,8 +271,8 @@ describe('Update interview', () => {
         expectedInterviewAsState.sectionLoaded = 'section';
         
         // Do the actual test
-        const { callback } = SurveyActions.startUpdateInterview('section', _cloneDeep(valuesByPath), undefined, _cloneDeep(interviewAttributes), updateCallback);
-        await callback(mockNext, mockDispatch, mockGetState);
+        const callback = SurveyActions.startUpdateInterview('section', _cloneDeep(valuesByPath), undefined, _cloneDeep(interviewAttributes), updateCallback);
+        await callback(mockDispatch, mockGetState);
 
         // Verifications
         expect(mockPrepareSectionWidgets).toHaveBeenCalledTimes(2);
@@ -308,7 +304,6 @@ describe('Update interview', () => {
             type: 'DECREMENT_LOADING_STATE'
         });
         expect(updateCallback).toHaveBeenCalledWith(expectedInterviewAsState);
-        expect(mockNext).toHaveBeenCalledTimes(1);
     });
 
     test('With local exception', async () => {
@@ -320,8 +315,8 @@ describe('Update interview', () => {
         (expectedInterviewToPrepare.responses as any).section1.q1 = 'foo';
         
         // Do the actual test
-        const { callback } = SurveyActions.startUpdateInterview('section', _cloneDeep(valuesByPath), undefined, _cloneDeep(interviewAttributes), updateCallback);
-        await callback(mockNext, mockDispatch, mockGetState);
+        const callback = SurveyActions.startUpdateInterview('section', _cloneDeep(valuesByPath), undefined, _cloneDeep(interviewAttributes), updateCallback);
+        await callback(mockDispatch, mockGetState);
 
         // Verifications
         expect(mockPrepareSectionWidgets).toHaveBeenCalledTimes(1);
@@ -335,7 +330,6 @@ describe('Update interview', () => {
             type: 'DECREMENT_LOADING_STATE'
         });
         expect(updateCallback).not.toHaveBeenCalled();
-        expect(mockNext).toHaveBeenCalledTimes(1);
         expect(mockedHandleClientError).toHaveBeenCalledTimes(1);
         expect(mockedHandleClientError).toHaveBeenCalledWith(new Error('error'), { history: undefined, interviewId: interviewAttributes.id });
     });
@@ -350,8 +344,8 @@ describe('Update interview', () => {
         (expectedInterviewToPrepare.responses as any).section1.q1 = 'foo';
         
         // Do the actual test
-        const { callback } = SurveyActions.startUpdateInterview('section', _cloneDeep(valuesByPath), undefined, _cloneDeep(interviewAttributes), updateCallback);
-        await callback(mockNext, mockDispatch, mockGetState);
+        const callback = SurveyActions.startUpdateInterview('section', _cloneDeep(valuesByPath), undefined, _cloneDeep(interviewAttributes), updateCallback);
+        await callback(mockDispatch, mockGetState);
 
         // Verifications
         expect(mockPrepareSectionWidgets).toHaveBeenCalledTimes(1);
@@ -365,7 +359,6 @@ describe('Update interview', () => {
             type: 'DECREMENT_LOADING_STATE'
         });
         expect(updateCallback).not.toHaveBeenCalled();
-        expect(mockNext).toHaveBeenCalledTimes(1);
         expect(mockedHandleHttpOtherResponseCode).toHaveBeenCalledTimes(1);
         expect(mockedHandleHttpOtherResponseCode).toHaveBeenCalledWith(401, mockDispatch, undefined);
     });
@@ -379,8 +372,8 @@ describe('Update interview', () => {
         const expectedInterviewAsState = _cloneDeep(initialInterview);
 
         // Do the actual test
-        const { callback } = SurveyActions.startUpdateInterview('section', _cloneDeep(valuesByPath), undefined, _cloneDeep(initialInterview), updateCallback);
-        await callback(mockNext, mockDispatch, mockGetState);
+        const callback = SurveyActions.startUpdateInterview('section', _cloneDeep(valuesByPath), undefined, _cloneDeep(initialInterview), updateCallback);
+        await callback(mockDispatch, mockGetState);
 
         // Verifications
         expect(mockPrepareSectionWidgets).toHaveBeenCalledTimes(1);
@@ -402,7 +395,6 @@ describe('Update interview', () => {
             type: 'DECREMENT_LOADING_STATE'
         });
         expect(updateCallback).toHaveBeenCalledWith(expectedInterviewAsState);
-        expect(mockNext).toHaveBeenCalledTimes(1);
     });
 
 });
@@ -412,9 +404,10 @@ describe('startAddGroupedObjects', () => {
     mockedAddGroupedObject.mockReturnValue(defaultAddGroupResponse);
 
     let startUpdateInterviewSpy;
+    const startUpdateInterviewMock = jest.fn();
 
     beforeAll(() => {
-        startUpdateInterviewSpy = jest.spyOn(SurveyActions, 'startUpdateInterview').mockReturnValue({ queue: 'UPDATE_INTERVIEW', callback: jest.fn() });
+        startUpdateInterviewSpy = jest.spyOn(SurveyActions, 'startUpdateInterview').mockReturnValue(startUpdateInterviewMock);
     });
 
     afterAll(() => {
@@ -437,10 +430,7 @@ describe('startAddGroupedObjects', () => {
         expect(startUpdateInterviewSpy).toHaveBeenCalledTimes(1);
         expect(startUpdateInterviewSpy).toHaveBeenCalledWith(null, defaultAddGroupResponse, undefined, undefined, undefined);
         expect(mockDispatch).toHaveBeenCalledTimes(1);
-        expect(mockDispatch).toHaveBeenCalledWith({ 
-            queue: 'UPDATE_INTERVIEW',
-            callback: expect.any(Function),
-        });
+        expect(mockDispatch).toHaveBeenCalledWith(startUpdateInterviewMock);
     });
 
     test('Call with return only and callback', async () => {
@@ -481,10 +471,7 @@ describe('startAddGroupedObjects', () => {
         expect(startUpdateInterviewSpy).toHaveBeenCalledTimes(1);
         expect(startUpdateInterviewSpy).toHaveBeenCalledWith(null, defaultAddGroupResponse, undefined, undefined, callback);
         expect(mockDispatch).toHaveBeenCalledTimes(1);
-        expect(mockDispatch).toHaveBeenCalledWith({ 
-            queue: 'UPDATE_INTERVIEW',
-            callback: expect.any(Function),
-        });
+        expect(mockDispatch).toHaveBeenCalledWith(startUpdateInterviewMock);
     });
 
 });
@@ -494,10 +481,11 @@ describe('startRemoveGroupedObjects', () => {
     mockedRemoveGroupedObject.mockReturnValue(defaultRemoveGroupResponse);
 
     let startUpdateInterviewSpy;
+    const startUpdateInterviewMock = jest.fn();
 
     beforeAll(() => {
-        startUpdateInterviewSpy = jest.spyOn(SurveyActions, 'startUpdateInterview').mockReturnValue({ queue: 'UPDATE_INTERVIEW', callback: jest.fn() });
-    });
+        startUpdateInterviewSpy = jest.spyOn(SurveyActions, 'startUpdateInterview').mockReturnValue(startUpdateInterviewMock);
+    })
 
     afterAll(() => {
         startUpdateInterviewSpy.mockRestore();
@@ -517,10 +505,7 @@ describe('startRemoveGroupedObjects', () => {
         expect(startUpdateInterviewSpy).toHaveBeenCalledTimes(1);
         expect(startUpdateInterviewSpy).toHaveBeenCalledWith(null, defaultRemoveGroupResponse[0], defaultRemoveGroupResponse[1], undefined, undefined);
         expect(mockDispatch).toHaveBeenCalledTimes(1);
-        expect(mockDispatch).toHaveBeenCalledWith({ 
-            queue: 'UPDATE_INTERVIEW',
-            callback: expect.any(Function),
-        });
+        expect(mockDispatch).toHaveBeenCalledWith(startUpdateInterviewMock);
     });
 
     test('Call with return only and callback', async () => {
@@ -555,10 +540,7 @@ describe('startRemoveGroupedObjects', () => {
         expect(startUpdateInterviewSpy).toHaveBeenCalledTimes(1);
         expect(startUpdateInterviewSpy).toHaveBeenCalledWith(null, defaultRemoveGroupResponse[0], defaultRemoveGroupResponse[1], undefined, callback);
         expect(mockDispatch).toHaveBeenCalledTimes(1);
-        expect(mockDispatch).toHaveBeenCalledWith({ 
-            queue: 'UPDATE_INTERVIEW',
-            callback: expect.any(Function),
-        });
+        expect(mockDispatch).toHaveBeenCalledWith(startUpdateInterviewMock);
     });
 
 });

--- a/packages/evolution-frontend/src/store/configureStore.ts
+++ b/packages/evolution-frontend/src/store/configureStore.ts
@@ -6,7 +6,6 @@
  */
 import { createStore, Store, combineReducers, applyMiddleware, compose, CombinedState, AnyAction } from 'redux';
 import thunk from 'redux-thunk';
-import ReduxAsyncQueue from 'redux-async-queue';
 
 import { AuthState, authReducer } from 'chaire-lib-frontend/lib/store/auth';
 import { SurveyState, surveyReducer } from '../store/survey';
@@ -48,7 +47,7 @@ export default () => {
     const store: Store<typeof initialState> = createStore(
         rootReducer,
         initialState,
-        composeEnhancers(applyMiddleware(thunk), applyMiddleware(ReduxAsyncQueue))
+        composeEnhancers(applyMiddleware(thunk))
     );
     return store;
 };


### PR DESCRIPTION
This package is 9 years old, unmaintained and very little used. And it is not compatible with the newer redux approach. So we drop it and simply use the habitual approach with redux-thunk. It does not appear to have any side effects.