### PR TITLE
auth: fix admin auth configuration

### DIFF
--- a/example/demo_survey/config.js
+++ b/example/demo_survey/config.js
@@ -39,6 +39,14 @@ module.exports = {
   includePartTimeStudentOccupation: false,
   includeWorkerAndStudentOccupation: false,
   acceptUnknownDidTrips: false,
+  adminAuth: {
+    localLogin: {
+      registerWithPassword: true,
+      registerWithEmailOnly: true,
+      confirmEmail: false,
+      forgotPasswordPage: true
+    }
+  },
   auth: {
     passwordless: {
       directFirstLogin: true

--- a/example/demo_survey/webpack.admin.config.js
+++ b/example/demo_survey/webpack.admin.config.js
@@ -15,6 +15,21 @@ if (!process.env.NODE_ENV) {
 
 const configuration = require('chaire-lib-backend/lib/config/server.config');
 const config = configuration.default ? configuration.default : configuration;
+// For the admin app, the adminAuth should replace the auth configuration
+// FIXME This is the kind of config that should come from the server, not be inserted in the client in webpack
+if (!config.adminAuth) {
+    console.warn('Configuration error: you need to specify the adminAuth key in the config.js file. Will use default values.');
+    config.adminAuth = {
+        localLogin: {
+            registerWithPassword: true,
+            registerWithEmailOnly: true,
+            confirmEmail: false,
+            forgotPasswordPage: true
+        }
+    };
+}
+config.auth = config.adminAuth;
+delete config.adminAuth;
 
 // Public directory from which files are served
 const publicDirectory = path.join(__dirname, '..', '..', 'public');

--- a/packages/evolution-legacy/src/apps/admin/server/index.js
+++ b/packages/evolution-legacy/src/apps/admin/server/index.js
@@ -27,6 +27,21 @@ process.on('uncaughtException', function(err) {
     console.error("Just caught an uncaught exception!", err);
 });
 
+// For the admin app, the adminAuth should replace the auth configuration
+if (!config.adminAuth) {
+    console.warn('Configuration error: you need to specify the adminAuth key in the config.js file. Will use default values.');
+    config.adminAuth = {
+        localLogin: {
+            registerWithPassword: true,
+            registerWithEmailOnly: true,
+            confirmEmail: false,
+            forgotPasswordPage: true
+        }
+    };
+}
+config.auth = config.adminAuth;
+delete config.adminAuth;
+
 export const setupServer = (serverSetupFct = undefined) => {
     const app = express();
     const { session } = setupServerApp(app, serverSetupFct);


### PR DESCRIPTION
commit 40bea0acf8ab6d4128d5696a56a82ce4a1545f39 removed the localLogin from the demo_survey application. But that configuration was used for the admin application.

A new configuration option, `adminAuth`, can be used to configure the admin login configuration. In webpack and in the server initialization, the `adminAuth` replaces the `auth` option of the configuration.