### PR TITLE
api: add express middleware to validate uuid format

### DIFF
--- a/packages/evolution-backend/src/api/helpers/__tests__/validateUuidMiddleware.test.ts
+++ b/packages/evolution-backend/src/api/helpers/__tests__/validateUuidMiddleware.test.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { v4 as uuidV4 } from 'uuid';
+import request from 'supertest';
+import express from 'express';
+import validateUuidMiddleware from '../validateUuidMiddleware';
+
+// Default handler that returns a 200 status code
+const requestHandler = jest.fn().mockImplementation((_req, res) => res.status(200).send());
+
+// Prepare the app and router for the test
+const app = express();
+const router = express.Router();
+// Add the middleware to test before each route
+router.get('/testWithUuid/:interviewUuid', validateUuidMiddleware, requestHandler);
+router.get('/testWithId/:interviewId', validateUuidMiddleware, requestHandler);
+app.use('/test', router)
+
+beforeEach(() => {
+    jest.clearAllMocks();
+})
+
+test('Valid uuid in interviewUuid', async () => {
+    const uuid = uuidV4()
+    const response = await request(app).get(`/test/testWithUuid/${uuid}`);
+    expect(response.status).toBe(200);
+    expect(requestHandler).toHaveBeenCalled();
+});
+
+test('Invalid uuid in interviewUuid', async () => {
+    const response = await request(app).get('/test/testWithUuid/null');
+    expect(response.status).toBe(400);
+    expect(requestHandler).not.toHaveBeenCalled();
+});
+
+test('Valid uuid in interviewId', async () => {
+    const uuid = uuidV4()
+    const response = await request(app).get(`/test/testWithId/${uuid}`);
+    expect(response.status).toBe(200);
+    expect(requestHandler).toHaveBeenCalled();
+});
+
+test('Invalid uuid in interviewId', async () => {
+    const response = await request(app).get('/test/testWithId/null');
+    expect(response.status).toBe(400);
+    expect(requestHandler).not.toHaveBeenCalled();
+});
+

--- a/packages/evolution-backend/src/api/helpers/validateUuidMiddleware.ts
+++ b/packages/evolution-backend/src/api/helpers/validateUuidMiddleware.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { NextFunction, Request, Response } from 'express';
+import { validate as uuidValidate } from 'uuid';
+
+// Middleware that validates that the interviewUuid request parameter is a valid
+// uuid. The interview UUID should be in the request parameters under the key
+// 'interviewUuid' or 'interviewId'.
+const validateUuidMiddleware = (req: Request, res: Response, next: NextFunction) => {
+    const interviewUuid = req.params.interviewUuid || req.params.interviewId;
+    if (!uuidValidate(interviewUuid)) {
+        console.warn(`Received an invalid interview ID from client: ${interviewUuid}`);
+        return res.status(400).json({ status: 'failed', error: 'Invalid interview ID' });
+    }
+    next();
+};
+
+export default validateUuidMiddleware;

--- a/packages/evolution-backend/src/api/survey.user.routes.ts
+++ b/packages/evolution-backend/src/api/survey.user.routes.ts
@@ -20,6 +20,7 @@ import serverConfig from '../config/projectConfig';
 import { InterviewLoggingMiddlewares } from '../services/logging/queryLoggingMiddleware';
 import { logClientSide } from '../services/logging/messageLogging';
 import { addRolesToInterview, updateInterview } from '../services/interviews/interview';
+import validateUuidMiddleware from './helpers/validateUuidMiddleware';
 
 export default (authorizationMiddleware, loggingMiddleware: InterviewLoggingMiddlewares): Router => {
     const router = express.Router();
@@ -81,6 +82,7 @@ export default (authorizationMiddleware, loggingMiddleware: InterviewLoggingMidd
 
     router.get(
         '/survey/activeInterview/:interviewId',
+        validateUuidMiddleware,
         authorizationMiddleware(['update', 'read']),
         loggingMiddleware.openingInterview(false),
         async (req: Request, res: Response) => {

--- a/packages/evolution-backend/src/api/survey.validation.routes.ts
+++ b/packages/evolution-backend/src/api/survey.validation.routes.ts
@@ -9,6 +9,7 @@
  * */
 import express, { Request, Response } from 'express';
 import moment from 'moment';
+
 import Interviews, { FilterType } from '../services/interviews/interviews';
 import { updateInterview, copyResponsesToValidatedData } from '../services/interviews/interview';
 import interviewUserIsAuthorized, { isUserAllowed } from '../services/auth/userAuthorization';
@@ -19,6 +20,7 @@ import { logUserAccessesMiddleware } from '../services/logging/queryLoggingMiddl
 import { _booleish, _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { Audits } from '../services/audits/Audits';
 import { InterviewAttributes } from 'evolution-common/lib/services/questionnaire/types';
+import validateUuidMiddleware from './helpers/validateUuidMiddleware';
 
 const router = express.Router();
 
@@ -26,6 +28,7 @@ router.use(interviewUserIsAuthorized(['validate', 'read']));
 
 router.get(
     '/survey/validateInterview/:interviewUuid',
+    validateUuidMiddleware,
     logUserAccessesMiddleware.openingInterview(true),
     async (req: Request, res: Response) => {
         if (req.params.interviewUuid) {
@@ -70,6 +73,7 @@ router.get(
 
 router.post(
     '/survey/updateValidateInterview/:interviewUuid',
+    validateUuidMiddleware,
     logUserAccessesMiddleware.updatingInterview(true),
     async (req: Request, res: Response) => {
         try {


### PR DESCRIPTION
If the interviewUuid received is of a bad format, the logging middleware and the query itself will throw exceptions about the format. We add a proper middleware to validate the interview UUID format before those calls and return a `400` bad request response to the client instead of server error.

This middleware is used in validation and user routes that have a uuid parameter.

Add unit tests for this middleware