### PR TITLE
survey: decrement the loading state in a finally block

### DIFF
--- a/packages/evolution-frontend/src/actions/Survey.ts
+++ b/packages/evolution-frontend/src/actions/Survey.ts
@@ -155,7 +155,6 @@ const startUpdateInterviewCallback = async (
         if (isEqual(updatedValuesByPath, { _all: true }) && _isBlank(unsetPaths)) {
             // '_all' means the "save" button was clicked and the form was submitted, so the form may not follow the normal form change workflow
             dispatch(updateInterview(_cloneDeep(updatedInterview), {}, true));
-            dispatch(decrementLoadingState());
             if (typeof callback === 'function') {
                 callback(updatedInterview);
             }
@@ -254,17 +253,16 @@ const startUpdateInterviewCallback = async (
             console.log(`Update interview: wrong responses status: ${response.status}`);
             await handleHttpOtherResponseCode(response.status, dispatch, navigate);
         }
-        // Loading state needs to be decremented, no matter the return value, otherwise the page won't get updated
-        dispatch(decrementLoadingState());
     } catch (error) {
         console.log('Error updating interview', error);
-        // Loading state needs to be decremented, no matter the return value, otherwise the page won't get updated
-        // TODO Put in the finally block if we are sure there are no side effect in the code path that returns before the fetch
-        dispatch(decrementLoadingState());
+
         handleClientError(error instanceof Error ? error : new Error(String(error)), {
             navigate,
             interviewId: getState().survey.interview!.id
         });
+    } finally {
+        // Loading state needs to be decremented, so the page can be updated
+        dispatch(decrementLoadingState());
     }
 };
 


### PR DESCRIPTION
This makes sure all code path decrement the loading state, without repeating it at every necessary place. All code paths have been tested and there is no side-effect. The only difference is that if there is no call to the server to make, the callback is now run before decrementing the state instead of after, which may have been a mistake in the first place as the call to the `callback` is done before decrementing the loading state in the other code path.