### PR TITLE
app: move the participant server app to evolution-backend

### DIFF
--- a/example/demo_survey/src/server.ts
+++ b/example/demo_survey/src/server.ts
@@ -6,7 +6,7 @@
  */
 import path from 'path';
 
-import setupServer from 'evolution-legacy/lib/apps/participant/server';
+import setupServer from 'evolution-backend/lib/apps/participant';
 import { setProjectConfig } from 'evolution-backend/lib/config/projectConfig';
 import { registerTranslationDir, addTranslationNamespace } from 'chaire-lib-backend/lib/config/i18next';
 import serverUpdateCallbacks from './server/serverFieldUpdate';

--- a/packages/evolution-backend/package.json
+++ b/packages/evolution-backend/package.json
@@ -28,6 +28,7 @@
         "@casl/ability": "^5.4.4",
         "chaire-lib-backend": "^0.2.2",
         "chaire-lib-common": "^0.2.2",
+        "connect-session-knex": "^4.0.2",
         "evolution-common": "^0.5.0",
         "express": "^4.21.2",
         "express-session": "^1.18.1",
@@ -36,11 +37,15 @@
         "knex-postgis": "^0.14.3",
         "lodash": "^4.17.21",
         "moment": "^2.30.1",
+        "morgan": "^1.10.0",
         "papaparse": "^5.4.1",
+        "request-ip": "^3.3.0",
+        "serve-favicon": "^2.5.0",
         "slugify": "^1.6.6",
         "typescript": "^5.7.2",
         "uuid": "^11.0.3",
-        "workerpool": "^6.5.1"
+        "workerpool": "^6.5.1",
+        "yargs": "^17.7.2"
     },
     "devDependencies": {
         "@types/express": "^4.17.21",

--- a/packages/evolution-backend/src/apps/participant/index.ts
+++ b/packages/evolution-backend/src/apps/participant/index.ts
@@ -4,10 +4,11 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-require('@babel/register');
-
 import 'chaire-lib-backend/lib/config/dotenv.config';
 import config from 'chaire-lib-backend/lib/config/server.config';
+import { createServer as httpCreateServer } from 'http';
+import { createServer as httpsCreateServer } from 'https';
+import fs from 'fs';
 import { join } from 'path';
 import yargs from 'yargs/yargs';
 import { hideBin } from 'yargs/helpers';
@@ -15,50 +16,51 @@ import { registerTranslationDir } from 'chaire-lib-backend/lib/config/i18next';
 import express from 'express';
 import { setupServerApp } from './serverApp';
 
-const argv = yargs(hideBin(process.argv)).argv;
+const argv = yargs(hideBin(process.argv)).argv as { [key: string]: unknown; ssl?: boolean; port?: string };
 
 const useSSL = argv.ssl;
 const port = argv.port ? parseInt(argv.port) : useSSL ? 8443 : 8080;
 
 console.log(`starting server for project ${config.projectShortname} with port ${port}`);
 
-process.on('uncaughtException', function(err) {
+process.on('uncaughtException', (err) => {
     // handle the error safely
-    console.error("Just caught an uncaught exception!", err);
+    console.error('Just caught an uncaught exception!', err);
 });
 
-export const setupServer = (serverSetupFct = undefined) => {
+export const setupServer = (serverSetupFct: (() => void) | undefined = undefined) => {
     const app = express();
-    const { session } = setupServerApp(app, serverSetupFct);
+    setupServerApp(app, serverSetupFct);
     if (!useSSL) {
         // Create http server
-        const http             = require('http');
-        const server           = http.createServer(app);
+        const server = httpCreateServer(app);
         server.listen(port);
     } else {
         // Create the https server
         const pk = process.env.SSL_PRIVATE_KEY;
         const crt = process.env.SSL_CERT;
         if (!pk || !crt) {
-            console.error('Configuration error: you need to specify the SSL_PRIVATE_KEY and SSL_CERT keys in the .env file');
+            console.error(
+                'Configuration error: you need to specify the SSL_PRIVATE_KEY and SSL_CERT keys in the .env file'
+            );
+            // eslint-disable-next-line n/no-process-exit
             process.exit();
         }
-        const fs = require('fs');
         try {
-            const privateKey  = fs.readFileSync(pk, 'utf8');
+            const privateKey = fs.readFileSync(pk, 'utf8');
             const certificate = fs.readFileSync(crt, 'utf8');
-            const https = require('https');
-            const credentials = {key: privateKey, cert: certificate};
-            const httpsServer = https.createServer(credentials, app);
+            const credentials = { key: privateKey, cert: certificate };
+            const httpsServer = httpsCreateServer(credentials, app);
             httpsServer.listen(port);
         } catch (err) {
-            console.error("Error starting the https server: ", err);
+            console.error('Error starting the https server: ', err);
+            // eslint-disable-next-line n/no-process-exit
             process.exit();
         }
     }
 
     // Register server translations
-    registerTranslationDir(join(__dirname, `../../../../../../locales/`));
-}
+    registerTranslationDir(join(__dirname, '../../../../../locales/'));
+};
 
 export default setupServer;

--- a/packages/evolution-backend/src/apps/participant/serverApp.ts
+++ b/packages/evolution-backend/src/apps/participant/serverApp.ts
@@ -4,33 +4,31 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-const config           = require('chaire-lib-backend/lib/config/server.config').default;
-const knex             = require('chaire-lib-backend/lib/config/shared/db.config').default;
-const path             = require('path');
+import config from 'chaire-lib-backend/lib/config/server.config';
+import knex from 'chaire-lib-backend/lib/config/shared/db.config';
+import path from 'path';
 import _camelCase from 'lodash/camelCase';
-const express          = require('express');
-const favicon          = require('serve-favicon');
-const expressSession   = require('express-session');
-const KnexSessionStore = require('connect-session-knex')(expressSession);
-const morgan           = require('morgan') // http logger
+import express, { Express } from 'express';
+import favicon from 'serve-favicon';
+import expressSession from 'express-session';
+import connectSessionKnex from 'connect-session-knex';
+import morgan from 'morgan'; // http logger
 import trRoutingRouter from 'chaire-lib-backend/lib/api/trRouting.routes';
-import { participantAuthModel } from 'evolution-backend/lib/services/auth/participantAuthModel';
+import { participantAuthModel } from '../../services/auth/participantAuthModel';
 import configurePassport from 'chaire-lib-backend/lib/config/auth';
-
-//const WebSocket        = require('ws');
-const requestIp        = require('request-ip');
-
+import requestIp from 'request-ip';
 import { directoryManager } from 'chaire-lib-backend/lib/utils/filesystem/directoryManager';
 import authRoutes from 'chaire-lib-backend/lib/api/auth.routes';
-import participantRoutes from 'evolution-backend/lib/apps/participant/routes';
+import participantRoutes from '../../apps/participant/routes';
 
-export const setupServerApp = (app, serverSetupFct = undefined) => {
+const KnexSessionStore = connectSessionKnex(expressSession);
 
+export const setupServerApp = (app: Express, serverSetupFct: (() => void) | undefined = undefined) => {
     // Public directory from which files are served
-    const publicDirectory = path.join(__dirname, '..', '..', '..', '..', '..', '..', 'public');
-    const publicDistDirectory = path.join(publicDirectory, 'dist', config.projectShortname, 'survey', );
+    const publicDirectory = path.join(__dirname, '..', '..', '..', '..', '..', 'public');
+    const publicDistDirectory = path.join(publicDirectory, 'dist', config.projectShortname, 'survey');
     // Local path where locales are stored
-    const localeDirectory = path.join(__dirname, '..', '..', '..', '..', '..', '..', 'locales');
+    const localeDirectory = path.join(__dirname, '..', '..', '..', '..', '..', 'locales');
 
     directoryManager.createDirectoryIfNotExistsAbsolute(publicDistDirectory);
     directoryManager.createDirectoryIfNotExists('logs');
@@ -40,28 +38,36 @@ export const setupServerApp = (app, serverSetupFct = undefined) => {
     directoryManager.createDirectoryIfNotExists('parsers');
     directoryManager.createDirectoryIfNotExists('tasks');
 
-    const indexPath = path.join(publicDistDirectory, `index-survey-${config.projectShortname}${process.env.NODE_ENV === 'test' ? '_test' : ''}.html`);
+    const indexPath = path.join(
+        publicDistDirectory,
+        `index-survey-${config.projectShortname}${process.env.NODE_ENV === 'test' ? '_test' : ''}.html`
+    );
     const publicPath = express.static(publicDistDirectory);
     const localePath = express.static(localeDirectory);
 
     const sessionStore = new KnexSessionStore({
-        knex     : knex,
+        knex: knex,
         tablename: 'sessions' // optional. Defaults to 'sessions'
     });
 
     const session = expressSession({
-        key: "trsession" + _camelCase(config.projectShortname + (process.env.PROJECT_SAMPLE ? "_" + process.env.PROJECT_SAMPLE : "")),
-        secret: process.env.EXPRESS_SESSION_SECRET_KEY,
+        name: 'evsession_' + _camelCase(config.projectShortname),
+        secret: process.env.EXPRESS_SESSION_SECRET_KEY as string,
         resave: false,
         saveUninitialized: false,
         store: sessionStore
     });
     const passport = configurePassport(participantAuthModel);
 
-    app.use(morgan('combined', {
-        // do not log if nolog=true is part of the url params:
-        skip: function (req, res) { return req.url.indexOf('nolog=true') !== -1; }
-    }));
+    app.use(
+        morgan('combined', {
+            // do not log if nolog=true is part of the url params:
+            // FIXME Why would we want to skip logging?
+            skip: function (req, _res) {
+                return req.url.indexOf('nolog=true') !== -1;
+            }
+        })
+    );
     app.use(express.json({ limit: '500mb' }));
     app.use(express.urlencoded({ limit: '500mb', extended: true }));
     app.use(session);
@@ -73,17 +79,17 @@ export const setupServerApp = (app, serverSetupFct = undefined) => {
     // TODO: move all routes to socket routes:
     authRoutes(app, participantAuthModel, passport);
 
-    app.set('trust proxy',true); // allow nginx or other proxy server to send request ip address
+    app.set('trust proxy', true); // allow nginx or other proxy server to send request ip address
 
     // send js and css compressed (gzip) to save bandwidth:
-    app.get('*.js', function(req, res, next) {
+    app.get('*.js', (req, res, next) => {
         req.url = req.url + '.gz';
         res.set('Content-Encoding', 'gzip');
         res.set('Content-Type', 'text/javascript');
         next();
     });
 
-    app.get('*.css', function(req, res, next) {
+    app.get('*.css', (req, res, next) => {
         req.url = req.url + '.gz';
         res.set('Content-Encoding', 'gzip');
         res.set('Content-Type', 'text/css');
@@ -99,30 +105,32 @@ export const setupServerApp = (app, serverSetupFct = undefined) => {
         if (typeof serverSetupFct === 'function') {
             serverSetupFct();
         }
-    } catch(error) {
+    } catch (error) {
         console.log('Error running project specific server setup function: ', error);
     }
     participantRoutes(app);
     // Add the trRouting routes
     trRoutingRouter(app);
 
-    app.get('/incompatible', function (req, res) { res.sendFile(path.join(publicDirectory, 'incompatible.html')); });
-
-    app.get('/ping', function(req, res) {
-    return res.status(200).json({
-        status: 'online'
-    });
+    app.get('/incompatible', (req, res) => {
+        res.sendFile(path.join(publicDirectory, 'incompatible.html'));
     });
 
-    app.get('*', function (req, res) {
-        res.sendFile(indexPath); 
+    app.get('/ping', (req, res) => {
+        return res.status(200).json({
+            status: 'online'
+        });
+    });
+
+    app.get('*', (req, res) => {
+        res.sendFile(indexPath);
     });
 
     return { app, session };
-}
+};
 
-process.on('unhandledRejection', function(err){
-    console.error(err.stack);
+process.on('unhandledRejection', (err) => {
+    console.error(err);
 });
 
 export default setupServerApp;


### PR DESCRIPTION
** BREAKING CHANGE **

Survey's server entry file now need to import the server app function from evolution-backend instead of legacy. For example:

```
import setupServer from 'evolution-backend/lib/apps/participant';
```