### PR TITLE
authPage: do not consider auth methods set to `false`

### DIFF
--- a/locales/en/auth.json
+++ b/locales/en/auth.json
@@ -57,7 +57,6 @@
   "AuthMainIntroduction": "How would you like to identify yourself?",
   "AuthTitle": "",
   "OAuthTitle": "With a Sign-In Partner",
-  "OAuthIntroduction": "You will be able to continue an incomplete survey",
   "PasswordlessHeader": "Please enter an email address to continue",
   "UseAnonymousLogin": "Log in anonymously",
   "Email": "By email",

--- a/locales/fr/auth.json
+++ b/locales/fr/auth.json
@@ -57,7 +57,6 @@
   "AuthMainIntroduction": "Comment désirez-vous vous identifier?",
   "AuthTitle": "",
   "OAuthTitle": "Avec un partenaire de connexion",
-  "OAuthIntroduction": "Vous pourrez vous-même continuer une entrevue incomplète",
   "PasswordlessHeader": "Veuillez entrer une adresse courriel pour continuer",
   "UseAnonymousLogin": "Se connecter de façon anonyme",
   "Email": "Par courriel",

--- a/packages/evolution-frontend/src/components/pages/auth/AuthPage.tsx
+++ b/packages/evolution-frontend/src/components/pages/auth/AuthPage.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 import appConfiguration from 'chaire-lib-frontend/lib/config/application.config';
-import config from 'chaire-lib-common/lib/config/shared/project.config';
+import config from 'evolution-common/lib/config/project.config';
 import AnonymousLogin from 'chaire-lib-frontend/lib/components/forms/auth/anonymous/AnonymousLogin';
 import PwdLessLoginForm from 'chaire-lib-frontend/lib/components/forms/auth/passwordless/PwdLessLoginForm';
 import DirectTokenLogin from './DirectTokenLogin';
@@ -125,27 +125,19 @@ const AuthPage: React.FunctionComponent = () => {
                         </div>
                     )}
 
-                    {(config.connectWithGoogle ||
-                        config.auth?.google ||
-                        config.connectWithFacebook ||
-                        config.auth?.facebook) && (
+                    {(config.auth?.google || config.auth?.facebook) && (
                         <div className="apptr__auth-box">
                             <p className="_label apptr__form__label-standalone">
                                 {t(['survey:auth:OAuthTitle', 'auth:OAuthTitle'])}
                             </p>
-                            {/*<div className={'apptr__form-label-container apptr_form-oauth-introduction'}>
-                            <div className="apptr__form__label-standalone no-question">
-                                <p className="_green _strong">{props.t(['survey:auth:OAuthIntroduction', 'auth:OAuthIntroduction'])}</p>
-                            </div>
-                        </div>*/}
-                            {(config.connectWithGoogle || config.auth?.google) && (
+                            {config.auth?.google && (
                                 <div className="google-oauth-button-container apptr_form-oauth-google-login">
                                     <a className="google-oauth-button" href="/googlelogin">
                                         {t('auth:signInWithGoogle')}
                                     </a>
                                 </div>
                             )}
-                            {(config.connectWithFacebook || config.auth?.facebook) && (
+                            {config.auth?.facebook && (
                                 <div className="facebook-oauth-button-container apptr_form-oauth-facebook-login">
                                     <a className="facebook-oauth-button" href="/facebooklogin">
                                         {t('auth:signInWithFacebook')}

--- a/packages/evolution-frontend/src/components/pages/auth/AuthPage.tsx
+++ b/packages/evolution-frontend/src/components/pages/auth/AuthPage.tsx
@@ -59,7 +59,9 @@ const AuthPage: React.FunctionComponent = () => {
     const authMethods = React.useMemo(
         () =>
             config.auth
-                ? Object.keys(config.auth).filter((authMethod) => !unmanagedAuthMethods.includes(authMethod))
+                ? Object.keys(config.auth).filter(
+                    (authMethod) => config.auth[authMethod] !== false && !unmanagedAuthMethods.includes(authMethod)
+                )
                 : ['passwordless'],
         []
     );


### PR DESCRIPTION
fixes #861
    
In the `AuthPage` component, the authMethods considered for the page are
only those whose value is not `false`. This will make sure that the
`passwordless` box is not shown if the `passwordless` value is `false`
and avoids having to make those checks later in the component children.

Also

auth: remove references to `connectWithGoogle` and `connectWithFacebook`