### PR TITLE
Add github workflow to build docker images

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,0 +1,66 @@
+name: Container Build and Push
+
+on:
+  push:
+    branches: 
+      - "main"
+  workflow_dispatch:
+
+env:
+  GITHUB_REGISTRY: ghcr.io
+  DOCKERHUB_REGISTRY: docker.io
+  DOCKERHUB_IMAGE: chairemobilite/${{ github.event.repository.name }}
+  GITHUB_IMAGE: ${{ github.repository }}
+
+jobs:
+  # Branch push job - builds and pushes to both registries
+  branch-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Generate Docker tags for branch
+        id: branch-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.DOCKERHUB_REGISTRY }}/${{ env.DOCKERHUB_IMAGE }}
+            ${{ env.GITHUB_REGISTRY }}/${{ env.GITHUB_IMAGE }}
+          tags: |
+            # Tag as latest for main
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            # Include the branch name as a tag
+            type=ref,event=branch
+
+      - name: Build and push branch images
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.branch-meta.outputs.tags }}
+          labels: ${{ steps.branch-meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/test-docker-build.yml
+++ b/.github/workflows/test-docker-build.yml
@@ -1,0 +1,28 @@
+# Test that we can build the docker image on each PR. Will not push the image
+name: PR Container Build Check
+
+on:
+  pull_request:
+    branches: 
+      - "main"
+
+jobs:
+  pr-build-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          load: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
First workflow will test docker build on each PR
Second will build the docker image and push to both docker hub and github package repo

(This have been applied to trRouting and transition so far)