### PR TITLE
Add UI Test run on CI

### DIFF
--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -1,0 +1,72 @@
+# Run the UI tests
+
+name: UI Tests
+
+on:
+  push:
+    branches: [ main ]
+  # We are not running on Pull Request, since we need the Google API Key
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgis/postgis
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        env:
+          POSTGRES_USER: testuser
+          POSTGRES_PASSWORD: testpassword
+          POSTGRES_DB: testdb
+    strategy:
+      matrix:
+        node-version: [22.x]
+    env:
+      PROJECT_CONFIG: ${{ github.workspace }}/example/demo_survey/config.js
+      PG_CONNECTION_STRING_PREFIX: postgres://testuser:testpassword@localhost:5432/
+      PG_DATABASE_PRODUCTION: testdb
+      GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY_GITHUB_PUBLIC }}
+      CI: true ## This is to make sure that the tests run in CI mode
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - name: copy env file
+      run: cp .env.example .env
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Install
+      run: yarn
+    - name: Compile
+      run: yarn compile
+    - name: Build Client bundle
+      run: yarn build:prod
+      # Skipped build:admin since we don't have UI for them at the moment
+    - name: Create DB
+      run: yarn setup && yarn migrate
+      env:
+        NODE_ENV: production
+    - name: Get Playwright config
+      run: cp packages/evolution-frontend/playwright-example.config.ts example/demo_survey/playwright.config.ts
+    - name: Start application
+      run: yarn start &
+      env:
+        NODE_ENV: production
+    - name: Run tests
+      run: yarn test:ui
+    - name: Archive UI Test results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: playwright-results-${{matrix.node-version}} # This is to make sure that the results are stored in a unique name
+        path: example/demo_survey/test-results
+        retention-days: 2
+      # End of automated UI tests


### PR DESCRIPTION
New github workflow that runs the playwright ui tests. Based on the main CI one, without the lint/unit-test/etc.
Start a postgresql DB to be able to run the application.

We only run on commit to have access to the Google Key secret

Extracted and adapted from PR #682 