### PR TITLE
doc: update Readme with correct instructions to run UI tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,13 +137,13 @@ yarn start
 
 Run the UI tests
 ```
-yarn test:survey
+yarn test:ui
 ```
 
-*Notes:* In the `test:survey` script to define in the project, add the `LOCALE_DIR` environment variable, to register the translations for the current project. For example, in the `demo_survey` project, the script is defined as follows:
+*Notes:* In the `test:ui` script to define in the project, add the `LOCALE_DIR` environment variable, to register the translations for the current project. For example, in the `demo_survey` project, the script is defined as follows:
 
 ```
-"test:survey": "LOCALE_DIR=$(pwd)/locales npx playwright test"
+"test:ui": "LOCALE_DIR=$(pwd)/locales npx playwright test"
 ```
 
 Each test defined needs to get its own context for the test execution. The following gives and example of how to start a UI test for an application:


### PR DESCRIPTION
fix: https://github.com/chairemobilite/evolution/issues/871

The command has recently been changed to `yarn test:ui` to run the playwright tests, in coherence with most of the surveys and to make it clearer that it is UI tests.