### PR TITLE
Restrict the build docker workflow to run only on the official repo

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -15,6 +15,8 @@ env:
 jobs:
   # Branch push job - builds and pushes to both registries
   branch-push:
+    # This workflow is only for pushing builds from the official repo
+    if: github.repository_owner == 'chairemobilite'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
We don't want it to run on people's forks