### PR TITLE
Type redux actions

### DIFF
--- a/packages/evolution-common/src/services/questionnaire/types/Data.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/Data.ts
@@ -271,6 +271,13 @@ export interface InterviewStatusAttributesBase {
 }
 
 /**
+ * Function to redirect the page to a specific URL. It takes as argument either
+ * a string with the URL to redirect to, or an object with the pathname and
+ * search keys (to add as query strings)
+ */
+export type GotoFunction = (to: string | { pathname?: string; search?: string }) => void | Promise<void>;
+
+/**
  * Type of the callback to send interview updates to the server
  *
  * @param sectionShortname The shortname of the current section
@@ -281,16 +288,16 @@ export interface InterviewStatusAttributesBase {
  * will be exploded to the corresponding nested object path.
  * @param interview The current interview
  * @param callback An optional function to call after the interview has been updated
- * @param history The history object to redirect the user in case of error
+ * @param gotoFunction A function used to redirect the page to a specific URL
  * @returns void
  */
 export type StartUpdateInterview = (
     sectionShortname: string | null,
     valuesByPath?: { [path: string]: unknown },
     unsetPaths?: string[],
-    interview?: UserInterviewAttributes,
-    callback?: (interview: UserInterviewAttributes) => void,
-    history?: History
+    interview?: UserRuntimeInterviewAttributes,
+    callback?: (interview: UserRuntimeInterviewAttributes) => void,
+    gotoFunction?: GotoFunction
 ) => void;
 
 export type StartAddGroupedObjects = (
@@ -298,13 +305,13 @@ export type StartAddGroupedObjects = (
     insertSequence: number | undefined,
     path: string,
     attributes?: { [objectField: string]: unknown }[],
-    callback?: (interview: UserInterviewAttributes) => void,
+    callback?: (interview: UserRuntimeInterviewAttributes) => void,
     returnOnly?: boolean
 ) => any;
 
 export type StartRemoveGroupedObjects = (
     paths: string | string[],
-    callback?: (interview: UserInterviewAttributes) => void,
+    callback?: (interview: UserRuntimeInterviewAttributes) => void,
     returnOnly?: boolean
 ) => any;
 
@@ -323,7 +330,7 @@ export type ParsingFunctionWithCallbacks<T> = (
 
 export type ButtonAction = (
     callbacks: InterviewUpdateCallbacks,
-    interview: UserInterviewAttributes,
+    interview: UserRuntimeInterviewAttributes,
     path: string,
     section: string,
     sections: { [key: string]: any },

--- a/packages/evolution-common/src/tests/surveys/testCasesInterview.ts
+++ b/packages/evolution-common/src/tests/surveys/testCasesInterview.ts
@@ -5,7 +5,7 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 
-import { UserInterviewAttributes } from '../../services/questionnaire/types';
+import { UserInterviewAttributes, UserRuntimeInterviewAttributes } from '../../services/questionnaire/types';
 
 const baseInterviewAttributes: Pick<
     UserInterviewAttributes,
@@ -42,7 +42,7 @@ const baseInterviewAttributes: Pick<
  * This base interview is used by many unit tests to test the behavior of the
  * widgets. Do not change it too much, as it may impact other tests.
  */
-export const interviewAttributesForTestCases: UserInterviewAttributes = {
+export const interviewAttributesForTestCases: UserRuntimeInterviewAttributes = {
     ...baseInterviewAttributes,
     responses: {
         home: {
@@ -273,5 +273,9 @@ export const interviewAttributesForTestCases: UserInterviewAttributes = {
             }
         }
     },
-    validations: {}
+    validations: {},
+    widgets: {},
+    groups: {},
+    visibleWidgets: [],
+    allWidgetsValid: true
 };

--- a/packages/evolution-frontend/src/actions/LoadingState.ts
+++ b/packages/evolution-frontend/src/actions/LoadingState.ts
@@ -5,10 +5,12 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 
+import { LoadingStateActionTypes } from '../store/loadingState';
+
 export const incrementLoadingState = () => ({
-    type: 'INCREMENT_LOADING_STATE'
+    type: LoadingStateActionTypes.INCREMENT_LOADING_STATE
 });
 
 export const decrementLoadingState = () => ({
-    type: 'DECREMENT_LOADING_STATE'
+    type: LoadingStateActionTypes.DECREMENT_LOADING_STATE
 });

--- a/packages/evolution-frontend/src/actions/Survey.ts
+++ b/packages/evolution-frontend/src/actions/Survey.ts
@@ -11,7 +11,6 @@ import _cloneDeep from 'lodash/cloneDeep';
 import isEqual from 'lodash/isEqual';
 import _unset from 'lodash/unset';
 import bowser from 'bowser';
-import { NavigateFunction } from 'react-router';
 import { ThunkDispatch } from 'redux-thunk';
 
 /* eslint-disable-next-line */
@@ -37,6 +36,7 @@ import i18n from '../config/i18n.config';
 import { handleClientError, handleHttpOtherResponseCode } from '../services/errorManagement/errorHandling';
 import applicationConfiguration from '../config/application.config';
 import {
+    GotoFunction,
     StartAddGroupedObjects,
     StartRemoveGroupedObjects,
     StartUpdateInterview,
@@ -432,11 +432,14 @@ export const startRemoveGroupedObjects = function (
 export const startSetInterview = (
     activeSection: string | null = null,
     surveyUuid: string | undefined = undefined,
-    navigate: NavigateFunction | undefined = undefined,
+    navigate: GotoFunction | undefined = undefined,
     preFilledResponses: { [key: string]: unknown } | undefined = undefined
 ) => {
     // FIXME There's a lot of code duplication with the startCreateInterview function, either merge them or make them more DRY
-    return async (dispatch, _getState) => {
+    return async (
+        dispatch: ThunkDispatch<RootState, unknown, SurveyAction | AuthAction | LoadingStateAction>,
+        _getState: () => RootState
+    ) => {
         try {
             const browserTechData = bowser.getParser(window.navigator.userAgent).parse();
             // get the interview from the server for the current user, or with a specific survey uuid
@@ -501,7 +504,10 @@ export const startSetInterview = (
 
 export const startCreateInterview = (preFilledResponses: { [key: string]: unknown } | undefined = undefined) => {
     const browserTechData = bowser.getParser(window.navigator.userAgent).parse();
-    return async (dispatch, _getState) => {
+    return async (
+        dispatch: ThunkDispatch<RootState, unknown, SurveyAction | AuthAction | LoadingStateAction>,
+        _getState: () => RootState
+    ) => {
         try {
             // create a new interview on the server for the current user
             const response = await fetch('/api/survey/createInterview', {

--- a/packages/evolution-frontend/src/actions/Survey.ts
+++ b/packages/evolution-frontend/src/actions/Survey.ts
@@ -37,6 +37,8 @@ import i18n from '../config/i18n.config';
 import { handleClientError, handleHttpOtherResponseCode } from '../services/errorManagement/errorHandling';
 import applicationConfiguration from '../config/application.config';
 import {
+    StartAddGroupedObjects,
+    StartRemoveGroupedObjects,
     StartUpdateInterview,
     UserRuntimeInterviewAttributes
 } from 'evolution-common/lib/services/questionnaire/types';
@@ -367,16 +369,19 @@ export const addConsent = (consented: boolean) => ({
  * @returns The dispatched action
  */
 export const startAddGroupedObjects = (
-    newObjectsCount: number,
-    insertSequence: number | undefined,
-    path: string,
-    attributes: { [objectField: string]: unknown }[] = [],
-    callback?: (interview: UserRuntimeInterviewAttributes) => void,
-    returnOnly = false
+    newObjectsCount: Parameters<StartAddGroupedObjects>[0],
+    insertSequence: Parameters<StartAddGroupedObjects>[1],
+    path: Parameters<StartAddGroupedObjects>[2],
+    attributes: Parameters<StartAddGroupedObjects>[3] = [],
+    callback?: Parameters<StartAddGroupedObjects>[4],
+    returnOnly: Parameters<StartAddGroupedObjects>[5] = false
 ) => {
     surveyHelper.devLog(`Add ${newObjectsCount} grouped objects for path ${path} at sequence ${insertSequence}`);
-    return (dispatch, getState) => {
-        const interview = _cloneDeep(getState().survey.interview); // needed because we cannot mutate state
+    return (
+        dispatch: ThunkDispatch<RootState, unknown, SurveyAction | AuthAction | LoadingStateAction>,
+        getState: () => RootState
+    ) => {
+        const interview = _cloneDeep(getState().survey.interview) as UserRuntimeInterviewAttributes; // needed because we cannot mutate state
         const changedValuesByPath = surveyHelper.addGroupedObjects(
             interview,
             newObjectsCount,
@@ -405,13 +410,16 @@ export const startAddGroupedObjects = (
  * @returns
  */
 export const startRemoveGroupedObjects = function (
-    paths: string | string[],
-    callback?: (interview: UserRuntimeInterviewAttributes) => void,
-    returnOnly = false
+    paths: Parameters<StartRemoveGroupedObjects>[0],
+    callback?: Parameters<StartRemoveGroupedObjects>[1],
+    returnOnly: Parameters<StartRemoveGroupedObjects>[2] = false
 ) {
     surveyHelper.devLog('Remove grouped objects at paths', paths);
-    return (dispatch, getState) => {
-        const interview = _cloneDeep(getState().survey.interview); // needed because we cannot mutate state
+    return (
+        dispatch: ThunkDispatch<RootState, unknown, SurveyAction | AuthAction | LoadingStateAction>,
+        getState: () => RootState
+    ) => {
+        const interview = _cloneDeep(getState().survey.interview) as UserRuntimeInterviewAttributes; // needed because we cannot mutate state
         const [valuesByPath, unsetPaths] = surveyHelper.removeGroupedObjects(interview, paths);
         if (returnOnly) {
             return [valuesByPath, unsetPaths];

--- a/packages/evolution-frontend/src/actions/SurveyAdmin.ts
+++ b/packages/evolution-frontend/src/actions/SurveyAdmin.ts
@@ -204,7 +204,10 @@ export const startSetSurveyValidateInterview = (
         return;
     }
 ) => {
-    return async (dispatch, _getState) => {
+    return async (
+        dispatch: ThunkDispatch<RootState, unknown, SurveyAction | AuthAction | LoadingStateAction>,
+        _getState: () => RootState
+    ) => {
         return fetch(`/api/survey/validateInterview/${interviewUuid}`, {
             credentials: 'include'
         })

--- a/packages/evolution-frontend/src/actions/SurveyAdmin.ts
+++ b/packages/evolution-frontend/src/actions/SurveyAdmin.ts
@@ -54,11 +54,9 @@ export const startUpdateSurveyValidateInterview = (
     ) => {
         //surveyHelper.devLog(`Update interview and section with values by path`, valuesByPath);
         try {
-            if (interview === null) {
-                interview = _cloneDeep(getState().survey.interview);
-            }
-
-            //interview.sectionLoaded = null;
+            interview = interview
+                ? interview
+                : (_cloneDeep(getState().survey.interview) as UserRuntimeInterviewAttributes);
 
             dispatch(incrementLoadingState());
 
@@ -68,9 +66,6 @@ export const startUpdateSurveyValidateInterview = (
                     JSON.parse(JSON.stringify(valuesByPath))
                 );
             }
-
-            //const oldInterview = _cloneDeep(interview);
-            //const previousSection = surveyHelper.getResponse(interview, '_activeSection', null);
 
             const affectedPaths = {};
 
@@ -200,7 +195,6 @@ export const startUpdateSurveyValidateInterview = (
  * @param {*} callback
  * @returns
  */
-// Almost the same as startSetValidateInterview, TODO: refactor to use the same function
 // TODO: unit test
 export const startSetSurveyValidateInterview = (
     interviewUuid: string,
@@ -220,7 +214,7 @@ export const startSetSurveyValidateInterview = (
                     response.json().then((body) => {
                         if (body.interview) {
                             const interview = body.interview;
-                            dispatch(startUpdateSurveyValidateInterview('home', {}, undefined, interview, callback));
+                            dispatch(startUpdateSurveyValidateInterview(null, {}, undefined, interview, callback));
                         }
                     });
                 }
@@ -294,12 +288,15 @@ export const startSurveyValidateRemoveGroupedObjects = (
  */
 // TODO: unit test
 export const startResetValidateInterview = (
-    interviewUuid,
-    callback = function () {
+    interviewUuid: string,
+    callback: (interview: UserRuntimeInterviewAttributes) => void = function () {
         return;
     }
 ) => {
-    return (dispatch, _getState) => {
+    return (
+        dispatch: ThunkDispatch<RootState, unknown, SurveyAction | AuthAction | LoadingStateAction>,
+        _getState: () => RootState
+    ) => {
         return fetch(`/api/survey/validateInterview/${interviewUuid}?reset=true`, {
             credentials: 'include'
         })
@@ -308,65 +305,13 @@ export const startResetValidateInterview = (
                     response.json().then((body) => {
                         if (body.interview) {
                             const interview = body.interview;
-                            dispatch(
-                                startUpdateSurveyValidateInterview(
-                                    'validationOnePager',
-                                    {},
-                                    undefined,
-                                    interview,
-                                    callback
-                                )
-                            );
+                            dispatch(startUpdateSurveyValidateInterview(null, {}, undefined, interview, callback));
                         }
                     });
                 }
             })
             .catch((err) => {
                 surveyHelper.devLog('Error fetching interview to reset.', err);
-            });
-    };
-};
-
-/**
- * Fetch an interview from server and set it for display in a one page summary.
- *
- * TODO Only the section ('home', 'validationOnePager') is different from 'startSetSurveyValidateInterview' Re-use
- *
- * @param {*} interviewUuid The uuid of the interview to open
- * @param {*} callback
- * @returns
- */
-// TODO: unit test
-export const startSetValidateInterview = (
-    interviewUuid,
-    callback = function () {
-        return;
-    }
-) => {
-    return (dispatch, _getState) => {
-        return fetch(`/api/survey/validateInterview/${interviewUuid}`, {
-            credentials: 'include'
-        })
-            .then((response) => {
-                if (response.status === 200) {
-                    response.json().then((body) => {
-                        if (body.interview) {
-                            const interview = body.interview;
-                            dispatch(
-                                startUpdateSurveyValidateInterview(
-                                    'validationOnePager',
-                                    {},
-                                    undefined,
-                                    interview,
-                                    callback
-                                )
-                            );
-                        }
-                    });
-                }
-            })
-            .catch((err) => {
-                surveyHelper.devLog('Error fetching interview to validate.', err);
             });
     };
 };

--- a/packages/evolution-frontend/src/actions/SurveyAdmin.ts
+++ b/packages/evolution-frontend/src/actions/SurveyAdmin.ts
@@ -29,6 +29,7 @@ import * as surveyHelper from 'evolution-common/lib/utils/helpers';
 import {
     StartAddGroupedObjects,
     StartRemoveGroupedObjects,
+    StartUpdateInterview,
     UserRuntimeInterviewAttributes
 } from 'evolution-common/lib/services/questionnaire/types';
 import { incrementLoadingState, decrementLoadingState } from './LoadingState';
@@ -40,14 +41,17 @@ import { SurveyAction } from '../store/survey';
 import { LoadingStateAction } from '../store/loadingState';
 import { AuthAction } from 'chaire-lib-frontend/lib/store/auth';
 
-export const startUpdateSurveyValidateInterview = function (
-    sectionShortname: string | null,
-    valuesByPath: { [path: string]: unknown } | null = null,
-    unsetPaths: string[] | null = null,
-    interview: UserRuntimeInterviewAttributes | null = null,
-    callback?: (interview: UserRuntimeInterviewAttributes) => void
-) {
-    return async (dispatch, getState) => {
+export const startUpdateSurveyValidateInterview = (
+    sectionShortname: Parameters<StartUpdateInterview>[0],
+    valuesByPath?: Parameters<StartUpdateInterview>[1],
+    unsetPaths?: Parameters<StartUpdateInterview>[2],
+    interview?: Parameters<StartUpdateInterview>[3],
+    callback?: Parameters<StartUpdateInterview>[4]
+) => {
+    return async (
+        dispatch: ThunkDispatch<RootState, unknown, SurveyAction | AuthAction | LoadingStateAction>,
+        getState: () => RootState
+    ) => {
         //surveyHelper.devLog(`Update interview and section with values by path`, valuesByPath);
         try {
             if (interview === null) {
@@ -216,7 +220,7 @@ export const startSetSurveyValidateInterview = (
                     response.json().then((body) => {
                         if (body.interview) {
                             const interview = body.interview;
-                            dispatch(startUpdateSurveyValidateInterview('home', {}, null, interview, callback));
+                            dispatch(startUpdateSurveyValidateInterview('home', {}, undefined, interview, callback));
                         }
                     });
                 }
@@ -252,7 +256,7 @@ export const startSurveyValidateAddGroupedObjects = (
         if (returnOnly) {
             return changedValuesByPath;
         } else {
-            dispatch(startUpdateSurveyValidateInterview(null, changedValuesByPath, null, null, callback));
+            dispatch(startUpdateSurveyValidateInterview(null, changedValuesByPath, undefined, undefined, callback));
         }
     };
 };
@@ -305,7 +309,13 @@ export const startResetValidateInterview = (
                         if (body.interview) {
                             const interview = body.interview;
                             dispatch(
-                                startUpdateSurveyValidateInterview('validationOnePager', {}, null, interview, callback)
+                                startUpdateSurveyValidateInterview(
+                                    'validationOnePager',
+                                    {},
+                                    undefined,
+                                    interview,
+                                    callback
+                                )
                             );
                         }
                     });
@@ -343,7 +353,13 @@ export const startSetValidateInterview = (
                         if (body.interview) {
                             const interview = body.interview;
                             dispatch(
-                                startUpdateSurveyValidateInterview('validationOnePager', {}, null, interview, callback)
+                                startUpdateSurveyValidateInterview(
+                                    'validationOnePager',
+                                    {},
+                                    undefined,
+                                    interview,
+                                    callback
+                                )
                             );
                         }
                     });

--- a/packages/evolution-frontend/src/components/admin/pages/ValidateSurvey.tsx
+++ b/packages/evolution-frontend/src/components/admin/pages/ValidateSurvey.tsx
@@ -6,6 +6,7 @@
  */
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { ThunkDispatch } from 'redux-thunk';
 import { useLocation, useParams } from 'react-router';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import moment from 'moment';
@@ -21,7 +22,8 @@ import LoadingPage from 'chaire-lib-frontend/lib/components/pages/LoadingPage';
 import {
     startSetSurveyValidateInterview,
     startUpdateSurveyValidateInterview,
-    startSurveyValidateAddGroupedObjects
+    startSurveyValidateAddGroupedObjects,
+    startSurveyValidateRemoveGroupedObjects
 } from '../../../actions/SurveyAdmin';
 import { InterviewContext } from '../../../contexts/InterviewContext';
 import { withPreferencesHOC } from '../../hoc/WithPreferencesHoc';
@@ -34,8 +36,6 @@ import {
 import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
 import { InterviewState } from '../../../contexts/InterviewContext';
 import { RootState } from '../../../store/configureStore';
-import { startRemoveGroupedObjects } from '../../../actions/Survey';
-import { ThunkDispatch } from 'redux-thunk';
 import { SurveyAction } from '../../../store/survey';
 import { SectionProps } from '../../hooks/useSectionTemplate';
 
@@ -244,7 +244,14 @@ const ValidateSurveyWrapper = (props) => {
         dispatch(startSetSurveyValidateInterview(interviewUuid, callback));
     const startUpdateInterviewAction = (sectionShortname, valuesByPath, unsetPaths, interview, callback) =>
         dispatch(startUpdateSurveyValidateInterview(sectionShortname, valuesByPath, unsetPaths, interview, callback));
-    const startAddGroupedObjectsAction = (newObjectsCount, insertSequence, path, attributes, callback, returnOnly) =>
+    const startAddGroupedObjectsAction: StartAddGroupedObjects = (
+        newObjectsCount,
+        insertSequence,
+        path,
+        attributes,
+        callback,
+        returnOnly
+    ) =>
         dispatch(
             startSurveyValidateAddGroupedObjects(
                 newObjectsCount,
@@ -255,8 +262,8 @@ const ValidateSurveyWrapper = (props) => {
                 returnOnly
             )
         );
-    const startRemoveGroupedObjectsAction = (paths, callback, returnOnly) =>
-        dispatch(startRemoveGroupedObjects(paths, callback, returnOnly));
+    const startRemoveGroupedObjectsAction: StartRemoveGroupedObjects = (paths, callback, returnOnly) =>
+        dispatch(startSurveyValidateRemoveGroupedObjects(paths, callback, returnOnly));
 
     return (
         <MainValidateSurvey

--- a/packages/evolution-frontend/src/components/admin/pages/ValidateSurvey.tsx
+++ b/packages/evolution-frontend/src/components/admin/pages/ValidateSurvey.tsx
@@ -39,6 +39,8 @@ import { RootState } from '../../../store/configureStore';
 import { SurveyAction } from '../../../store/survey';
 import { SectionProps } from '../../hooks/useSectionTemplate';
 
+type StartSetInterview = (surveyUuid: string, callback?: (interview: UserRuntimeInterviewAttributes) => void) => void;
+
 export type SurveyProps = {
     interview: UserRuntimeInterviewAttributes;
     interviewLoaded: boolean;
@@ -51,10 +53,7 @@ export type SurveyProps = {
     location: Location;
     interviewContext: InterviewState;
     // FIXME This is the only difference with the Survey component props. Different name and arguments
-    startSetSurveyValidateInterview: (
-        surveyUuid: string | undefined,
-        callback?: (interview: UserRuntimeInterviewAttributes) => void
-    ) => void;
+    startSetSurveyValidateInterview: StartSetInterview;
     startUpdateInterview: StartUpdateInterview;
     startAddGroupedObjects: StartAddGroupedObjects;
     startRemoveGroupedObjects: StartRemoveGroupedObjects;
@@ -240,7 +239,7 @@ const ValidateSurveyWrapper = (props) => {
     const { sectionShortname, interviewUuid } = useParams();
     const { state } = React.useContext(InterviewContext);
 
-    const startSetInterviewAction = (interviewUuid, callback) =>
+    const startSetInterviewAction: StartSetInterview = (interviewUuid, callback) =>
         dispatch(startSetSurveyValidateInterview(interviewUuid, callback));
     const startUpdateInterviewAction = (sectionShortname, valuesByPath, unsetPaths, interview, callback) =>
         dispatch(startUpdateSurveyValidateInterview(sectionShortname, valuesByPath, unsetPaths, interview, callback));

--- a/packages/evolution-frontend/src/components/admin/pages/ValidateSurvey.tsx
+++ b/packages/evolution-frontend/src/components/admin/pages/ValidateSurvey.tsx
@@ -241,8 +241,13 @@ const ValidateSurveyWrapper = (props) => {
 
     const startSetInterviewAction: StartSetInterview = (interviewUuid, callback) =>
         dispatch(startSetSurveyValidateInterview(interviewUuid, callback));
-    const startUpdateInterviewAction = (sectionShortname, valuesByPath, unsetPaths, interview, callback) =>
-        dispatch(startUpdateSurveyValidateInterview(sectionShortname, valuesByPath, unsetPaths, interview, callback));
+    const startUpdateInterviewAction: StartUpdateInterview = (
+        sectionShortname,
+        valuesByPath,
+        unsetPaths,
+        interview,
+        callback
+    ) => dispatch(startUpdateSurveyValidateInterview(sectionShortname, valuesByPath, unsetPaths, interview, callback));
     const startAddGroupedObjectsAction: StartAddGroupedObjects = (
         newObjectsCount,
         insertSequence,

--- a/packages/evolution-frontend/src/components/admin/pages/ValidationPage.tsx
+++ b/packages/evolution-frontend/src/components/admin/pages/ValidationPage.tsx
@@ -12,7 +12,7 @@ import { faFolderOpen } from '@fortawesome/free-solid-svg-icons/faFolderOpen';
 import { ThunkDispatch } from 'redux-thunk';
 
 import InterviewSummary from '../validations/InterviewSummary';
-import { startSetValidateInterview } from '../../../actions/SurveyAdmin';
+import { startSetSurveyValidateInterview } from '../../../actions/SurveyAdmin';
 import InterviewListComponent from '../validations/InterviewListComponent';
 import { RootState } from '../../../store/configureStore';
 import { SurveyAction } from '../../../store/survey';
@@ -43,7 +43,7 @@ const ValidationPage = () => {
                 const nextUuid = listButton.getAttribute('data-next-uuid');
 
                 dispatch(
-                    startSetValidateInterview(interviewUuid, () => {
+                    startSetSurveyValidateInterview(interviewUuid, () => {
                         setPrevInterviewUuid(prevUuid === null ? undefined : prevUuid);
                         setNextInterviewUuid(nextUuid === null ? undefined : nextUuid);
                     })

--- a/packages/evolution-frontend/src/components/admin/validations/InterviewSummary.tsx
+++ b/packages/evolution-frontend/src/components/admin/validations/InterviewSummary.tsx
@@ -23,6 +23,7 @@ import { RootState } from '../../../store/configureStore';
 import { ThunkDispatch } from 'redux-thunk';
 import { SurveyAction } from '../../../store/survey';
 import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
+import { UserRuntimeInterviewAttributes } from 'evolution-common/lib/services/questionnaire/types';
 
 type InterviewSummaryProps = {
     prevInterviewUuid?: string;
@@ -33,9 +34,10 @@ type InterviewSummaryProps = {
 const InterviewSummary = (props: InterviewSummaryProps) => {
     const { t } = useTranslation();
     const dispatch = useDispatch<ThunkDispatch<RootState, unknown, SurveyAction>>();
-    const interview = useSelector((state: RootState) => state.survey.interview);
+    const interview = useSelector((state: RootState) => state.survey.interview) as UserRuntimeInterviewAttributes;
     const user = useSelector((state: RootState) => state.auth.user) as CliUser;
-    const validationDataDirty = interview?.validationDataDirty;
+    // FIXME Add the validationDataDirty to the interview type, but it is only for the admin
+    const validationDataDirty = (interview as any)?.validationDataDirty;
 
     const refreshInterview = useCallback(() => {
         dispatch(startSetValidateInterview(interview.uuid));
@@ -73,9 +75,10 @@ const InterviewSummary = (props: InterviewSummaryProps) => {
                         handleInterviewSummaryChange={props.handleInterviewSummaryChange}
                         updateValuesByPath={updateValuesByPath}
                         interviewIsValid={interview.is_valid}
-                        interviewIsQuestionable={interview.is_questionable}
+                        interviewIsQuestionable={interview.is_questionable || false}
                         interviewIsComplete={interview.is_completed}
-                        interviewIsValidated={interview.is_validated}
+                        // FIXME Add the is_validated to the interview type, but it is only for the admin
+                        interviewIsValidated={(interview as any).is_validated}
                         interviewUuid={interview.uuid}
                         prevInterviewUuid={props.prevInterviewUuid}
                         nextInterviewUuid={props.nextInterviewUuid}

--- a/packages/evolution-frontend/src/components/admin/validations/InterviewSummary.tsx
+++ b/packages/evolution-frontend/src/components/admin/validations/InterviewSummary.tsx
@@ -12,7 +12,7 @@ import LoadingPage from 'chaire-lib-frontend/lib/components/pages/LoadingPage';
 import ValidationOnePageSummary from './ValidationOnePageSummary';
 import * as surveyHelperNew from 'evolution-common/lib/utils/helpers';
 import {
-    startSetValidateInterview,
+    startSetSurveyValidateInterview,
     startUpdateSurveyValidateInterview,
     startResetValidateInterview
 } from '../../../actions/SurveyAdmin';
@@ -40,7 +40,7 @@ const InterviewSummary = (props: InterviewSummaryProps) => {
     const validationDataDirty = (interview as any)?.validationDataDirty;
 
     const refreshInterview = useCallback(() => {
-        dispatch(startSetValidateInterview(interview.uuid));
+        dispatch(startSetSurveyValidateInterview(interview.uuid));
     }, [dispatch, interview.uuid]);
 
     const resetInterview = useCallback(() => {

--- a/packages/evolution-frontend/src/components/admin/validations/ValidationCommentForm.tsx
+++ b/packages/evolution-frontend/src/components/admin/validations/ValidationCommentForm.tsx
@@ -31,7 +31,7 @@ const ValidationCommentForm = ({ interview }: ValidationCommentFormProps) => {
             'responses._validationComment': e.target.value
         };
         dispatch(
-            startUpdateSurveyValidateInterview(null, valuesByPath, null, null, () => {
+            startUpdateSurveyValidateInterview(null, valuesByPath, undefined, undefined, () => {
                 /* parameter required, but nothing to do */
             })
         );

--- a/packages/evolution-frontend/src/components/admin/validations/ValidationOnePageSummary.tsx
+++ b/packages/evolution-frontend/src/components/admin/validations/ValidationOnePageSummary.tsx
@@ -26,7 +26,8 @@ const ValidationOnePageSummary = () => {
     const [InterviewStats, setInterviewStats] = useState<React.ComponentType<InterviewStatsProps> | null>(null);
     const [InterviewMap, setInterviewMap] = useState<React.ComponentType<InterviewMapProps> | null>(null);
 
-    const interview = useSelector((state: RootState) => state.survey.interview);
+    // FIXME Admin interview type should be different from participant, with more types
+    const interview = useSelector((state: RootState) => state.survey.interview) as any;
     const user = useSelector((state: RootState) => state.auth.user);
     const dispatch = useDispatch<ThunkDispatch<RootState, unknown, SurveyAction>>();
     const startUpdateInterview = (sectionShortname, valuesByPath, unsetPaths, interview, callback) =>

--- a/packages/evolution-frontend/src/components/pages/Survey.tsx
+++ b/packages/evolution-frontend/src/components/pages/Survey.tsx
@@ -289,8 +289,13 @@ const SurveyWrapper: React.FC = (props) => {
 
     const startSetInterviewAction = (sectionShortname, surveyUuid, preFilledResponses) =>
         dispatch(startSetInterview(sectionShortname, surveyUuid, navigate, preFilledResponses));
-    const startUpdateInterviewAction = (sectionShortname, valuesByPath, unsetPaths, interview, callback) =>
-        dispatch(startUpdateInterview(sectionShortname, valuesByPath, unsetPaths, interview, callback, navigate));
+    const startUpdateInterviewAction: StartUpdateInterview = (
+        sectionShortname,
+        valuesByPath,
+        unsetPaths,
+        interview,
+        callback
+    ) => dispatch(startUpdateInterview(sectionShortname, valuesByPath, unsetPaths, interview, callback, navigate));
     const startAddGroupedObjectsAction = (newObjectsCount, insertSequence, path, attributes, callback, returnOnly) =>
         dispatch(startAddGroupedObjects(newObjectsCount, insertSequence, path, attributes, callback, returnOnly));
     const startRemoveGroupedObjectsAction = (paths, callback, returnOnly) =>

--- a/packages/evolution-frontend/src/components/pages/Survey.tsx
+++ b/packages/evolution-frontend/src/components/pages/Survey.tsx
@@ -296,9 +296,15 @@ const SurveyWrapper: React.FC = (props) => {
         interview,
         callback
     ) => dispatch(startUpdateInterview(sectionShortname, valuesByPath, unsetPaths, interview, callback, navigate));
-    const startAddGroupedObjectsAction = (newObjectsCount, insertSequence, path, attributes, callback, returnOnly) =>
-        dispatch(startAddGroupedObjects(newObjectsCount, insertSequence, path, attributes, callback, returnOnly));
-    const startRemoveGroupedObjectsAction = (paths, callback, returnOnly) =>
+    const startAddGroupedObjectsAction: StartAddGroupedObjects = (
+        newObjectsCount,
+        insertSequence,
+        path,
+        attributes,
+        callback,
+        returnOnly
+    ) => dispatch(startAddGroupedObjects(newObjectsCount, insertSequence, path, attributes, callback, returnOnly));
+    const startRemoveGroupedObjectsAction: StartRemoveGroupedObjects = (paths, callback, returnOnly) =>
         dispatch(startRemoveGroupedObjects(paths, callback, returnOnly));
 
     return (

--- a/packages/evolution-frontend/src/components/pages/Survey.tsx
+++ b/packages/evolution-frontend/src/components/pages/Survey.tsx
@@ -42,6 +42,12 @@ import { RootState } from '../../store/configureStore';
 import { ThunkDispatch } from 'redux-thunk';
 import { SurveyAction } from '../../store/survey';
 
+type StartSetInterview = (
+    activeSection: string | null,
+    surveyUuid: string | undefined,
+    preFilledResponses: { [key: string]: unknown } | undefined
+) => void;
+
 export type SurveyProps = {
     interview: UserRuntimeInterviewAttributes;
     interviewLoaded: boolean;
@@ -54,11 +60,7 @@ export type SurveyProps = {
     uuid?: string;
     location: Location;
     interviewContext: InterviewState;
-    startSetInterview: (
-        activeSection: string | null,
-        surveyUuid: string | undefined,
-        preFilledResponses: { [key: string]: unknown } | undefined
-    ) => void;
+    startSetInterview: StartSetInterview;
     startUpdateInterview: StartUpdateInterview;
     startAddGroupedObjects: StartAddGroupedObjects;
     startRemoveGroupedObjects: StartRemoveGroupedObjects;
@@ -287,7 +289,7 @@ const SurveyWrapper: React.FC = (props) => {
     const { sectionShortname, uuid } = useParams();
     const { state } = React.useContext(InterviewContext);
 
-    const startSetInterviewAction = (sectionShortname, surveyUuid, preFilledResponses) =>
+    const startSetInterviewAction: StartSetInterview = (sectionShortname, surveyUuid, preFilledResponses) =>
         dispatch(startSetInterview(sectionShortname, surveyUuid, navigate, preFilledResponses));
     const startUpdateInterviewAction: StartUpdateInterview = (
         sectionShortname,

--- a/packages/evolution-frontend/src/components/survey/Button.tsx
+++ b/packages/evolution-frontend/src/components/survey/Button.tsx
@@ -10,17 +10,17 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { withSurveyContext, WithSurveyContextProps } from '../hoc/WithSurveyContextHoc';
 import ConfirmModal from 'chaire-lib-frontend/lib/components/modal/ConfirmModal';
-import { ButtonWidgetConfig } from 'evolution-common/lib/services/questionnaire/types';
+import { ButtonWidgetConfig, UserRuntimeInterviewAttributes } from 'evolution-common/lib/services/questionnaire/types';
 import { WidgetStatus } from 'evolution-common/lib/services/questionnaire/types';
 import * as surveyHelper from 'evolution-common/lib/utils/helpers';
-import { InterviewUpdateCallbacks, UserInterviewAttributes } from 'evolution-common/lib/services/questionnaire/types';
+import { InterviewUpdateCallbacks } from 'evolution-common/lib/services/questionnaire/types';
 import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
 
 type ButtonProps = InterviewUpdateCallbacks & {
     widgetConfig: ButtonWidgetConfig;
     widgetStatus: WidgetStatus;
     loadingState: number;
-    interview: UserInterviewAttributes;
+    interview: UserRuntimeInterviewAttributes;
     user?: CliUser;
     path: string;
     label?: string;

--- a/packages/evolution-frontend/src/services/errorManagement/errorHandling.ts
+++ b/packages/evolution-frontend/src/services/errorManagement/errorHandling.ts
@@ -4,14 +4,15 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import { NavigateFunction } from 'react-router';
-import { Dispatch } from 'redux';
+import { ThunkDispatch } from 'redux-thunk';
 import verifyAuthentication from 'chaire-lib-frontend/lib/services/auth/verifyAuthentication';
+import { GotoFunction } from 'evolution-common/lib/services/questionnaire/types';
+import { AuthAction, AuthState } from 'chaire-lib-frontend/lib/store/auth';
 
 const unauthorizedPage = '/unauthorized';
 const errorPage = '/error';
 
-const redirectToErrorPage = (navigate?: NavigateFunction) => {
+const redirectToErrorPage = (navigate?: GotoFunction) => {
     if (navigate) {
         // FIXME: Used history previous with following comment, make sure it is
         // still valid and update if necessary: History avoids reload the page
@@ -38,7 +39,7 @@ const redirectToErrorPage = (navigate?: NavigateFunction) => {
  */
 export const handleClientError = (
     error: unknown,
-    { interviewId, navigate }: { interviewId?: number; navigate?: NavigateFunction }
+    { interviewId, navigate }: { interviewId?: number; navigate?: GotoFunction }
 ) => {
     logClientSideMessage(error, { interviewId });
     redirectToErrorPage(navigate);
@@ -55,8 +56,8 @@ export const handleClientError = (
  */
 export const handleHttpOtherResponseCode = async (
     responseCode: number,
-    dispatch: Dispatch,
-    navigate?: NavigateFunction
+    dispatch: ThunkDispatch<{ auth: AuthState }, unknown, AuthAction>,
+    navigate?: GotoFunction
 ) => {
     if (responseCode === 401) {
         // Verify authentication, so that we get the new authentication status

--- a/packages/evolution-frontend/src/store/survey/__tests__/reducer.test.ts
+++ b/packages/evolution-frontend/src/store/survey/__tests__/reducer.test.ts
@@ -4,11 +4,11 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import { UserInterviewAttributes } from 'evolution-common/lib/services/questionnaire/types';
+import { UserRuntimeInterviewAttributes } from 'evolution-common/lib/services/questionnaire/types';
 import { surveyReducer } from '../reducer';
 import { SurveyActionTypes } from '../types';
 
-const testInterview: UserInterviewAttributes = {
+const testInterview: UserRuntimeInterviewAttributes = {
     id: 1,
     uuid: 'arbitrary uuid',
     participant_id: 1,
@@ -31,7 +31,11 @@ const testInterview: UserInterviewAttributes = {
             q1: true
         }
     } as any,
-    is_valid: true
+    is_valid: true,
+    widgets: {},
+    groups: {},
+    visibleWidgets: [],
+    allWidgetsValid: true
 };
 test('Test setting an interview', () => {
     const action = {

--- a/packages/evolution-frontend/src/store/survey/types.ts
+++ b/packages/evolution-frontend/src/store/survey/types.ts
@@ -4,6 +4,8 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
+import { UserRuntimeInterviewAttributes } from 'evolution-common/lib/services/questionnaire/types';
+
 export enum SurveyActionTypes {
     SET_INTERVIEW = 'SET_INTERVIEW',
     UPDATE_INTERVIEW = 'UPDATE_INTERVIEW',
@@ -35,7 +37,7 @@ export type SurveyAction =
       };
 
 export interface SurveyState {
-    readonly interview?: any;
+    readonly interview?: UserRuntimeInterviewAttributes;
     readonly interviewLoaded?: boolean;
     readonly errors?: {
         [key: string]: {


### PR DESCRIPTION
This makes sure all redux actions are properly typed in their signature, but also in the callers. This will simplify their modification by forcing compilation errors.

See individual commits for more details

fixes #892