### PR TITLE
Add a SectionProgressBar in the Section page. (#907)

### DIFF
--- a/.github/workflows/evolution.yml
+++ b/.github/workflows/evolution.yml
@@ -5,9 +5,9 @@ name: CI
 
 on:
   push:
-    branches: [ main, od_2023 ]
+    branches: [ main, od_2023, v0.3.0 ]
   pull_request:
-    branches: [ main, od_2023 ]
+    branches: [ main, od_2023, v0.3.0 ]
 
 jobs:
   build-and-test:

--- a/example/demo_survey/config.js
+++ b/example/demo_survey/config.js
@@ -87,4 +87,5 @@ module.exports = {
   defaultLocale: "fr",
   timezone: 'America/Montreal',
   region: 'CA', // Used for Google Maps localization. See https://developers.google.com/maps/coverage for possible region codes
+  hasSectionProgressBar: true, // If true, show a progress bar at the top of each section
 };

--- a/example/demo_survey/src/survey/widgets.ts
+++ b/example/demo_survey/src/survey/widgets.ts
@@ -7,7 +7,7 @@
 import { faCheckCircle } from '@fortawesome/free-solid-svg-icons/faCheckCircle';
 import { faPlay } from '@fortawesome/free-solid-svg-icons/faPlay';
 
-import surveyHelper from 'evolution-legacy/lib/helpers/survey/survey';
+import { validateButtonActionWithCompleteSection } from 'evolution-frontend/lib/services/display/frontendHelper';
 import { getSwitchPersonWidgets } from 'evolution-common/lib/services/questionnaire/sections/common/widgetsSwitchPerson';
 import { getButtonValidateAndGotoNextSection } from 'evolution-common/lib/services/questionnaire/sections/common/buttonValidateAndGotoNextSection';
 
@@ -154,9 +154,11 @@ export const completedText: any                                 = endWidgets.com
 // multi-sections widgets:
 
 const buttonOptions = {
-    iconMapper: { 'check-circle': faCheckCircle },
-    buttonActions: { validateButtonAction: surveyHelper.validateButtonAction },
-}
+  iconMapper: { "check-circle": faCheckCircle },
+  buttonActions: {
+    validateButtonAction: validateButtonActionWithCompleteSection,
+  },
+};
 
 export const buttonSaveNextSection = getButtonValidateAndGotoNextSection('survey:SaveAndContinue', buttonOptions);
 
@@ -173,7 +175,7 @@ export const buttonStartNextSection: any = {
   hideWhenRefreshing: true,
   icon: faPlay,
   align: 'center',
-  action: surveyHelper.validateButtonAction
+  action: validateButtonActionWithCompleteSection
 }
 
 export const buttonContinueNextSection = getButtonValidateAndGotoNextSection('survey:Continue', buttonOptions);;

--- a/example/demo_survey/tests/test-one-person-helpers.ts
+++ b/example/demo_survey/tests/test-one-person-helpers.ts
@@ -3,7 +3,7 @@ import * as testHelpers from 'evolution-frontend/tests/ui-testing/testHelpers';
 // These functions are used in both the one person and input verification tests, in order to avoid code duplication
 
 export function completeHomePage(context) {
-    testHelpers.sectionProgressBarTest({context, sectionName: 'Home', completionPercentage: 10 });
+    testHelpers.sectionProgressBarTest({context, sectionName: 'Home', completionPercentage: 0 });
     testHelpers.inputStringTest({ context, path: 'accessCode', value: '1111-2222' });
     testHelpers.inputRadioTest({ context, path: 'household.size', value: '1' });
     testHelpers.inputStringTest({ context, path: 'household.carNumber', value: '2' });
@@ -19,7 +19,7 @@ export function completeHomePage(context) {
 };
 
 export function completeHouseholdPage(context) {
-    testHelpers.sectionProgressBarTest({context, sectionName: 'Household members', completionPercentage: 20 });
+    testHelpers.sectionProgressBarTest({context, sectionName: 'Household members', completionPercentage: 11 });
     testHelpers.inputStringTest({ context, path: 'household.persons.${personId[0]}.age', value: '30' });
     testHelpers.inputRadioTest({ context, path: 'household.persons.${personId[0]}.gender', value: 'male' });
     testHelpers.inputSelectTest({ context, path: 'household.persons.${personId[0]}.occupation', value: 'fullTimeWorker' });
@@ -33,17 +33,21 @@ export function completeHouseholdPage(context) {
 };
 
 export function completeProfilePage(context) {
-    testHelpers.sectionProgressBarTest({context, sectionName: 'Profile', completionPercentage: 40 });
+    testHelpers.sectionProgressBarTest({context, sectionName: 'Profile', completionPercentage: 33 });
     testHelpers.inputRadioTest({ context, path: 'household.persons.${personId[0]}.workOnTheRoad', value: false });
     testHelpers.inputRadioTest({ context, path: 'household.persons.${personId[0]}.usualWorkPlaceIsHome', value: true });
     testHelpers.inputNextButtonTest({ context, text: 'Save and continue', nextPageUrl: '/survey/end' });
 };
 
 export function completeEndPage(context) {
-    testHelpers.sectionProgressBarTest({context, sectionName: 'End', completionPercentage: 90 });
+    testHelpers.sectionProgressBarTest({context, sectionName: 'End', completionPercentage: 89 });
     testHelpers.inputSelectTest({ context, path: 'household.residentialPhoneType', value: 'landLine' });
     testHelpers.inputRadioTest({ context, path: 'household.didAlsoRespondByPhone', value: false });
     testHelpers.inputRadioTest({ context, path: 'household.wouldLikeToParticipateInOtherSurveys', value: false });
     testHelpers.inputSelectTest({ context, path: 'household.income', value: '060000_089999' });
     testHelpers.inputNextButtonTest({ context, text: 'Complete interview', nextPageUrl: '/survey/completed' });
 };
+
+export function completeCompletedPage(context) {
+    testHelpers.sectionProgressBarTest({context, sectionName: 'Interview completed', completionPercentage: 100 });
+}

--- a/example/demo_survey/tests/test-one-person-helpers.ts
+++ b/example/demo_survey/tests/test-one-person-helpers.ts
@@ -3,6 +3,7 @@ import * as testHelpers from 'evolution-frontend/tests/ui-testing/testHelpers';
 // These functions are used in both the one person and input verification tests, in order to avoid code duplication
 
 export function completeHomePage(context) {
+    testHelpers.sectionProgressBarTest({context, sectionName: 'Home', completionPercentage: 10 });
     testHelpers.inputStringTest({ context, path: 'accessCode', value: '1111-2222' });
     testHelpers.inputRadioTest({ context, path: 'household.size', value: '1' });
     testHelpers.inputStringTest({ context, path: 'household.carNumber', value: '2' });
@@ -18,6 +19,7 @@ export function completeHomePage(context) {
 };
 
 export function completeHouseholdPage(context) {
+    testHelpers.sectionProgressBarTest({context, sectionName: 'Household members', completionPercentage: 20 });
     testHelpers.inputStringTest({ context, path: 'household.persons.${personId[0]}.age', value: '30' });
     testHelpers.inputRadioTest({ context, path: 'household.persons.${personId[0]}.gender', value: 'male' });
     testHelpers.inputSelectTest({ context, path: 'household.persons.${personId[0]}.occupation', value: 'fullTimeWorker' });
@@ -31,12 +33,14 @@ export function completeHouseholdPage(context) {
 };
 
 export function completeProfilePage(context) {
+    testHelpers.sectionProgressBarTest({context, sectionName: 'Profile', completionPercentage: 40 });
     testHelpers.inputRadioTest({ context, path: 'household.persons.${personId[0]}.workOnTheRoad', value: false });
     testHelpers.inputRadioTest({ context, path: 'household.persons.${personId[0]}.usualWorkPlaceIsHome', value: true });
     testHelpers.inputNextButtonTest({ context, text: 'Save and continue', nextPageUrl: '/survey/end' });
 };
 
 export function completeEndPage(context) {
+    testHelpers.sectionProgressBarTest({context, sectionName: 'End', completionPercentage: 90 });
     testHelpers.inputSelectTest({ context, path: 'household.residentialPhoneType', value: 'landLine' });
     testHelpers.inputRadioTest({ context, path: 'household.didAlsoRespondByPhone', value: false });
     testHelpers.inputRadioTest({ context, path: 'household.wouldLikeToParticipateInOtherSurveys', value: false });

--- a/example/demo_survey/tests/test-one-person-no-trips.UI.spec.ts
+++ b/example/demo_survey/tests/test-one-person-no-trips.UI.spec.ts
@@ -34,4 +34,7 @@ onePersonTestHelpers.completeProfilePage(context);
 // Test the end page
 onePersonTestHelpers.completeEndPage(context);
 
+// Test the completed page
+onePersonTestHelpers.completeCompletedPage(context);
+
 surveyTestHelpers.logout({ context });

--- a/locales/en/survey.yml
+++ b/locales/en/survey.yml
@@ -60,3 +60,6 @@ futureToday: "in {{count}} days"
 
 # Error message
 ResponseIsRequired: "This response is required."
+
+# Section Progress Bar
+completed: 'completed'

--- a/locales/fr/survey.yml
+++ b/locales/fr/survey.yml
@@ -70,3 +70,6 @@ futureToday: "dans {{count}} jours"
 
 # Error message
 ResponseIsRequired: "Cette réponse est requise."
+
+# Section Progress Bar
+completed: 'complété'

--- a/packages/evolution-common/src/utils/helpers.ts
+++ b/packages/evolution-common/src/utils/helpers.ts
@@ -620,7 +620,7 @@ export const isSectionComplete = ({
  * @param {UserInterviewAttributes} options.interview - The interview object.
  * @param {Object} options.sections - The sections object.
  * @param {string} options.sectionName - The shortname of the current section.
- * @param {string} options.sectionTarget - The target section ('current' or 'next').
+ * @param {string} options.sectionTarget - The target section for the completion rate ('currentSection' or 'nextSection').
  * @returns {number} - The calculated completion percentage.
  */
 export const calculateSurveyCompletionPercentage = ({
@@ -632,28 +632,31 @@ export const calculateSurveyCompletionPercentage = ({
     interview: UserInterviewAttributes;
     sections: { [key: string]: unknown };
     sectionName: string;
-    sectionTarget: 'current' | 'next';
+    sectionTarget: 'currentSection' | 'nextSection';
 }): number => {
-    const LAST_SECTION_NAME = 'completed';
+    const LAST_SECTION_NAME = 'completed'; // NOTE: Only survey with the last section named 'completed' are supported for this function.
     const MINIMUM_COMPLETION_PERCENTAGE = 0;
     const MAXIMUM_COMPLETION_PERCENTAGE = 100;
 
+    // Get the stored completion percentage from the interview responses
     const storedCompletionPercentage: number =
         interview?.responses?._completionPercentage || MINIMUM_COMPLETION_PERCENTAGE;
+
+    // Count the number of sections without the last one
     const sectionsWithoutCompleted = Object.keys(sections).filter((sectionName) => sectionName !== LAST_SECTION_NAME);
     const totalSectionsWithoutCompleted = sectionsWithoutCompleted.length;
-    let targetSectionIndex = Object.keys(sections).findIndex((key) => key === sectionName);
 
-    // Increment the index if the section target is 'next'
-    if (sectionTarget === 'next') {
-        targetSectionIndex = Math.min(targetSectionIndex + 1, totalSectionsWithoutCompleted);
+    // Increment the index if the section target is 'nextSection'
+    let sectionTargetIndex = Object.keys(sections).findIndex((key) => key === sectionName);
+    if (sectionTarget === 'nextSection') {
+        sectionTargetIndex = Math.min(sectionTargetIndex + 1, totalSectionsWithoutCompleted);
     }
 
-    const currentCompletionPercentage = Number(((targetSectionIndex / totalSectionsWithoutCompleted) * 100).toFixed(0));
+    // Return the maximum survey completion percentage
+    const targetCompletionPercentage = Number(((sectionTargetIndex / totalSectionsWithoutCompleted) * 100).toFixed(0));
     const completionPercentage = Math.min(
         MAXIMUM_COMPLETION_PERCENTAGE,
-        Math.max(storedCompletionPercentage, currentCompletionPercentage)
+        Math.max(storedCompletionPercentage, targetCompletionPercentage)
     );
-
     return completionPercentage;
 };

--- a/packages/evolution-frontend/src/components/pageParts/Section.tsx
+++ b/packages/evolution-frontend/src/components/pageParts/Section.tsx
@@ -112,7 +112,7 @@ export const Section: React.FC<SectionProps & WithTranslation & WithSurveyContex
                         <SectionProgressBar
                             title={props.sectionConfig.title}
                             interview={props.interview}
-                            shortname={props.shortname}
+                            sectionName={props.shortname}
                             sections={props.surveyContext.sections}
                         />
                     </React.Fragment>

--- a/packages/evolution-frontend/src/components/pageParts/Section.tsx
+++ b/packages/evolution-frontend/src/components/pageParts/Section.tsx
@@ -9,13 +9,15 @@ import React from 'react';
 import _get from 'lodash/get';
 import _shuffle from 'lodash/shuffle';
 
-import * as surveyHelper from 'evolution-common/lib/utils/helpers';
+import config from 'chaire-lib-common/lib/config/shared/project.config';
+import { devLog } from 'evolution-common/lib/utils/helpers';
 import { withSurveyContext, WithSurveyContextProps } from '../hoc/WithSurveyContextHoc';
 import { Widget } from '../survey/Widget';
 import LoadingPage from 'chaire-lib-frontend/lib/components/pages/LoadingPage';
 import { SectionConfig, UserRuntimeInterviewAttributes } from 'evolution-common/lib/services/questionnaire/types';
 import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
 import { SectionProps, useSectionTemplate } from '../hooks/useSectionTemplate';
+import SectionProgressBar from './SectionProgressBar';
 
 export const Section: React.FC<SectionProps & WithTranslation & WithSurveyContextProps> = (
     props: SectionProps & WithTranslation & WithSurveyContextProps
@@ -76,7 +78,7 @@ export const Section: React.FC<SectionProps & WithTranslation & WithSurveyContex
 
     const widgetsComponentByShortname: { [key: string]: React.ReactNode } = {};
 
-    surveyHelper.devLog('%c rendering section ' + props.shortname, 'background: rgba(0,0,255,0.1);');
+    devLog('%c rendering section ' + props.shortname, 'background: rgba(0,0,255,0.1);');
     for (let i = 0, count = props.sectionConfig.widgets.length; i < count; i++) {
         const widgetShortname = props.sectionConfig.widgets[i];
 
@@ -104,7 +106,19 @@ export const Section: React.FC<SectionProps & WithTranslation & WithSurveyContex
 
     return (
         <section className={`survey-section survey-section-shortname-${props.shortname}`}>
-            <div className="survey-section__content">{sortedWidgetsComponents}</div>
+            <div className="survey-section__content">
+                {props?.sectionConfig?.title && config?.hasSectionProgressBar === true && (
+                    <React.Fragment>
+                        <SectionProgressBar
+                            title={props.sectionConfig.title}
+                            interview={props.interview}
+                            shortname={props.shortname}
+                            sections={props.surveyContext.sections}
+                        />
+                    </React.Fragment>
+                )}
+                <div>{sortedWidgetsComponents}</div>
+            </div>
         </section>
     );
 };

--- a/packages/evolution-frontend/src/components/pageParts/SectionProgressBar.tsx
+++ b/packages/evolution-frontend/src/components/pageParts/SectionProgressBar.tsx
@@ -21,7 +21,7 @@ const SectionProgressBar: React.FC<SectionProgressBarProps> = ({ title, intervie
         interview,
         sections,
         sectionName,
-        sectionTarget: 'current'
+        sectionTarget: 'currentSection'
     });
 
     // Circular progress bar properties

--- a/packages/evolution-frontend/src/components/pageParts/SectionProgressBar.tsx
+++ b/packages/evolution-frontend/src/components/pageParts/SectionProgressBar.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { I18nData } from 'evolution-common/lib/services/questionnaire/types';
+import { UserInterviewAttributes } from 'evolution-common/lib/services/questionnaire/types';
+import { translateString } from 'evolution-common/lib/utils/helpers';
+
+type SectionProgressBarProps = {
+    title: I18nData;
+    interview: UserInterviewAttributes;
+    shortname: string;
+    sections: { [key: string]: any };
+};
+
+// Section Progress Bar Component to show the completion percentage of the survey and the section title
+const SectionProgressBar: React.FC<SectionProgressBarProps> = ({ title, interview, shortname, sections }) => {
+    const { t, i18n } = useTranslation();
+
+    // Calculate the completion percentage based on the current section index and total sections.
+    // The percentage will be 100% when the last section (completed section) is started.
+    const maximumCompletionPercentage: number = interview?.responses?._completionPercentage || 0;
+    const currentSectionIndex = Object.keys(sections).findIndex((key) => key === shortname) + 1;
+    const totalSections = Object.keys(sections).length;
+    const currentCompletionPercentage = Number(((currentSectionIndex / totalSections) * 100).toFixed(0));
+    const completionPercentage = Math.max(maximumCompletionPercentage, currentCompletionPercentage);
+
+    // Circular progress bar properties
+    const radius = 45; // Adjusted radius to fit within 100px diameter
+    const strokeWidth = 10; // Adjusted stroke width
+    const circumference = 2 * Math.PI * radius; // Circumference of the circle
+    const offset = circumference - (completionPercentage / 100) * circumference; // Stroke offset for progress
+
+    return (
+        <div className="survey-section__progress-bar">
+            {/* Draw a circle with the completion percentage */}
+            <svg width="100" height="100" viewBox="0 0 100 100" className="circular-progress">
+                <circle className="bg" cx="50" cy="50" r={radius} strokeWidth={strokeWidth} />
+                <circle
+                    className="fg"
+                    cx="50"
+                    cy="50"
+                    r={radius}
+                    strokeWidth={strokeWidth}
+                    strokeDasharray={circumference}
+                    strokeDashoffset={offset}
+                />
+                <text x="50" y="45" textAnchor="middle" className="percentage-text">
+                    {completionPercentage}%
+                </text>
+                <text x="50" y="60" textAnchor="middle" className="completed-text">
+                    {t('survey:completed')}
+                </text>
+            </svg>
+            <div className="big-text">{translateString(title, i18n, interview, shortname)} - Section</div>
+        </div>
+    );
+};
+
+export default SectionProgressBar;

--- a/packages/evolution-frontend/src/components/pageParts/SectionProgressBar.tsx
+++ b/packages/evolution-frontend/src/components/pageParts/SectionProgressBar.tsx
@@ -3,26 +3,26 @@ import { useTranslation } from 'react-i18next';
 
 import { I18nData } from 'evolution-common/lib/services/questionnaire/types';
 import { UserInterviewAttributes } from 'evolution-common/lib/services/questionnaire/types';
-import { translateString } from 'evolution-common/lib/utils/helpers';
+import { translateString, calculateSurveyCompletionPercentage } from 'evolution-common/lib/utils/helpers';
 
 type SectionProgressBarProps = {
     title: I18nData;
     interview: UserInterviewAttributes;
-    shortname: string;
+    sectionName: string;
     sections: { [key: string]: any };
 };
 
 // Section Progress Bar Component to show the completion percentage of the survey and the section title
-const SectionProgressBar: React.FC<SectionProgressBarProps> = ({ title, interview, shortname, sections }) => {
+const SectionProgressBar: React.FC<SectionProgressBarProps> = ({ title, interview, sectionName, sections }) => {
     const { t, i18n } = useTranslation();
 
-    // Calculate the completion percentage based on the current section index and total sections.
-    // The percentage will be 100% when the last section (completed section) is started.
-    const maximumCompletionPercentage: number = interview?.responses?._completionPercentage || 0;
-    const currentSectionIndex = Object.keys(sections).findIndex((key) => key === shortname) + 1;
-    const totalSections = Object.keys(sections).length;
-    const currentCompletionPercentage = Number(((currentSectionIndex / totalSections) * 100).toFixed(0));
-    const completionPercentage = Math.max(maximumCompletionPercentage, currentCompletionPercentage);
+    // Calculate the survey completion percentage based on the number of completed sections
+    const completionPercentage = calculateSurveyCompletionPercentage({
+        interview,
+        sections,
+        sectionName,
+        sectionTarget: 'current'
+    });
 
     // Circular progress bar properties
     const radius = 45; // Adjusted radius to fit within 100px diameter
@@ -32,6 +32,7 @@ const SectionProgressBar: React.FC<SectionProgressBarProps> = ({ title, intervie
 
     return (
         <div className="survey-section__progress-bar">
+            <div className="big-text">{translateString(title, i18n, interview, sectionName)} - Section</div>
             {/* Draw a circle with the completion percentage */}
             <svg width="100" height="100" viewBox="0 0 100 100" className="circular-progress">
                 <circle className="bg" cx="50" cy="50" r={radius} strokeWidth={strokeWidth} />
@@ -51,7 +52,6 @@ const SectionProgressBar: React.FC<SectionProgressBarProps> = ({ title, intervie
                     {t('survey:completed')}
                 </text>
             </svg>
-            <div className="big-text">{translateString(title, i18n, interview, shortname)} - Section</div>
         </div>
     );
 };

--- a/packages/evolution-frontend/src/services/display/__tests__/frontendHelper.test.ts
+++ b/packages/evolution-frontend/src/services/display/__tests__/frontendHelper.test.ts
@@ -6,6 +6,7 @@
  */
 import moment from 'moment';
 import i18n from '../../../config/i18n.config';
+import _cloneDeep from 'lodash/cloneDeep';
 
 import { TFunction } from 'i18next';
 import {

--- a/packages/evolution-frontend/src/services/display/__tests__/frontendHelper.test.ts
+++ b/packages/evolution-frontend/src/services/display/__tests__/frontendHelper.test.ts
@@ -8,14 +8,23 @@ import moment from 'moment';
 import i18n from '../../../config/i18n.config';
 
 import { TFunction } from 'i18next';
-import { getGenderedStrings, getFormattedDate, secondsSinceMidnightToTimeStrWithSuffix, validateButtonAction } from '../frontendHelper';
+import {
+    getGenderedStrings,
+    getFormattedDate,
+    secondsSinceMidnightToTimeStrWithSuffix,
+    validateButtonAction,
+    validateButtonActionWithCompleteSection,
+    getVisitedPlaceDescription
+} from '../frontendHelper';
 import { interviewAttributesForTestCases } from 'evolution-common/lib/tests/surveys';
 
 jest.mock('../../../config/i18n.config', () => ({
-    t: jest.fn((key, options) => `${key}${options && options.context ? `_${options.context}` : ''}${options && options.count !== undefined ? `_${options.count}` : '' }`)
+    t: jest.fn(
+        (key, options) =>
+            `${key}${options && options.context ? `_${options.context}` : ''}${options && options.count !== undefined ? `_${options.count}` : ''}`
+    )
 }));
 const mockedT = i18n.t as jest.MockedFunction<TFunction>;
-
 
 describe('getGenderedSuffixes', () => {
     it('should return default suffixes for undefined person', () => {
@@ -147,36 +156,181 @@ describe('secondsSinceMidnightToTimeStrWithSuffix', () => {
 describe('validateButtonAction', () => {
     const interview = interviewAttributesForTestCases;
     const callbacks = {
-        startUpdateInterview: jest.fn().mockImplementation((_shortname, _values, _unset, _interview, callback, _history) => callback?.({ ...interview, allWidgetsValid: true })),
+        startUpdateInterview: jest
+            .fn()
+            .mockImplementation((_shortname, _values, _unset, _interview, callback, _history) =>
+                callback?.({ ...interview, allWidgetsValid: true })
+            ),
         startAddGroupedObjects: jest.fn(),
         startRemoveGroupedObjects: jest.fn()
     };
 
     beforeEach(() => {
         jest.clearAllMocks();
-    })
+    });
 
     test('no callback', () => {
-        validateButtonAction(callbacks, interview, 'path', 'section', { section: { nextSection: 'next' }});
+        validateButtonAction(callbacks, interview, 'path', 'section', { section: { nextSection: 'next' } });
         expect(callbacks.startUpdateInterview).toHaveBeenCalledTimes(2);
-        expect(callbacks.startUpdateInterview).toHaveBeenCalledWith('section', { _all: true }, undefined, interview, expect.any(Function));
+        expect(callbacks.startUpdateInterview).toHaveBeenCalledWith(
+            'section',
+            { _all: true },
+            undefined,
+            interview,
+            expect.any(Function)
+        );
         expect(callbacks.startUpdateInterview).toHaveBeenCalledWith('section', { 'responses._activeSection': 'next' });
     });
 
     test('with callback', () => {
         const saveCallback = jest.fn();
-        validateButtonAction(callbacks, interview, 'path', 'section', { section: { nextSection: 'next' }}, saveCallback);
+        validateButtonAction(
+            callbacks,
+            interview,
+            'path',
+            'section',
+            { section: { nextSection: 'next' } },
+            saveCallback
+        );
         expect(callbacks.startUpdateInterview).toHaveBeenCalledTimes(1);
-        expect(callbacks.startUpdateInterview).toHaveBeenCalledWith('section', { _all: true }, undefined, interview, expect.any(Function));
+        expect(callbacks.startUpdateInterview).toHaveBeenCalledWith(
+            'section',
+            { _all: true },
+            undefined,
+            interview,
+            expect.any(Function)
+        );
         expect(saveCallback).toHaveBeenCalledWith(callbacks, { ...interview, allWidgetsValid: true }, 'path');
     });
 
     test('widgets invalid', () => {
-        callbacks.startUpdateInterview.mockImplementationOnce((_shortname, _values, _unset, _interview, callback, _history) => callback({ ...interview, allWidgetsValid: false }));
+        callbacks.startUpdateInterview.mockImplementationOnce(
+            (_shortname, _values, _unset, _interview, callback, _history) =>
+                callback({ ...interview, allWidgetsValid: false })
+        );
         const saveCallback = jest.fn();
         validateButtonAction(callbacks, interview, 'path', 'section', {}, saveCallback);
         expect(saveCallback).not.toHaveBeenCalled();
         expect(callbacks.startUpdateInterview).toHaveBeenCalledTimes(1);
     });
-    
+});
+
+describe('validateButtonActionWithCompleteSection', () => {
+    const interview = interviewAttributesForTestCases;
+    const callbacks = {
+        startUpdateInterview: jest
+            .fn()
+            .mockImplementation((_shortname, _values, _unset, _interview, callback, _history) =>
+                callback?.({ ...interview, allWidgetsValid: true })
+            ),
+        startAddGroupedObjects: jest.fn(),
+        startRemoveGroupedObjects: jest.fn()
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('no callback', () => {
+        validateButtonActionWithCompleteSection(callbacks, interview, 'path', 'section', {
+            section: { nextSection: 'next' }
+        });
+        expect(callbacks.startUpdateInterview).toHaveBeenCalledTimes(2);
+        expect(callbacks.startUpdateInterview).toHaveBeenCalledWith(
+            'section',
+            { _all: true },
+            undefined,
+            interview,
+            expect.any(Function)
+        );
+        expect(callbacks.startUpdateInterview).toHaveBeenCalledWith('section', {
+            'responses._activeSection': 'next',
+            'responses._sections.section._isCompleted': true,
+            'responses._completionPercentage': 100
+        });
+    });
+
+    test('with callback', () => {
+        const saveCallback = jest.fn();
+        validateButtonActionWithCompleteSection(
+            callbacks,
+            interview,
+            'path',
+            'section',
+            { section: { nextSection: 'next' } },
+            saveCallback
+        );
+        expect(callbacks.startUpdateInterview).toHaveBeenCalledTimes(1);
+        expect(callbacks.startUpdateInterview).toHaveBeenCalledWith(
+            'section',
+            { _all: true },
+            undefined,
+            interview,
+            expect.any(Function)
+        );
+        expect(saveCallback).toHaveBeenCalledWith(callbacks, { ...interview, allWidgetsValid: true }, 'path');
+    });
+
+    test('widgets invalid', () => {
+        callbacks.startUpdateInterview.mockImplementationOnce(
+            (_shortname, _values, _unset, _interview, callback, _history) =>
+                callback({ ...interview, allWidgetsValid: false })
+        );
+        const saveCallback = jest.fn();
+        validateButtonActionWithCompleteSection(callbacks, interview, 'path', 'section', {}, saveCallback);
+        expect(saveCallback).not.toHaveBeenCalled();
+        expect(callbacks.startUpdateInterview).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('getVisitedPlaceDescription', () => {
+    const interview = _cloneDeep(interviewAttributesForTestCases);
+    // Add times to places
+    const visitedPlaces = interview.responses.household!.persons!.personId1!.journeys!.journeyId1!.visitedPlaces!;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('without times or html, place with no name', () => {
+        const description = getVisitedPlaceDescription(visitedPlaces.homePlace1P1, false, false);
+        expect(description).toEqual('survey:visitedPlace:activities:home');
+    });
+
+    test('without times or html, place with name', () => {
+        const description = getVisitedPlaceDescription(visitedPlaces.workPlace1P1, false, false);
+        expect(description).toEqual('survey:visitedPlace:activities:work • This is my work');
+    });
+
+    test('with times and html, complete place with no name', () => {
+        const visitedPlace = _cloneDeep(visitedPlaces.homePlace1P1);
+        visitedPlace.departureTime = 3600;
+        visitedPlace.arrivalTime = 1800;
+        const description = getVisitedPlaceDescription(visitedPlace, true, true);
+        expect(description).toEqual('survey:visitedPlace:activities:home 0:30 -> 1:00');
+    });
+
+    test('with times and html, complete place with no name, test midnight', () => {
+        const visitedPlace = _cloneDeep(visitedPlaces.homePlace1P1);
+        visitedPlace.departureTime = 3600;
+        visitedPlace.arrivalTime = 0;
+        const description = getVisitedPlaceDescription(visitedPlace, true, true);
+        expect(description).toEqual('survey:visitedPlace:activities:home 0:00 -> 1:00');
+    });
+
+    test('with times and html, complete place with name', () => {
+        const visitedPlace = _cloneDeep(visitedPlaces.workPlace1P1);
+        visitedPlace.departureTime = 3600;
+        visitedPlace.arrivalTime = 1800;
+        const description = getVisitedPlaceDescription(visitedPlace, true, true);
+        expect(description).toEqual('survey:visitedPlace:activities:work • <em>This is my work</em> 0:30 -> 1:00');
+    });
+
+    test('with times, but place with no times', () => {
+        const visitedPlace = _cloneDeep(visitedPlaces.workPlace1P1);
+        delete visitedPlace.departureTime;
+        delete visitedPlace.arrivalTime;
+        const description = getVisitedPlaceDescription(visitedPlace, true, true);
+        expect(description).toEqual('survey:visitedPlace:activities:work • <em>This is my work</em>');
+    });
 });

--- a/packages/evolution-frontend/src/services/display/frontendHelper.ts
+++ b/packages/evolution-frontend/src/services/display/frontendHelper.ts
@@ -156,7 +156,7 @@ export const validateButtonActionWithCompleteSection: ButtonAction = (
                     interview,
                     sections,
                     sectionName: section,
-                    sectionTarget: 'next'
+                    sectionTarget: 'nextSection'
                 });
 
                 // Mark the section as completed and update the completion percentage

--- a/packages/evolution-frontend/src/services/display/frontendHelper.ts
+++ b/packages/evolution-frontend/src/services/display/frontendHelper.ts
@@ -10,6 +10,7 @@ import moment from 'moment';
 import i18n from '../../config/i18n.config';
 import { secondsSinceMidnightToTimeStr } from 'chaire-lib-common/lib/utils/DateTimeUtils';
 import { ButtonAction, Person, VisitedPlace } from 'evolution-common/lib/services/questionnaire/types';
+import { calculateSurveyCompletionPercentage } from 'evolution-common/lib/utils/helpers';
 
 type GenderedData = {
     [gender: string]: {
@@ -150,17 +151,13 @@ export const validateButtonActionWithCompleteSection: ButtonAction = (
             if (typeof saveCallback === 'function') {
                 saveCallback(callbacks, updatedInterview, path);
             } else {
-                // Calculate the completion percentage based on the next section index and total sections.
-                // The percentage will be 100% when the last section (completed section) is started.
-                const MAXIMUM_COMPLETION_PERCENTAGE = 100;
-                const currentCompletionPercentage: number = interview?.responses?._completionPercentage || 0;
-                const nextSectionIndex = Object.keys(sections).findIndex((key) => key === section) + 2;
-                const totalSections = Object.keys(sections).length;
-                const nextCompletionPercentage = Number(((nextSectionIndex / totalSections) * 100).toFixed(0));
-                const completionPercentage = Math.min(
-                    MAXIMUM_COMPLETION_PERCENTAGE,
-                    Math.max(currentCompletionPercentage, nextCompletionPercentage)
-                );
+                // Calculate the survey completion percentage based on the number of completed sections
+                const completionPercentage = calculateSurveyCompletionPercentage({
+                    interview,
+                    sections,
+                    sectionName: section,
+                    sectionTarget: 'next'
+                });
 
                 // Mark the section as completed and update the completion percentage
                 // Go to next section

--- a/packages/evolution-frontend/src/services/display/frontendHelper.ts
+++ b/packages/evolution-frontend/src/services/display/frontendHelper.ts
@@ -9,7 +9,7 @@ import moment from 'moment';
 
 import i18n from '../../config/i18n.config';
 import { secondsSinceMidnightToTimeStr } from 'chaire-lib-common/lib/utils/DateTimeUtils';
-import { ButtonAction, Person } from 'evolution-common/lib/services/questionnaire/types';
+import { ButtonAction, Person, VisitedPlace } from 'evolution-common/lib/services/questionnaire/types';
 
 type GenderedData = {
     [gender: string]: {

--- a/packages/evolution-generator/src/scripts/generate_UI_tests.py
+++ b/packages/evolution-generator/src/scripts/generate_UI_tests.py
@@ -110,6 +110,10 @@ def generate_UI_tests(input_file: str, output_file: str):
                     f"/********** Tests {current_section} section **********/\n\n"
                 )
 
+                # Add a section progress bar test for the section
+                ts_code += f"// Progress bar test for {section} section\n"
+                ts_code += f"testHelpers.sectionProgressBarTest({{ context, sectionName: '{section}', completionPercentage: 0 }});\n\n"
+
             # Adjust path for widgets in groups using mappings or '?' for unknown groups
             if group:
                 # TODO: Get the group mapping from the Group widget path

--- a/packages/evolution-generator/src/scripts/generate_section_configs.py
+++ b/packages/evolution-generator/src/scripts/generate_section_configs.py
@@ -146,11 +146,12 @@ def generate_section_configs(excel_file_path: str, section_config_output_folder:
                 ts_section_code += f"{INDENT}nextSection: nextSectionName,\n"
                 if parent_section is not None:
                     ts_section_code += f"{INDENT}parentSection: parentSectionName,\n"
-                if title_en and title_fr is not None and in_nav == True:
+                if title_en and title_fr is not None:
                     ts_section_code += f"{INDENT}title: {{\n"
                     ts_section_code += f"{INDENT}{INDENT}fr: '{title_fr}',\n"
                     ts_section_code += f"{INDENT}{INDENT}en: '{title_en}'\n"
                     ts_section_code += f"{INDENT}}},\n"
+                if title_en and title_fr is not None and in_nav == True:
                     ts_section_code += f"{INDENT}menuName: {{\n"
                     ts_section_code += f"{INDENT}{INDENT}fr: '{title_fr}',\n"
                     ts_section_code += f"{INDENT}{INDENT}en: '{title_en}'\n"

--- a/packages/evolution-legacy/src/styles/survey/_survey.scss
+++ b/packages/evolution-legacy/src/styles/survey/_survey.scss
@@ -152,7 +152,7 @@
         .survey-section__progress-bar {
             display: flex;
             gap: 1rem;
-            justify-content: left;
+            justify-content: space-between;
             align-items: center;
             margin: 1rem 0;
 

--- a/packages/evolution-legacy/src/styles/survey/_survey.scss
+++ b/packages/evolution-legacy/src/styles/survey/_survey.scss
@@ -1,168 +1,236 @@
 .form {
-  display: flex;
-  flex-direction: column;
-  >* {
-    margin-bottom: $m-size;
-  }
+    display: flex;
+    flex-direction: column;
+    > * {
+        margin-bottom: $m-size;
+    }
 }
 
 .survey {
-  margin-top: -1.8em;
-  //border-top: 1px solid $black-pale;
-  /*background-image: url(/dist/images/ornaments/ornament_wide_bottom_pale.svg), url(/dist/images/ornaments/ornament_flower_points_pale.svg);
-  background-size: 12rem, 6rem;
-  background-position: center 1.8em, 90% 100.5%;
-  background-repeat: no-repeat, no-repeat;*/
-  background-image: url(../../assets/images/ornaments/ornament_flower_points_pale.svg);
-  background-size: 6rem;
-  background-position: 90% 100.5%;
-  background-repeat: no-repeat;
-  padding: 2em 0 12rem 0;
-  display: flex;
-  align-items: top;
-  justify-content: center;
-  flex: 1;
-  min-height: 100vh; // this is to force the second background to be at the bottom of the window when the section height is smaller
-  
-  &.validation {
-    margin-top: 0;
-    background: none;
-    padding: 1em 0 1rem 0;
-    min-height: inherit;
-  }
-  
-  .apptr__form {
-    /*background: rgba(255,255,255,1);*/
-    /*border: 1px solid rgba(0,0,0,0.1);*/
-    max-width: 100rem;
-    margin: 0 auto;
-  }
-
-  .ornament_bottom {
-    padding-bottom: 3rem;
-    background: linear-gradient(to right, rgba(0,0,0,0.0) 0, $black-pale 30%, $black-pale 70%, rgba(0,0,0,0.0) 100%), url(../../assets/images/ornaments/ornament_wide_bottom_pale.svg);
-    background-size: 100% 1px, 12rem;
-    background-position: left bottom 2.4rem, center bottom 1px;
-    background-repeat: no-repeat, no-repeat;
-    margin-bottom: 1rem;
-  }
-
-
-
-  h2 {
-    width: 100%;
-    text-align: center;
-    font-weight: 300;
-    color: $dark-pale;
-    font-size: $font-size-xlarge;
-    padding: 0;
-    margin: 0;
-  }
-
-  h2::after {
-    content: "";
-    display: block;
-    width: 100%;
-    height: 2.5rem;
-    margin-bottom: 1rem;
-    background: linear-gradient(to right, rgba(0,0,0,0.0) 0, $black-pale 30%, $black-pale 70%, rgba(0,0,0,0.0) 100%), url(../../assets/images/ornaments/ornament_wide_bottom_pale.svg);
-    background-size: 100% 1px, 12rem;
-    background-position: left top, center top 1px;
-    background-repeat: no-repeat, no-repeat;
-  }
-
-  h3 {
-    width: 100%;
-    text-align: center;
-    font-weight: 300;
-    color: $dark-pale;
-    font-size: $font-size-large;
-    padding: 0;
-    margin: 0;
-  }
-
-  h3::after {
-    content: "";
-    display: block;
-    width: 100%;
-    height: 2px;
-    margin-bottom: 0.5rem;
-    background: linear-gradient(to right, rgba(0,0,0,0.0) 0, rgba(0,0,0,0.0) 20%, $black-pale 40%, $black-pale 60%, rgba(0,0,0,0.0) 80%, rgba(0,0,0,0.0) 100%);
-    background-size: 100% 1px;
-    background-position: left top;
+    margin-top: -1.8em;
+    //border-top: 1px solid $black-pale;
+    /*background-image: url(/dist/images/ornaments/ornament_wide_bottom_pale.svg), url(/dist/images/ornaments/ornament_flower_points_pale.svg);
+    background-size: 12rem, 6rem;
+    background-position: center 1.8em, 90% 100.5%;
+    background-repeat: no-repeat, no-repeat;*/
+    background-image: url(../../assets/images/ornaments/ornament_flower_points_pale.svg);
+    background-size: 6rem;
+    background-position: 90% 100.5%;
     background-repeat: no-repeat;
-  }
-
-  .survey-group-object {
-    background-color: rgba(255,255,255,0.4);
-    border: 1px solid rgba(255,255,255,0.7);
-    border-radius: 0 0 1rem 1rem;
-    padding: 1rem;
-    margin-bottom: 2rem;
-  }
-  
-  .survey-group-object + .survey-group-object {
-    margin-top: -1rem;
-  }
-
-  .survey-group-object__title {
-    div {
-      display: 'flex';
-      justify-content: 'center';
-      align-items: 'center';
-    }
-    
-  }
-
-  .survey-section__content {
-    width: 100%;
-    padding: 0 $s-size;
-    @media only screen and (min-width: $desktop-breakpoint) {
-      padding: 0 $l-size;
-    }
-  }
-  
-  .survey-section-nav {
-  
+    padding: 2em 0 12rem 0;
     display: flex;
-    align-items: center;
+    align-items: top;
     justify-content: center;
-    flex-wrap: wrap;
-    margin-bottom: 1rem;
-    
-    .nav-button {
-      color: $dark-pale;
-      font-size: $font-size-medium;
-      font-weight: 700;
-      line-height: 1;
-      text-decoration: none;
-      padding: 0 0.5rem;
-      margin: 0 0;
-      background: none;
-      display: inline-block;
-      border: none;
+    flex: 1;
+    min-height: 100vh; // this is to force the second background to be at the bottom of the window when the section height is smaller
+
+    &.validation {
+        margin-top: 0;
+        background: none;
+        padding: 1em 0 1rem 0;
+        min-height: inherit;
     }
 
-    .completed-section {
-      color: $green;
+    .apptr__form {
+        /*background: rgba(255,255,255,1);*/
+        /*border: 1px solid rgba(0,0,0,0.1);*/
+        max-width: 100rem;
+        margin: 0 auto;
     }
 
-    .active-section, .active-section.completed-section {
-      color: $blue;
+    .ornament_bottom {
+        padding-bottom: 3rem;
+        background: linear-gradient(
+                to right,
+                rgba(0, 0, 0, 0) 0,
+                $black-pale 30%,
+                $black-pale 70%,
+                rgba(0, 0, 0, 0) 100%
+            ),
+            url(../../assets/images/ornaments/ornament_wide_bottom_pale.svg);
+        background-size:
+            100% 1px,
+            12rem;
+        background-position:
+            left bottom 2.4rem,
+            center bottom 1px;
+        background-repeat: no-repeat, no-repeat;
+        margin-bottom: 1rem;
     }
-  
-  }
-  
-  .survey-info-map__map-container {
-    margin-bottom: 1rem;
-  }
 
-  .infoMap-title p {
-    margin-bottom: 0;
-    text-align: center;
-  }
-  
+    h2 {
+        width: 100%;
+        text-align: center;
+        font-weight: 300;
+        color: $dark-pale;
+        font-size: $font-size-xlarge;
+        padding: 0;
+        margin: 0;
+    }
 
+    h2::after {
+        content: '';
+        display: block;
+        width: 100%;
+        height: 2.5rem;
+        margin-bottom: 1rem;
+        background: linear-gradient(
+                to right,
+                rgba(0, 0, 0, 0) 0,
+                $black-pale 30%,
+                $black-pale 70%,
+                rgba(0, 0, 0, 0) 100%
+            ),
+            url(../../assets/images/ornaments/ornament_wide_bottom_pale.svg);
+        background-size:
+            100% 1px,
+            12rem;
+        background-position:
+            left top,
+            center top 1px;
+        background-repeat: no-repeat, no-repeat;
+    }
+
+    h3 {
+        width: 100%;
+        text-align: center;
+        font-weight: 300;
+        color: $dark-pale;
+        font-size: $font-size-large;
+        padding: 0;
+        margin: 0;
+    }
+
+    h3::after {
+        content: '';
+        display: block;
+        width: 100%;
+        height: 2px;
+        margin-bottom: 0.5rem;
+        background: linear-gradient(
+            to right,
+            rgba(0, 0, 0, 0) 0,
+            rgba(0, 0, 0, 0) 20%,
+            $black-pale 40%,
+            $black-pale 60%,
+            rgba(0, 0, 0, 0) 80%,
+            rgba(0, 0, 0, 0) 100%
+        );
+        background-size: 100% 1px;
+        background-position: left top;
+        background-repeat: no-repeat;
+    }
+
+    .survey-group-object {
+        background-color: rgba(255, 255, 255, 0.4);
+        border: 1px solid rgba(255, 255, 255, 0.7);
+        border-radius: 0 0 1rem 1rem;
+        padding: 1rem;
+        margin-bottom: 2rem;
+    }
+
+    .survey-group-object + .survey-group-object {
+        margin-top: -1rem;
+    }
+
+    .survey-group-object__title {
+        div {
+            display: 'flex';
+            justify-content: 'center';
+            align-items: 'center';
+        }
+    }
+
+    .survey-section__content {
+        width: 100%;
+        padding: 0 $s-size;
+        @media only screen and (min-width: $desktop-breakpoint) {
+            padding: 0 $l-size;
+        }
+
+        // For SectionProgressBar.tsx
+        .survey-section__progress-bar {
+            display: flex;
+            gap: 1rem;
+            justify-content: left;
+            align-items: center;
+            margin: 1rem 0;
+
+            // Draw the progress bar as a circle
+            .circular-progress {
+                width: 100px;
+                height: 100px;
+
+                .bg {
+                    fill: none;
+                    stroke: $button-grey-gradient-top; // Background circle color
+                }
+
+                .fg {
+                    fill: none;
+                    stroke: $blue; // Foreground (progress) circle color
+                    stroke-linecap: round;
+                    transform: rotate(-90deg);
+                    transform-origin: center;
+                }
+
+                .percentage-text {
+                    font-size: $font-size-xlarge;
+                    font-weight: 700;
+                    dominant-baseline: middle; // Vertical alignment
+                }
+
+                .completed-text {
+                    font-size: $font-size-small;
+                    font-weight: 300;
+                    dominant-baseline: middle; // Vertical alignment
+                }
+            }
+        }
+    }
+
+    .survey-section-nav {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-wrap: wrap;
+        margin-bottom: 1rem;
+
+        .nav-button {
+            color: $dark-pale;
+            font-size: $font-size-medium;
+            font-weight: 700;
+            line-height: 1;
+            text-decoration: none;
+            padding: 0 0.5rem;
+            margin: 0 0;
+            background: none;
+            display: inline-block;
+            border: none;
+        }
+
+        .completed-section {
+            color: $green;
+        }
+
+        .active-section,
+        .active-section.completed-section {
+            color: $blue;
+        }
+    }
+
+    .survey-info-map__map-container {
+        margin-bottom: 1rem;
+    }
+
+    .infoMap-title p {
+        margin-bottom: 0;
+        text-align: center;
+    }
+
+    .big-text {
+        font-size: $font-size-xlarge;
+        color: black;
+        font-weight: 700;
+    }
 }
-
-


### PR DESCRIPTION
# Pull request

- [x] Cherry-pick from 3e0fcf2
- [x] Cherry-pick bug with section progress and title

## Description
Calculate and save the survey completion percentage when clicking on the 'Save and Continue' button. Put the survey completion inside a circular-progress. Only show SectionProgressBar if the config is hasSectionProgressBar for each section. Add a sectionProgressBarTest UI test. Add these tests to the demo_survey. Also generate the sectionProgressBarTest inside the UI template tests. Format _survey.scss.
Format frontendHelper.test.ts and a responses._completionPercentage inside validateButtonActionWithCompleteSection
Cherry-pick of a314ff3

Run test on 0.3.0 branch 
Enable the basic workflow for the 0.3.0 branch
Cherry-pick from 3e0fcf2
Add the VisitedPlace type and _cloneDeep function in this commit, to fix compilation problems.

The section completion percentage will now start at 0% when the first section begins and will reach 100% once the last section is initiated.
To achieve this, we will disregard completed sections when calculating the total number of sections.
Test the completed page and the section progress bar in the demo survey.
Cherry-pick from dcf8790
Add a few types to solve the compilation problems.

Move the circular progress at the end. 
Move the circular progress at the end of the div so the user will read the title more easily and only focus on the completion rate if needed.
Cherry-pick from 02b84ca

Generate the title when possible. 
We identified a bug that prevented the section title from displaying when the section was not included in the navigation.
To resolve this issue, we will generate the title whenever possible.
Cherry-pick from e120371

Update sectionTarget parameter to use more descriptive values in completion calculations
Cherry-pick from 80776b0