### PR TITLE
Fix bug with SectionProgressBar

### DIFF
--- a/example/demo_survey/tests/test-one-person-helpers.ts
+++ b/example/demo_survey/tests/test-one-person-helpers.ts
@@ -3,7 +3,7 @@ import * as testHelpers from 'evolution-frontend/tests/ui-testing/testHelpers';
 // These functions are used in both the one person and input verification tests, in order to avoid code duplication
 
 export function completeHomePage(context) {
-    testHelpers.sectionProgressBarTest({context, sectionName: 'Home', completionPercentage: 10 });
+    testHelpers.sectionProgressBarTest({context, sectionName: 'Home', completionPercentage: 0 });
     testHelpers.inputStringTest({ context, path: 'accessCode', value: '1111-2222' });
     testHelpers.inputRadioTest({ context, path: 'household.size', value: '1' });
     testHelpers.inputStringTest({ context, path: 'household.carNumber', value: '2' });
@@ -19,7 +19,7 @@ export function completeHomePage(context) {
 };
 
 export function completeHouseholdPage(context) {
-    testHelpers.sectionProgressBarTest({context, sectionName: 'Household members', completionPercentage: 20 });
+    testHelpers.sectionProgressBarTest({context, sectionName: 'Household members', completionPercentage: 11 });
     testHelpers.inputStringTest({ context, path: 'household.persons.${personId[0]}.age', value: '30' });
     testHelpers.inputRadioTest({ context, path: 'household.persons.${personId[0]}.gender', value: 'male' });
     testHelpers.inputSelectTest({ context, path: 'household.persons.${personId[0]}.occupation', value: 'fullTimeWorker' });
@@ -33,17 +33,21 @@ export function completeHouseholdPage(context) {
 };
 
 export function completeProfilePage(context) {
-    testHelpers.sectionProgressBarTest({context, sectionName: 'Profile', completionPercentage: 40 });
+    testHelpers.sectionProgressBarTest({context, sectionName: 'Profile', completionPercentage: 33 });
     testHelpers.inputRadioTest({ context, path: 'household.persons.${personId[0]}.workOnTheRoad', value: false });
     testHelpers.inputRadioTest({ context, path: 'household.persons.${personId[0]}.usualWorkPlaceIsHome', value: true });
     testHelpers.inputNextButtonTest({ context, text: 'Save and continue', nextPageUrl: '/survey/end' });
 };
 
 export function completeEndPage(context) {
-    testHelpers.sectionProgressBarTest({context, sectionName: 'End', completionPercentage: 90 });
+    testHelpers.sectionProgressBarTest({context, sectionName: 'End', completionPercentage: 89 });
     testHelpers.inputSelectTest({ context, path: 'household.residentialPhoneType', value: 'landLine' });
     testHelpers.inputRadioTest({ context, path: 'household.didAlsoRespondByPhone', value: false });
     testHelpers.inputRadioTest({ context, path: 'household.wouldLikeToParticipateInOtherSurveys', value: false });
     testHelpers.inputSelectTest({ context, path: 'household.income', value: '060000_089999' });
     testHelpers.inputNextButtonTest({ context, text: 'Complete interview', nextPageUrl: '/survey/completed' });
 };
+
+export function completeCompletedPage(context) {
+    testHelpers.sectionProgressBarTest({context, sectionName: 'Interview completed', completionPercentage: 100 });
+}

--- a/example/demo_survey/tests/test-one-person-no-trips.UI.spec.ts
+++ b/example/demo_survey/tests/test-one-person-no-trips.UI.spec.ts
@@ -34,4 +34,7 @@ onePersonTestHelpers.completeProfilePage(context);
 // Test the end page
 onePersonTestHelpers.completeEndPage(context);
 
+// Test the completed page
+onePersonTestHelpers.completeCompletedPage(context);
+
 surveyTestHelpers.logout({ context });

--- a/packages/evolution-common/src/utils/helpers.ts
+++ b/packages/evolution-common/src/utils/helpers.ts
@@ -640,7 +640,7 @@ export const isSectionComplete = ({
  * @param {UserInterviewAttributes} options.interview - The interview object.
  * @param {Object} options.sections - The sections object.
  * @param {string} options.sectionName - The shortname of the current section.
- * @param {string} options.sectionTarget - The target section ('current' or 'next').
+ * @param {string} options.sectionTarget - The target section for the completion rate ('currentSection' or 'nextSection').
  * @returns {number} - The calculated completion percentage.
  */
 export const calculateSurveyCompletionPercentage = ({
@@ -652,28 +652,31 @@ export const calculateSurveyCompletionPercentage = ({
     interview: UserInterviewAttributes;
     sections: { [key: string]: unknown };
     sectionName: string;
-    sectionTarget: 'current' | 'next';
+    sectionTarget: 'currentSection' | 'nextSection';
 }): number => {
-    const LAST_SECTION_NAME = 'completed';
+    const LAST_SECTION_NAME = 'completed'; // NOTE: Only survey with the last section named 'completed' are supported for this function.
     const MINIMUM_COMPLETION_PERCENTAGE = 0;
     const MAXIMUM_COMPLETION_PERCENTAGE = 100;
 
+    // Get the stored completion percentage from the interview responses
     const storedCompletionPercentage: number =
         interview?.responses?._completionPercentage || MINIMUM_COMPLETION_PERCENTAGE;
+
+    // Count the number of sections without the last one
     const sectionsWithoutCompleted = Object.keys(sections).filter((sectionName) => sectionName !== LAST_SECTION_NAME);
     const totalSectionsWithoutCompleted = sectionsWithoutCompleted.length;
-    let targetSectionIndex = Object.keys(sections).findIndex((key) => key === sectionName);
 
-    // Increment the index if the section target is 'next'
-    if (sectionTarget === 'next') {
-        targetSectionIndex = Math.min(targetSectionIndex + 1, totalSectionsWithoutCompleted);
+    // Increment the index if the section target is 'nextSection'
+    let sectionTargetIndex = Object.keys(sections).findIndex((key) => key === sectionName);
+    if (sectionTarget === 'nextSection') {
+        sectionTargetIndex = Math.min(sectionTargetIndex + 1, totalSectionsWithoutCompleted);
     }
 
-    const currentCompletionPercentage = Number(((targetSectionIndex / totalSectionsWithoutCompleted) * 100).toFixed(0));
+    // Return the maximum survey completion percentage
+    const targetCompletionPercentage = Number(((sectionTargetIndex / totalSectionsWithoutCompleted) * 100).toFixed(0));
     const completionPercentage = Math.min(
         MAXIMUM_COMPLETION_PERCENTAGE,
-        Math.max(storedCompletionPercentage, currentCompletionPercentage)
+        Math.max(storedCompletionPercentage, targetCompletionPercentage)
     );
-
     return completionPercentage;
 };

--- a/packages/evolution-common/src/utils/helpers.ts
+++ b/packages/evolution-common/src/utils/helpers.ts
@@ -631,3 +631,49 @@ export const isSectionComplete = ({
 
     return isSectionComplete;
 };
+
+/**
+ * Calculate the survey completion percentage based on the number of completed sections.
+ * The percentage begins at 0% when starting the first section and reaches 100% when the last section is initiated.
+ *
+ * @param {Object} options - The options object.
+ * @param {UserInterviewAttributes} options.interview - The interview object.
+ * @param {Object} options.sections - The sections object.
+ * @param {string} options.sectionName - The shortname of the current section.
+ * @param {string} options.sectionTarget - The target section ('current' or 'next').
+ * @returns {number} - The calculated completion percentage.
+ */
+export const calculateSurveyCompletionPercentage = ({
+    interview,
+    sections,
+    sectionName,
+    sectionTarget
+}: {
+    interview: UserInterviewAttributes;
+    sections: { [key: string]: unknown };
+    sectionName: string;
+    sectionTarget: 'current' | 'next';
+}): number => {
+    const LAST_SECTION_NAME = 'completed';
+    const MINIMUM_COMPLETION_PERCENTAGE = 0;
+    const MAXIMUM_COMPLETION_PERCENTAGE = 100;
+
+    const storedCompletionPercentage: number =
+        interview?.responses?._completionPercentage || MINIMUM_COMPLETION_PERCENTAGE;
+    const sectionsWithoutCompleted = Object.keys(sections).filter((sectionName) => sectionName !== LAST_SECTION_NAME);
+    const totalSectionsWithoutCompleted = sectionsWithoutCompleted.length;
+    let targetSectionIndex = Object.keys(sections).findIndex((key) => key === sectionName);
+
+    // Increment the index if the section target is 'next'
+    if (sectionTarget === 'next') {
+        targetSectionIndex = Math.min(targetSectionIndex + 1, totalSectionsWithoutCompleted);
+    }
+
+    const currentCompletionPercentage = Number(((targetSectionIndex / totalSectionsWithoutCompleted) * 100).toFixed(0));
+    const completionPercentage = Math.min(
+        MAXIMUM_COMPLETION_PERCENTAGE,
+        Math.max(storedCompletionPercentage, currentCompletionPercentage)
+    );
+
+    return completionPercentage;
+};

--- a/packages/evolution-frontend/src/components/pageParts/Section.tsx
+++ b/packages/evolution-frontend/src/components/pageParts/Section.tsx
@@ -108,7 +108,7 @@ export const Section: React.FC<SectionProps & WithSurveyContextProps> = (
                         <SectionProgressBar
                             title={props.sectionConfig.title}
                             interview={props.interview}
-                            shortname={props.shortname}
+                            sectionName={props.shortname}
                             sections={props.surveyContext.sections}
                         />
                     </React.Fragment>

--- a/packages/evolution-frontend/src/components/pageParts/SectionProgressBar.tsx
+++ b/packages/evolution-frontend/src/components/pageParts/SectionProgressBar.tsx
@@ -21,7 +21,7 @@ const SectionProgressBar: React.FC<SectionProgressBarProps> = ({ title, intervie
         interview,
         sections,
         sectionName,
-        sectionTarget: 'current'
+        sectionTarget: 'currentSection'
     });
 
     // Circular progress bar properties

--- a/packages/evolution-frontend/src/components/pageParts/SectionProgressBar.tsx
+++ b/packages/evolution-frontend/src/components/pageParts/SectionProgressBar.tsx
@@ -3,26 +3,26 @@ import { useTranslation } from 'react-i18next';
 
 import { I18nData } from 'evolution-common/lib/services/questionnaire/types';
 import { UserInterviewAttributes } from 'evolution-common/lib/services/questionnaire/types';
-import { translateString } from 'evolution-common/lib/utils/helpers';
+import { translateString, calculateSurveyCompletionPercentage } from 'evolution-common/lib/utils/helpers';
 
 type SectionProgressBarProps = {
     title: I18nData;
     interview: UserInterviewAttributes;
-    shortname: string;
+    sectionName: string;
     sections: { [key: string]: any };
 };
 
 // Section Progress Bar Component to show the completion percentage of the survey and the section title
-const SectionProgressBar: React.FC<SectionProgressBarProps> = ({ title, interview, shortname, sections }) => {
+const SectionProgressBar: React.FC<SectionProgressBarProps> = ({ title, interview, sectionName, sections }) => {
     const { t, i18n } = useTranslation();
 
-    // Calculate the completion percentage based on the current section index and total sections.
-    // The percentage will be 100% when the last section (completed section) is started.
-    const maximumCompletionPercentage: number = interview?.responses?._completionPercentage || 0;
-    const currentSectionIndex = Object.keys(sections).findIndex((key) => key === shortname) + 1;
-    const totalSections = Object.keys(sections).length;
-    const currentCompletionPercentage = Number(((currentSectionIndex / totalSections) * 100).toFixed(0));
-    const completionPercentage = Math.max(maximumCompletionPercentage, currentCompletionPercentage);
+    // Calculate the survey completion percentage based on the number of completed sections
+    const completionPercentage = calculateSurveyCompletionPercentage({
+        interview,
+        sections,
+        sectionName,
+        sectionTarget: 'current'
+    });
 
     // Circular progress bar properties
     const radius = 45; // Adjusted radius to fit within 100px diameter
@@ -32,6 +32,7 @@ const SectionProgressBar: React.FC<SectionProgressBarProps> = ({ title, intervie
 
     return (
         <div className="survey-section__progress-bar">
+            <div className="big-text">{translateString(title, i18n, interview, sectionName)} - Section</div>
             {/* Draw a circle with the completion percentage */}
             <svg width="100" height="100" viewBox="0 0 100 100" className="circular-progress">
                 <circle className="bg" cx="50" cy="50" r={radius} strokeWidth={strokeWidth} />
@@ -51,7 +52,6 @@ const SectionProgressBar: React.FC<SectionProgressBarProps> = ({ title, intervie
                     {t('survey:completed')}
                 </text>
             </svg>
-            <div className="big-text">{translateString(title, i18n, interview, shortname)} - Section</div>
         </div>
     );
 };

--- a/packages/evolution-frontend/src/services/display/frontendHelper.ts
+++ b/packages/evolution-frontend/src/services/display/frontendHelper.ts
@@ -156,7 +156,7 @@ export const validateButtonActionWithCompleteSection: ButtonAction = (
                     interview,
                     sections,
                     sectionName: section,
-                    sectionTarget: 'next'
+                    sectionTarget: 'nextSection'
                 });
 
                 // Mark the section as completed and update the completion percentage

--- a/packages/evolution-frontend/src/services/display/frontendHelper.ts
+++ b/packages/evolution-frontend/src/services/display/frontendHelper.ts
@@ -10,6 +10,7 @@ import moment from 'moment';
 import i18n from '../../config/i18n.config';
 import { secondsSinceMidnightToTimeStr } from 'chaire-lib-common/lib/utils/DateTimeUtils';
 import { ButtonAction, Person, VisitedPlace } from 'evolution-common/lib/services/questionnaire/types';
+import { calculateSurveyCompletionPercentage } from 'evolution-common/lib/utils/helpers';
 
 type GenderedData = {
     [gender: string]: {
@@ -150,17 +151,13 @@ export const validateButtonActionWithCompleteSection: ButtonAction = (
             if (typeof saveCallback === 'function') {
                 saveCallback(callbacks, updatedInterview, path);
             } else {
-                // Calculate the completion percentage based on the next section index and total sections.
-                // The percentage will be 100% when the last section (completed section) is started.
-                const MAXIMUM_COMPLETION_PERCENTAGE = 100;
-                const currentCompletionPercentage: number = interview?.responses?._completionPercentage || 0;
-                const nextSectionIndex = Object.keys(sections).findIndex((key) => key === section) + 2;
-                const totalSections = Object.keys(sections).length;
-                const nextCompletionPercentage = Number(((nextSectionIndex / totalSections) * 100).toFixed(0));
-                const completionPercentage = Math.min(
-                    MAXIMUM_COMPLETION_PERCENTAGE,
-                    Math.max(currentCompletionPercentage, nextCompletionPercentage)
-                );
+                // Calculate the survey completion percentage based on the number of completed sections
+                const completionPercentage = calculateSurveyCompletionPercentage({
+                    interview,
+                    sections,
+                    sectionName: section,
+                    sectionTarget: 'next'
+                });
 
                 // Mark the section as completed and update the completion percentage
                 // Go to next section

--- a/packages/evolution-frontend/src/styles/survey/_survey.scss
+++ b/packages/evolution-frontend/src/styles/survey/_survey.scss
@@ -152,7 +152,7 @@
         .survey-section__progress-bar {
             display: flex;
             gap: 1rem;
-            justify-content: left;
+            justify-content: space-between;
             align-items: center;
             margin: 1rem 0;
 

--- a/packages/evolution-generator/src/scripts/generate_section_configs.py
+++ b/packages/evolution-generator/src/scripts/generate_section_configs.py
@@ -151,11 +151,12 @@ def generate_section_configs(excel_file_path: str, section_config_output_folder:
                 ts_section_code += f"{INDENT}nextSection: nextSectionName,\n"
                 if parent_section is not None:
                     ts_section_code += f"{INDENT}parentSection: parentSectionName,\n"
-                if title_en and title_fr is not None and in_nav == True:
+                if title_en and title_fr is not None:
                     ts_section_code += f"{INDENT}title: {{\n"
                     ts_section_code += f"{INDENT}{INDENT}fr: '{title_fr}',\n"
                     ts_section_code += f"{INDENT}{INDENT}en: '{title_en}'\n"
                     ts_section_code += f"{INDENT}}},\n"
+                if title_en and title_fr is not None and in_nav == True:
                     ts_section_code += f"{INDENT}menuName: {{\n"
                     ts_section_code += f"{INDENT}{INDENT}fr: '{title_fr}',\n"
                     ts_section_code += f"{INDENT}{INDENT}en: '{title_en}'\n"


### PR DESCRIPTION
# Pull request

## Description
Fix bug with SectionProgressBar
The section completion percentage will now start at 0% when the first section begins and will reach 100% once the last section is initiated.
To achieve this, we will disregard completed sections when calculating the total number of sections.
Test the completed page and the section progress bar in the demo survey.

Move the circular progress at the end.
Move the circular progress at the end of the div so the user will read the title more easily and only focus on the completion rate if needed.  

Generate the title when possible.
We identified a bug that prevented the section title from displaying when the section was not included in the navigation.
To resolve this issue, we will generate the title whenever possible.

Update sectionTarget parameter to use more descriptive values in completion calculations