### PR TITLE
Admin: Download survey questionnaire list Text file

### DIFF
--- a/example/demo_survey/references/questionnaire_list_en.txt
+++ b/example/demo_survey/references/questionnaire_list_en.txt
@@ -1,0 +1,608 @@
+// NOTE: This is a real example of a questionnaire survey list in English.
+// NOTE: The following content does not represent the actual questions of this demo survey.
+// NOTE: We can generate it with Evolution-Generator.
+
+Section: Home
+
+Please complete the following information regarding your household and home.
+
+How many people live permanently in your household during the week, including yourself?
+
+Does your household own or rent your home?
+- Rent
+- Own
+- I don't know
+- I prefer not to answer
+
+How many motorized vehicles of each type does your household own?
+Do not include carsharing vehicles
+
+Conventional or hybrid (non-plug-in) gasoline-powered car, SUV or pickup truck
+
+
+100% electric or plug-in hybrid vehicle
+
+
+Electric or gasoline-powered two-wheeler requiring a license (motorcycle, moped, scooter)
+
+Do you have access to private off-street parking?
+- Yes
+- No
+- I don't know
+
+City of your home
+
+Address of your home
+
+Postal code of your home (optional)
+For example, H1A 1A1
+
+Positioning your home
+Search for your home using its postal code or address by clicking the button below, or please position the location on the map by navigating, zooming, and clicking. Once the location is located, you can move the point for greater precision.
+
+Is there at least one person in your household with a permanent physical or mental dissability that limits their daily movements?
+- Yes
+- No
+- I prefer not to answer
+
+Do you (or someone in your household) own a secondary home (e.g., cabin)?
+- Yes
+- No, but we plan to have one in the next year
+- No, we do not have any secondary property
+
+Save and continue
+
+
+
+Section: Household
+
+We will now ask you questions about each member of your household.
+
+We will now ask you questions about yourself.
+
+Name or nickname that will allow you to identify this person for the remainder of the survey.
+Can be a nickname, initials, or an identifier that allows you to easily identify each person (eg: 'Me', 'Kiddo', 'Mum', 'JT'). This name is only used during the survey and will not be saved in the final file.
+
+Age
+For babies under the age of 1, write "0"
+
+Gender
+- Man
+- Woman
+- I prefer not to answer
+- Other (specify)
+
+Worker
+Including self-employed, artist, on sick leave or parental leave.
+- Yes, full time
+- Yes, part time
+- No
+
+Student
+- Yes, full time
+- Yes, part time
+- No
+
+Driving license
+- Yes
+- No
+- I don't know
+
+Save and continue
+
+
+
+Section: Transport
+
+Which household member are you?
+
+Do you have a permanent disability that limits your daily movements?
+- Yes
+- No
+
+In the past year, have you driven a carsharing vehicle?
+For example, Communauto
+- Yes
+- No
+- I don't know
+
+Do you have an OPUS card?
+- Yes, with subscription (weekly, monthly, yearly)
+- Yes, without subscription
+- No
+
+Have you used a bikesharing service (eg: BIXI, àVélo) in 2024?
+Please answer even if bikesharing services are not available where you live.
+- Yes, with subscription (weekly, monthly, yearly)
+- Yes, without subscription
+- No
+
+Do you own at least one regular bicycle?
+- Yes
+- No
+
+Do you own at least one electric-assist bicycle?
+- Yes
+- No
+
+Do you own at least one cargo bicycle?
+- Yes
+- No
+
+Is public transit available in your neighbourhood even if you don't personally use it?
+- Yes
+- No
+- I don't know
+
+Save and continue
+
+
+
+Section: Profile
+
+What is your main mode of transport at the moment?
+- Private vehicule as driver
+- Private vehicule as passenger
+- Shared vehicule (e.g. Communauto)
+- Public transit
+- Bike
+- Walk (or wheelchair)
+- Parantrasit
+- Other (specify)
+
+Do you have a workplace outside the home?
+- Yes
+- No
+- I don't know
+
+City of your workplace
+
+Address or name of your workplace
+Alternatively, please provide the postal code or nearest intersection (street 1 / street 2).
+If you have multiple regular workplaces, please indicate the one you go to most often.
+
+Positioning your workplace
+Search for your workplace using its address by clicking the button below, or please position the location on the map by navigating, zooming, and clicking. Once the location is located, you can move the point for greater precision.
+
+On average, over the last 4 weeks, how many times per week did you go to your usual workplace?
+- Never or almost never
+- Less than 1 time / week
+- 1 time / week
+- 2 times / week
+- 3 times / week
+- 4 times / week
+- 5 times / week or more
+
+Over the last 4 weeks, which mode of transport did you use most often to get to your usual workplace?
+- Private vehicule as driver
+- Private vehicule as passenger
+- Shared vehicule (e.g. Communauto)
+- Public transit
+- Bike
+- Walk (or wheelchair)
+- Parantrasit
+- Other (specify)
+
+Do you use any other mode of transport to get to work?
+- Yes
+- No
+
+What is your second most frequent mode of transport to get to work?
+- Private vehicule as driver
+- Private vehicule as passenger
+- Shared vehicule (e.g. Communauto)
+- Public transit
+- Bike
+- Walk (or wheelchair)
+- Parantrasit
+- Other (specify)
+
+Do you have a fixed place of study outside the home?
+- Yes
+- No
+- I don't know
+
+City of your place of study
+
+Name of your place of study
+Alternatively, please provide the address, postal code, or nearest intersection (street 1 / street 2).
+
+Positioning your place of study
+Search for your place of study using its address or its name by clicking the button below, or please position the location on the map by navigating, zooming, and clicking. Once the location is located, you can move the point for greater precision.
+
+On average, over the last 4 weeks, how many times per week did you go to your place of study?
+- Never or almost never
+- Less than 1 time / week
+- 1 time / week
+- 2 times / week
+- 3 times / week
+- 4 times / week
+- 5 times / week or more
+
+Over the last 4 weeks, which mode of transport did you use most often to get to your place of study?
+- Private vehicule as driver
+- Private vehicule as passenger
+- Shared vehicule (e.g. Communauto)
+- Public transit
+- Bike
+- Walk (or wheelchair)
+- Parantrasit
+- Other (specify)
+
+Do you use any other mode of transport to get to your place of study?
+- Yes
+- No
+
+What is your second most frequent mode of transport to get to your place of study?
+- Private vehicule as driver
+- Private vehicule as passenger
+- Shared vehicule (e.g. Communauto)
+- Public transit
+- Bike
+- Walk (or wheelchair)
+- Parantrasit
+- Other (specify)
+
+Save and continue
+
+
+
+Section: Usual places
+
+On average, during the last 4 weeks, how many times per week do you travel outside your home to do activities (including to your workplace and/or study place)?
+- Never or almost never
+- Less than 1 time / week
+- 1 time / week
+- 2 times / week
+- 3 times / week
+- 4 times / week
+- 5 times / week or more
+
+For all of your trips, including for work/study, over the last 4 weeks, how often did you use the following modes?
+
+Walking or wheeling (using a wheelchair)
+- Never or almost never
+- Less than 1 time / week
+- 1 time / week
+- 2 times / week
+- 3 times / week
+- 4 times / week
+- 5 times / week or more
+
+Bicycle
+- Never or almost never
+- Less than 1 time / week
+- 1 time / week
+- 2 times / week
+- 3 times / week
+- 4 times / week
+- 5 times / week or more
+
+Car driver
+- Never or almost never
+- Less than 1 time / week
+- 1 time / week
+- 2 times / week
+- 3 times / week
+- 4 times / week
+- 5 times / week or more
+
+Car passenger
+- Never or almost never
+- Less than 1 time / week
+- 1 time / week
+- 2 times / week
+- 3 times / week
+- 4 times / week
+- 5 times / week or more
+
+Public transit
+- Never or almost never
+- Less than 1 time / week
+- 1 time / week
+- 2 times / week
+- 3 times / week
+- 4 times / week
+- 5 times / week or more
+
+Taxi or ridehailing (e.g. Uber)
+- Never or almost never
+- Less than 1 time / week
+- 1 time / week
+- 2 times / week
+- 3 times / week
+- 4 times / week
+- 5 times / week or more
+
+Paratransit
+- Never or almost never
+- Less than 1 time / week
+- 1 time / week
+- 2 times / week
+- 3 times / week
+- 4 times / week
+- 5 times / week or more
+
+Save and continue
+
+
+
+Section: Stages of change
+
+Among the following statements, which one best describes your use of the car as a driver?
+- I'm satisfied with my use of the car for my daily trips and see no reason to change my mode of transport.
+- I would like to reduce my car use, but it seems impossible.
+- I'm thinking of reducing my use, but I don't know how or when to do it.
+- My goal is to reduce my car use. I know which trip(s) to replace and which mode of transport to use, but I haven't started yet on a regular basis.
+- I'm trying to use other modes of transport than the car as much as possible. I will maintain or reduce my low car use even further in the coming months.
+- I don't use the car at all, or only very rarely. I can hardly reduce my use any further.
+
+Which of the following statements best describe your feeling towards the number of cars owned by your household?
+- My household does not own any vehicles and that is fine.
+- I'm satisfied with the number of vehicle(s) owned by my household. I don't see any reason to change.
+- I would like my household to have an extra vehicle to meet our mobility needs.
+- I would like my household to dispose of one of its vehicles.
+
+You indicated wanting an additional vehicle. Which statement best describes your current thinking?
+- We've started shopping and we know which vehicle we would like.
+- We have not yet made our choice of vehicle.
+- It seems impossible/very difficult at the moment to acquire an additional vehicle.
+
+You indicated wanting to dispose of one of your vehicle. Which statement best describes your current thinking?
+- It seems impossible/very difficult at the moment to dispose of one of our vehicle(s).
+- We are thinking seriously about it, but we don't how or when to do it.
+- We wait until the end of the vehicle's life to get rid of it and not replace it.
+
+Save and continue
+
+
+
+Section: Perceptions
+
+I feel free and independent when I drive a car
+
+A car is primarily a tool to accomplish what I want to do
+
+I only use a car to get from A to B
+
+It doesn’t matter to me what vehicle type I drive
+
+A car can give me a certain status and prestige
+
+I can distinguish myself from others (with my car)
+
+I have fun driving a car
+
+I feel safe when I travel by car
+
+To be in a car is comfortable and relaxing
+
+Save and continue
+
+
+
+Section: Perceptions
+
+Owning a car is expensive
+
+When you drive, you're always stuck in traffic
+
+Car maintenance is an unpleasant obligation
+
+To verify that you are paying attention, please select 8/10 for this question
+
+There are too many cars on the road
+
+Finding a parking space at the places I go is complicated
+
+Save and continue
+
+
+
+Section: Perceptions
+
+I love riding my bike
+
+I feel good after cycling
+
+I can reach many of my important destinations by bike
+
+I'm not the kind of person who rides a bicycle
+
+Cycling can be the quickest way to travel around
+
+I feel safe cycling in the city
+
+Cycling is part of me, of who I am
+
+I identify myself as a cyclist
+
+Save and continue
+
+
+
+Section: Perceptions
+
+I like taking public transport
+
+Taking public transport is relaxing
+
+I can reach many of my important destinations by public transport
+
+I'm not the kind of person who uses public transport
+
+Public transport can be the quickest way to get around
+
+I feel safe using public transport
+
+Getting around by public transport is part of who I am
+
+I identify as a public transport user
+
+Save and continue
+
+
+
+Section: Perceptions
+
+Traveling by {{mainMode}} is something…
+
+... I do frequently
+
+... I do automatically, without thinking
+
+... that belongs to my daily routine
+
+Save and continue
+
+
+
+Section: Perceptions
+
+Please indicate how much you agree with the following statements about your car
+
+Please indicate how much you agree with the following statements about cars in general
+
+If, for X reason, I had to give up my car (and no longer own one), I would be discouraged or angry
+
+If I had to give up my car, it wouldn't be easy, but I'd accept the situation
+
+I can't imagine my life without a car
+
+People close to me would disapprove or criticise me if I took public transport or travelled by bike
+
+People close to me would disapprove or criticise my decision to live without a car
+
+People who are important to me think it's normal to own a car
+
+Most people close to me (friends, colleagues, family, neighbours) own a car
+
+To verify that you are paying attention, please select 3/10 for this question.
+
+I identify myself as a motorist
+
+Save and continue
+
+
+
+Section: Perceptions
+
+I am concerned about environmental and climate issues
+
+I don't really see why I should change my habits when new technologies like electric cars will solve environmental problems
+
+Globally, the use of private cars has negative consequences (ex.: on the environment, on the climate, on population's health, on the quality of living environment).
+
+It's important for me to minimise the environmental footprint of my journeys
+
+Save and continue
+
+
+
+Section: Perceptions
+
+Finally, we would like to know your opinion on various solutions that can address mobility challenges, as well as what you would like to do personally
+
+I'm in favour of policies, regulations and planning that restrict the level of car traffic on our roads
+
+Motorists should pay more (in parking, taxes, etc.) because of the negative impacts of car use on the environment and on communities (GHG emissions, congestion, public finances, health, etc.)
+
+Our leaders should stop waging war on cars
+
+Companies like the one I work for should put in place facilities and measures to encourage us to use public and active transport
+
+Everyone should do their bit by using private cars less
+
+It would be a good idea to reduce the space on the street dedicated to cars (traffic lanes, parking) to leave more space for active modes and public transport (bike lanes, wider sidewalks, reserved lanes for buses and carpooling)
+
+In our neighbourhoods, I am in favour of measures such as reducing the maximum speed and adding speed bumps or curb extensions
+
+Adding lanes or building new roads would reduce congestion
+
+Save and continue
+
+
+
+Section: Perceptions
+
+Complete the sentence by indicating how much you agree with the following statements about your intentions in the coming months. In the future, I intend ...
+
+... inform myself more about the negative impacts associated with private car use
+
+… to increase the frequency at which I use an alternative transport mode for my daily trips (ex.: public transport, walking, cycling, etc.)
+
+... discuss the benefits of active transport (walking, cycling, etc.) with friends, colleagues and family
+
+... publicly demonstrate (e.g. on social networks, at meetings, etc.) my support for initiatives that promote the use of alternative modes of transport to the car (e.g. new cycle infrastructure, protected bus lanes)
+
+... buy a subscription to public transport, bixi or a car-sharing service
+
+... attend a meeting of my borough or city council to discuss mobility issues or propose solutions
+
+Save and continue
+
+
+
+Section: End
+
+What was your household income before taxes (gross income) in 2023?
+- Less than $14,999
+- $15,000 to $29,999
+- $30,000 to $59,999
+- $60,000 to $89,999
+- $90,000 to $119,999
+- $120,000 to $149,999
+- $150,000 and more
+- I don't know
+- I prefer not to answer
+
+Would you be interested in participating in other studies conducted by the Chaire Mobilité at Polytechnique Montréal?
+- Yes
+- No
+
+Email
+
+How do you assess the complexity of this questionnaire?
+
+How much time do you think you spent answering this questionnaire (in minutes)?
+
+Have you been inclined, at any point, to abandon the survey?
+- Yes
+- No
+
+In which section(s) were you inclined to abandon?
+Select all that apply
+- Home
+- Household
+- Transport
+- Profile
+- Usual places
+- Stages of change
+- Perceptions
+
+For which reason(s) were you inclined to abandon (optional)?
+
+Your comments and suggestions about the survey (optional)
+
+Your comments about your transportation experience in your region (optional)
+
+Finish the survey
+
+
+
+Section: Survey completed
+
+Thank you for your participation!
+
+We thank you for taking the time to fill out this survey. Your answers have been recorded. You can edit your answers by clicking on any of the sections in the menu at the top of the page.
+
+Thank you for your participation!
+
+However, there are no adults in your household. We thank you for taking the time to complete this survey.
+
+Thank you for your participation!
+
+Your home location is outside the surveyed territory. We thank you for taking the time to fill out this survey.
+
+
+

--- a/example/demo_survey/references/questionnaire_list_fr.txt
+++ b/example/demo_survey/references/questionnaire_list_fr.txt
@@ -1,0 +1,608 @@
+// NOTE: This is a real example of a questionnaire survey list in French.
+// NOTE: The following content does not represent the actual questions of this demo survey.
+// NOTE: We can generate it with Evolution-Generator.
+
+Section: Domicile
+
+Veuillez compléter les informations suivantes concernant votre ménage et votre domicile.
+
+Combien de personnes habitent votre domicile de façon permanente, y compris vous-même, pendant la semaine ?
+
+Votre ménage est-il locataire ou propriétaire de votre domicile ?
+- Locataire
+- Propriétaire
+- Je ne sais pas
+- Je préfère ne pas répondre
+
+Combien de véhicules motorisés de chaque type posséde votre ménage ?
+Ne pas inclure les véhicules en autopartage
+
+Véhicule automobile, VUS ou camoniette à essence conventionnel ou hybride (non-branchable)
+
+
+Véhicule 100 % électrique ou hybride branchable
+
+
+Deux-roues électrique ou à essence nécessitant un permis (moto, mobylette, scooter)
+
+Avez-vous accès à un stationnement privé hors-rue ?
+- Oui
+- Non
+- Je ne sais pas
+
+Ville de votre domicile
+
+Adresse de votre domicile
+
+Code postal de votre domicile (facultatif)
+Par exemple, H1A 1A1
+
+Positionnement de votre domicile
+Recherchez votre domicile en utilisant son code postal ou son adresse en cliquant sur le bouton ci-dessous, ou veuillez positionner le lieu sur la carte en naviguant, zoomant et cliquant. Une fois le lieu localisé, vous pouvez déplacer le point pour plus de précision.
+
+Y a-t-il au moins une personne dans votre ménage avec une incapacité physique ou mentale permanente qui limite ses déplacements quotidiens ?
+- Oui
+- Non
+- Je préfère ne pas répondre
+
+Possédez-vous (ou quelqu'un de votre ménage) une propriété secondaire (ex. chalet)?
+- Oui
+- Non, mais nous prévoyons en avoir une dans la prochaine année
+- Non, nous n'avons pas de propriété secondaire
+
+Enregistrer et continuer
+
+
+
+Section: Ménage
+
+Nous allons maintenant vous poser des questions concernant chacun des membres de votre ménage.
+
+Nous allons maintenant vous poser des questions vous concernant.
+
+Nom ou surnom pour identifier cette personne pour la suite de l'enquête.
+Peut être un surnom, des initiales, ou encore un identifiant qui vous permet facilement d'identifier chaque personne (ex.: 'Moi', 'Toto', 'Maman', 'PN'). Ce nom est seulement utilisé lors de l'enquête et ne sera pas enregistré dans le fichier final.
+
+Âge
+Pour les bébés de moins de 1 an, inscrivez "0"
+
+Genre
+- Homme
+- Femme
+- Je préfère ne pas répondre
+- Autre (spécifiez)
+
+Travailleur ou travailleuse
+Incluant travailleur autonome, artiste, travailleur en congé de maladie ou parental.
+- Oui, à temps plein
+- Oui, à temps partiel
+- Non
+
+Étudiant(e)
+- Oui, à temps plein
+- Oui, à temps partiel
+- Non
+
+Permis de conduire
+- Oui
+- Non
+- Je ne sais pas
+
+Enregistrer et continuer
+
+
+
+Section: Transport
+
+Quel membre du ménage êtes-vous?
+
+Avez-vous une incapacité permanente qui limite vos déplacements quotidiens?
+- Oui
+- Non
+
+Au cours de la dernière année, avez-vous conduit un véhicule d'autopartage ?
+Par exemple, Communauto
+- Oui
+- Non
+- Je ne sais pas
+
+Avez-vous une carte OPUS ?
+- Oui, avec abonnement (hebdomadaire, mensuel, annuel)
+- Oui, sans abonnement
+- Non
+
+Avez-vous utilisé un service de partage de vélos (ex.: BIXI, àVélo) en 2024 ?
+Veuillez répondre même si les services de partage de vélos ne sont pas disponibles là où vous habitez.
+- Oui, avec abonnement (hebdomadaire, mensuel, annuel)
+- Oui, sans abonnement
+- Non
+
+Possèdez-vous au moins un vélo régulier ?
+- Oui
+- Non
+
+Possèdez-vous au moins un vélo à assistance électrique ?
+- Oui
+- Non
+
+Possèdez-vous au moins un vélo cargo ?
+- Oui
+- Non
+
+Est-ce que le transport collectif est disponible dans votre quartier même si vous ne l'utilisez pas personnellement ?
+- Oui
+- Non
+- Je ne sais pas
+
+Enregistrer et continuer
+
+
+
+Section: Profil
+
+Quel est votre mode de transport principal en ce moment ?
+- Automobile privée comme conducteur·trice
+- Automobile privée comme passager·ère
+- Automobile partagée (ex: Communauto)
+- Transport collectif
+- Vélo
+- Marche (ou chaise roulante)
+- Transport adapté
+- Autre (spécifiez)
+
+Avez-vous un lieu de travail à l'extérieur du domicile ?
+- Oui
+- Non
+- Je ne sais pas
+
+Ville de votre lieu de travail
+
+Adresse ou nom de votre lieu de travail
+Vous pouvez également fournir le code postal ou l'intersection (rue 1 / rue 2) la plus proche.
+Si vous avez plusieurs lieux de travail réguliers, indiquez celui auquel vous vous rendez le plus souvent.
+
+Positionnement de votre lieu de travail
+Recherchez votre lieu de travail en utilisant son adresse en cliquant sur le bouton ci-dessous, ou veuillez positionner le lieu sur la carte en naviguant, zoomant et cliquant. Une fois le lieu localisé, vous pouvez déplacer le point pour plus de précision.
+
+En moyenne, au cours des 4 dernières semaines, combien de fois par semaine vous-êtes vous rendu sur votre lieu de travail habituel ?
+- Jamais ou presque jamais
+- Moins de 1 fois / semaine
+- 1 fois / semaine
+- 2 fois / semaine
+- 3 fois / semaine
+- 4 fois / semaine
+- 5 fois / semaine ou plus
+
+Au cours des 4 dernières semaines, quel mode de transport avez-vous utilisé le plus souvent pour vous rendre à votre lieu de travail habituel ?
+- Automobile privée comme conducteur·trice
+- Automobile privée comme passager·ère
+- Automobile partagée (ex: Communauto)
+- Transport collectif
+- Vélo
+- Marche (ou chaise roulante)
+- Transport adapté
+- Autre (spécifiez)
+
+Utilisez-vous un autre mode de transport pour vous rendre au travail ?
+- Oui
+- Non
+
+Quel est votre deuxième mode de transport le plus fréquent pour vous rendre au travail ?
+- Automobile privée comme conducteur·trice
+- Automobile privée comme passager·ère
+- Automobile partagée (ex: Communauto)
+- Transport collectif
+- Vélo
+- Marche (ou chaise roulante)
+- Transport adapté
+- Autre (spécifiez)
+
+Avez-vous un lieu d'études fixe à l'extérieur du domicile ?
+- Oui
+- Non
+- Je ne sais pas
+
+Ville de votre lieu d'études
+
+Nom de votre lieu d'études
+Vous pouvez également fournir l'adresse, le code postal ou l'intersection (rue 1 / rue 2) la plus proche.
+
+Positionnement de votre lieu d'études
+Recherchez votre lieu d'études en utilisant son adresse ou son nom en cliquant sur le bouton ci-dessous, ou veuillez positionner le lieu sur la carte en naviguant, zoomant et cliquant. Une fois le lieu localisé, vous pouvez déplacer le point pour plus de précision.
+
+En moyenne, au cours des 4 dernières semaines, combien de fois par semaine vous-êtes vous rendu à votre lieu d'études ?
+- Jamais ou presque jamais
+- Moins de 1 fois / semaine
+- 1 fois / semaine
+- 2 fois / semaine
+- 3 fois / semaine
+- 4 fois / semaine
+- 5 fois / semaine ou plus
+
+Au cours des 4 dernières semaines, quel mode de transport avez-vous utilisé le plus souvent pour vous rendre à votre lieu d'études ?
+- Automobile privée comme conducteur·trice
+- Automobile privée comme passager·ère
+- Automobile partagée (ex: Communauto)
+- Transport collectif
+- Vélo
+- Marche (ou chaise roulante)
+- Transport adapté
+- Autre (spécifiez)
+
+Utilisez-vous un autre mode de transport pour vous rendre à votre lieu d'études ?
+- Oui
+- Non
+
+Quel est votre deuxième mode de transport le plus fréquent pour vous rendre à votre lieu d'études ?
+- Automobile privée comme conducteur·trice
+- Automobile privée comme passager·ère
+- Automobile partagée (ex: Communauto)
+- Transport collectif
+- Vélo
+- Marche (ou chaise roulante)
+- Transport adapté
+- Autre (spécifiez)
+
+Enregistrer et continuer
+
+
+
+Section: Lieux Habituels
+
+En moyenne, au cours des 4 dernières semaines, combien de fois par semaine vous déplacez-vous hors de votre domicile pour réaliser des activités (incluant vers vos lieux de travail et/ou d'études) ? 
+- Jamais ou presque jamais
+- Moins de 1 fois / semaine
+- 1 fois / semaine
+- 2 fois / semaine
+- 3 fois / semaine
+- 4 fois / semaine
+- 5 fois / semaine ou plus
+
+Pour l'ensemble de vos déplacements incluant le travail/les études, au cours des 4 dernières semaines, à quelle fréquence utilisez-vous les modes de transport suivants ?
+
+Marche ou chaise roulante
+- Jamais ou presque jamais
+- Moins de 1 fois / semaine
+- 1 fois / semaine
+- 2 fois / semaine
+- 3 fois / semaine
+- 4 fois / semaine
+- 5 fois / semaine ou plus
+
+Vélo
+- Jamais ou presque jamais
+- Moins de 1 fois / semaine
+- 1 fois / semaine
+- 2 fois / semaine
+- 3 fois / semaine
+- 4 fois / semaine
+- 5 fois / semaine ou plus
+
+Auto conducteur
+- Jamais ou presque jamais
+- Moins de 1 fois / semaine
+- 1 fois / semaine
+- 2 fois / semaine
+- 3 fois / semaine
+- 4 fois / semaine
+- 5 fois / semaine ou plus
+
+Auto passager
+- Jamais ou presque jamais
+- Moins de 1 fois / semaine
+- 1 fois / semaine
+- 2 fois / semaine
+- 3 fois / semaine
+- 4 fois / semaine
+- 5 fois / semaine ou plus
+
+Transport collectif
+- Jamais ou presque jamais
+- Moins de 1 fois / semaine
+- 1 fois / semaine
+- 2 fois / semaine
+- 3 fois / semaine
+- 4 fois / semaine
+- 5 fois / semaine ou plus
+
+Taxi ou service de transport avec chauffeur (ex.: Uber)
+- Jamais ou presque jamais
+- Moins de 1 fois / semaine
+- 1 fois / semaine
+- 2 fois / semaine
+- 3 fois / semaine
+- 4 fois / semaine
+- 5 fois / semaine ou plus
+
+Transport adapté
+- Jamais ou presque jamais
+- Moins de 1 fois / semaine
+- 1 fois / semaine
+- 2 fois / semaine
+- 3 fois / semaine
+- 4 fois / semaine
+- 5 fois / semaine ou plus
+
+Enregistrer et continuer
+
+
+
+Section: Étapes du changement
+
+Parmi les énoncés suivants, lequel décrit le mieux votre sentiment vis-à-vis de votre utilisation de l'automobile à titre de conducteur ou conductrice ?
+- Je suis satisfait(e) de mon utilisation de l’auto pour mes déplacements quotidiens et je ne vois aucune raison de changer de mode de transport.
+- J’aimerais réduire mon utilisation de l’auto, mais cela me semble impossible.
+- Je pense à réduire mon utilisation, mais je ne sais pas comment ni quand le faire.
+- J’ai comme objectif de réduire mon utilisation de l’auto. Je sais quel(s) trajet(s) remplacer et quel mode de transport utiliser, mais je n’ai pas encore commencé à le faire de manière régulière.
+- J’essaie d’utiliser le plus possible d’autres modes de transport que l’auto. Je vais maintenir ou réduire encore plus ma faible utilisation de l’auto dans les mois à venir.
+- Je n'utilise pas ou que très rarement l'automobile. Je peux difficilement réduire davantage mon utilisation.
+
+Lequel des énoncés suivants décrit le mieux votre sentiment par rapport au nombre de véhicules de votre ménage ?
+- Mon ménage ne possède aucun véhicule et c'est très bien ainsi
+- Je suis satisfait·e du nombre de véhicule(s) que mon ménage possède. Je ne vois pas de raison de changer.
+- J'aimerais que mon ménage se procure un véhicule de plus pour répondre à nos besoins de mobilité.
+- J'aimerais que mon ménage se départisse de l'un de ses véhicules.
+
+Vous avez indiqué souhaiter avoir un véhicule de plus. Quel est le niveau d'avancement de votre réflexion ?
+- Nous avons commencer à magasiner et savons quel véhicule nous voulons. 
+- Nous n'avons pas encore fait notre choix de véhicule.
+- Cela nous semble impossible/très difficile présentement d'aquérir un véhicule de plus.
+
+Vous avez indiqué souhaiter vous départir d'un véhicule. Quel est le niveau d'avancement de votre réflexion ?
+- Cela nous semble impossible/très difficile présentement de se départir de l'un de nos véhicules.
+- Nous y pensons sérieusement, mais nous ne savons pas comment ni quand le faire.
+- Nous attendons la fin de vie du véhicule pour s'en débarasser et ne pas le remplacer.
+
+Enregistrer et continuer
+
+
+
+Section: Perceptions
+
+Je me sens libre et indépendant·e lorsque je conduis une voiture
+
+Pour moi, une voiture est avant tout un outil pour accomplir ce que je veux faire
+
+Je n'utilise une voiture que pour aller de A à B.
+
+Le type de véhicule que je conduis n'a pas d'importance pour moi
+
+Une voiture peut me procurer un certain statut et prestige
+
+Je peux me distinguer des autres avec ma voiture.
+
+J'ai du plaisir à me déplacer en voiture
+
+Je me sens en sécurité quand je me déplace en voiture
+
+Me déplacer en voiture est confortable et relaxant
+
+Enregistrer et continuer
+
+
+
+Section: Perceptions
+
+Posséder une auto est dispendieux
+
+En auto, on est toujours pris dans la congestion
+
+Entretenir une auto est une obligation déplaisante
+
+Pour vérifier que vous êtes attentif, veuillez sélectionner 8/10 pour cette question
+
+Il y a trop d'autos sur les routes
+
+Trouver un espace de stationnement aux endroits où je vais est compliqué
+
+Enregistrer et continuer
+
+
+
+Section: Perceptions
+
+J'aime faire du vélo
+
+Je me sens bien après avoir fait du vélo
+
+Je peux me rendre à plusieurs de mes destinations importantes en vélo
+
+Je ne suis pas le genre de personne qui fait du vélo
+
+Le vélo peut être le moyen le plus rapide de se déplacer au quotidien
+
+Je me sens en sécurité à vélo en ville
+
+Faire du vélo fait partie de moi, de qui je suis
+
+Je m'identifie comme un·e cycliste
+
+Enregistrer et continuer
+
+
+
+Section: Perceptions
+
+J'aime prendre le transport collectif
+
+Prendre le transport collectif est relaxant
+
+Je peux me rendre à plusieurs de mes destinations importantes en transport collectif
+
+Je ne suis pas le genre de personne qui utilise les transports en commun
+
+Le transport collectif peut être le moyen le plus rapide de se déplacer
+
+Je me sens en sécurité en transport collectif
+
+Me déplacer en transport collectif fait partie de moi, de qui je suis
+
+Je m'identifie comme un·e usager·ère du transport collectif
+
+Enregistrer et continuer
+
+
+
+Section: Perceptions
+
+Me déplacer en {{mainMode}} est quelque chose…
+
+... que je fais fréquemment
+
+... que je fais de façon automatique, sans réfléchir
+
+... qui fait partie de ma routine quotidienne
+
+Enregistrer et continuer
+
+
+
+Section: Perceptions
+
+Indiquez à quel point vous êtes en accord avec les énoncés suivants concernant votre auto
+
+Indiquez à quel point vous êtes en accord avec les énoncés suivants concernant l'auto en général
+
+Si je devais, pour X raison, me départir de mon auto (et ne plus en posséder une), je serais découragé·e ou en colère
+
+Si je devais me départir de mon auto, ce ne serait pas facile, mais j'accepterais la situation
+
+Je ne peux pas imaginer ma vie sans auto
+
+Mes proches désapprouveraient ou me critiqueraient si je me déplaçais en transport collectif ou en vélo
+
+Mes proches désapprouveraient ou critiqueraient mon choix de vivre sans voiture
+
+Les gens importants pour moi pensent qu'il est normal de posséder une voiture
+
+La plupart de mes proches (amis, collègues, famille, voisins) possèdent une auto
+
+Pour vérifier que vous êtes attentif, veuillez sélectionner 3/10 pour cette question.
+
+Je m'identifie comme un·e automobiliste
+
+Enregistrer et continuer
+
+
+
+Section: Perceptions
+
+Je me considère préoccupé·e par les enjeux environnementaux et climatiques
+
+Je ne vois pas trop pourquoi je changerais mes habitudes alors que de nouvelles technologies comme l'auto électrique règleront les problèmes environnementaux
+
+De façon globale, l'utilisation de l'auto privée amène plusieurs conséquences négatives (ex. sur l'environnement, le climat, la santé de la population, la qualité des milieux de vie).
+
+Il est important pour moi de minimiser l'empreinte environmentale de mes déplacements
+
+Enregistrer et continuer
+
+
+
+Section: Perceptions
+
+Pour terminer, nous aimerions connaître votre opinion sur diverses solutions pouvant répondre aux enjeux de mobilité, ainsi que ce que vous souhaitez faire personnellement
+
+Je suis favorable aux politiques, règlementations et aménagements qui limite la circulation automobile sur nos routes
+
+Les automobilistes devraient payer davantage (en stationnement, en taxes, etc.) en raison des impacts négatifs de l'utilisation de l'auto sur l'environnement et les collectivités (émissions de GES, congestion, finances publiques, santé, etc.)
+
+Nos dirigeant·es devraient arrêter de faire la guerre à l'auto
+
+Les entreprises, comme celle où je travaille, devraient mettre en place des installations et des mesures pour nous encourager à utiliser les transports collectifs et actifs
+
+Chaque individu devrait faire sa part en utilisant moins l'auto privée
+
+Ce serait une bonne idée de réduire l'espace réservé aux voitures sur les rues (voies de circulation, stationnement) pour laisser plus de place aux modes actifs et collectifs (pistes cyclables, trottoirs élargis, voies pour autobus et covoiturage) 
+
+Dans nos quartiers, je suis favorable à des mesures telles la diminution de la vitesse maximale et l'ajout de dos d'ânes ou de saillies de trottoirs
+
+Ajouter des voies ou construire de nouvelles routes permettrait de réduire la congestion
+
+Enregistrer et continuer
+
+
+
+Section: Perceptions
+
+Complétez la phrase en indiquant à quel point vous êtes en accord avec les énoncés suivants concernant vos intentions dans les prochains mois. Dans l'avenir, j'ai l'intention ...
+
+... de m'informer davantage sur les impacts négatifs associés à l'utilisation de l'auto privée
+
+... d'augmenter la fréquence à laquelle j'utilise un mode de transport alternatif pour mes trajets quotidiens (p.ex., transports en commun, marche, vélo)
+
+... de discuter avec mes proches (ami·es, collègues, famille) des bienfaits des transports actifs (marche, vélo, etc.)
+
+... de démontrer publiquement (p.ex., sur les réseaux sociaux, lors de rencontres, etc.) mon appui à des initiatives favorisant l'utilisation de modes de transport alternatifs à l'auto (p.ex., nouvelles infrastructures cyclables, voies protégées pour autobus)
+
+... d'acheter un abonnement au transport collectif, à bixi ou à un service d'autopartage
+
+... de participer à une séance du conseil de mon arrondissement ou de ma ville pour discuter des enjeux de mobilité ou proposer des solutions
+
+Enregistrer et continuer
+
+
+
+Section: Fin
+
+Quel était le revenu de votre ménage avant impôts (revenu brut) en 2023 ?
+- Moins de 14 999 $
+- 15 000 $ à 29 999 $
+- 30 000 $ à 59 999 $
+- 60 000 $ à 89 999 $
+- 90 000 $ à 119 999 $
+- 120 000 $ à 149 999 $
+- 150 000 $ et plus
+- Je ne sais pas
+- Je préfère ne pas répondre
+
+Souhaiteriez-vous participer à d'autres études menées par la Chaire Mobilité de Polytechnique Montréal ?
+- Oui
+- Non
+
+Courriel
+
+Comment évaluez-vous le niveau de complexité de ce questionnaire ?
+
+Combien de temps pensez-vous avoir passé à répondre à ce questionnaire (en minutes) ?
+
+Avez-vous été tenté(e), à un certain point, d'abandonner l'enquête ?
+- Oui
+- Non
+
+Dans quelle(s) section(s) avez-vous été tenté(e) d'abandonner?
+Sélectionnez toutes les réponses appropriées
+- Domicile
+- Ménage
+- Transport
+- Profil
+- Lieux Habituels
+- Étapes du changement
+- Perceptions
+
+Pour quelle(s) raison(s) avez-vous été tenté(e) d'abandonner (facultatif) ?
+
+Vos commentaires et suggestions sur l'enquête (facultatif)
+
+Vos commentaires concernant votre expérience de mobilité dans votre région (facultatif)
+
+Terminer l'enquête
+
+
+
+Section: Questionnaire complété
+
+Merci pour votre participation!
+
+Nous vous remercions d'avoir pris le temps de remplir cette enquête. Vos réponses ont été enregistrées avec succès. Vous pouvez modifier vos réponses en cliquant sur les sections dans le menu ci-dessus.
+
+Merci pour votre participation!
+
+Toutefois, il n'y a pas d'adultes dans votre ménage. Nous vous remercions d'avoir pris le temps de remplir cette enquête.
+
+Merci pour votre participation!
+
+Toutefois, votre domicile n'est pas dans le territoire enquêté. Nous vous remercions d'avoir pris le temps de remplir cette enquête.
+
+
+

--- a/locales/en/admin.json
+++ b/locales/en/admin.json
@@ -139,7 +139,11 @@
     "ServerExportForbidden": "You are not authorized to export data",
     "PrepareDataError": "Unexpected error while preparing data for export",
     "UpdateOrWaitError": "Error while updating export files. Please wait a few seconds and try again",
-    "WaitForFileError": "Error getting the files to export from server"
+    "WaitForFileError": "Error getting the files to export from server",
+    "DownloadSurveyQuestionnaireListTxt": "Download survey questionnaire list - Text file",
+    "DownloadSurveyQuestionnaireListError": "Error while downloading the survey questionnaire list",
+    "DownloadSurveyQuestionnaireListNotFound": "Survey questionnaire list file was not found",
+    "DownloadSurveyQuestionnaireListUnauthorized": "You are not authorized to download the survey questionnaire list"
   },
   "UnknownError": "An unknown error occurred. See console for logs or contact the administrators."
 }

--- a/locales/fr/admin.json
+++ b/locales/fr/admin.json
@@ -139,7 +139,11 @@
     "ServerExportForbidden": "Vous n'êtes pas autorisé à exporter les données d'enquête",
     "PrepareDataError": "Erreur inattendue en préparant les fichiers d'export",
     "UpdateOrWaitError": "Erreur lors de la mise à jour des fichiers d'export. Veuillez ré-essayer plus tard.",
-    "WaitForFileError": "Erreur en attendant la fin de la préparation des fichiers d'export"
+    "WaitForFileError": "Erreur en attendant la fin de la préparation des fichiers d'export",
+    "DownloadSurveyQuestionnaireListTxt": "Télécharger la liste des questionnaires d'enquête - Fichier texte",
+    "DownloadSurveyQuestionnaireListError": "Erreur lors du téléchargement de la liste des questionnaires d'enquête",
+    "DownloadSurveyQuestionnaireListNotFound": "Le fichier de la liste des questionnaires d'enquête est introuvable",
+    "DownloadSurveyQuestionnaireListUnauthorized": "Vous n'êtes pas autorisé à télécharger la liste des questionnaires d'enquête"
   },
   "UnknownError": "Une erreur s'est produite. Voir les logs de la console ou contacter les administrateurs de l'enquête."
 }

--- a/packages/evolution-backend/src/api/admin/__tests__/exports.routes.test.ts
+++ b/packages/evolution-backend/src/api/admin/__tests__/exports.routes.test.ts
@@ -8,26 +8,50 @@ import request from 'supertest';
 import express, { RequestHandler } from 'express';
 import { addExportRoutes } from '../exports.routes';
 import router from 'chaire-lib-backend/lib/api/admin.routes';
-import { exportAllToCsvByObject} from '../../../services/adminExport/exportAllToCsvByObject';
+import { directoryManager } from 'chaire-lib-backend/lib/utils/filesystem/directoryManager';
+import { fileManager } from 'chaire-lib-backend/lib/utils/filesystem/fileManager';
+import { exportAllToCsvByObject } from '../../../services/adminExport/exportAllToCsvByObject';
 
 // Mock the authorization function, isAuthorized returns a function
-jest.mock('chaire-lib-backend/lib/services/auth/authorization', () => jest.fn().mockReturnValue(jest.fn().mockImplementation((req, res, next) => next())));
+jest.mock('chaire-lib-backend/lib/services/auth/authorization', () =>
+    jest.fn().mockReturnValue(jest.fn().mockImplementation((req, res, next) => next()))
+);
 // Mock the export functions
 jest.mock('../../../services/adminExport/exportAllToCsvByObject', () => ({
     exportAllToCsvByObject: jest.fn().mockReturnValue('exportStarted')
 }));
+
+// Mock the file path on server
+jest.mock('chaire-lib-backend/lib/utils/filesystem/directoryManager', () => ({
+    directoryManager: {
+        getAbsolutePath: jest.fn()
+    }
+}));
+
+// Mock the file manager
+jest.mock('chaire-lib-backend/lib/utils/filesystem/fileManager', () => ({
+    fileManager: {
+        fileExistsAbsolute: jest.fn()
+    }
+}));
+
 const exportAllToCsvByObjectMock = exportAllToCsvByObject as jest.MockedFunction<typeof exportAllToCsvByObject>;
+const fileExistsAbsoluteMock = fileManager.fileExistsAbsolute as jest.MockedFunction<
+    typeof fileManager.fileExistsAbsolute
+>;
+const getAbsolutePathMock = directoryManager.getAbsolutePath as jest.MockedFunction<
+    typeof directoryManager.getAbsolutePath
+>;
 
 let app: express.Application;
 beforeAll(() => {
     app = express();
     app.use(express.json() as RequestHandler);
     addExportRoutes();
-    app.use('/api/admin', router)
+    app.use('/api/admin', router);
 });
 
 describe('prepareCsvFileForExportByObject route', () => {
-    
     it('Should prepare validated data by default', async () => {
         const response = await request(app).get('/api/admin/data/prepareCsvFileForExportByObject');
         expect(response.status).toBe(200);
@@ -38,7 +62,9 @@ describe('prepareCsvFileForExportByObject route', () => {
     });
 
     it('Should prepare validated data, if specified', async () => {
-        const response = await request(app).get('/api/admin/data/prepareCsvFileForExportByObject?responseType=validatedIfAvailable');
+        const response = await request(app).get(
+            '/api/admin/data/prepareCsvFileForExportByObject?responseType=validatedIfAvailable'
+        );
         expect(response.status).toBe(200);
         expect(response.body).toEqual({
             status: 'exportStarted'
@@ -47,7 +73,9 @@ describe('prepareCsvFileForExportByObject route', () => {
     });
 
     it('Should prepare validated data, if invalid value is specified', async () => {
-        const response = await request(app).get('/api/admin/data/prepareCsvFileForExportByObject?responseType=unknownType');
+        const response = await request(app).get(
+            '/api/admin/data/prepareCsvFileForExportByObject?responseType=unknownType'
+        );
         expect(response.status).toBe(200);
         expect(response.body).toEqual({
             status: 'exportStarted'
@@ -56,11 +84,63 @@ describe('prepareCsvFileForExportByObject route', () => {
     });
 
     it('Should prepare participant data, if specified', async () => {
-        const response = await request(app).get('/api/admin/data/prepareCsvFileForExportByObject?responseType=participant');
+        const response = await request(app).get(
+            '/api/admin/data/prepareCsvFileForExportByObject?responseType=participant'
+        );
         expect(response.status).toBe(200);
         expect(response.body).toEqual({
             status: 'exportStarted'
         });
         expect(exportAllToCsvByObjectMock).toHaveBeenCalledWith({ responseType: 'participant' });
+    });
+});
+
+describe('downloadSurveyQuestionnaireListTxt route', () => {
+    it('Should return the English questionnaire file if lang is en', async () => {
+        fileExistsAbsoluteMock.mockReturnValueOnce(true);
+        getAbsolutePathMock.mockReturnValueOnce(__dirname + '/questionnaire_list_en.txt');
+
+        const response = await request(app).get('/api/admin/data/downloadSurveyQuestionnaireListTxt?lang=en');
+        expect(response.status).toBe(200);
+        expect(response.header['content-type']).toBe('text/plain; charset=utf-8');
+        expect(response.header['content-disposition']).toContain('attachment; filename=questionnaire_list_en.txt');
+        expect(getAbsolutePathMock).toHaveBeenCalledWith('../references/questionnaire_list_en.txt');
+        expect(getAbsolutePathMock).toHaveReturnedWith(__dirname + '/questionnaire_list_en.txt');
+    });
+
+    it('Should return the French questionnaire file if lang is fr', async () => {
+        fileExistsAbsoluteMock.mockReturnValueOnce(true);
+        getAbsolutePathMock.mockReturnValueOnce(__dirname + '/questionnaire_list_fr.txt');
+
+        const response = await request(app).get('/api/admin/data/downloadSurveyQuestionnaireListTxt?lang=fr');
+        expect(response.status).toBe(200);
+        expect(response.header['content-type']).toBe('text/plain; charset=utf-8');
+        expect(response.header['content-disposition']).toContain('attachment; filename=questionnaire_list_fr.txt');
+        expect(getAbsolutePathMock).toHaveBeenCalledWith('../references/questionnaire_list_fr.txt');
+        expect(getAbsolutePathMock).toHaveReturnedWith(__dirname + '/questionnaire_list_en.txt');
+    });
+
+    it('Should default to English if lang is not provided', async () => {
+        fileExistsAbsoluteMock.mockReturnValueOnce(true);
+        getAbsolutePathMock.mockReturnValueOnce(__dirname + '/questionnaire_list_en.txt');
+
+        const response = await request(app).get('/api/admin/data/downloadSurveyQuestionnaireListTxt');
+        expect(response.status).toBe(200);
+        expect(response.header['content-type']).toBe('text/plain; charset=utf-8');
+        expect(response.header['content-disposition']).toContain('attachment; filename=questionnaire_list_en.txt');
+        expect(getAbsolutePathMock).toHaveBeenCalledWith('../references/questionnaire_list_en.txt');
+        expect(getAbsolutePathMock).toHaveReturnedWith(__dirname + '/questionnaire_list_en.txt');
+    });
+
+    it('Should return 404 if the file does not exist', async () => {
+        fileExistsAbsoluteMock.mockReturnValueOnce(false);
+        getAbsolutePathMock.mockReturnValueOnce(__dirname + '/questionnaire_list_doesNotExist.txt');
+
+        const response = await request(app).get('/api/admin/data/downloadSurveyQuestionnaireListTxt?lang=en');
+        expect(response.status).toBe(404);
+        expect(response.body).toEqual({
+            status: 'notFound',
+            message: 'file does not exist for language: en'
+        });
     });
 });

--- a/packages/evolution-backend/src/api/admin/__tests__/questionnaire_list_en.txt
+++ b/packages/evolution-backend/src/api/admin/__tests__/questionnaire_list_en.txt
@@ -1,0 +1,1 @@
+// This file is a mock of the questionnaire_list_en.txt file.

--- a/packages/evolution-backend/src/api/admin/__tests__/questionnaire_list_fr.txt
+++ b/packages/evolution-backend/src/api/admin/__tests__/questionnaire_list_fr.txt
@@ -1,0 +1,1 @@
+// This file is a mock of the questionnaire_list_fr.txt file.


### PR DESCRIPTION
## Pull request
fix: #650 

## TODO

- [x] Add unit test
- [x] Download the file for real. (Not working yet).
- [x] Move the road to a more logical place.
- [x] Only show if the document is there. Else, put an error.

## Description
Admin: Download survey questionnaire list Text file
Add a new admin data route to download questionnaire list text file in many languages.
Handle possible errors with this new admin data route.
Align to the left all export button, because it's easier to readed.
Put an example file in French and English for questionnaire_list. Normally we generated this with Evolution-Generator.
Add unit tests for the new admin data route, mock some functions to make it works.
Fix some errors messages on ExportInterviewData.tsx: it will now show the localizedMessage.