### PR TITLE
StartUpdateInterview: use named argument instead of positional

### DIFF
--- a/example/demo_survey/src/survey/sections.ts
+++ b/example/demo_survey/src/survey/sections.ts
@@ -90,10 +90,13 @@ const sections: { [sectionName: string]: SectionConfig } = {
     ],
     preload: function (interview, { startUpdateInterview, callback }) {
       if (!getResponse(interview, 'tripsDate')) {
-        startUpdateInterview('home', {
-          'responses.tripsDate': moment().prevBusinessDay().format('YYYY-MM-DD'),
-          'responses._startedAt': moment().unix()
-        }, null, null, callback);
+        startUpdateInterview({
+          sectionShortname: 'home',
+          valuesByPath: {
+            'responses.tripsDate': moment().prevBusinessDay().format('YYYY-MM-DD'),
+            'responses._startedAt': moment().unix()
+          }
+        }, callback);
         return null;
       }
       callback(interview);
@@ -220,10 +223,13 @@ const sections: { [sectionName: string]: SectionConfig } = {
       if (personsCount === 1)
       {
         const personIds = odSurveyHelper.getPersons({ interview });
-        startUpdateInterview('selectPerson', {
-          'responses._activePersonId': Object.keys(personIds)[0],
-          'responses._activeSection': 'profile'
-        }, null, null, callback);
+        startUpdateInterview({
+          sectionShortname: 'selectPerson', 
+          valuesByPath: {
+            'responses._activePersonId': Object.keys(personIds)[0],
+            'responses._activeSection': 'profile'
+          }
+        }, callback);
         return null;
       }
       callback(interview);
@@ -262,15 +268,17 @@ const sections: { [sectionName: string]: SectionConfig } = {
       {
         if ((person.didTripsOnTripsDate !== 'yes' && person.didTripsOnTripsDate !== true) || person.didTripsOnTripsDateKnowTrips === 'no') // if no trip, go to next no trip section
         {
-          startUpdateInterview('profile', {
-            'responses._activeSection': 'travelBehavior'
-          }, null, null, callback);
+          startUpdateInterview({
+            sectionShortname: 'profile',
+            valuesByPath: {'responses._activeSection': 'travelBehavior'}
+          }, callback);
         }
         else
         {
-          startUpdateInterview('profile', {
-            'responses._activeSection': 'tripsIntro'
-          }, null, null, callback);
+          startUpdateInterview({
+            sectionShortname: 'profile', 
+            valuesByPath: { 'responses._activeSection': 'tripsIntro' }
+          }, callback);
         }
         return null;
       }
@@ -309,12 +317,15 @@ const sections: { [sectionName: string]: SectionConfig } = {
       const person = odSurveyHelper.getPerson({ interview }) as any;
       if ((person.didTripsOnTripsDate !== 'yes' && person.didTripsOnTripsDate !== true) || person.didTripsOnTripsDateKnowTrips === 'no') // if no trip, go to next no trip section
       {
-        startUpdateInterview('tripsIntro', {
-          [`responses.household.persons.${person._uuid}.journeys`]: undefined,
-          [`responses.household.persons.${person._uuid}.lastVisitedPlaceNotHome`]: undefined,
-          [`responses.household.persons.${person._uuid}.departurePlaceType`]: undefined,
-          'responses._activeSection': 'travelBehavior'
-        }, null, null, callback);
+        startUpdateInterview({
+          sectionShortname: 'tripsIntro', 
+          valuesByPath: {
+            [`responses.household.persons.${person._uuid}.journeys`]: undefined,
+            [`responses.household.persons.${person._uuid}.lastVisitedPlaceNotHome`]: undefined,
+            [`responses.household.persons.${person._uuid}.departurePlaceType`]: undefined,
+            'responses._activeSection': 'travelBehavior'
+          }
+        }, callback);
         return null;
       }
       else if (person.didTripsOnTripsDate === 'yes' || person.didTripsOnTripsDate === true)
@@ -327,23 +338,30 @@ const sections: { [sectionName: string]: SectionConfig } = {
             {
               const firstVisitedPlace         = visitedPlaces[0];
               const firstVisitedPlaceActivity = firstVisitedPlace ? firstVisitedPlace.activity : null;
-              startUpdateInterview('tripsIntro', {
-                [`responses.household.persons.${person._uuid}.journeys.${currentJourney._uuid}.departurePlaceType`]: (firstVisitedPlaceActivity === 'home' ? 'home' : 'other'),
-                'responses._activeSection': 'visitedPlaces',
-                'responses._activeJourneyId': currentJourney._uuid
-              }, null, null, callback);
+              startUpdateInterview({
+                sectionShortname: 'tripsIntro', 
+                valuesByPath: {
+                  [`responses.household.persons.${person._uuid}.journeys.${currentJourney._uuid}.departurePlaceType`]: (firstVisitedPlaceActivity === 'home' ? 'home' : 'other'),
+                  'responses._activeSection': 'visitedPlaces',
+                  'responses._activeJourneyId': currentJourney._uuid
+                }
+              }, callback);
             }
         } else {
             // Make sure to set initialize a journey for this person if it does not exist
-            startUpdateInterview('tripsIntro', {
-                ...(addGroupedObjects(interview, 1, 1, `household.persons.${person._uuid}.journeys`, [{ startDate: getResponse(interview, 'tripsDate') }])),
-            }, null, null, (updatedInterview) => {
+            startUpdateInterview({
+                sectionShortname: 'tripsIntro', 
+                valuesByPath: {
+                  ...(addGroupedObjects(interview, 1, 1, `household.persons.${person._uuid}.journeys`, [{ startDate: getResponse(interview, 'tripsDate') }])),
+                }
+            }, (updatedInterview) => {
                 const _person = odSurveyHelper.getPerson({ interview: updatedInterview});
                 const journeys = odSurveyHelper.getJourneysArray({ person: _person });
                 const currentJourney = journeys[0];
-                startUpdateInterview('visitedPlaces', {
-                    [`responses._activeJourneyId`]: currentJourney._uuid
-                }, null, null, callback);
+                startUpdateInterview({
+                    sectionShortname: 'visitedPlaces', 
+                    valuesByPath: { [`responses._activeJourneyId`]: currentJourney._uuid }
+                }, callback);
             });
         }
       }
@@ -390,9 +408,10 @@ const sections: { [sectionName: string]: SectionConfig } = {
       const person = odSurveyHelper.getPerson({ interview }) as any;
       if ((person.didTripsOnTripsDate !== 'yes' && person.didTripsOnTripsDate !== true) || person.didTripsOnTripsDateKnowTrips === 'no') // if no trip, go to next no trip section
       {
-        startUpdateInterview('tripsIntro', {
-          'responses._activeSection': 'travelBehavior'
-        }, null, null, callback);
+        startUpdateInterview({
+          sectionShortname: 'tripsIntro', 
+          valuesByPath: { 'responses._activeSection': 'travelBehavior' }
+        }, callback);
         return null;
       }
 
@@ -419,23 +438,29 @@ const sections: { [sectionName: string]: SectionConfig } = {
       }
       if (!_isBlank(tripsUpdatesValueByPath))
       {
-        startUpdateInterview('visitedPlaces', tripsUpdatesValueByPath, null, null, function(_interview) {
+        startUpdateInterview({ sectionShortname: 'visitedPlaces', valuesByPath: tripsUpdatesValueByPath}, function(_interview) {
           const _person = odSurveyHelper.getPerson({ interview: _interview });
           const journey = odSurveyHelper.getJourneysArray({ person: _person })[0];
           const selectedVisitedPlaceId = helper.selectNextVisitedPlaceId(odSurveyHelper.getVisitedPlacesArray({ journey }));
-          startUpdateInterview('visitedPlaces', {
-            [`responses._activeVisitedPlaceId`]: selectedVisitedPlaceId,
-            [`responses._activeJourneyId`]: currentJourney._uuid
-          }, null, null, callback);
+          startUpdateInterview({
+            sectionShortname: 'visitedPlaces', 
+            valuesByPath: {
+              [`responses._activeVisitedPlaceId`]: selectedVisitedPlaceId,
+              [`responses._activeJourneyId`]: currentJourney._uuid
+            }
+          }, callback);
         });
       }
       else
       {
         const selectedVisitedPlaceId = helper.selectNextVisitedPlaceId(odSurveyHelper.getVisitedPlacesArray({ journey: currentJourney }));
-        startUpdateInterview('visitedPlaces', {
-          [`responses._activeVisitedPlaceId`]: selectedVisitedPlaceId,
-          [`responses._activeJourneyId`]: currentJourney._uuid
-        }, null, null, callback);
+        startUpdateInterview({
+          sectionShortname: 'visitedPlaces', 
+          valuesByPath: {
+            [`responses._activeVisitedPlaceId`]: selectedVisitedPlaceId,
+            [`responses._activeJourneyId`]: currentJourney._uuid
+          }
+        }, callback);
       }
       return null;
     },
@@ -472,10 +497,13 @@ const sections: { [sectionName: string]: SectionConfig } = {
       if ((interview as any).visibleWidgets.indexOf(`household.persons.${person._uuid}.noSchoolTripReason`) <= -1 && (interview as any).visibleWidgets.indexOf(`household.persons.${person._uuid}.noWorkTripReason`) <= -1 && (interview as any).visibleWidgets.indexOf(`household.persons.${person._uuid}.whoAnsweredForThisPerson`) <= -1)
       {
         const person = odSurveyHelper.getPerson({ interview });
-        startUpdateInterview('travelBehavior', {
-          [`responses.household.persons.${person._uuid}.whoAnsweredForThisPerson`]: person._uuid,
-          'responses._activeSection': 'end'
-        }, null, null, callback);
+        startUpdateInterview({
+          sectionShortname: 'travelBehavior', 
+          valuesByPath: {
+            [`responses.household.persons.${person._uuid}.whoAnsweredForThisPerson`]: person._uuid,
+            'responses._activeSection': 'end'
+          }
+        }, callback);
         return null;
       }
       callback(interview);
@@ -521,19 +549,23 @@ const sections: { [sectionName: string]: SectionConfig } = {
         const person = persons[personId] as any;
         if (person.age >= 5 && _isBlank(person.whoAnsweredForThisPerson))
         {
-          startUpdateInterview('end', {
-            'responses._activePersonId'    : person._uuid,
-            'responses._activeSection'     : 'profile',
-            'responses._showNewPersonPopup': true
-          }, null, null, callback);
+          startUpdateInterview({
+            sectionShortname: 'end', 
+            valuesByPath: {
+              'responses._activePersonId'    : person._uuid,
+              'responses._activeSection'     : 'profile',
+              'responses._showNewPersonPopup': true
+            }
+          }, callback);
           return null;
         }
       }
       if (getResponse(interview, '_showNewPersonPopup', null) !== false)
       {
-        startUpdateInterview('end', {
-          'responses._showNewPersonPopup': false
-        }, null, null, callback);
+        startUpdateInterview({
+          sectionShortname: 'end', 
+          valuesByPath: { 'responses._showNewPersonPopup': false }
+        }, callback);
         return null;
       }
       callback(interview);
@@ -570,25 +602,31 @@ const sections: { [sectionName: string]: SectionConfig } = {
       {
         if (!user || (user && user.is_admin !== true))
         {
-          startUpdateInterview('end', {
-            'responses._partTwoCompletedAt': moment().unix(),
-            'responses._partTwoIsCompleted': true,
-            'responses._completedAt': moment().unix(),
-            'responses._isCompleted': true
-          }, null, null, callback);
+          startUpdateInterview({
+            sectionShortname: 'end', 
+            valuesByPath: {
+              'responses._partTwoCompletedAt': moment().unix(),
+              'responses._partTwoIsCompleted': true,
+              'responses._completedAt': moment().unix(),
+              'responses._isCompleted': true
+            }
+          }, callback);
         }
       }
       else
       {
         if (!user || (user && user.is_admin !== true))
         {
-          startUpdateInterview('end', {
-            'responses._completedAt': moment().unix(),
-            'responses._isCompleted': true
-          }, null, null, callback);
+          startUpdateInterview({
+            sectionShortname: 'end', 
+            valuesByPath: {
+              'responses._completedAt': moment().unix(),
+              'responses._isCompleted': true
+            }
+          }, callback);
         }
       }
-      startUpdateInterview('end', {}, null, null, callback);
+      startUpdateInterview({ sectionShortname: 'end', valuesByPath: {} }, callback);
       return null;
     }
     

--- a/example/demo_survey/src/survey/templates/VisitedPlacesSection.tsx
+++ b/example/demo_survey/src/survey/templates/VisitedPlacesSection.tsx
@@ -73,7 +73,7 @@ export const VisitedPlacesSection: React.FC<SectionProps> = (
             updateValuesByPath[`responses.${beforeLastVisitedPlacePath}.nextPlaceCategory`] = null;
         }
         updateValuesByPath[`responses._activeVisitedPlaceId`] = helper.selectNextVisitedPlaceId(visitedPlaces);
-        props.startUpdateInterview('visitedPlaces', updateValuesByPath);
+        props.startUpdateInterview({ sectionShortname: 'visitedPlaces', valuesByPath: updateValuesByPath });
         }));
     }
 
@@ -82,8 +82,9 @@ export const VisitedPlacesSection: React.FC<SectionProps> = (
         {
             e.preventDefault();
         }
-        props.startUpdateInterview('visitedPlaces', {
-            [`responses._activeVisitedPlaceId`]: visitedPlaceUuid
+        props.startUpdateInterview({
+            sectionShortname: 'visitedPlaces', 
+            valuesByPath: {[`responses._activeVisitedPlaceId`]: visitedPlaceUuid }
         });
     }
   
@@ -387,7 +388,7 @@ export const VisitedPlacesSection: React.FC<SectionProps> = (
               [`validations.household.persons.${person._uuid}.journeys.${currentJourney._uuid}.trips`]: {},
               [`responses._activeSection`]: 'tripsIntro'
             };
-            props.startUpdateInterview('visitedPlaces', valuesByPath);
+            props.startUpdateInterview({ sectionShortname: 'visitedPlaces', valuesByPath });
           }.bind(this)
         }>{t('survey:visitedPlace:resetVisitedPlaces')}</button></div>)}
       </section>

--- a/example/demo_survey/src/survey/widgets/householdMembers.tsx
+++ b/example/demo_survey/src/survey/widgets/householdMembers.tsx
@@ -1093,15 +1093,19 @@ export const buttonSaveNextSectionHouseholdMembers = {
     const householdSize = surveyHelperNew.getResponse(interview, 'household.size', null);
     if (householdSize !== personsCount)
     {
-      callbacks.startUpdateInterview('householdMembers', {
-        [`responses.household.size`]: personsCount,
-        [`responses._activeSection`]: 'selectPerson'
+      callbacks.startUpdateInterview({
+        sectionShortname: 'householdMembers',
+        valuesByPath: {
+          [`responses.household.size`]: personsCount,
+          [`responses._activeSection`]: 'selectPerson'
+        }
       });
     }
     else
     {
-      callbacks.startUpdateInterview('householdMembers', {
-        [`responses._activeSection`]: 'selectPerson'
+      callbacks.startUpdateInterview({
+        sectionShortname: 'householdMembers',
+        valuesByPath: { [`responses._activeSection`]: 'selectPerson' }
       });
     }
     //return null;

--- a/example/demo_survey/src/survey/widgets/visitedPlaces.tsx
+++ b/example/demo_survey/src/survey/widgets/visitedPlaces.tsx
@@ -1553,13 +1553,13 @@ export const buttonSaveVisitedPlace = {
           const currentJourney = journeys[0];
           const visitedPlaces = odSurveyHelper.getVisitedPlacesArray({ journey: currentJourney });
           updateValuesbyPath[`responses._activeVisitedPlaceId`] = helper.selectNextVisitedPlaceId(visitedPlaces);
-          callbacks.startUpdateInterview('visitedPlaces', updateValuesbyPath);
+          callbacks.startUpdateInterview({ sectionShortname: 'visitedPlaces', valuesByPath: updateValuesbyPath });
         }).bind(this));
         return null;
       }
     }
     updateValuesbyPath[`responses._activeVisitedPlaceId`] = helper.selectNextVisitedPlaceId(visitedPlaces);
-    callbacks.startUpdateInterview('visitedPlaces', updateValuesbyPath);
+    callbacks.startUpdateInterview({ sectionShortname: 'visitedPlaces', valuesByPath: updateValuesbyPath });
     return null;
   },
   action: validateButtonAction

--- a/packages/evolution-common/src/services/questionnaire/sections/common/__tests__/widgetsSwitchPerson.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/common/__tests__/widgetsSwitchPerson.test.ts
@@ -138,7 +138,7 @@ describe('buttonSwitchPerson widget', () => {
         expect(action).toBeDefined();
         const callbackMocks = { startUpdateInterview: jest.fn(), startAddGroupedObjects: jest.fn(), startRemoveGroupedObjects: jest.fn() };
         action(callbackMocks, interviewAttributesForTestCases, 'path', 'section', {}, jest.fn());
-        expect(callbackMocks.startUpdateInterview).toHaveBeenCalledWith('section', { 'responses._activeSection': 'selectPerson'});
+        expect(callbackMocks.startUpdateInterview).toHaveBeenCalledWith({ sectionShortname: 'section', valuesByPath: { 'responses._activeSection': 'selectPerson'}});
     });
 
     test('label', () => {

--- a/packages/evolution-common/src/services/questionnaire/sections/common/widgetsSwitchPerson.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/common/widgetsSwitchPerson.ts
@@ -59,8 +59,11 @@ const buttonSwitchPerson: ButtonWidgetConfig = {
         _saveCallback
     ) {
         // FIXME: We navigate to the selectPerson section... That means this widget should be part of a feature that contains this section
-        callbacks.startUpdateInterview(section, {
-            'responses._activeSection': 'selectPerson'
+        callbacks.startUpdateInterview({
+            sectionShortname: section,
+            valuesByPath: {
+                'responses._activeSection': 'selectPerson'
+            }
         });
     }
 };

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/buttonSaveTripSegments.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/buttonSaveTripSegments.test.ts
@@ -149,10 +149,13 @@ describe('getButtonSaveTripSegmentsConfig save callback', () => {
         expect(mockedGetResponse).toHaveBeenCalledWith(interviewAttributesForTestCases, 'path.to.trip.segments', {});
         expect(mockedGetActiveJourney).toHaveBeenCalledWith({ interview: interviewAttributesForTestCases });
         expect(mockedSelectNextIncompleteTrip).toHaveBeenCalledWith({ journey });
-        expect(updateCallbacks.startUpdateInterview).toHaveBeenCalledWith('segments', {
-            'responses.path.to.trip.segments.segment1._isNew': false,
-            'responses.path.to.trip.segments.segment2._isNew': false,
-            'responses._activeTripId': 'trip1'
+        expect(updateCallbacks.startUpdateInterview).toHaveBeenCalledWith({
+            sectionShortname: 'segments',
+            valuesByPath: {
+                'responses.path.to.trip.segments.segment1._isNew': false,
+                'responses.path.to.trip.segments.segment2._isNew': false,
+                'responses._activeTripId': 'trip1'
+            }
         });
     });
 
@@ -168,11 +171,14 @@ describe('getButtonSaveTripSegmentsConfig save callback', () => {
         expect(mockedGetResponse).toHaveBeenCalledWith(interviewAttributesForTestCases, 'path.to.trip.segments', {});
         expect(mockedGetActiveJourney).toHaveBeenCalledWith({ interview: interviewAttributesForTestCases });
         expect(mockedSelectNextIncompleteTrip).not.toHaveBeenCalled();
-        expect(updateCallbacks.startUpdateInterview).toHaveBeenCalledWith('segments', {
-            'responses.path.to.trip.segments.segment1._isNew': false,
-            'responses.path.to.trip.segments.segment2._isNew': false,
-            'responses._activeTripId': null
-        });
+        expect(updateCallbacks.startUpdateInterview).toHaveBeenCalledWith({
+            sectionShortname: 'segments',
+            valuesByPath: {
+                'responses.path.to.trip.segments.segment1._isNew': false,
+                'responses.path.to.trip.segments.segment2._isNew': false,
+                'responses._activeTripId': null
+            }
+        })
     });
 
     test('should set all _isNew to `false` and select no trip if no incomplete trip', () => {
@@ -189,10 +195,13 @@ describe('getButtonSaveTripSegmentsConfig save callback', () => {
         expect(mockedGetResponse).toHaveBeenCalledWith(interviewAttributesForTestCases, 'path.to.trip.segments', {});
         expect(mockedGetActiveJourney).toHaveBeenCalledWith({ interview: interviewAttributesForTestCases });
         expect(mockedSelectNextIncompleteTrip).toHaveBeenCalledWith({ journey });
-        expect(updateCallbacks.startUpdateInterview).toHaveBeenCalledWith('segments', {
-            'responses.path.to.trip.segments.segment1._isNew': false,
-            'responses.path.to.trip.segments.segment2._isNew': false,
-            'responses._activeTripId': null
+        expect(updateCallbacks.startUpdateInterview).toHaveBeenCalledWith({
+            sectionShortname: 'segments',
+            valuesByPath: {
+                'responses.path.to.trip.segments.segment1._isNew': false,
+                'responses.path.to.trip.segments.segment2._isNew': false,
+                'responses._activeTripId': null
+            }
         });
     });
 
@@ -211,8 +220,9 @@ describe('getButtonSaveTripSegmentsConfig save callback', () => {
         expect(mockedGetResponse).toHaveBeenCalledWith(interviewAttributesForTestCases, 'path.to.trip.segments', {});
         expect(mockedGetActiveJourney).toHaveBeenCalledWith({ interview: interviewAttributesForTestCases });
         expect(mockedSelectNextIncompleteTrip).toHaveBeenCalledWith({ journey });
-        expect(updateCallbacks.startUpdateInterview).toHaveBeenCalledWith('segments', {
-            'responses._activeTripId': 'trip1'
+        expect(updateCallbacks.startUpdateInterview).toHaveBeenCalledWith({
+            sectionShortname: 'segments',
+            valuesByPath: { 'responses._activeTripId': 'trip1' }
         });
     });
 

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/sectionSegment.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/sectionSegment.test.ts
@@ -124,8 +124,8 @@ describe('getSegmentsSectionConfig preload function', () => {
     const widgetConfig = getSegmentsSectionConfig({});
 
     const mockCallback = jest.fn();
-    const mockStartUpdateInterview = jest.fn().mockImplementation((section, values, unsetPaths, interview, callback) => {
-        callback(interview);
+    const mockStartUpdateInterview = jest.fn().mockImplementation((data, callback) => {
+        callback(data.interview);
     });
 
     // Mock journey and person for all tests. Individual tests may override if needed
@@ -156,12 +156,15 @@ describe('getSegmentsSectionConfig preload function', () => {
         expect(mockedAddGroupedObjects).toHaveBeenCalledWith(interviewAttributesForTestCases, 1, 1, 'household.persons.testPerson1.journeys.testJourney1.trips', [{ _originVisitedPlaceUuid: 'testPlace1', _destinationVisitedPlaceUuid: 'testPlace2' }]);
         expect(mockedRemoveGroupedObjects).not.toHaveBeenCalled();
         expect(mockStartUpdateInterview).toHaveBeenCalledTimes(2);
-        expect(mockStartUpdateInterview).toHaveBeenNthCalledWith(1, 'segments', {
-            'responses.household.persons.testPerson1.journeys.testJourney1.trips.tripId1': newTrip
-        }, [], undefined, expect.any(Function));
-        expect(mockStartUpdateInterview).toHaveBeenNthCalledWith(2, 'segments', {
-            'responses._activeTripId': null
-        }, undefined, undefined, mockCallback);
+        expect(mockStartUpdateInterview).toHaveBeenNthCalledWith(1, {
+            sectionShortname: 'segments',
+            valuesByPath: { 'responses.household.persons.testPerson1.journeys.testJourney1.trips.tripId1': newTrip },
+            unsetPaths: []
+        }, expect.any(Function));
+        expect(mockStartUpdateInterview).toHaveBeenNthCalledWith(2, {
+            sectionShortname: 'segments',
+            valuesByPath: { 'responses._activeTripId': null }
+        }, mockCallback);
         expect(mockedSelectNextIncompleteTrip).toHaveBeenCalledWith({ journey: activeJourney });
     });
 
@@ -190,10 +193,11 @@ describe('getSegmentsSectionConfig preload function', () => {
         expect(mockedRemoveGroupedObjects).toHaveBeenCalledWith(interviewAttributesForTestCases, pathsToDelete);
         expect(mockedAddGroupedObjects).not.toHaveBeenCalled();
         expect(mockStartUpdateInterview).toHaveBeenCalledTimes(2);
-        expect(mockStartUpdateInterview).toHaveBeenNthCalledWith(1, 'segments', {}, pathsToDelete.flatMap(path => [ `response.${path}`, `validations.${path}` ]), undefined, expect.any(Function));
-        expect(mockStartUpdateInterview).toHaveBeenNthCalledWith(2, 'segments', {
-            'responses._activeTripId': null
-        }, undefined, undefined, mockCallback);
+        expect(mockStartUpdateInterview).toHaveBeenNthCalledWith(1, { sectionShortname: 'segments', valuesByPath: {}, unsetPaths: pathsToDelete.flatMap(path => [ `response.${path}`, `validations.${path}` ]) }, expect.any(Function));
+        expect(mockStartUpdateInterview).toHaveBeenNthCalledWith(2, {
+            sectionShortname: 'segments',
+            valuesByPath: { 'responses._activeTripId': null }
+        }, mockCallback);
         expect(mockedSelectNextIncompleteTrip).toHaveBeenCalledWith({ journey: activeJourney });
     });
 
@@ -217,17 +221,22 @@ describe('getSegmentsSectionConfig preload function', () => {
         expect(mockedRemoveGroupedObjects).not.toHaveBeenCalled();
         expect(mockedAddGroupedObjects).not.toHaveBeenCalled();
         expect(mockStartUpdateInterview).toHaveBeenCalledTimes(2);
-        expect(mockStartUpdateInterview).toHaveBeenNthCalledWith(1, 'segments', {
-            'responses.household.persons.testPerson1.journeys.testJourney1.trips.tripId1._originVisitedPlaceUuid': places[0]._uuid,
-            'responses.household.persons.testPerson1.journeys.testJourney1.trips.tripId1._destinationVisitedPlaceUuid': places[1]._uuid,
-            'responses.household.persons.testPerson1.journeys.testJourney1.trips.tripId1.segments': undefined,
-            'responses.household.persons.testPerson1.journeys.testJourney1.trips.tripId2._originVisitedPlaceUuid': places[1]._uuid,
-            'responses.household.persons.testPerson1.journeys.testJourney1.trips.tripId2._destinationVisitedPlaceUuid': places[2]._uuid,
-            'responses.household.persons.testPerson1.journeys.testJourney1.trips.tripId2.segments': undefined,
-        }, [], undefined, expect.any(Function));
-        expect(mockStartUpdateInterview).toHaveBeenNthCalledWith(2, 'segments', {
-            'responses._activeTripId': null
-        }, undefined, undefined, mockCallback);
+        expect(mockStartUpdateInterview).toHaveBeenNthCalledWith(1, {
+            sectionShortname: 'segments',
+            valuesByPath: {
+                'responses.household.persons.testPerson1.journeys.testJourney1.trips.tripId1._originVisitedPlaceUuid': places[0]._uuid,
+                'responses.household.persons.testPerson1.journeys.testJourney1.trips.tripId1._destinationVisitedPlaceUuid': places[1]._uuid,
+                'responses.household.persons.testPerson1.journeys.testJourney1.trips.tripId1.segments': undefined,
+                'responses.household.persons.testPerson1.journeys.testJourney1.trips.tripId2._originVisitedPlaceUuid': places[1]._uuid,
+                'responses.household.persons.testPerson1.journeys.testJourney1.trips.tripId2._destinationVisitedPlaceUuid': places[2]._uuid,
+                'responses.household.persons.testPerson1.journeys.testJourney1.trips.tripId2.segments': undefined,
+            },
+            unsetPaths: []
+        }, expect.any(Function));
+        expect(mockStartUpdateInterview).toHaveBeenNthCalledWith(2, {
+            sectionShortname: 'segments',
+            valuesByPath: { 'responses._activeTripId': null }
+        }, mockCallback);
         expect(mockedSelectNextIncompleteTrip).toHaveBeenCalledWith({ journey: activeJourney });
     });
 
@@ -253,9 +262,10 @@ describe('getSegmentsSectionConfig preload function', () => {
         expect(mockedRemoveGroupedObjects).not.toHaveBeenCalled();
         expect(mockedAddGroupedObjects).not.toHaveBeenCalled();
         expect(mockStartUpdateInterview).toHaveBeenCalledTimes(1);
-        expect(mockStartUpdateInterview).toHaveBeenCalledWith('segments', {
-            'responses._activeTripId': trips[1]._uuid
-        }, undefined, undefined, mockCallback);
+        expect(mockStartUpdateInterview).toHaveBeenCalledWith({
+            sectionShortname: 'segments',
+            valuesByPath: { 'responses._activeTripId': trips[1]._uuid }
+        }, mockCallback);
     });
 
     test('should go to next section if no active person', () => {
@@ -265,7 +275,7 @@ describe('getSegmentsSectionConfig preload function', () => {
         widgetConfig.preload!(interviewAttributesForTestCases, { startUpdateInterview: mockStartUpdateInterview, startAddGroupedObjects: jest.fn(), startRemoveGroupedObjects: jest.fn(), callback: mockCallback } as any);
 
         expect(mockStartUpdateInterview).toHaveBeenCalledTimes(1);
-        expect(mockStartUpdateInterview).toHaveBeenCalledWith('tripsIntro', { 'responses._activeSection': 'tripsIntro' }, undefined, undefined, mockCallback);
+        expect(mockStartUpdateInterview).toHaveBeenCalledWith({ sectionShortname: 'tripsIntro', valuesByPath: { 'responses._activeSection': 'tripsIntro' } }, mockCallback);
     });
 
     test('should go to next section if no active journey', () => {
@@ -275,7 +285,7 @@ describe('getSegmentsSectionConfig preload function', () => {
         widgetConfig.preload!(interviewAttributesForTestCases, { startUpdateInterview: mockStartUpdateInterview, startAddGroupedObjects: jest.fn(), startRemoveGroupedObjects: jest.fn(), callback: mockCallback } as any);
 
         expect(mockStartUpdateInterview).toHaveBeenCalledTimes(1);
-        expect(mockStartUpdateInterview).toHaveBeenCalledWith('tripsIntro', { 'responses._activeSection': 'tripsIntro' }, undefined, undefined, mockCallback);
+        expect(mockStartUpdateInterview).toHaveBeenCalledWith({ sectionShortname: 'tripsIntro', valuesByPath: { 'responses._activeSection': 'tripsIntro' } }, mockCallback);
     });
 
 });

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/buttonSaveTripSegments.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/buttonSaveTripSegments.ts
@@ -45,7 +45,7 @@ export const getButtonSaveTripSegmentsConfig = (
             const journey = odHelpers.getActiveJourney({ interview });
             const nextTrip = journey !== null ? odHelpers.selectNextIncompleteTrip({ journey }) : null;
             updateValuesbyPath['responses._activeTripId'] = nextTrip ? nextTrip._uuid : null;
-            callbacks.startUpdateInterview('segments', updateValuesbyPath);
+            callbacks.startUpdateInterview({ sectionShortname: 'segments', valuesByPath: updateValuesbyPath });
         },
         conditional: function (interview, path) {
             const segments = getResponse(interview, path, {}, '../segments') as { [segmentId: string]: Segment };

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/sectionSegments.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/sectionSegments.ts
@@ -35,7 +35,7 @@ export const getSegmentsSectionConfig = (
             const currentJourney = odHelpers.getActiveJourney({ interview, person });
             if (person === null || currentJourney === null) {
                 responsesContent['responses._activeSection'] = 'tripsIntro';
-                startUpdateInterview('tripsIntro', responsesContent, undefined, undefined, callback);
+                startUpdateInterview({ sectionShortname: 'tripsIntro', valuesByPath: responsesContent }, callback);
                 return null;
             }
 
@@ -94,10 +94,11 @@ export const getSegmentsSectionConfig = (
 
             if (!_isEmpty(tripsUpdatesValueByPath) || !_isEmpty(tripsUpdatesUnsetPaths)) {
                 startUpdateInterview(
-                    sectionShortname,
-                    tripsUpdatesValueByPath,
-                    tripsUpdatesUnsetPaths,
-                    undefined,
+                    {
+                        sectionShortname,
+                        valuesByPath: tripsUpdatesValueByPath,
+                        unsetPaths: tripsUpdatesUnsetPaths
+                    },
                     (_interview) => {
                         const _currentJourney = odHelpers.getActiveJourney({ interview: _interview });
                         if (_currentJourney === null) {
@@ -106,20 +107,20 @@ export const getSegmentsSectionConfig = (
                                 'No active journey after updating trips in segments section, but there was an active journey earlier. What happened?'
                             );
                             responsesContent['responses._activeTripId'] = null;
-                            startUpdateInterview(sectionShortname, responsesContent, undefined, undefined, callback);
+                            startUpdateInterview({ sectionShortname, valuesByPath: responsesContent }, callback);
                             return;
                         }
                         const selectedTrip = odHelpers.selectNextIncompleteTrip({ journey: _currentJourney });
                         responsesContent['responses._activeTripId'] = selectedTrip !== null ? selectedTrip._uuid : null;
                         // FIXME There was an action generation for the segment section of this person, but the navigator should handle that
-                        startUpdateInterview(sectionShortname, responsesContent, undefined, undefined, callback);
+                        startUpdateInterview({ sectionShortname, valuesByPath: responsesContent }, callback);
                     }
                 );
             } else {
                 const selectedTrip = odHelpers.selectNextIncompleteTrip({ journey: currentJourney });
                 responsesContent['responses._activeTripId'] = selectedTrip !== null ? selectedTrip._uuid : null;
                 // FIXME There was an action generation for the segment section of this person, but the navigator should handle that
-                startUpdateInterview(sectionShortname, responsesContent, undefined, undefined, callback);
+                startUpdateInterview({ sectionShortname, valuesByPath: responsesContent }, callback);
             }
             return null;
         },

--- a/packages/evolution-common/src/services/questionnaire/types/Data.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/Data.ts
@@ -293,24 +293,31 @@ export type GotoFunction = (to: string | { pathname?: string; search?: string })
 /**
  * Type of the callback to send interview updates to the server
  *
- * @param sectionShortname The shortname of the current section
- * @param valuesByPath The values to update in the interview. The key is the
- * path to update and the value is the new value. A dot-separated path will be
- * exploded to the corresponding nested object path.
- * @param unsetPaths The paths to unset in the interview. A dot-separated path
- * will be exploded to the corresponding nested object path.
- * @param interview The current interview
- * @param callback An optional function to call after the interview has been updated
- * @param gotoFunction A function used to redirect the page to a specific URL
+ * @param {Object} data
+ * @param {string} [data.sectionShortname] The shortname of the current section
+ * @param {Object} [data.valuesByPath] The values to update in the interview.
+ * The key is the path to update and the value is the new value. A dot-separated
+ * path will be exploded to the corresponding nested object path.
+ * @param {string[]} [data.unsetPaths] The paths to unset in the interview. A
+ * dot-separated path will be exploded to the corresponding nested object path.
+ * @param {UserRuntimeInterviewAttributes} [data.interview] The current
+ * interview
+ * @param {GotoFunction} [data.gotoFunction] A function used to redirect the
+ * page to a specific URL
+ * @param {(interview: UserRuntimeInterviewAttributes) => void} [callback] An
+ * optional function to call after the interview has been updated
+ *
  * @returns void
  */
 export type StartUpdateInterview = (
-    sectionShortname: string | null,
-    valuesByPath?: { [path: string]: unknown },
-    unsetPaths?: string[],
-    interview?: UserRuntimeInterviewAttributes,
-    callback?: (interview: UserRuntimeInterviewAttributes) => void,
-    gotoFunction?: GotoFunction
+    data: {
+        sectionShortname?: string;
+        valuesByPath?: { [path: string]: unknown };
+        unsetPaths?: string[];
+        interview?: UserRuntimeInterviewAttributes;
+        gotoFunction?: GotoFunction;
+    },
+    callback?: (interview: UserRuntimeInterviewAttributes) => void
 ) => void;
 
 export type StartAddGroupedObjects = (

--- a/packages/evolution-frontend/src/actions/__tests__/Survey.test.ts
+++ b/packages/evolution-frontend/src/actions/__tests__/Survey.test.ts
@@ -130,7 +130,7 @@ describe('Update interview', () => {
         expectedInterviewAsState.sectionLoaded = 'section';
         
         // Do the actual test
-        const callback = SurveyActions.startUpdateInterview('section', _cloneDeep(valuesByPath), undefined, _cloneDeep(interviewAttributes), updateCallback);
+        const callback = SurveyActions.startUpdateInterview({ sectionShortname: 'section', valuesByPath: _cloneDeep(valuesByPath), interview: _cloneDeep(interviewAttributes) }, updateCallback);
         await callback(mockDispatch, mockGetState);
 
         // Verifications
@@ -183,7 +183,7 @@ describe('Update interview', () => {
         (expectedInterviewAsState.validations as any).section1.q2 = true;
         
         // Do the actual test
-        const callback = SurveyActions.startUpdateInterview('section', _cloneDeep(valuesByPath), unsetPaths, _cloneDeep(interviewAttributes), updateCallback);
+        const callback = SurveyActions.startUpdateInterview({ sectionShortname: 'section', valuesByPath: _cloneDeep(valuesByPath), unsetPaths, interview: _cloneDeep(interviewAttributes) }, updateCallback);
         await callback(mockDispatch, mockGetState);
 
         // Verifications
@@ -231,7 +231,7 @@ describe('Update interview', () => {
         expectedInterviewAsState.sectionLoaded = 'section';
         
         // Do the actual test
-        const callback = SurveyActions.startUpdateInterview('section', _cloneDeep(valuesByPath), undefined, _cloneDeep(interviewAttributes), updateCallback);
+        const callback = SurveyActions.startUpdateInterview({ sectionShortname: 'section', valuesByPath: _cloneDeep(valuesByPath), interview:_cloneDeep(interviewAttributes) }, updateCallback);
         await callback(mockDispatch, mockLocalGetState);
 
         // Verifications
@@ -281,7 +281,7 @@ describe('Update interview', () => {
         expectedInterviewAsState.sectionLoaded = 'section';
         
         // Do the actual test
-        const callback = SurveyActions.startUpdateInterview('section', _cloneDeep(valuesByPath), undefined, _cloneDeep(interviewAttributes), updateCallback);
+        const callback = SurveyActions.startUpdateInterview({ sectionShortname: 'section', valuesByPath: _cloneDeep(valuesByPath), interview: _cloneDeep(interviewAttributes) }, updateCallback);
         await callback(mockDispatch, mockGetState);
 
         // Verifications
@@ -325,7 +325,7 @@ describe('Update interview', () => {
         (expectedInterviewToPrepare.responses as any).section1.q1 = 'foo';
         
         // Do the actual test
-        const callback = SurveyActions.startUpdateInterview('section', _cloneDeep(valuesByPath), undefined, _cloneDeep(interviewAttributes), updateCallback);
+        const callback = SurveyActions.startUpdateInterview({ sectionShortname: 'section', valuesByPath: _cloneDeep(valuesByPath), interview: _cloneDeep(interviewAttributes) }, updateCallback);
         await callback(mockDispatch, mockGetState);
 
         // Verifications
@@ -354,7 +354,7 @@ describe('Update interview', () => {
         (expectedInterviewToPrepare.responses as any).section1.q1 = 'foo';
         
         // Do the actual test
-        const callback = SurveyActions.startUpdateInterview('section', _cloneDeep(valuesByPath), undefined, _cloneDeep(interviewAttributes), updateCallback);
+        const callback = SurveyActions.startUpdateInterview({ sectionShortname: 'section', valuesByPath: _cloneDeep(valuesByPath), interview: _cloneDeep(interviewAttributes) }, updateCallback);
         await callback(mockDispatch, mockGetState);
 
         // Verifications
@@ -382,7 +382,7 @@ describe('Update interview', () => {
         const expectedInterviewAsState = _cloneDeep(initialInterview);
 
         // Do the actual test
-        const callback = SurveyActions.startUpdateInterview('section', _cloneDeep(valuesByPath), undefined, _cloneDeep(initialInterview), updateCallback);
+        const callback = SurveyActions.startUpdateInterview({ sectionShortname: 'section', valuesByPath: _cloneDeep(valuesByPath), interview: _cloneDeep(initialInterview) }, updateCallback);
         await callback(mockDispatch, mockGetState);
 
         // Verifications
@@ -438,7 +438,7 @@ describe('startAddGroupedObjects', () => {
         expect(mockedAddGroupedObject).toHaveBeenCalledTimes(1);
         expect(mockedAddGroupedObject).toHaveBeenCalledWith(interviewAttributes, newObjectCnt, insertSeq, path, []);
         expect(startUpdateInterviewSpy).toHaveBeenCalledTimes(1);
-        expect(startUpdateInterviewSpy).toHaveBeenCalledWith(null, defaultAddGroupResponse, undefined, undefined, undefined);
+        expect(startUpdateInterviewSpy).toHaveBeenCalledWith({ valuesByPath: defaultAddGroupResponse }, undefined);
         expect(mockDispatch).toHaveBeenCalledTimes(1);
         expect(mockDispatch).toHaveBeenCalledWith(startUpdateInterviewMock);
     });
@@ -479,7 +479,7 @@ describe('startAddGroupedObjects', () => {
         expect(mockedAddGroupedObject).toHaveBeenCalledTimes(1);
         expect(mockedAddGroupedObject).toHaveBeenCalledWith(interviewAttributes, newObjectCnt, insertSeq, path, attributes);
         expect(startUpdateInterviewSpy).toHaveBeenCalledTimes(1);
-        expect(startUpdateInterviewSpy).toHaveBeenCalledWith(null, defaultAddGroupResponse, undefined, undefined, callback);
+        expect(startUpdateInterviewSpy).toHaveBeenCalledWith({ valuesByPath: defaultAddGroupResponse }, callback);
         expect(mockDispatch).toHaveBeenCalledTimes(1);
         expect(mockDispatch).toHaveBeenCalledWith(startUpdateInterviewMock);
     });
@@ -513,7 +513,7 @@ describe('startRemoveGroupedObjects', () => {
         expect(mockedRemoveGroupedObject).toHaveBeenCalledTimes(1);
         expect(mockedRemoveGroupedObject).toHaveBeenCalledWith(interviewAttributes, paths);
         expect(startUpdateInterviewSpy).toHaveBeenCalledTimes(1);
-        expect(startUpdateInterviewSpy).toHaveBeenCalledWith(null, defaultRemoveGroupResponse[0], defaultRemoveGroupResponse[1], undefined, undefined);
+        expect(startUpdateInterviewSpy).toHaveBeenCalledWith({ valuesByPath: defaultRemoveGroupResponse[0], unsetPaths: defaultRemoveGroupResponse[1] }, undefined);
         expect(mockDispatch).toHaveBeenCalledTimes(1);
         expect(mockDispatch).toHaveBeenCalledWith(startUpdateInterviewMock);
     });
@@ -548,7 +548,7 @@ describe('startRemoveGroupedObjects', () => {
         expect(mockedRemoveGroupedObject).toHaveBeenCalledTimes(1);
         expect(mockedRemoveGroupedObject).toHaveBeenCalledWith(interviewAttributes, paths);
         expect(startUpdateInterviewSpy).toHaveBeenCalledTimes(1);
-        expect(startUpdateInterviewSpy).toHaveBeenCalledWith(null, defaultRemoveGroupResponse[0], defaultRemoveGroupResponse[1], undefined, callback);
+        expect(startUpdateInterviewSpy).toHaveBeenCalledWith({ valuesByPath: defaultRemoveGroupResponse[0], unsetPaths: defaultRemoveGroupResponse[1] }, callback);
         expect(mockDispatch).toHaveBeenCalledTimes(1);
         expect(mockDispatch).toHaveBeenCalledWith(startUpdateInterviewMock);
     });
@@ -606,10 +606,13 @@ describe('startSetInterview', () => {
         }));
         expect(mockDispatch).toHaveBeenCalledTimes(1);
         expect(mockDispatch).toHaveBeenCalledWith(startUpdateInterviewMock);
-        expect(SurveyActions.startUpdateInterview).toHaveBeenCalledWith('sectionFirst',{
-            'responses._activeSection': 'sectionFirst',
-            'responses._browser': expect.anything()
-        }, undefined, returnedInterview, undefined, undefined);
+        expect(SurveyActions.startUpdateInterview).toHaveBeenCalledWith({
+            sectionShortname: 'sectionFirst', 
+            valuesByPath: {
+                'responses._activeSection': 'sectionFirst',
+                'responses._browser': expect.anything()
+            }, interview: returnedInterview
+        });
 
     });
 
@@ -631,12 +634,15 @@ describe('startSetInterview', () => {
         }));
         expect(mockDispatch).toHaveBeenCalledTimes(1);
         expect(mockDispatch).toHaveBeenCalledWith(startUpdateInterviewMock);
-        expect(SurveyActions.startUpdateInterview).toHaveBeenCalledWith('sectionFirst',{
-            'responses._activeSection': 'sectionFirst',
-            'responses._browser': expect.anything(),
-            'responses.fieldA': 'valueA',
-            'responses.fieldB': 'valueB'
-        }, undefined, returnedInterview, undefined, undefined);
+        expect(SurveyActions.startUpdateInterview).toHaveBeenCalledWith({
+            sectionShortname: 'sectionFirst',
+            valuesByPath: {
+                'responses._activeSection': 'sectionFirst',
+                'responses._browser': expect.anything(),
+                'responses.fieldA': 'valueA',
+                'responses.fieldB': 'valueB'
+            }, interview: returnedInterview
+        });
 
     });
 
@@ -679,10 +685,13 @@ describe('startSetInterview', () => {
         }));
         expect(mockDispatch).toHaveBeenCalledTimes(1);
         expect(mockDispatch).toHaveBeenCalledWith(startUpdateInterviewMock);
-        expect(SurveyActions.startUpdateInterview).toHaveBeenCalledWith('sectionFirst',{
-            'responses._activeSection': 'sectionFirst',
-            'responses._browser': expect.anything()
-        }, undefined, returnedInterview, undefined, undefined);
+        expect(SurveyActions.startUpdateInterview).toHaveBeenCalledWith({
+            sectionShortname: 'sectionFirst',
+            valuesByPath: {
+                'responses._activeSection': 'sectionFirst',
+                'responses._browser': expect.anything()
+            }, interview: returnedInterview
+        });
 
     });
 
@@ -779,10 +788,13 @@ describe('startCreateInterview', () => {
         }));
         expect(mockDispatch).toHaveBeenCalledTimes(1);
         expect(mockDispatch).toHaveBeenCalledWith(startUpdateInterviewMock);
-        expect(SurveyActions.startUpdateInterview).toHaveBeenCalledWith('sectionFirst',{
-            'responses._activeSection': 'sectionFirst',
-            'responses._browser': expect.anything()
-        }, undefined, returnedInterview);
+        expect(SurveyActions.startUpdateInterview).toHaveBeenCalledWith({
+            sectionShortname: 'sectionFirst',
+            valuesByPath: {
+                'responses._activeSection': 'sectionFirst',
+                'responses._browser': expect.anything()
+            }, interview: returnedInterview
+        });
 
     });
 
@@ -812,12 +824,15 @@ describe('startCreateInterview', () => {
         }));
         expect(mockDispatch).toHaveBeenCalledTimes(1);
         expect(mockDispatch).toHaveBeenCalledWith(startUpdateInterviewMock);
-        expect(SurveyActions.startUpdateInterview).toHaveBeenCalledWith('sectionFirst',{
-            'responses._activeSection': 'sectionFirst',
-            'responses._browser': expect.anything(),
-            'responses.fieldA': 'valueA',
-            'responses.fieldB': 'valueB'
-        }, undefined, returnedInterview);
+        expect(SurveyActions.startUpdateInterview).toHaveBeenCalledWith({
+            sectionShortname: 'sectionFirst',
+            valuesByPath: {
+                'responses._activeSection': 'sectionFirst',
+                'responses._browser': expect.anything(),
+                'responses.fieldA': 'valueA',
+                'responses.fieldB': 'valueB'
+            }, interview: returnedInterview
+        });
 
     });
 

--- a/packages/evolution-frontend/src/components/admin/pages/ValidateSurvey.tsx
+++ b/packages/evolution-frontend/src/components/admin/pages/ValidateSurvey.tsx
@@ -113,8 +113,9 @@ export class ValidateSurvey extends React.Component<SurveyProps, SurveyState> {
             return null;
         }
         if (allWidgetsValid) {
-            this.props.startUpdateInterview(activeSection, {
-                'responses._activeSection': parentSection
+            this.props.startUpdateInterview({
+                sectionShortname: activeSection,
+                valuesByPath: { 'responses._activeSection': parentSection }
             });
         } else {
             this.setState(
@@ -241,13 +242,8 @@ const ValidateSurveyWrapper = (props) => {
 
     const startSetInterviewAction: StartSetInterview = (interviewUuid, callback) =>
         dispatch(startSetSurveyValidateInterview(interviewUuid, callback));
-    const startUpdateInterviewAction: StartUpdateInterview = (
-        sectionShortname,
-        valuesByPath,
-        unsetPaths,
-        interview,
-        callback
-    ) => dispatch(startUpdateSurveyValidateInterview(sectionShortname, valuesByPath, unsetPaths, interview, callback));
+    const startUpdateInterviewAction: StartUpdateInterview = (data, callback) =>
+        dispatch(startUpdateSurveyValidateInterview(data, callback));
     const startAddGroupedObjectsAction: StartAddGroupedObjects = (
         newObjectsCount,
         insertSequence,

--- a/packages/evolution-frontend/src/components/admin/validations/InterviewStats.tsx
+++ b/packages/evolution-frontend/src/components/admin/validations/InterviewStats.tsx
@@ -67,7 +67,7 @@ const InterviewStats = (props: InterviewStatsProps) => {
     const keepDiscard = ({ choice, personId }) => {
         const valuesByPath = {};
         valuesByPath[`responses.household.persons.${personId}.keepDiscard`] = choice;
-        props.startUpdateInterview(null, valuesByPath, undefined, undefined);
+        props.startUpdateInterview({ valuesByPath });
     };
 
     const interview = props.interview;

--- a/packages/evolution-frontend/src/components/admin/validations/InterviewSummary.tsx
+++ b/packages/evolution-frontend/src/components/admin/validations/InterviewSummary.tsx
@@ -50,7 +50,7 @@ const InterviewSummary = (props: InterviewSummaryProps) => {
     const updateValuesByPath = useCallback(
         (valuesByPath) => {
             dispatch(
-                startUpdateSurveyValidateInterview('validationOnePager', valuesByPath, undefined, undefined, () => {
+                startUpdateSurveyValidateInterview({ sectionShortname: 'validationOnePager', valuesByPath }, () => {
                     /* nothing to do */
                 })
             );

--- a/packages/evolution-frontend/src/components/admin/validations/ValidationCommentForm.tsx
+++ b/packages/evolution-frontend/src/components/admin/validations/ValidationCommentForm.tsx
@@ -31,7 +31,7 @@ const ValidationCommentForm = ({ interview }: ValidationCommentFormProps) => {
             'responses._validationComment': e.target.value
         };
         dispatch(
-            startUpdateSurveyValidateInterview(null, valuesByPath, undefined, undefined, () => {
+            startUpdateSurveyValidateInterview({ valuesByPath }, () => {
                 /* parameter required, but nothing to do */
             })
         );

--- a/packages/evolution-frontend/src/components/admin/validations/ValidationOnePageSummary.tsx
+++ b/packages/evolution-frontend/src/components/admin/validations/ValidationOnePageSummary.tsx
@@ -19,6 +19,7 @@ import { ThunkDispatch } from 'redux-thunk';
 import { SurveyAction } from '../../../store/survey';
 import { InterviewMapProps } from './InterviewMap';
 import { InterviewStatsProps } from './InterviewStats';
+import { StartUpdateInterview } from 'evolution-common/lib/services/questionnaire/types';
 
 const ValidationOnePageSummary = () => {
     const [activePlacePath, setActivePlacePath] = React.useState<string | undefined>(undefined);
@@ -30,8 +31,8 @@ const ValidationOnePageSummary = () => {
     const interview = useSelector((state: RootState) => state.survey.interview) as any;
     const user = useSelector((state: RootState) => state.auth.user);
     const dispatch = useDispatch<ThunkDispatch<RootState, unknown, SurveyAction>>();
-    const startUpdateInterview = (sectionShortname, valuesByPath, unsetPaths, interview, callback) =>
-        dispatch(startUpdateSurveyValidateInterview(sectionShortname, valuesByPath, unsetPaths, interview, callback));
+    const startUpdateInterview: StartUpdateInterview = (data, callback) =>
+        dispatch(startUpdateSurveyValidateInterview(data, callback));
 
     useEffect(() => {
         const loadComponents = async () => {

--- a/packages/evolution-frontend/src/components/pages/Survey.tsx
+++ b/packages/evolution-frontend/src/components/pages/Survey.tsx
@@ -43,7 +43,7 @@ import { ThunkDispatch } from 'redux-thunk';
 import { SurveyAction } from '../../store/survey';
 
 type StartSetInterview = (
-    activeSection: string | null,
+    activeSection: string | undefined,
     surveyUuid: string | undefined,
     preFilledResponses: { [key: string]: unknown } | undefined
 ) => void;
@@ -100,11 +100,11 @@ class Survey extends React.Component<SurveyProps, SurveyState> {
         const existingActiveSection: string | null = this.props.interview
             ? (surveyHelperNew.getResponse(this.props.interview, '_activeSection', null) as string | null)
             : null;
-        const pathSectionShortname: string | null = this.props.sectionShortname || null;
-        const pathSectionParentSection: string | null =
+        const pathSectionShortname: string | undefined = this.props.sectionShortname;
+        const pathSectionParentSection: string | undefined =
             pathSectionShortname && this.props.surveyContext.sections[pathSectionShortname]
-                ? (this.props.surveyContext.sections[pathSectionShortname].parentSection as string | null)
-                : null;
+                ? (this.props.surveyContext.sections[pathSectionShortname].parentSection as string | undefined)
+                : undefined;
         this.props.startSetInterview(
             existingActiveSection || pathSectionParentSection,
             surveyUuid,
@@ -136,8 +136,9 @@ class Survey extends React.Component<SurveyProps, SurveyState> {
             return null;
         }
         if (allWidgetsValid) {
-            this.props.startUpdateInterview(activeSection, {
-                'responses._activeSection': parentSection
+            this.props.startUpdateInterview({
+                sectionShortname: activeSection,
+                valuesByPath: { 'responses._activeSection': parentSection }
             });
         } else {
             this.setState(
@@ -291,13 +292,8 @@ const SurveyWrapper: React.FC = (props) => {
 
     const startSetInterviewAction: StartSetInterview = (sectionShortname, surveyUuid, preFilledResponses) =>
         dispatch(startSetInterview(sectionShortname, surveyUuid, navigate, preFilledResponses));
-    const startUpdateInterviewAction: StartUpdateInterview = (
-        sectionShortname,
-        valuesByPath,
-        unsetPaths,
-        interview,
-        callback
-    ) => dispatch(startUpdateInterview(sectionShortname, valuesByPath, unsetPaths, interview, callback, navigate));
+    const startUpdateInterviewAction: StartUpdateInterview = (data, callback) =>
+        dispatch(startUpdateInterview({ ...data, gotoFunction: navigate }, callback));
     const startAddGroupedObjectsAction: StartAddGroupedObjects = (
         newObjectsCount,
         insertSequence,

--- a/packages/evolution-frontend/src/components/survey/Question.tsx
+++ b/packages/evolution-frontend/src/components/survey/Question.tsx
@@ -125,7 +125,7 @@ export class Question extends React.Component<QuestionProps & WithSurveyContextP
             if (isValid && typeof (widgetConfig as any).saveCallback === 'function') {
                 saveCallback = (widgetConfig as any).saveCallback.bind(this);
             }
-            this.props.startUpdateInterview(this.props.section, valuesByPath, undefined, undefined, saveCallback);
+            this.props.startUpdateInterview({ sectionShortname: this.props.section, valuesByPath }, saveCallback);
         }
 
         if (isWidgetModal(widgetConfig) && this.state.modalIsOpen && isValid) {

--- a/packages/evolution-frontend/src/components/survey/sectionTemplates/TripsAndSegmentsSection.tsx
+++ b/packages/evolution-frontend/src/components/survey/sectionTemplates/TripsAndSegmentsSection.tsx
@@ -43,8 +43,9 @@ export const SegmentsSection: React.FC<SectionProps & WithTranslation & WithSurv
         if (e) {
             e.preventDefault();
         }
-        props.startUpdateInterview('segments', {
-            ['responses._activeTripId']: tripUuid
+        props.startUpdateInterview({
+            sectionShortname: 'segments',
+            valuesByPath: { ['responses._activeTripId']: tripUuid }
         });
     };
 

--- a/packages/evolution-frontend/src/components/survey/sectionTemplates/__tests__/TripsAndSegmentsSection.test.tsx
+++ b/packages/evolution-frontend/src/components/survey/sectionTemplates/__tests__/TripsAndSegmentsSection.test.tsx
@@ -283,8 +283,9 @@ describe('SegmentsSection behavior', () => {
 
         // Find and click (with mousedown/mouseup) on the button itself and make sure the action has been called
         fireEvent.click(editButton!);
-        expect(props.startUpdateInterview).toHaveBeenCalledWith('segments', {
-            ['responses._activeTripId']: 'trip1'
+        expect(props.startUpdateInterview).toHaveBeenCalledWith({
+            sectionShortname: 'segments',
+            valuesByPath: { ['responses._activeTripId']: 'trip1' }
         });
     });
 
@@ -300,8 +301,9 @@ describe('SegmentsSection behavior', () => {
 
         // Find and click (with mousedown/mouseup) on the button itself and make sure the action has been called
         fireEvent.click(editButton!);
-        expect(props.startUpdateInterview).toHaveBeenCalledWith('segments', {
-            ['responses._activeTripId']: 'trip2'
+        expect(props.startUpdateInterview).toHaveBeenCalledWith({
+            sectionShortname: 'segments',
+            valuesByPath: { ['responses._activeTripId']: 'trip2' }
         });
     });
     

--- a/packages/evolution-frontend/src/services/display/__tests__/frontendHelper.test.ts
+++ b/packages/evolution-frontend/src/services/display/__tests__/frontendHelper.test.ts
@@ -158,8 +158,8 @@ describe('validateButtonAction', () => {
     const callbacks = {
         startUpdateInterview: jest
             .fn()
-            .mockImplementation((_shortname, _values, _unset, _interview, callback, _history) =>
-                callback?.({ ...interview, allWidgetsValid: true })
+            .mockImplementation((data, callback) =>
+                callback?.({ ...data.interview, allWidgetsValid: true })
             ),
         startAddGroupedObjects: jest.fn(),
         startRemoveGroupedObjects: jest.fn()
@@ -173,13 +173,10 @@ describe('validateButtonAction', () => {
         validateButtonAction(callbacks, interview, 'path', 'section', { section: { nextSection: 'next' } });
         expect(callbacks.startUpdateInterview).toHaveBeenCalledTimes(2);
         expect(callbacks.startUpdateInterview).toHaveBeenCalledWith(
-            'section',
-            { _all: true },
-            undefined,
-            interview,
+            { sectionShortname: 'section', valuesByPath: { _all: true }, interview },
             expect.any(Function)
         );
-        expect(callbacks.startUpdateInterview).toHaveBeenCalledWith('section', { 'responses._activeSection': 'next' });
+        expect(callbacks.startUpdateInterview).toHaveBeenCalledWith({ sectionShortname: 'section', valuesByPath: { 'responses._activeSection': 'next' } });
     });
 
     test('with callback', () => {
@@ -194,10 +191,7 @@ describe('validateButtonAction', () => {
         );
         expect(callbacks.startUpdateInterview).toHaveBeenCalledTimes(1);
         expect(callbacks.startUpdateInterview).toHaveBeenCalledWith(
-            'section',
-            { _all: true },
-            undefined,
-            interview,
+            { sectionShortname: 'section', valuesByPath: { _all: true }, interview },
             expect.any(Function)
         );
         expect(saveCallback).toHaveBeenCalledWith(callbacks, { ...interview, allWidgetsValid: true }, 'path');
@@ -205,8 +199,8 @@ describe('validateButtonAction', () => {
 
     test('widgets invalid', () => {
         callbacks.startUpdateInterview.mockImplementationOnce(
-            (_shortname, _values, _unset, _interview, callback, _history) =>
-                callback({ ...interview, allWidgetsValid: false })
+            (data, callback) =>
+                callback({ ...data.interview, allWidgetsValid: false })
         );
         const saveCallback = jest.fn();
         validateButtonAction(callbacks, interview, 'path', 'section', {}, saveCallback);
@@ -220,7 +214,7 @@ describe('validateButtonActionWithCompleteSection', () => {
     const callbacks = {
         startUpdateInterview: jest
             .fn()
-            .mockImplementation((_shortname, _values, _unset, _interview, callback, _history) =>
+            .mockImplementation((_data, callback) =>
                 callback?.({ ...interview, allWidgetsValid: true })
             ),
         startAddGroupedObjects: jest.fn(),
@@ -237,16 +231,16 @@ describe('validateButtonActionWithCompleteSection', () => {
         });
         expect(callbacks.startUpdateInterview).toHaveBeenCalledTimes(2);
         expect(callbacks.startUpdateInterview).toHaveBeenCalledWith(
-            'section',
-            { _all: true },
-            undefined,
-            interview,
+            { sectionShortname: 'section', valuesByPath: { _all: true }, interview },
             expect.any(Function)
         );
-        expect(callbacks.startUpdateInterview).toHaveBeenCalledWith('section', {
-            'responses._activeSection': 'next',
-            'responses._sections.section._isCompleted': true,
-            'responses._completionPercentage': 100
+        expect(callbacks.startUpdateInterview).toHaveBeenCalledWith({
+            sectionShortname: 'section', 
+            valuesByPath: {
+                'responses._activeSection': 'next',
+                'responses._sections.section._isCompleted': true,
+                'responses._completionPercentage': 100
+            }
         });
     });
 
@@ -262,10 +256,7 @@ describe('validateButtonActionWithCompleteSection', () => {
         );
         expect(callbacks.startUpdateInterview).toHaveBeenCalledTimes(1);
         expect(callbacks.startUpdateInterview).toHaveBeenCalledWith(
-            'section',
-            { _all: true },
-            undefined,
-            interview,
+            { sectionShortname: 'section', valuesByPath: { _all: true }, interview },
             expect.any(Function)
         );
         expect(saveCallback).toHaveBeenCalledWith(callbacks, { ...interview, allWidgetsValid: true }, 'path');
@@ -273,7 +264,7 @@ describe('validateButtonActionWithCompleteSection', () => {
 
     test('widgets invalid', () => {
         callbacks.startUpdateInterview.mockImplementationOnce(
-            (_shortname, _values, _unset, _interview, callback, _history) =>
+            (_data, callback) =>
                 callback({ ...interview, allWidgetsValid: false })
         );
         const saveCallback = jest.fn();

--- a/packages/evolution-frontend/src/services/display/frontendHelper.ts
+++ b/packages/evolution-frontend/src/services/display/frontendHelper.ts
@@ -121,19 +121,23 @@ export const secondsSinceMidnightToTimeStrWithSuffix = function (
 };
 
 export const validateButtonAction: ButtonAction = (callbacks, interview, path, section, sections, saveCallback) => {
-    callbacks.startUpdateInterview(section, { _all: true }, undefined, interview, (updatedInterview) => {
-        if ((updatedInterview as any).allWidgetsValid) {
-            if (typeof saveCallback === 'function') {
-                saveCallback(callbacks, updatedInterview, path);
-            } else {
-                // go to next section
-                window.scrollTo(0, 0);
-                callbacks.startUpdateInterview(section, {
-                    'responses._activeSection': sections[section].nextSection
-                });
+    callbacks.startUpdateInterview(
+        { sectionShortname: section, valuesByPath: { _all: true }, interview },
+        (updatedInterview) => {
+            if ((updatedInterview as any).allWidgetsValid) {
+                if (typeof saveCallback === 'function') {
+                    saveCallback(callbacks, updatedInterview, path);
+                } else {
+                    // go to next section
+                    window.scrollTo(0, 0);
+                    callbacks.startUpdateInterview({
+                        sectionShortname: section,
+                        valuesByPath: { 'responses._activeSection': sections[section].nextSection }
+                    });
+                }
             }
         }
-    });
+    );
 };
 
 // Add that the section is completed when the button is clicked in addition to navigating to next section
@@ -146,30 +150,36 @@ export const validateButtonActionWithCompleteSection: ButtonAction = (
     sections,
     saveCallback
 ) => {
-    callbacks.startUpdateInterview(section, { _all: true }, undefined, interview, (updatedInterview) => {
-        if ((updatedInterview as any).allWidgetsValid) {
-            if (typeof saveCallback === 'function') {
-                saveCallback(callbacks, updatedInterview, path);
-            } else {
-                // Calculate the survey completion percentage based on the number of completed sections
-                const completionPercentage = calculateSurveyCompletionPercentage({
-                    interview,
-                    sections,
-                    sectionName: section,
-                    sectionTarget: 'nextSection'
-                });
+    callbacks.startUpdateInterview(
+        { sectionShortname: section, valuesByPath: { _all: true }, interview },
+        (updatedInterview) => {
+            if ((updatedInterview as any).allWidgetsValid) {
+                if (typeof saveCallback === 'function') {
+                    saveCallback(callbacks, updatedInterview, path);
+                } else {
+                    // Calculate the survey completion percentage based on the number of completed sections
+                    const completionPercentage = calculateSurveyCompletionPercentage({
+                        interview,
+                        sections,
+                        sectionName: section,
+                        sectionTarget: 'nextSection'
+                    });
 
-                // Mark the section as completed and update the completion percentage
-                // Go to next section
-                window.scrollTo(0, 0);
-                callbacks.startUpdateInterview(section, {
-                    'responses._activeSection': sections[section].nextSection,
-                    [`responses._sections.${section}._isCompleted`]: true,
-                    'responses._completionPercentage': completionPercentage
-                });
+                    // Mark the section as completed and update the completion percentage
+                    // Go to next section
+                    window.scrollTo(0, 0);
+                    callbacks.startUpdateInterview({
+                        sectionShortname: section,
+                        valuesByPath: {
+                            'responses._activeSection': sections[section].nextSection,
+                            [`responses._sections.${section}._isCompleted`]: true,
+                            'responses._completionPercentage': completionPercentage
+                        }
+                    });
+                }
             }
         }
-    });
+    );
 };
 
 /**


### PR DESCRIPTION
The second parameter of the `StartUpdateInterview` function type is not a `data` parameter with typed arguments. The `valuesByPath`, `unsetPaths`, interview` and `gotoFunction` are placed in this argument, to more easily allow for undefined parameters and add eventual new parameters to this call.

The `callback` function is now the third optional parameter of the call.

Update all usages of this call.