### PR TITLE
survey update: add field to differentiate the user action from side e…

### DIFF
--- a/packages/evolution-backend/src/api/survey.common.routes.ts
+++ b/packages/evolution-backend/src/api/survey.common.routes.ts
@@ -62,14 +62,24 @@ export default (router: Router, authorizationMiddleware, loggingMiddleware: Inte
                 delete session.clientValues;
 
                 const content = req.body;
-                if (!content.valuesByPath || !content.interviewId) {
-                    console.log('Missing valuesByPath or unspecified interview ID');
+                if ((!content.valuesByPath && !content.userAction) || !content.interviewId) {
+                    if (!content.valuesByPath && !content.userAction) {
+                        console.log('updateInterview route: Missing valuesByPath or userAction');
+                    } else {
+                        console.log('updateInterview route: Unspecified interview ID');
+                    }
                     return res.status(400).json({ status: 'BadRequest' });
                 }
                 const valuesByPath = content.valuesByPath || {};
                 const unsetPaths = content.unsetPaths || [];
+                const userAction = content.userAction;
 
-                if (unsetPaths.length === 0 && Object.keys(valuesByPath).length === 0 && !sessionClientPaths) {
+                if (
+                    unsetPaths.length === 0 &&
+                    Object.keys(valuesByPath).length === 0 &&
+                    !userAction &&
+                    !sessionClientPaths
+                ) {
                     return res.status(200).json({
                         status: 'success',
                         interviewId: req.params.interviewUuid
@@ -83,6 +93,7 @@ export default (router: Router, authorizationMiddleware, loggingMiddleware: Inte
                     const retInterview = await updateInterview(interview, {
                         valuesByPath,
                         unsetPaths,
+                        userAction,
                         serverValidations: serverConfig.serverValidations,
                         fieldsToUpdate: ['responses', 'validations'],
                         deferredUpdateCallback: async (newValuesByPath) => {

--- a/packages/evolution-common/src/services/questionnaire/types/Data.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/Data.ts
@@ -291,6 +291,23 @@ export interface InterviewStatusAttributesBase {
 export type GotoFunction = (to: string | { pathname?: string; search?: string }) => void | Promise<void>;
 
 /**
+ * Type of the user action that can be sent to the server when updating the
+ * interview. This is used to track the actions of the user in the survey and
+ * to provide a better experience for the user.
+ */
+export type UserAction =
+    | {
+          type: 'buttonClick';
+          buttonId: string;
+      }
+    | {
+          type: 'widgetInteraction';
+          widgetType: string;
+          path: string;
+          value: unknown;
+      };
+
+/**
  * Type of the callback to send interview updates to the server
  *
  * @param {Object} data
@@ -304,6 +321,8 @@ export type GotoFunction = (to: string | { pathname?: string; search?: string })
  * interview
  * @param {GotoFunction} [data.gotoFunction] A function used to redirect the
  * page to a specific URL
+ * @param {UserAction} [data.userAction] The user action that triggered the
+ * update. Leave empty if the update was not triggered by a user action.
  * @param {(interview: UserRuntimeInterviewAttributes) => void} [callback] An
  * optional function to call after the interview has been updated
  *
@@ -316,6 +335,7 @@ export type StartUpdateInterview = (
         unsetPaths?: string[];
         interview?: UserRuntimeInterviewAttributes;
         gotoFunction?: GotoFunction;
+        userAction?: UserAction;
     },
     callback?: (interview: UserRuntimeInterviewAttributes) => void
 ) => void;

--- a/packages/evolution-frontend/src/components/survey/Button.tsx
+++ b/packages/evolution-frontend/src/components/survey/Button.tsx
@@ -10,7 +10,11 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { withSurveyContext, WithSurveyContextProps } from '../hoc/WithSurveyContextHoc';
 import ConfirmModal from 'chaire-lib-frontend/lib/components/modal/ConfirmModal';
-import { ButtonWidgetConfig, UserRuntimeInterviewAttributes } from 'evolution-common/lib/services/questionnaire/types';
+import {
+    ButtonWidgetConfig,
+    StartUpdateInterview,
+    UserRuntimeInterviewAttributes
+} from 'evolution-common/lib/services/questionnaire/types';
 import { WidgetStatus } from 'evolution-common/lib/services/questionnaire/types';
 import * as surveyHelper from 'evolution-common/lib/utils/helpers';
 import { InterviewUpdateCallbacks } from 'evolution-common/lib/services/questionnaire/types';
@@ -49,6 +53,20 @@ const Button: React.FC<ButtonProps & WithSurveyContextProps & WithTranslation> =
         setLoadingState(props.loadingState);
     }, [props.loadingState]);
 
+    const startUpdateInterviewForButtonClick: StartUpdateInterview = React.useCallback(
+        (data, callback) => {
+            // Set the button click user action to the startUpdateInterview call
+            if (data.userAction === undefined) {
+                data.userAction = {
+                    type: 'buttonClick',
+                    buttonId: props.path
+                };
+            }
+            return props.startUpdateInterview(data, callback);
+        },
+        [props.startUpdateInterview]
+    );
+
     const onMouseDown = () => {
         setWasMouseDowned(true);
     };
@@ -65,7 +83,12 @@ const Button: React.FC<ButtonProps & WithSurveyContextProps & WithTranslation> =
     const confirmButton = () => {
         props.widgetConfig.action(
             {
-                startUpdateInterview: props.startUpdateInterview,
+                // FIXME: setting the startUpdateInterview callback to the one
+                // sending the user action will cause multiple calls to this
+                // callback in the action to all send the userAction. If we move
+                // the navigation and side effects to the server, it does not
+                // matter, but a solution would need to be found if not.
+                startUpdateInterview: startUpdateInterviewForButtonClick,
                 startAddGroupedObjects: props.startAddGroupedObjects,
                 startRemoveGroupedObjects: props.startRemoveGroupedObjects
             },

--- a/packages/evolution-frontend/src/components/survey/__tests__/Button.test.tsx
+++ b/packages/evolution-frontend/src/components/survey/__tests__/Button.test.tsx
@@ -15,7 +15,7 @@ expect.extend(toHaveNoViolations);
 
 import { interviewAttributes } from '../../inputs/__tests__/interviewData.test';
 import Button from '../Button';
-import { WidgetStatus } from 'evolution-common/lib/services/questionnaire/types';
+import { ButtonWidgetConfig, InterviewUpdateCallbacks, WidgetStatus } from 'evolution-common/lib/services/questionnaire/types';
 
 // Mock react-markdown and remark-gfm as they use syntax not supported by jest
 jest.mock('react-markdown', () => 'Markdown');
@@ -32,7 +32,7 @@ const userAttributes = {
     showUserInfo: true
 };
 
-const commonWidgetConfig = {
+const commonWidgetConfig: ButtonWidgetConfig = {
     type: 'button' as const,
     label: 'label',
     action: jest.fn()
@@ -185,10 +185,56 @@ describe('Button widget: behavioral tests', () => {
         // The next action should have been called
         expect(commonWidgetConfig.action).toHaveBeenCalledTimes(1);
         expect(commonWidgetConfig.action).toHaveBeenCalledWith({
-            startUpdateInterview: startUpdateInterviewMock,
+            startUpdateInterview: expect.any(Function),
             startAddGroupedObjects: startAddGroupedObjectsMock,
             startRemoveGroupedObjects: startRemoveGroupedObjectsMock
         }, interviewAttributes, 'home.region', 'test', {}, undefined);
+    });
+
+    test('Button click, adding user action', async () => {
+        const testValuesByPath = { testPath: 'testvalue' };
+        // Call the startUpdateInterview, it should add the user action
+        const actionFunction: ButtonWidgetConfig['action'] = jest.fn().mockImplementation((callbacks: InterviewUpdateCallbacks, _i, _p, section) => {
+            callbacks.startUpdateInterview({ sectionShortname: section, valuesByPath: testValuesByPath });
+        });
+        const widgetConfig = {
+            ...commonWidgetConfig,
+            action: actionFunction
+        }
+        render(<Button
+            path='home.region'
+            section='test'
+            loadingState={0}
+            widgetConfig={widgetConfig}
+            interview={interviewAttributes}
+            user={userAttributes}
+            widgetStatus={defaultWidgetStatus}
+            startUpdateInterview={startUpdateInterviewMock}
+            startAddGroupedObjects={startAddGroupedObjectsMock}
+            startRemoveGroupedObjects={startRemoveGroupedObjectsMock}
+        />);
+        const user = userEvent.setup();
+
+        // Find and click (with mousedown/mouseup) on the button itself and make sure the action has been called
+        expect(screen.getByRole('button')).toBeInTheDocument();
+        await user.click(screen.getByRole('button'));
+
+        // The next action should have been called
+        expect(actionFunction).toHaveBeenCalledTimes(1);
+        expect(actionFunction).toHaveBeenCalledWith({
+            startUpdateInterview: expect.any(Function),
+            startAddGroupedObjects: startAddGroupedObjectsMock,
+            startRemoveGroupedObjects: startRemoveGroupedObjectsMock
+        }, interviewAttributes, 'home.region', 'test', {}, undefined);
+        expect(startUpdateInterviewMock).toHaveBeenCalledTimes(1);
+        expect(startUpdateInterviewMock).toHaveBeenCalledWith({
+            sectionShortname: 'test',
+            valuesByPath: testValuesByPath,
+            userAction: {
+                type: 'buttonClick',
+                buttonId: 'home.region'
+            }
+        }, undefined);
     });
 
     test('Button click, with modal, confirmed', async () => {
@@ -232,7 +278,7 @@ describe('Button widget: behavioral tests', () => {
         // The action should have been called
         expect(commonWidgetConfig.action).toHaveBeenCalledTimes(1);
         expect(commonWidgetConfig.action).toHaveBeenCalledWith({
-            startUpdateInterview: startUpdateInterviewMock,
+            startUpdateInterview: expect.any(Function),
             startAddGroupedObjects: startAddGroupedObjectsMock,
             startRemoveGroupedObjects: startRemoveGroupedObjectsMock
         }, interviewAttributes, 'home.region', 'test', {}, undefined);
@@ -255,7 +301,7 @@ describe('Button widget: behavioral tests', () => {
             interview: interviewAttributes,
             user: userAttributes,
             widgetStatus: defaultWidgetStatus,
-            startUpdateInterview: startUpdateInterviewMock,
+            startUpdateInterview: expect.any(Function),
             startAddGroupedObjects: startAddGroupedObjectsMock,
             startRemoveGroupedObjects: startRemoveGroupedObjectsMock,
         }
@@ -296,7 +342,7 @@ describe('Button widget: behavioral tests', () => {
             interview: interviewAttributes,
             user: userAttributes,
             widgetStatus: defaultWidgetStatus,
-            startUpdateInterview: startUpdateInterviewMock,
+            startUpdateInterview: expect.any(Function),
             startAddGroupedObjects: startAddGroupedObjectsMock,
             startRemoveGroupedObjects: startRemoveGroupedObjectsMock,
         }
@@ -323,7 +369,7 @@ describe('Button widget: behavioral tests', () => {
         />);
         expect(commonWidgetConfig.action).toHaveBeenCalledTimes(1);
         expect(commonWidgetConfig.action).toHaveBeenCalledWith({
-            startUpdateInterview: startUpdateInterviewMock,
+            startUpdateInterview: expect.any(Function),
             startAddGroupedObjects: startAddGroupedObjectsMock,
             startRemoveGroupedObjects: startRemoveGroupedObjectsMock
         }, interviewAttributes, 'home.region', 'test', {}, undefined);


### PR DESCRIPTION
…ffects

fixes #814

Add a `userAction` field in the `startUpdateInterview` callback data parameters.

For now, this user action parameter can either be a `buttonClick` with the ID of the button clicked by the user, or a `widgetInteraction` with a widget type and the path and value of the widget clicked. For the widget interacted with, this path and value replaces what was previously in the `valuesByPath` object, which now only contains the side-effects of the user interaction.

The `Button` and `Question` widgets now provide this user interaction when calling the `startUpdateInterview` callback. And this value is sent to the backend in the `updateInterview` and the
`updateValidateInterview` calls.

In the backend, the `userAction` parameter is received and we make sure that a valid request has either a `valuesByPath` or `userAction` parameter. For now, the interview update simply merges the widget interaction user action data to the valuesByPath to avoid having to change this code path right now, as it will be revisited (and simplified) soon when side effects are in the backend.