### PR TITLE
dep: remove un-used dependencies and put them in the right place

### DIFF
--- a/example/demo_generator/package.json
+++ b/example/demo_generator/package.json
@@ -50,6 +50,7 @@
         "@typescript-eslint/parser": "^8.31.1",
         "cross-env": "^7.0.3",
         "eslint": "^8.57.1",
-        "prettier-eslint-cli": "^8.0.1"
+        "prettier-eslint-cli": "^8.0.1",
+        "typescript": "^5.8.3"
     }
 }

--- a/example/demo_survey/package.json
+++ b/example/demo_survey/package.json
@@ -49,7 +49,6 @@
         "react-i18next": "^12.3.1",
         "react-router": "^7.5.2",
         "slugify": "^1.6.6",
-        "typescript": "^5.8.3",
         "uuid": "^11.1.0"
     },
     "devDependencies": {
@@ -71,6 +70,7 @@
         "source-map-loader": "^5.0.0",
         "ts-loader": "^9.5.1",
         "ts-shader-loader": "^2.0.2",
+        "typescript": "^5.8.3",
         "webpack": "^5.97.1",
         "webpack-cli": "^5.1.4"
     }

--- a/packages/evolution-backend/package.json
+++ b/packages/evolution-backend/package.json
@@ -43,7 +43,6 @@
         "request-ip": "^3.3.0",
         "serve-favicon": "^2.5.0",
         "slugify": "^1.6.6",
-        "typescript": "^5.8.3",
         "uuid": "^11.1.0",
         "workerpool": "^6.5.1",
         "yargs": "^17.7.2"
@@ -64,10 +63,11 @@
         "jest": "^29.7.0",
         "jest-each": "^29.7.0",
         "jest-fetch-mock": "^3.0.3",
-        "mock-knex": "^0.4.10",
+        "mockdate": "^3.0.5",
         "prettier-eslint-cli": "^8.0.1",
         "stream-mock": "^2.0.5",
         "supertest": "^7.0.0",
-        "ts-jest": "^29.3.2"
+        "ts-jest": "^29.3.2",
+        "typescript": "^5.8.3"
     }
 }

--- a/packages/evolution-common/package.json
+++ b/packages/evolution-common/package.json
@@ -26,10 +26,8 @@
     "chaire-lib-common": "^0.2.2",
     "geojson-validation": "^1.0.2",
     "i18next": "^24.0.5",
-    "libphonenumber-js": "^1.10.47",
     "lodash": "^4.17.21",
     "moment": "^2.30.1",
-    "typescript": "^5.8.3",
     "uuid": "^11.1.0",
     "@turf/turf": "^7.1.0"
   },
@@ -42,6 +40,7 @@
     "eslint": "^8.57.1",
     "eslint-plugin-n": "^15.7.0",
     "jest-each": "^29.7.0",
-    "prettier-eslint-cli": "^8.0.1"
+    "prettier-eslint-cli": "^8.0.1",
+    "typescript": "^5.8.3"
   }
 }

--- a/packages/evolution-frontend/package.json
+++ b/packages/evolution-frontend/package.json
@@ -70,8 +70,7 @@
     "react-table": "^7.8.0",
     "redux": "^5.0.1",
     "redux-thunk": "^3.1.0",
-    "remark-gfm": "^4.0.0",
-    "typescript": "^5.8.3"
+    "remark-gfm": "^4.0.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.50.0",
@@ -91,12 +90,15 @@
     "eslint": "^8.57.1",
     "eslint-plugin-n": "^15.7.0",
     "eslint-plugin-react": "^7.37.2",
+    "i18next-fs-backend": "^2.6.0",
     "jest": "^29.7.0",
     "jest-axe": "^9.0.0",
     "jest-each": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "mockdate": "^3.0.5",
     "prettier-eslint-cli": "^8.0.1",
-    "ts-jest": "^29.3.2"
+    "ts-jest": "^29.3.2",
+    "typescript": "^5.8.3",
+    "uuid": "^11.1.0"
   }
 }

--- a/packages/evolution-interviewer/package.json
+++ b/packages/evolution-interviewer/package.json
@@ -39,7 +39,6 @@
         "papaparse": "^5.5.2",
         "react": "^19.0.0",
         "react-i18next": "^12.3.1",
-        "typescript": "^5.8.3",
         "uuid": "^11.1.0"
     },
     "devDependencies": {
@@ -54,8 +53,8 @@
         "eslint-plugin-n": "^15.7.0",
         "jest": "^29.7.0",
         "jest-each": "^29.7.0",
-        "mock-knex": "^0.4.10",
         "prettier-eslint-cli": "^8.0.1",
-        "ts-jest": "^29.3.2"
+        "ts-jest": "^29.3.2",
+        "typescript": "^5.8.3"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5122,7 +5122,7 @@ bignumber.js@^9.1.0:
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.3.0.tgz#bdba7e2a4c1a2eba08290e8dcad4f36393c92acd"
   integrity sha512-EM7aMFTXbptt/wZdMlBv2t8IViwQL+h6SLHosp8Yf0dqJMTnY6iL32opnAB6kAdL0SZPuvcAzFr31o0c/R3/RA==
 
-bluebird@^3.4.1, bluebird@^3.5.1, bluebird@^3.7.2:
+bluebird@^3.5.1, bluebird@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
@@ -9157,11 +9157,6 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
-libphonenumber-js@^1.10.47:
-  version "1.11.18"
-  resolved "https://registry.yarnpkg.com/libphonenumber-js/-/libphonenumber-js-1.11.18.tgz#0ce5188a76487fae01afdf318255783cde36501e"
-  integrity sha512-okMm/MCoFrm1vByeVFLBdkFIXLSHy/AIK2AEGgY3eoicfWZeOZqv3GfhtQgICkzs/tqorAMm3a4GBg5qNCrqzg==
-
 lie@~3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
@@ -9271,7 +9266,7 @@ lodash.once@^4.0.0:
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==
 
-lodash@^4.0.1, lodash@^4.14.2, lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4:
+lodash@^4.0.1, lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -10091,15 +10086,6 @@ mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
-
-mock-knex@^0.4.10:
-  version "0.4.13"
-  resolved "https://registry.yarnpkg.com/mock-knex/-/mock-knex-0.4.13.tgz#edb248f883b2302132171b271e1d17e7527a6013"
-  integrity sha512-UmZlxiJH7bBdzjSWcrLJ1tnLfPNL7GfJO1IWL4sHWfMzLqdA3VAVWhotq1YiyE5NwVcrQdoXj3TGGjhTkBeIcQ==
-  dependencies:
-    bluebird "^3.4.1"
-    lodash "^4.14.2"
-    semver "^5.3.0"
 
 mock-spawn@^0.2.6:
   version "0.2.6"
@@ -11969,7 +11955,7 @@ semver-compare@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
   integrity sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.5.0:
+"semver@2 || 3 || 4 || 5", semver@^5.5.0:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
   integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==


### PR DESCRIPTION
Using npm's `depcheck` module, validate that all packages in the `package.json` are used and put in the right `dependencies` or `devDependencies` section.