### PR TITLE
refactor: rename validationListFilter to simplifiedInterviewListFilter

### DIFF
--- a/example/demo_generator/src/admin/server.ts
+++ b/example/demo_generator/src/admin/server.ts
@@ -10,7 +10,7 @@ import setupServer from 'evolution-backend/lib/apps/admin';
 import { setProjectConfig } from 'evolution-backend/lib/config/projectConfig';
 import { registerTranslationDir, addTranslationNamespace } from 'chaire-lib-backend/lib/config/i18next';
 import roleDefinitions from '../survey/server/roleDefinition';
-import validationListFilter from '../survey/server/validationListFilter';
+import simplifiedInterviewListFilter from '../survey/server/simplifiedInterviewListFilter';
 import serverUpdateCallbacks from '../survey/server/serverFieldUpdate';
 import serverValidations from '../survey/server/serverValidations';
 
@@ -19,7 +19,7 @@ const configureServer = () => {
         serverUpdateCallbacks,
         serverValidations,
         roleDefinitions,
-        validationListFilter
+        simplifiedInterviewListFilter
     });
 };
 

--- a/example/demo_generator/src/server.ts
+++ b/example/demo_generator/src/server.ts
@@ -10,7 +10,6 @@ import setupServer from 'evolution-backend/lib/apps/participant';
 import { setProjectConfig } from 'evolution-backend/lib/config/projectConfig';
 import { registerTranslationDir, addTranslationNamespace } from 'chaire-lib-backend/lib/config/i18next';
 import roleDefinitions from './survey/server/roleDefinition';
-import validationListFilter from './survey/server/validationListFilter';
 import serverUpdateCallbacks from './survey/server/serverFieldUpdate';
 import serverValidations from './survey/server/serverValidations';
 
@@ -18,8 +17,7 @@ const configureServer = () => {
     setProjectConfig({
         serverUpdateCallbacks,
         serverValidations,
-        roleDefinitions,
-        validationListFilter
+        roleDefinitions
     });
 };
 

--- a/example/demo_generator/src/survey/server/simplifiedInterviewListFilter.ts
+++ b/example/demo_generator/src/survey/server/simplifiedInterviewListFilter.ts
@@ -8,9 +8,9 @@ import { defaultConfig } from 'evolution-backend/lib/config/projectConfig';
 import { InterviewListAttributes } from 'evolution-common/lib/services/questionnaire/types';
 
 // TODO Type the unknown attributes here
-// Add the access code to the validation status list
+// Add the access code to the simplifiedInterview status list
 export default (interview: InterviewListAttributes) => {
-    const status = defaultConfig.validationListFilter(interview);
+    const status = defaultConfig.simplifiedInterviewListFilter(interview);
     status.responses = {
         ...status.responses,
         accessCode: interview.responses ? (interview.responses as any).accessCode : undefined

--- a/packages/evolution-backend/src/api/survey.validation.routes.ts
+++ b/packages/evolution-backend/src/api/survey.validation.routes.ts
@@ -142,7 +142,7 @@ router.post(
     }
 );
 
-router.post('/validationList', async (req, res) => {
+router.post('/simplifiedInterviewList', async (req, res) => {
     try {
         const { pageIndex, pageSize, updatedAt, sortBy, ...filters } = req.body;
         const page =
@@ -172,10 +172,10 @@ router.post('/validationList', async (req, res) => {
         return res.status(200).json({
             status: 'success',
             totalCount: response.totalCount,
-            interviews: response.interviews.map(projectConfig.validationListFilter)
+            interviews: response.interviews.map(projectConfig.simplifiedInterviewListFilter)
         });
     } catch (error) {
-        console.log('error getting interview list:', error);
+        console.log('error getting simplified interview list:', error);
         return res.status(500).json({ status: 'Error' });
     }
 });

--- a/packages/evolution-backend/src/config/__tests__/projectConfig.test.ts
+++ b/packages/evolution-backend/src/config/__tests__/projectConfig.test.ts
@@ -35,9 +35,9 @@ const nullResponsesInterview = {
     google: false
 };
 
-describe('Validation List Filter', () => {
-    test('test default validation filter', () => {
-        const interviewStatus = projectConfig.validationListFilter(interview);
+describe('Simplified Interview List Filter', () => {
+    test('test default simplified interview list filter', () => {
+        const interviewStatus = projectConfig.simplifiedInterviewListFilter(interview);
         expect(interviewStatus).toEqual({
             id: interview.id,
             uuid: interview.uuid,
@@ -52,8 +52,8 @@ describe('Validation List Filter', () => {
         });
     });
 
-    test('test default validation filter with null values for resonses and validated data', () => {
-        const interviewStatus = projectConfig.validationListFilter(nullResponsesInterview as any);
+    test('test default simplified interview list filter with null values for responses and validated data', () => {
+        const interviewStatus = projectConfig.simplifiedInterviewListFilter(nullResponsesInterview as any);
         expect(interviewStatus).toEqual({
             id: interview.id,
             uuid: interview.uuid,
@@ -68,13 +68,13 @@ describe('Validation List Filter', () => {
     });
 
     test('Add project specific filter', () => {
-        setProjectConfig({ validationListFilter: (interview: InterviewListAttributes) => {
-            const status = defaultConfig.validationListFilter(interview) as InterviewStatusAttributesBase;
+        setProjectConfig({ simplifiedInterviewListFilter: (interview: InterviewListAttributes) => {
+            const status = defaultConfig.simplifiedInterviewListFilter(interview) as InterviewStatusAttributesBase;
             (status.responses as any).accessCode = (interview.responses as any).accessCode;
             return status;
         } });
 
-        const interviewStatus = projectConfig.validationListFilter(interview);
+        const interviewStatus = projectConfig.simplifiedInterviewListFilter(interview);
         expect(interviewStatus).toEqual({
             id: interview.id,
             uuid: interview.uuid,

--- a/packages/evolution-backend/src/config/projectConfig.ts
+++ b/packages/evolution-backend/src/config/projectConfig.ts
@@ -15,10 +15,11 @@ import {
 
 interface ProjectServerConfig {
     /**
-     * Filters the interview object to return minimal data. Used server side
-     * before sending validation list to server
+     * Simplify the interview object to return minimal data.
+     * The filter will choose which fields to keep in the simplified interview.
+     * Used server side before sending interview list to server
      */
-    validationListFilter: (interview: InterviewListAttributes) => InterviewStatusAttributesBase;
+    simplifiedInterviewListFilter: (interview: InterviewListAttributes) => InterviewStatusAttributesBase;
     serverUpdateCallbacks: ServerFieldUpdateCallback[];
     serverValidations: ServerValidation;
     roleDefinitions: (() => void) | undefined;
@@ -53,7 +54,7 @@ interface ProjectServerConfig {
 }
 
 export const defaultConfig: ProjectServerConfig = {
-    validationListFilter: (interview: InterviewListAttributes) => {
+    simplifiedInterviewListFilter: (interview: InterviewListAttributes) => {
         const {
             id,
             uuid,

--- a/packages/evolution-common/src/services/questionnaire/types/Data.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/Data.ts
@@ -266,7 +266,7 @@ export interface InterviewListAttributes {
 }
 
 /**
- * Type of the interview for validation and administrative lists
+ * Type of the interview for audit and administrative lists
  *
  * TODO: See if the consumers of this type can template it so it can be fully
  * typed per project

--- a/packages/evolution-frontend/src/components/admin/validations/InterviewListComponent.tsx
+++ b/packages/evolution-frontend/src/components/admin/validations/InterviewListComponent.tsx
@@ -84,7 +84,7 @@ const InterviewListComponent: React.FunctionComponent<InterviewListComponentProp
         });
 
         try {
-            const response = await fetch('/api/validationList', {
+            const response = await fetch('/api/simplifiedInterviewList', {
                 headers: {
                     Accept: 'application/json',
                     'Content-Type': 'application/json'


### PR DESCRIPTION
This commit implements updates to align with the Evolution Platform Nomenclature guidelines:

- Renamed validationListFilter to simplifiedInterviewListFilter to accurately reflect its purpose of providing simplified interview data for admin views
- Updated API endpoint from /validationList to /simplifiedInterviewList
- Improved function documentation to clarify that this filter selects fields to include in the simplified interview representation
- Updated imports, function calls, and test descriptions to use the new terminology
- Corrected comments and error messages to match the new terminology

This is a work in progress for #745