### PR TITLE
sectionConfig: update section config type for repeated blocks

### DIFF
--- a/example/demo_survey/src/survey/helper.ts
+++ b/example/demo_survey/src/survey/helper.ts
@@ -43,7 +43,7 @@ const basicInfoForPersonComplete = function(person, householdSize) {
 const householdMembersSectionComplete = function(interview) {
     if (!homeSectionComplete(interview)) { return false; }
     const household = surveyHelperNew.getResponse(interview, 'household') as any;
-    if (household.size !== odSurveyHelper.countPersons({ interview })) { return false; }
+    if (household.size > odSurveyHelper.countPersons({ interview })) { return false; }
     const persons = odSurveyHelper.getPersons({ interview });
     for (const personId in persons)
     {
@@ -84,10 +84,11 @@ const profileInfoForPersonComplete = function(person, interview) {
 
 const tripsIntroForPersonComplete = function(person, interview) {
     if (person && person.age < 5) { return true; }
+    const journeys = odSurveyHelper.getJourneysArray({ person });
     if (
          !profileInfoForPersonComplete(person, interview)
       || _isBlank(person.didTripsOnTripsDate)
-      || ((person.didTripsOnTripsDate === 'yes' || person.didTripsOnTripsDate === true) && _isBlank(person.departurePlaceType))
+      || ((person.didTripsOnTripsDate === 'yes' || person.didTripsOnTripsDate === true) && (_isBlank(journeys[0]) || _isBlank(journeys[0].departurePlaceType)))
     ) { return false; }
     return true;
 };
@@ -392,6 +393,7 @@ export default {
     travelBehaviorForPersonComplete,
     tripsIntroForPersonComplete,
     tripsForPersonComplete,
+    visitedPlacesForPersonComplete,
     allPersonsTripsAndTravelBehaviorComplete,
     selectNextVisitedPlaceId,
     deleteVisitedPlace,

--- a/example/demo_survey/src/survey/sections.ts
+++ b/example/demo_survey/src/survey/sections.ts
@@ -14,7 +14,7 @@ import * as odSurveyHelper from 'evolution-common/lib/services/odSurvey/helpers'
 import { getSegmentsSectionConfig } from 'evolution-common/lib/services/questionnaire/sections/segments/sectionSegments';
 import helper from './helper';
 import config from 'chaire-lib-common/lib/config/shared/project.config';
-import { SectionConfig } from 'evolution-common/lib/services/questionnaire/types';
+import { getAndValidateSurveySections, SectionConfig } from 'evolution-common/lib/services/questionnaire/types';
 
 
 const homeWidgets = [
@@ -80,10 +80,6 @@ const sections: { [sectionName: string]: SectionConfig } = {
       fr: "Domicile",
       en: "Home"
     },
-    menuName: {
-      fr: "Domicile",
-      en: "Home"
-    },
     widgets: [
       ...homeWidgets,
       'buttonSaveNextSection'
@@ -115,9 +111,12 @@ const sections: { [sectionName: string]: SectionConfig } = {
       fr: "Membres du ménage",
       en: "Household members"
     },
-    menuName: {
-      fr: "Votre ménage",
-      en: "Your household"
+    navMenu: {
+      type: 'inNav',
+      menuName: {
+        fr: "Votre ménage",
+        en: "Your household"
+      }
     },
     widgets: [
       'householdMembers',
@@ -210,9 +209,12 @@ const sections: { [sectionName: string]: SectionConfig } = {
       fr: "Sélection du membre du ménage",
       en: "Household member selection"
     },
-    menuName: {
-      fr: "Profil",
-      en: "Profile"
+    navMenu: {
+      type: 'inNav',
+      menuName: {
+        fr: "Profil",
+        en: "Profile"
+      }
     },
     widgets: [
       'selectPerson',
@@ -247,12 +249,11 @@ const sections: { [sectionName: string]: SectionConfig } = {
   profile: {
     previousSection: 'selectPerson',
     nextSection: "tripsIntro",
-    parentSection: "selectPerson",
-    title: {
-      fr: "Profil",
-      en: "Profile"
+    navMenu: {
+      type: 'hidden',
+      parentSection: 'selectPerson'
     },
-    menuName: {
+    title: {
       fr: "Profil",
       en: "Profile"
     },
@@ -301,9 +302,12 @@ const sections: { [sectionName: string]: SectionConfig } = {
       fr: "Introduction aux déplacements",
       en: "Trips introduction"
     },
-    menuName: {
-      fr: "Déplacements",
-      en: "Trips"
+    navMenu: {
+      type: 'inNav',
+      menuName: {
+        fr: "Déplacements",
+        en: "Trips"
+      },
     },
     widgets: [
       'activePersonTitle',
@@ -381,13 +385,12 @@ const sections: { [sectionName: string]: SectionConfig } = {
   visitedPlaces: {
     previousSection: 'tripsIntro',
     nextSection: "segments",
-    parentSection: 'tripsIntro',
+    navMenu: {
+      type: 'hidden',
+      parentSection: 'tripsIntro'
+    },
     template: 'visitedPlaces',
     title: {
-      fr: "Déplacements",
-      en: "Trips"
-    },
-    menuName: {
       fr: "Déplacements",
       en: "Trips"
     },
@@ -479,10 +482,13 @@ const sections: { [sectionName: string]: SectionConfig } = {
   travelBehavior: {
     previousSection: 'segments',
     nextSection: "end",
-    parentSection: 'tripsIntro',
     title: {
       fr: "Mobilité",
       en: "Travel behavior"
+    },
+    navMenu: {
+      type: 'hidden',
+      parentSection: 'tripsIntro'
     },
     widgets: [
       'activePersonTitle',
@@ -523,10 +529,6 @@ const sections: { [sectionName: string]: SectionConfig } = {
     previousSection: 'travelBehavior',
     nextSection: "completed",
     title: {
-      fr: "Fin",
-      en: "End"
-    },
-    menuName: {
       fr: "Fin",
       en: "End"
     },
@@ -589,7 +591,10 @@ const sections: { [sectionName: string]: SectionConfig } = {
   completed: {
     previousSection: 'end',
     nextSection: null,
-    parentSection: 'end',
+    navMenu: {
+      type: 'hidden',
+      parentSection: 'end'
+    },
     title: {
       fr: "Entrevue complétée",
       en: "Interview completed"
@@ -634,4 +639,4 @@ const sections: { [sectionName: string]: SectionConfig } = {
 
 };
 
-export default sections;
+export default getAndValidateSurveySections(sections);

--- a/example/demo_survey/src/survey/sections.ts
+++ b/example/demo_survey/src/survey/sections.ts
@@ -201,7 +201,12 @@ const sections: { [sectionName: string]: SectionConfig } = {
       skipSelectionInNaturalFlow: true,
       activeSurveyObjectPath: '_activePersonId',
       pathPrefix: 'person',
-      sections: ['selectPerson', 'profile', 'tripsIntro', 'visitedPlaces', 'segments', 'travelBehavior']
+      sections: ['selectPerson', 'profile', 'tripsIntro', 'visitedPlaces', 'segments', 'travelBehavior'],
+      isIterationValid: (interview, iterationContext) => {
+          const personId = iterationContext[iterationContext.length - 1];
+          const person = odSurveyHelper.getPerson({ interview, personId });
+          return helper.travelBehaviorForPersonComplete(person, interview)
+      },
     }
   },
 

--- a/example/demo_survey/src/survey/templates/VisitedPlacesSection.tsx
+++ b/example/demo_survey/src/survey/templates/VisitedPlacesSection.tsx
@@ -216,6 +216,7 @@ export const VisitedPlacesSection: React.FC<SectionProps> = (
                 startUpdateInterview={props.startUpdateInterview}
                 startAddGroupedObjects={props.startAddGroupedObjects}
                 startRemoveGroupedObjects={props.startRemoveGroupedObjects}
+                startNavigate={props.startNavigate}
             />
         );
     }
@@ -310,6 +311,7 @@ export const VisitedPlacesSection: React.FC<SectionProps> = (
               startUpdateInterview        = {props.startUpdateInterview}
               startAddGroupedObjects      = {props.startAddGroupedObjects}
               startRemoveGroupedObjects   = {props.startRemoveGroupedObjects}
+              startNavigate = {props.startNavigate}
             />
           </li>
         );

--- a/example/demo_survey/src/survey/widgets/householdMembers.tsx
+++ b/example/demo_survey/src/survey/widgets/householdMembers.tsx
@@ -22,6 +22,8 @@ import { InterviewUpdateCallbacks, UserInterviewAttributes } from 'evolution-com
 import { GroupConfig } from 'evolution-common/lib/services/questionnaire/types';
 import { getFormattedDate, validateButtonAction } from 'evolution-frontend/lib/services/display/frontendHelper';
 import * as odSurveyHelper from 'evolution-common/lib/services/odSurvey/helpers';
+import { validateButtonActionWithCompleteSection } from 'evolution-frontend/lib/services/display/frontendHelper';
+
 
 const personsWidgets = [
     'personNickname',
@@ -1088,29 +1090,26 @@ export const buttonSaveNextSectionHouseholdMembers = {
     }
   },
   saveCallback: function(callbacks: InterviewUpdateCallbacks, interview: UserInterviewAttributes, path: string, user?: CliUser) {
-    
     const personsCount  = odSurveyHelper.countPersons({ interview });
     const householdSize = surveyHelperNew.getResponse(interview, 'household.size', null);
-    if (householdSize !== personsCount)
-    {
+    
+    // Update the household size if needed, then navigate to next section
+    if (householdSize !== personsCount) {
       callbacks.startUpdateInterview({
         sectionShortname: 'householdMembers',
         valuesByPath: {
-          [`response.household.size`]: personsCount,
-          [`response._activeSection`]: 'selectPerson'
+          [`response.household.size`]: personsCount
         }
+      }, () => {
+        // After the update is complete, use navigation service to go to the next section
+        callbacks.startNavigate();
       });
+    } else {
+      // Just navigate to the next section
+      callbacks.startNavigate();
     }
-    else
-    {
-      callbacks.startUpdateInterview({
-        sectionShortname: 'householdMembers',
-        valuesByPath: { [`response._activeSection`]: 'selectPerson' }
-      });
-    }
-    //return null;
   },
-  action: validateButtonAction
+  action: validateButtonActionWithCompleteSection
 };
 
 export const selectPerson = {

--- a/example/demo_survey/src/survey/widgets/travelBehavior.tsx
+++ b/example/demo_survey/src/survey/widgets/travelBehavior.tsx
@@ -308,7 +308,7 @@ export const personNoSchoolTripReason = {
     }
     // add student condition + not applicable for non-student:
     const journey = odSurveyHelper.getJourneysArray({ person })[0] as any;
-    const visitedPlaces = odSurveyHelper.getVisitedPlacesArray({ journey });
+    const visitedPlaces = journey === undefined ? [] : odSurveyHelper.getVisitedPlacesArray({ journey });
     if (helper.isStudent(person.occupation))
     {
       const schoolRelatedVisitedPlaces = visitedPlaces.filter((visitedPlace) => {

--- a/example/demo_survey/tests/test-navigation-bar.UI.spec.ts
+++ b/example/demo_survey/tests/test-navigation-bar.UI.spec.ts
@@ -25,7 +25,6 @@ surveyTestHelpers.startAndLoginAnonymously({ context, title: 'Démo', hasUser: f
 // Verify that the buttons have the expected class/colors and are disabled if we haven't been to the corresponding page yet.
 testHelpers.verifyNavBarButtonStatus({ context, buttonText: 'Home', buttonStatus: 'active', isDisabled: false });
 testHelpers.verifyNavBarButtonStatus({ context, buttonText: 'Your household', buttonStatus: 'inactive', isDisabled: true });
-testHelpers.verifyNavBarButtonStatus({ context, buttonText: 'Profile', buttonStatus: 'inactive', isDisabled: true });
 testHelpers.verifyNavBarButtonStatus({ context, buttonText: 'Trips', buttonStatus: 'inactive', isDisabled: true });
 testHelpers.verifyNavBarButtonStatus({ context, buttonText: 'End', buttonStatus: 'inactive', isDisabled: true });
 
@@ -34,7 +33,6 @@ onePersonTestHelpers.completeHomePage(context);
 
 testHelpers.verifyNavBarButtonStatus({ context, buttonText: 'Home', buttonStatus: 'completed', isDisabled: false });
 testHelpers.verifyNavBarButtonStatus({ context, buttonText: 'Your household', buttonStatus: 'active', isDisabled: false });
-testHelpers.verifyNavBarButtonStatus({ context, buttonText: 'Profile', buttonStatus: 'inactive', isDisabled: true });
 testHelpers.verifyNavBarButtonStatus({ context, buttonText: 'Trips', buttonStatus: 'inactive', isDisabled: true });
 testHelpers.verifyNavBarButtonStatus({ context, buttonText: 'End', buttonStatus: 'inactive', isDisabled: true });
 
@@ -45,7 +43,6 @@ testHelpers.changePageFromNavBar({ context, buttonText: 'Home', nextPageUrl: '/s
 
 testHelpers.verifyNavBarButtonStatus({ context, buttonText: 'Home', buttonStatus: 'activeAndCompleted', isDisabled: false });
 testHelpers.verifyNavBarButtonStatus({ context, buttonText: 'Your household', buttonStatus: 'inactive', isDisabled: false });
-testHelpers.verifyNavBarButtonStatus({ context, buttonText: 'Profile', buttonStatus: 'inactive', isDisabled: true });
 testHelpers.verifyNavBarButtonStatus({ context, buttonText: 'Trips', buttonStatus: 'inactive', isDisabled: true });
 testHelpers.verifyNavBarButtonStatus({ context, buttonText: 'End', buttonStatus: 'inactive', isDisabled: true });
 
@@ -59,7 +56,6 @@ onePersonTestHelpers.completeProfilePage(context);
 
 testHelpers.verifyNavBarButtonStatus({ context, buttonText: 'Home', buttonStatus: 'completed', isDisabled: false });
 testHelpers.verifyNavBarButtonStatus({ context, buttonText: 'Your household', buttonStatus: 'completed', isDisabled: false });
-testHelpers.verifyNavBarButtonStatus({ context, buttonText: 'Profile', buttonStatus: 'completed', isDisabled: false });
 testHelpers.verifyNavBarButtonStatus({ context, buttonText: 'Trips', buttonStatus: 'completed', isDisabled: false });
 testHelpers.verifyNavBarButtonStatus({ context, buttonText: 'End', buttonStatus: 'active', isDisabled: false });
 
@@ -67,8 +63,7 @@ testHelpers.changePageFromNavBar({ context, buttonText: 'Home', nextPageUrl: '/s
 testHelpers.changePageFromNavBar({ context, buttonText: 'Your household', nextPageUrl: '/survey/householdMembers' });
 // Since we are testing with no trips, the Trips button will redirect to the End page.
 // As such, we switch the order with Profile so that we will not stay on the same URL when testing Trips and End
-testHelpers.changePageFromNavBar({ context, buttonText: 'Trips', nextPageUrl: '/survey/end' });
-testHelpers.changePageFromNavBar({ context, buttonText: 'Profile', nextPageUrl: '/survey/profile' });
+testHelpers.changePageFromNavBar({ context, buttonText: 'Trips', nextPageUrl: '/survey/profile' });
 testHelpers.changePageFromNavBar({ context, buttonText: 'End', nextPageUrl: '/survey/end' });
 
 onePersonTestHelpers.completeEndPage(context);

--- a/example/demo_survey/tests/test-one-person-helpers.ts
+++ b/example/demo_survey/tests/test-one-person-helpers.ts
@@ -19,7 +19,7 @@ export function completeHomePage(context) {
 };
 
 export function completeHouseholdPage(context) {
-    testHelpers.sectionProgressBarTest({context, sectionName: 'Household members', completionPercentage: 11 });
+    testHelpers.sectionProgressBarTest({context, sectionName: 'Household members', completionPercentage: 10 });
     testHelpers.inputStringTest({ context, path: 'household.persons.${personId[0]}.age', value: '30' });
     testHelpers.inputRadioTest({ context, path: 'household.persons.${personId[0]}.gender', value: 'male' });
     testHelpers.inputSelectTest({ context, path: 'household.persons.${personId[0]}.occupation', value: 'fullTimeWorker' });
@@ -33,14 +33,14 @@ export function completeHouseholdPage(context) {
 };
 
 export function completeProfilePage(context) {
-    testHelpers.sectionProgressBarTest({context, sectionName: 'Profile', completionPercentage: 33 });
+    testHelpers.sectionProgressBarTest({context, sectionName: 'Profile', completionPercentage: 40 });
     testHelpers.inputRadioTest({ context, path: 'household.persons.${personId[0]}.workOnTheRoad', value: false });
     testHelpers.inputRadioTest({ context, path: 'household.persons.${personId[0]}.usualWorkPlaceIsHome', value: true });
     testHelpers.inputNextButtonTest({ context, text: 'Save and continue', nextPageUrl: '/survey/end' });
 };
 
 export function completeEndPage(context) {
-    testHelpers.sectionProgressBarTest({context, sectionName: 'End', completionPercentage: 89 });
+    testHelpers.sectionProgressBarTest({context, sectionName: 'End', completionPercentage: 90 });
     testHelpers.inputSelectTest({ context, path: 'household.residentialPhoneType', value: 'landLine' });
     testHelpers.inputRadioTest({ context, path: 'household.didAlsoRespondByPhone', value: false });
     testHelpers.inputRadioTest({ context, path: 'household.wouldLikeToParticipateInOtherSurveys', value: false });

--- a/example/demo_survey/tests/test-two-adults-no-trips.UI.spec.ts
+++ b/example/demo_survey/tests/test-two-adults-no-trips.UI.spec.ts
@@ -60,12 +60,9 @@ testHelpers.inputRadioTest({ context, path: 'household.persons.${personId[1]}.ha
 testHelpers.inputRadioTest({ context, path: 'household.persons.${personId[1]}.cellphoneOwner', value: 'no' });
 testHelpers.inputRadioTest({ context, path: 'household.persons.${personId[1]}.didTripsOnTripsDate', value: 'no' });
 
-// Go to next page
-testHelpers.inputNextButtonTest({ context, text: 'Save and continue', nextPageUrl: '/survey/selectPerson' });
-
-// Select the first person and continue
-testHelpers.inputRadioTest({ context, path: '_activePersonId', value: '${personId[0]}' });
-testHelpers.inputNextButtonTest({ context, text: 'Select this person and continue', nextPageUrl: '/survey/profile' });
+// Go to next page, should skip selection section and go to bob's interview
+testHelpers.inputNextButtonTest({ context, text: 'Save and continue', nextPageUrl: '/survey/profile' });
+testHelpers.waitTextVisible({ context, text: 'bob\'s interview' });
 
 // Test the profile page
 testHelpers.inputRadioTest({ context, path: 'household.persons.${personId[0]}.workOnTheRoad', value: false });
@@ -75,9 +72,11 @@ testHelpers.inputNextButtonTest({ context, text: 'Save and continue', nextPageUr
 // Test the travel behavior page for first person
 testHelpers.inputRadioTest({ context, path: 'household.persons.${personId[0]}.whoAnsweredForThisPerson', value: '${personId[0]}' });
 testHelpers.inputNextButtonTest({ context, text: 'Continue', nextPageUrl: '/survey/profile' });
+testHelpers.waitTextVisible({ context, text: 'alice\'s interview' });
 
 // Test the profile for the second
-testHelpers.inputPopupButtonTest({ context, text: 'Continue', popupText: 'If alice is available, she can come and continue the interview, or you can answer for her' });
+// FIXME Show popup functionality has not been brought back after navigation migration
+// testHelpers.inputPopupButtonTest({ context, text: 'Continue', popupText: 'If alice is available, she can come and continue the interview, or you can answer for her' });
 testHelpers.inputRadioTest({ context, path: 'household.persons.${personId[1]}.workOnTheRoad', value: false });
 testHelpers.inputRadioTest({ context, path: 'household.persons.${personId[1]}.usualWorkPlaceIsHome', value: true });
 testHelpers.inputNextButtonTest({ context, text: 'Save and continue', nextPageUrl: '/survey/travelBehavior' });

--- a/packages/evolution-backend/src/models/migrations/20250528154100_addChangeSectionActionType.ts
+++ b/packages/evolution-backend/src/models/migrations/20250528154100_addChangeSectionActionType.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { Knex } from 'knex';
+
+const eventTypeEnumName = 'paradata_events_type';
+const newEnumValue = 'section_change';
+
+export async function up(knex: Knex): Promise<unknown> {
+    return knex.raw(`ALTER TYPE ${eventTypeEnumName} ADD VALUE '${newEnumValue}';`);
+}
+
+export async function down(): Promise<unknown> {
+    // It is not recommended to remove values from an enum type in postgres as
+    // it may cause data corruption if rows were using it. We just keep it
+    return;
+}

--- a/packages/evolution-backend/src/models/paradataEvents.db.queries.ts
+++ b/packages/evolution-backend/src/models/paradataEvents.db.queries.ts
@@ -16,7 +16,8 @@ type ParadataEventType =
     | 'widget_interaction'
     | 'button_click'
     | 'side_effect'
-    | 'server_event';
+    | 'server_event'
+    | 'section_change';
 
 const log = async ({
     interviewId,

--- a/packages/evolution-backend/src/services/logging/__tests__/paradataLogging.test.ts
+++ b/packages/evolution-backend/src/services/logging/__tests__/paradataLogging.test.ts
@@ -76,6 +76,27 @@ describe('Log for a participant', () => {
         
     });
 
+    it('Should correctly log a section change', async () => {
+        const userAction = {
+            type: 'sectionChange' as const,
+            targetSection: { sectionShortname: 'section1' }
+        };
+        const logData = { valuesByPath: {someData: 'test'}, unsetPaths: ['path1', 'path2'] };
+
+        expect(await logFunction!({ userAction, ...logData})).toBe(true);
+
+        expect(mockLog).toHaveBeenCalledWith({
+            eventType: 'section_change',
+            eventData: {
+                ...logData,
+                userAction
+            },
+            interviewId,
+            userId: undefined
+        });
+        
+    });
+
     it('Should correctly log a server event', async () => {
         const logData = { valuesByPath: {someData: 'test'}, server: true };
 

--- a/packages/evolution-backend/src/services/logging/paradataLogging.ts
+++ b/packages/evolution-backend/src/services/logging/paradataLogging.ts
@@ -45,6 +45,22 @@ const enqueueLog = (logData: Parameters<typeof paradataEventsDbQueries.log>[0]):
     );
 };
 
+const userActionTypeToDbType = (
+    userAction: UserAction
+): Parameters<typeof paradataEventsDbQueries.log>[0]['eventType'] => {
+    switch (userAction.type) {
+    case 'buttonClick':
+        return 'button_click';
+    case 'widgetInteraction':
+        return 'widget_interaction';
+    case 'sectionChange':
+        return 'section_change';
+    default:
+        console.warn(`Unknown user action type: ${(userAction as any).type}. Falling back to 'legacy'.`);
+        return 'legacy';
+    }
+};
+
 /**
  * Get the paradata logging functions for a given interview and user
  *
@@ -88,7 +104,7 @@ export const getParadataLoggingFunction = (
                 return enqueueLog({
                     interviewId,
                     userId,
-                    eventType: userAction.type === 'buttonClick' ? 'button_click' : 'widget_interaction',
+                    eventType: userActionTypeToDbType(userAction),
                     eventData: logData
                 });
             }

--- a/packages/evolution-common/src/services/questionnaire/sections/NavigationService.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/NavigationService.ts
@@ -1,0 +1,707 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import _isEqual from 'lodash/isEqual';
+import _shuffle from 'lodash/shuffle';
+import { UserRuntimeInterviewAttributes } from '../types/Data';
+import { SurveySections, SectionConfigWithDefaultsBlock } from '../types/SectionConfig';
+import { NavigationSection, sectionToUrlPath, TargetSectionResult } from '../types/NavigationTypes';
+import { getLastVisitedSection, isIterationContextStarted } from './navigationHelpers';
+import { getResponse, parseBoolean } from '../../../utils/helpers';
+import { getInterviewablePersonsArray } from '../../odSurvey/helpers';
+
+/**
+ * NavigationService handles complex navigation for questionnaires,
+ * including repeated blocks of sections and conditional navigation.
+ */
+export class NavigationService {
+    private sections: SurveySections;
+
+    constructor(sections: SurveySections) {
+        this.sections = sections;
+    }
+
+    // Get the first section, the one that has no previous
+    private getFirstSection(): string {
+        const firstSection = Object.keys(this.sections).find(
+            (sectionName) => this.sections[sectionName].previousSection === null
+        );
+        if (firstSection === undefined) {
+            throw new Error('No first section found');
+        }
+        return firstSection;
+    }
+
+    // Determine if a section is enabled
+    private isSectionEnabled({
+        interview,
+        section
+    }: {
+        interview: UserRuntimeInterviewAttributes;
+        section: NavigationSection;
+    }): boolean {
+        const sectionConfig = this.sections[section.sectionShortname];
+        if (sectionConfig.enableConditional) {
+            return parseBoolean(sectionConfig.enableConditional, interview, section.sectionShortname);
+        }
+        // By default, the section is enabled if the previous section is completed
+        return sectionConfig.previousSection === null
+            ? true
+            : this.isSectionCompleted({
+                interview,
+                section: this.handleIterationContextOnSection({
+                    targetSection: {
+                        sectionShortname: sectionConfig.previousSection,
+                        iterationContext: section.iterationContext
+                    },
+                    interview
+                })
+            });
+    }
+
+    private isSectionCompleted({
+        interview,
+        section
+    }: {
+        interview: UserRuntimeInterviewAttributes;
+        section: NavigationSection;
+    }): boolean {
+        // TODO Should we check validity of current section widgets? If so, we'd
+        // need to make sure to be able to calculate them for sections that were
+        // not active. Maybe not...
+        const sectionConfig = this.sections[section.sectionShortname];
+        // Run the section's `isSectionCompleted` function if it exists
+        if (sectionConfig.isSectionCompleted) {
+            return sectionConfig.isSectionCompleted(interview, section.iterationContext);
+        }
+        // If there is no `isSectionCompleted` function, it is considered
+        // completed for navigation. Any validation should be done in the
+        // section itself.
+        return true;
+    }
+
+    // Verify that a section is both enabled and visible. Enable and visible are
+    // different from the point of view of navigation menu, but they are the
+    // same for navigation.
+    private isSectionEnabledAndVisible({
+        interview,
+        section
+    }: {
+        interview: UserRuntimeInterviewAttributes;
+        section: NavigationSection;
+    }): boolean {
+        if (!this.isSectionEnabled({ interview, section })) {
+            return false;
+        }
+        const sectionConfig = this.sections[section.sectionShortname];
+        // If the section is the selection section of a repeated block, make it invisible if there is only one iteration
+        if (sectionConfig.type === 'section' && sectionConfig.repeatedBlockSection) {
+            const blockSection = this.sections[sectionConfig.repeatedBlockSection] as SectionConfigWithDefaultsBlock;
+            if (blockSection.repeatedBlock.selectionSectionId === section.sectionShortname) {
+                const [iterationContexts] = this.getIterationContextsForBlock({ interview, blockSection });
+                return iterationContexts.length > 1;
+            }
+        }
+        // Run the section's `isSectionVisible` function if it exists
+        if (sectionConfig.isSectionVisible) {
+            return sectionConfig.isSectionVisible(interview, section.iterationContext);
+        }
+        // By default the section is visible
+        return true;
+    }
+
+    // Find the first section that shouldn't be skipped in the given direction
+    private findFirstNonSkippedSection({
+        interview,
+        currentSection,
+        direction
+    }: {
+        interview: UserRuntimeInterviewAttributes;
+        currentSection: NavigationSection;
+        direction: 'forward' | 'backward';
+    }): [NavigationSection] | [NavigationSection, Record<string, unknown> | undefined] {
+        // Section visited in the current iteration, can be disabled or not visible
+        let lastVisitedSection = currentSection;
+        // Section to navigate to, must be visible and enabled
+        const navigateToSection = currentSection;
+
+        // visited set to prevent infinite loops.
+        const visited = new Set<string>();
+
+        // Check for infinite loop
+        while (!visited.has(sectionToUrlPath(lastVisitedSection))) {
+            visited.add(sectionToUrlPath(lastVisitedSection));
+
+            // Get the next section in the direction
+            const sectionConfig = this.sections[lastVisitedSection.sectionShortname];
+            const targetSectionName =
+                direction === 'forward' ? sectionConfig.nextSection : sectionConfig.previousSection;
+
+            // If null, keep current section
+            if (targetSectionName === null) {
+                return [navigateToSection];
+            }
+
+            // Get the target section and add the iteration context if necessary
+            const targetSection = this.handleIterationContextOnSection({
+                targetSection: {
+                    sectionShortname: targetSectionName,
+                    iterationContext: lastVisitedSection.iterationContext
+                },
+                interview
+            });
+            // See if it is possible to go to this section. If not,
+            // continue navigation.
+            if (!this.isSectionEnabledAndVisible({ interview, section: targetSection })) {
+                lastVisitedSection = targetSection;
+                continue;
+            }
+
+            const [targetSectionWithRepeated, updatedValues] = this.maybeGetTargetFromRepeatedBlock({
+                interview,
+                targetSection,
+                originSection: lastVisitedSection,
+                direction
+            });
+
+            // If the target section in repeated block is different from original target section, verify visibility again.
+            if (
+                !_isEqual(targetSectionWithRepeated, targetSection) &&
+                !this.isSectionEnabledAndVisible({ interview, section: targetSectionWithRepeated })
+            ) {
+                lastVisitedSection = targetSectionWithRepeated;
+                continue;
+            }
+
+            // Return the section
+            return [targetSectionWithRepeated, updatedValues];
+        }
+        console.error(
+            `NavigationService: Infinite loop detected in 'findFirstNonSkippedSection'. Will return current section ${sectionToUrlPath(lastVisitedSection)}, but it may not be right.`
+        );
+        return [navigateToSection];
+    }
+
+    // If the section is one with a repeated block, get the actual next section
+    // from this block. Target section is the one who may be a repeated block
+    // and origin section is the origin of the navigation. They may not be
+    // identical if some sections were skipped in between
+    private maybeGetTargetFromRepeatedBlock = ({
+        interview,
+        targetSection,
+        originSection,
+        direction
+    }: {
+        interview: UserRuntimeInterviewAttributes;
+        targetSection: NavigationSection;
+        originSection: NavigationSection;
+        direction: 'forward' | 'backward';
+    }): [NavigationSection, Record<string, unknown> | undefined] => {
+        const targetSectionConfig = this.sections[targetSection.sectionShortname];
+        if (targetSectionConfig.type === 'repeatedBlock') {
+            return this.getTargetSectionFromRepeatedBlock({
+                interview,
+                originSection,
+                repeatedBlockSection: targetSectionConfig,
+                direction
+            });
+        }
+        return [targetSection, undefined];
+    };
+
+    // Get the list of contexts for the repeated block that will need to be
+    // iterated over. The values to update are any randomization values.
+    private getIterationContextsForBlock({
+        interview,
+        blockSection
+    }: {
+        interview: UserRuntimeInterviewAttributes;
+        blockSection: SectionConfigWithDefaultsBlock;
+    }): [string[][], Record<string, unknown> | undefined] {
+        const interviewFieldsToUpdate = {};
+
+        // Get the object ids from repeatForObjects
+        const getObjects = () => {
+            if (blockSection.repeatedBlock.iterationRule.type === 'builtin') {
+                if (blockSection.repeatedBlock.iterationRule.path === 'interviewablePersons') {
+                    return getInterviewablePersonsArray({ interview }).map((person) => person._uuid as string);
+                }
+            } else if (blockSection.repeatedBlock.iterationRule.type === 'surveyObjectPath') {
+                const surveyObjects = getResponse(
+                    interview,
+                    blockSection.repeatedBlock.iterationRule.path,
+                    {}
+                ) as Record<string, unknown>;
+                return Object.keys(surveyObjects);
+            }
+            throw new Error(`Unsupported repeatForObjects type: ${blockSection.repeatedBlock.iterationRule}`);
+        };
+        let objectIds = getObjects();
+
+        // See if we need to randomize
+        if (blockSection.repeatedBlock.order === 'random') {
+            // See if we already have a random order
+            const randomOrderPath = `_${blockSection.repeatedBlock.pathPrefix || ''}RandomSequence`;
+            const randomOrder = getResponse(interview, randomOrderPath, []) as string[];
+            // If the random order is not set or if it is not valid anymore, set it right
+            if (
+                randomOrder === undefined ||
+                randomOrder.length !== objectIds.length ||
+                randomOrder.some((id) => !objectIds.includes(id))
+            ) {
+                objectIds = _shuffle(objectIds);
+                interviewFieldsToUpdate[`response.${randomOrderPath}`] = objectIds;
+            } else {
+                // Otherwise, use the random order
+                objectIds.splice(0, objectIds.length - 1, ...randomOrder);
+            }
+        }
+
+        return [
+            objectIds.map((id) =>
+                blockSection.repeatedBlock.pathPrefix ? [blockSection.repeatedBlock.pathPrefix, id] : [id]
+            ),
+            Object.keys(interviewFieldsToUpdate).length === 0 ? undefined : interviewFieldsToUpdate
+        ];
+    }
+
+    private findFirstVisibleSectionInRepeatedBlock({
+        interview,
+        repeatedBlockSection,
+        iterationContext,
+        startFrom
+    }: {
+        interview: UserRuntimeInterviewAttributes;
+        repeatedBlockSection: SectionConfigWithDefaultsBlock;
+        iterationContext: string[];
+        startFrom: string;
+    }): string {
+        // Find the first visible section in the repeated block starting from
+        // the given section. If no section is found, return the first one.
+        const sections = repeatedBlockSection.repeatedBlock.sections;
+        const startIndex = sections.indexOf(startFrom);
+        if (startIndex === -1) {
+            return startFrom;
+        }
+        // Check visiblity of the section before returning, as otherwise the
+        // initNaviagion will navigate backward, thus out of the block/iteration
+        for (let i = startIndex; i < sections.length; i++) {
+            const sectionName = sections[i];
+            if (
+                this.isSectionEnabledAndVisible({
+                    interview,
+                    section: {
+                        sectionShortname: sectionName,
+                        iterationContext
+                    }
+                })
+            ) {
+                return sectionName;
+            }
+        }
+        // If no visible section found, return the first section, the caller will handle the invisibility depending on the navigation direction.
+        return startFrom;
+    }
+
+    private findTargetSectionInRepeatedBlock({
+        interview,
+        repeatedBlockSection,
+        iterationContext
+    }: {
+        interview: UserRuntimeInterviewAttributes;
+        repeatedBlockSection: SectionConfigWithDefaultsBlock;
+        iterationContext: string[];
+    }): string {
+        // There are 2 flow of possibilities for the target section of the block
+        // 1. If it is the natural flow (the new iteration has not started yet),
+        //    then we go to the first section of the block, or skip it if it is
+        //    the selection section and the block is configured to skip in
+        //    natural flow
+        // 2. If not in natural flow, go to the selection section if specified
+        //    or to the first one of the block
+
+        const isNaturalFlow = !isIterationContextStarted({ interview, iterationContext });
+        const firstBlockSection = repeatedBlockSection.repeatedBlock.sections[0];
+        if (isNaturalFlow) {
+            return this.findFirstVisibleSectionInRepeatedBlock({
+                interview,
+                repeatedBlockSection,
+                iterationContext,
+                startFrom:
+                    repeatedBlockSection.repeatedBlock.skipSelectionInNaturalFlow &&
+                    firstBlockSection === repeatedBlockSection.repeatedBlock.selectionSectionId
+                        ? repeatedBlockSection.repeatedBlock.sections[1]
+                        : firstBlockSection
+            });
+        } else {
+            // If not in natural flow, go to the selection section if specified
+            return this.findFirstVisibleSectionInRepeatedBlock({
+                interview,
+                repeatedBlockSection,
+                iterationContext,
+                startFrom: repeatedBlockSection.repeatedBlock.selectionSectionId
+                    ? repeatedBlockSection.repeatedBlock.selectionSectionId
+                    : firstBlockSection
+            });
+        }
+    }
+
+    private deactivateActiveSurveyObject({
+        repeatedBlockSection,
+        valuesByPath
+    }: {
+        repeatedBlockSection: SectionConfigWithDefaultsBlock;
+        valuesByPath: Record<string, unknown> | undefined;
+    }): Record<string, unknown> {
+        return Object.assign(valuesByPath || {}, {
+            [`response.${repeatedBlockSection.repeatedBlock.activeSurveyObjectPath}`]: undefined
+        });
+    }
+
+    private getTargetSectionFromRepeatedBlock({
+        interview,
+        originSection,
+        repeatedBlockSection,
+        direction
+    }: {
+        interview: UserRuntimeInterviewAttributes;
+        originSection: NavigationSection;
+        repeatedBlockSection: SectionConfigWithDefaultsBlock;
+        direction: string;
+    }): [NavigationSection, Record<string, unknown> | undefined] {
+        // Get the iteration contexts for which the block will be repeated
+        const [iterationContexts, updatedValues] = this.getIterationContextsForBlock({
+            interview,
+            blockSection: repeatedBlockSection
+        });
+
+        // Get the index of the current iteration in the iteration contexts
+        const currentIterationIndex = iterationContexts.findIndex((context) =>
+            _isEqual(context, originSection.iterationContext)
+        );
+
+        // See if we need to get off the block if current iteration is the last
+        // and the direction is fioward, or if the iteration is the first and
+        // direction is backward.
+        if (currentIterationIndex === iterationContexts.length - 1 && direction === 'forward') {
+            // FIXME The navigation in the repeated block section may not have
+            // been linear and some iterations might be invalid. We should add a
+            // iteration validator function to the repeated block to
+            // automatically select the invalid iteration if necessary instead
+            // of going to the next section directly.
+            return [
+                { sectionShortname: repeatedBlockSection.nextSection },
+                this.deactivateActiveSurveyObject({ repeatedBlockSection, valuesByPath: updatedValues })
+            ];
+        } else if (currentIterationIndex === 0 && direction === 'backward' && repeatedBlockSection.previousSection) {
+            return [
+                { sectionShortname: repeatedBlockSection.previousSection },
+                this.deactivateActiveSurveyObject({ repeatedBlockSection, valuesByPath: updatedValues })
+            ];
+        }
+
+        // Determine the next object to activate: if there was no previously
+        // selected object, take the first, otherwise, take the next one in the
+        // direction of the navigation
+        const nextIterationIndex =
+            currentIterationIndex === -1
+                ? 0
+                : Math.max(
+                    0,
+                    Math.min(currentIterationIndex + (direction === 'forward' ? 1 : -1), iterationContexts.length - 1)
+                );
+        const nextIterationContext = iterationContexts[nextIterationIndex];
+
+        // Go to the target section of the repeated block
+        const targetSectionName = this.findTargetSectionInRepeatedBlock({
+            interview,
+            repeatedBlockSection,
+            iterationContext: nextIterationContext
+        });
+
+        return [{ sectionShortname: targetSectionName, iterationContext: nextIterationContext }, updatedValues];
+    }
+
+    // Add the iteration context to the target section or remove any previous
+    // context if it is not in a repeated block
+    private goToCurrentIterationContextOrSelect({
+        interview,
+        sectionName,
+        repeatedBlockSectionName
+    }: {
+        interview: UserRuntimeInterviewAttributes;
+        sectionName: string;
+        repeatedBlockSectionName: string;
+    }): NavigationSection {
+        const sectionConfig = this.sections[repeatedBlockSectionName];
+        if (sectionConfig.type !== 'repeatedBlock') {
+            return {
+                sectionShortname: sectionName,
+                iterationContext: undefined
+            };
+        }
+        const repeatedBlock = sectionConfig.repeatedBlock;
+        // Get the current active object in the repeated block
+        const activeObjectId = getResponse(interview, repeatedBlock.activeSurveyObjectPath) as string | undefined;
+
+        if (activeObjectId === undefined) {
+            return {
+                sectionShortname: repeatedBlock.selectionSectionId || repeatedBlockSectionName,
+                iterationContext: undefined
+            };
+        } else {
+            return {
+                sectionShortname: sectionName,
+                iterationContext: repeatedBlock.pathPrefix
+                    ? [repeatedBlock.pathPrefix, activeObjectId]
+                    : [activeObjectId]
+            };
+        }
+    }
+
+    /**
+     * Main navigation function to determine the target section in the
+     * appropriate direction. If the navigation is not possible in the requested
+     * direction, the `TargetSectionResult` object will return the current
+     * navigation state.
+     *
+     * Note that the navigation service cannot determine if a form content is
+     * valid, so if the navigation is called, it means there are no invalid
+     * widgets, or navigation can take place. It will use the section's
+     * configuration and `isSectionCompleted` and `isSectionVisible` functions
+     * to determine respectively completion and visibility of a section.
+     *
+     * @param {Object} params The parameters for the navigation
+     * @param {UserRuntimeInterviewAttributes} params.interview The interview for which
+     * to navigate
+     * @param {NavigationSection} params.currentSection The current navigation section
+     * @param {'forward'|'backward'} [params.direction] The direction to navigate,
+     * either 'forward' or 'backward'. Defaults to `forward`
+     * @returns The next section to visit and the updated navigation state
+     */
+    public navigate({
+        interview,
+        currentSection,
+        direction = 'forward'
+    }: {
+        interview: UserRuntimeInterviewAttributes;
+        currentSection: NavigationSection;
+        direction?: 'forward' | 'backward';
+    }): TargetSectionResult {
+        // If direction is 'forward', validate that the current section is valid and completed. If not, return current section
+        if (direction === 'forward') {
+            if (!this.isSectionCompleted({ interview, section: currentSection })) {
+                return {
+                    targetSection: currentSection
+                };
+            }
+        }
+
+        const correctedCurrentSection = this.correctCurrentSectionIteration({ interview, currentSection });
+
+        // Find the first non-skipped section in the requested direction
+        const [targetSection, valuesByPath] = this.findFirstNonSkippedSection({
+            interview,
+            currentSection: correctedCurrentSection,
+            direction
+        });
+
+        // return current state if next section is the same as the current, otherwise, return the new state
+        const valuesToUpdate = this.getValuesToUpdate({ interview, targetSection });
+        return _isEqual(targetSection, currentSection)
+            ? { targetSection: currentSection }
+            : {
+                targetSection,
+                valuesByPath:
+                      valuesByPath === undefined ? valuesToUpdate : Object.assign(valuesByPath, valuesToUpdate)
+            };
+    }
+
+    // If the current section is the survey object selection section, update the current iteration to match the
+    // selected object. This is used to correct the current section iteration context when navigating to a section
+    // that is in a repeated block.
+    private correctCurrentSectionIteration({
+        interview,
+        currentSection
+    }: {
+        interview: UserRuntimeInterviewAttributes;
+        currentSection: NavigationSection;
+    }): NavigationSection {
+        const currentSectionConfig = this.sections[currentSection.sectionShortname];
+        if (currentSectionConfig.type === 'section' && currentSectionConfig.repeatedBlockSection) {
+            const repeatedBlockConfig = this.sections[
+                currentSectionConfig.repeatedBlockSection
+            ] as SectionConfigWithDefaultsBlock;
+            // If the section is not the selection section, no need for any correction
+            if (repeatedBlockConfig.repeatedBlock.selectionSectionId === currentSection.sectionShortname) {
+                // Just go to the current iteration of the section and return it if there is one, otherwise, keep the current section
+                const correctedCurrentSection = this.goToCurrentIterationContextOrSelect({
+                    interview,
+                    sectionName: currentSection.sectionShortname,
+                    repeatedBlockSectionName: currentSectionConfig.repeatedBlockSection
+                });
+                if (correctedCurrentSection.iterationContext !== undefined) {
+                    return correctedCurrentSection;
+                }
+            }
+        }
+        return currentSection;
+    }
+
+    // Add the iteration context to the target section if it is in a repeated
+    // block and not set yet, or reversely, remove it if it was set and not in a
+    // repeated block section
+    private handleIterationContextOnSection({
+        targetSection,
+        interview
+    }: {
+        targetSection: NavigationSection;
+        interview: UserRuntimeInterviewAttributes;
+    }) {
+        const sectionConfig = this.sections[targetSection.sectionShortname];
+        if (
+            targetSection.iterationContext === undefined &&
+            sectionConfig.type === 'section' &&
+            sectionConfig.repeatedBlockSection
+        ) {
+            return this.goToCurrentIterationContextOrSelect({
+                interview,
+                sectionName: targetSection.sectionShortname,
+                repeatedBlockSectionName: sectionConfig.repeatedBlockSection
+            });
+        } else if (
+            targetSection.iterationContext !== undefined &&
+            sectionConfig.type === 'section' &&
+            !sectionConfig.repeatedBlockSection
+        ) {
+            // Remove the iteration context if it is not in a repeated block
+            return { sectionShortname: targetSection.sectionShortname, iterationContext: undefined };
+        }
+        return targetSection;
+    }
+
+    private getValuesToUpdate({
+        interview,
+        targetSection
+    }: {
+        interview: UserRuntimeInterviewAttributes;
+        targetSection: NavigationSection;
+    }): { [key: string]: any } | undefined {
+        if (targetSection.iterationContext !== undefined) {
+            // Make sure the proper iteration context is set in the interview
+            const sectionConfig = this.sections[targetSection.sectionShortname];
+            const repeatedBlock =
+                sectionConfig.type === 'section' && sectionConfig.repeatedBlockSection
+                    ? (this.sections[sectionConfig.repeatedBlockSection] as SectionConfigWithDefaultsBlock)
+                        .repeatedBlock
+                    : (sectionConfig as any).repeatedBlock;
+            if (repeatedBlock) {
+                // Get the current active object in the repeated block
+                const activeObjectId = getResponse(interview, repeatedBlock.activeSurveyObjectPath) as
+                    | string
+                    | undefined;
+
+                if (activeObjectId !== targetSection.iterationContext[targetSection.iterationContext.length - 1]) {
+                    // Need to update the active object in the interview
+                    return {
+                        [`response.${repeatedBlock.activeSurveyObjectPath}`]:
+                            targetSection.iterationContext[targetSection.iterationContext.length - 1]
+                    };
+                }
+            }
+        }
+        return undefined;
+    }
+
+    /**
+     * Go to a specific section or initialize a new navigation state. This can
+     * either happen when the page is first loaded to go to the last section, or
+     * when the user requests a specific section, for example through the URL or
+     * by clicking the navigation menu. In any case, it will not navigate to a
+     * section that is not enabled or accessible yet.
+     *
+     * @param {Object} params The parameters for the navigation state
+     * @param {UserRuntimeInterviewAttributes} params.interview The interview for which
+     * to create the navigation state
+     * @param {string} [params.requestedSection] The section to navigate to. If left
+     * blank, it will either navigate to the last visited (or allowed) section
+     * or the first one.
+     */
+    public initNavigationState({
+        interview,
+        requestedSection
+    }: {
+        interview: UserRuntimeInterviewAttributes;
+        requestedSection?: string;
+    }): TargetSectionResult {
+        // Find the target section: either the requested section or last visited
+        // section in the interview, or the first one
+        const getTargetSection = () => {
+            if (requestedSection && this.sections[requestedSection]) {
+                return { sectionShortname: requestedSection };
+            }
+            const lastVisitedSection = getLastVisitedSection({ interview });
+            if (lastVisitedSection && this.sections[lastVisitedSection.sectionShortname]) {
+                return lastVisitedSection;
+            }
+            return { sectionShortname: this.getFirstSection() };
+        };
+        const targetSection = getTargetSection();
+        // Find the iteration context for the target section if necessary
+        const targetSectionWithContext = this.handleIterationContextOnSection({ targetSection, interview });
+
+        // TODO Make sure all the sections prior to the requested one are valid and complete
+
+        // See if it is possible to go to this section. If so, return the section
+        if (this.isSectionEnabledAndVisible({ interview, section: targetSectionWithContext })) {
+            const [targetSectionWithRepeated, updatedValues] = this.maybeGetTargetFromRepeatedBlock({
+                interview,
+                targetSection: targetSectionWithContext,
+                originSection: targetSectionWithContext,
+                direction: 'forward'
+            });
+            if (
+                _isEqual(targetSectionWithRepeated, targetSectionWithContext) ||
+                this.isSectionEnabledAndVisible({ interview, section: targetSectionWithRepeated })
+            ) {
+                const finalUpdatedValues = this.getValuesToUpdate({
+                    interview,
+                    targetSection: targetSectionWithRepeated
+                });
+                return {
+                    targetSection: targetSectionWithRepeated,
+                    valuesByPath:
+                        updatedValues === undefined
+                            ? finalUpdatedValues
+                            : Object.assign({}, finalUpdatedValues, updatedValues)
+                };
+            }
+        }
+
+        // Otherwise, find the first incomplete section backwards
+        const [targetSectionNonSkipped, valuesByPath] = this.findFirstNonSkippedSection({
+            interview,
+            currentSection: targetSectionWithContext,
+            direction: 'backward'
+        });
+
+        const valuestoUpdate = this.getValuesToUpdate({ interview, targetSection: targetSectionNonSkipped });
+        return {
+            targetSection: targetSectionNonSkipped,
+            valuesByPath: valuesByPath === undefined ? valuestoUpdate : Object.assign(valuesByPath, valuestoUpdate)
+        };
+    }
+}
+
+/**
+ * Create a navigation service instance from survey sections
+ *
+ * @param {SurveySections} sections The survey sections description for the current survey
+ * @returns {NavigationService} The navigation service instance
+ */
+export function createNavigationService(sections: SurveySections): NavigationService {
+    return new NavigationService(sections);
+}

--- a/packages/evolution-common/src/services/questionnaire/sections/__tests__/NavigationService.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/__tests__/NavigationService.test.ts
@@ -1,0 +1,2093 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import _cloneDeep from 'lodash/cloneDeep';
+import _shuffle from 'lodash/shuffle';
+import {  SectionConfigWithDefaultsBlock, SurveySections, UserRuntimeInterviewAttributes, getAndValidateSurveySections } from '../../types';
+import { createNavigationService } from '../NavigationService';
+
+jest.mock('lodash/shuffle', () => ({
+    __esModule: true,
+    default: jest.fn((array) => array)
+}));
+const mockShuffle = _shuffle as jest.MockedFunction<typeof _shuffle>;
+
+// TODO Add a basic interview object
+const interview: UserRuntimeInterviewAttributes = {
+    id: 1,
+    uuid: 'uuid',
+    participant_id: 1,
+    is_completed: false,
+    response: { },
+    validations: { },
+    is_valid: false,
+    // These are widgets statuses for the current section, if they are not grouped
+    widgets: { },
+    // These are the widget status for the groups in the current section
+    groups: { },
+    // Contains the paths in the responses of the visible widgets... FIXME Rename?
+    visibleWidgets: [],
+    allWidgetsValid: true,
+    // Name of the currently loaded section
+    sectionLoaded: undefined
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+// Define a simple navigation for tests
+const hhSectionEnabled = jest.fn().mockReturnValue(true);
+const hhSectionCompleted = jest.fn().mockReturnValue(true);
+const homeSectionCompleted = jest.fn().mockReturnValue(true);
+const hhShouldSectionBeVisible = jest.fn().mockReturnValue(true);
+const simpleSectionsConfig: SurveySections = getAndValidateSurveySections({
+    home: {
+        title: 'Home',
+        previousSection: null,
+        nextSection: 'householdMembers',
+        widgets: ['homeWidget'],
+        isSectionCompleted: homeSectionCompleted
+    },
+    householdMembers: {
+        title: 'Household members',
+        previousSection: 'home',
+        nextSection: 'end',
+        widgets: ['hhWidget'],
+        isSectionVisible: hhShouldSectionBeVisible,
+        isSectionCompleted: hhSectionCompleted,
+        enableConditional: hhSectionEnabled
+    },
+    end: {
+        title: 'End',
+        previousSection: 'householdMembers',
+        nextSection: null,
+        widgets: ['endWidget']
+    }
+});
+
+// Define a navigation with repeated blocks
+const tbIsSectionVisible = jest.fn().mockReturnValue(true);
+const tbIsSectionEnabled = jest.fn().mockReturnValue(true);
+const tripsIsEnabled = jest.fn().mockReturnValue(true);
+const complexSectionsConfig: SurveySections = getAndValidateSurveySections({
+    home: {
+        title: 'Home',
+        previousSection: null,
+        nextSection: 'householdMembers',
+        widgets: ['homeWidget']
+    },
+    householdMembers: {
+        title: 'Household members',
+        previousSection: 'home',
+        nextSection: 'personsTrips',
+        widgets: ['hhWidget']
+    },
+    personsTrips: {
+        title: 'Trips',
+        previousSection: 'householdMembers',
+        nextSection: 'end',
+        widgets: ['hhWidget'],
+        enableConditional: tripsIsEnabled,
+        repeatedBlock: {
+            iterationRule: { type: 'builtin', path: 'interviewablePersons' },
+            activeSurveyObjectPath: '_activePersonId',
+            sections: ['selectPerson', 'visitedPlaces', 'travelBehavior'],
+            selectionSectionId: 'selectPerson',
+            skipSelectionInNaturalFlow: true
+        }
+    },
+    selectPerson: {
+        title: 'Select person',
+        previousSection: 'personsTrips',
+        nextSection: 'visitedPlaces',
+        widgets: ['hhWidget']
+    },
+    visitedPlaces: {
+        title: 'Visited places',
+        previousSection: 'selectPerson',
+        nextSection: 'travelBehavior',
+        widgets: ['hhWidget']
+    },
+    travelBehavior: {
+        title: 'Travel behavior',
+        previousSection: 'visitedPlaces',
+        nextSection: 'personsTrips',
+        widgets: ['hhWidget'],
+        isSectionVisible: tbIsSectionVisible,
+        enableConditional: tbIsSectionEnabled
+    },
+    end: {
+        title: 'End',
+        previousSection: 'personsTrips',
+        nextSection: null,
+        widgets: ['endWidget']
+    }
+});
+const hhWithPersonsResponse = {
+    household: {
+        persons: {
+            personId1: {
+                _uuid: 'personId1',
+                _sequence: 1,
+                age: 30
+            },
+            personId2: {
+                _uuid: 'personId2',
+                _sequence: 2,
+                age: 35
+            },
+            personId3: {
+                _uuid: 'personId3',
+                _sequence: 3,
+                age: 3
+            }
+        }
+    }
+};
+
+describe('Simple direct navigation, each section in nav bar', () => {
+
+    const navigationService = createNavigationService(simpleSectionsConfig);
+
+    describe('initNavigationState',() => {
+        test('should navigate to first section when no previous navigation', () => {
+            const expectedSection = 'home';
+
+            // Navigate to the first section
+            const nextSectionResult = navigationService.initNavigationState({ interview });
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: undefined
+                }
+            });
+        });
+
+        test('should navigate to last visited section if there are previous navigations', () => {
+            const expectedSection = 'householdMembers';
+
+            // Prepare the interview with section navigation history
+            const testInterview = _cloneDeep(interview);
+            // FIXME The type of the _sections is not quite right, this should be valid but it is not
+            testInterview.response._sections = {
+                home: { _startedAt: 1, _isCompleted: true },
+                householdMembers: { _startedAt: 2 },
+                _actions: [
+                    { section: 'home', action: 'start' as const, ts: 1 },
+                    { section: 'householdMembers', action: 'start' as const, ts: 2 },
+                ]
+            } as any;
+
+            // Navigate to last visited section
+            const nextSectionResult = navigationService.initNavigationState({ interview: testInterview });
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: undefined
+                }
+            });
+        });
+
+        test('should navigate to requested section, even with previous navigations that reaches later', () => {
+            const requestedSection = 'householdMembers';
+            const expectedSection = 'householdMembers';
+
+            // Prepare the interview with section navigation history
+            const testInterview = _cloneDeep(interview);
+            // FIXME The type of the _sections is not quite right, this should be valid but it is not
+            testInterview.response._sections = {
+                home: { _startedAt: 1, _isCompleted: true },
+                householdMembers: { _startedAt: 2, _isCompleted: true },
+                end: { _startedAt: 3 },
+                _actions: [
+                    { section: 'home', action: 'start' as const, ts: 1 },
+                    { section: 'householdMembers', action: 'start' as const, ts: 2 },
+                    { section: 'end', action: 'start' as const, ts: 3 },
+                ]
+            } as any;
+
+            // Navigate to the requested section
+            const nextSectionResult = navigationService.initNavigationState({ interview: testInterview, requestedSection});
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: undefined
+                }
+            });
+        });
+
+        test('should navigate to last possible section if requested section is not enabled yet, using default enable', () => {
+            const requestedSection = 'end';
+            const expectedSection = 'householdMembers';
+
+            // Let the previous section completion conditional return `false` so end section cannot be reached
+            hhSectionCompleted.mockReturnValueOnce(false);
+
+            // Prepare the interview with section navigation history
+            const testInterview = _cloneDeep(interview);
+            // FIXME The type of the _sections is not quite right, this should be valid but it is not
+            testInterview.response._sections = {
+                home: { _startedAt: 1, _isCompleted: true },
+                householdMembers: { _startedAt: 2 },
+                _actions: [
+                    { section: 'home', action: 'start' as const, ts: 1 },
+                    { section: 'householdMembers', action: 'start' as const, ts: 2 },
+                ]
+            } as any;
+
+            // Navigate to a specific section
+            const nextSectionResult = navigationService.initNavigationState({ interview: testInterview, requestedSection });
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: undefined
+                }
+            });
+            // The completion conditional of the previous section should have been called
+            expect(hhSectionCompleted).toHaveBeenCalledWith(testInterview, undefined);
+        });
+
+        test('should navigate to last possible section if requested section is not enabled yet, using enableConditional', () => {
+            const requestedSection = 'householdMembers';
+            const expectedSection = 'home';
+
+            // Let the enable conditional return `false` so the section cannot be started
+            hhSectionEnabled.mockReturnValueOnce(false);
+
+            // Prepare the interview with section navigation history
+            const testInterview = _cloneDeep(interview);
+            // FIXME The type of the _sections is not quite right, this should be valid but it is not
+            testInterview.response._sections = {
+                home: { _startedAt: 1, _isCompleted: true },
+                householdMembers: { _startedAt: 2 },
+                _actions: [
+                    { section: 'home', action: 'start' as const, ts: 1 },
+                    { section: 'householdMembers', action: 'start' as const, ts: 2 },
+                ]
+            } as any;
+
+            // Navigate to a specific section
+            const nextSectionResult = navigationService.initNavigationState({ interview: testInterview, requestedSection });
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: undefined
+                }
+            });
+            // The completion conditional of the previous section should have been called
+            expect(hhSectionEnabled).toHaveBeenCalledWith(testInterview, 'householdMembers', undefined);
+        });
+
+        test('should recursively navigate to last possible section if previous sections not enabled yet, using default enable', () => {
+            const requestedSection = 'end';
+            const expectedSection = 'home';
+
+            // Let the householdMembers section return false for both enabled and completed, to recursively go back to home section
+            hhSectionCompleted.mockReturnValueOnce(false);
+            hhSectionEnabled.mockReturnValueOnce(false);
+
+            // Prepare the interview with section navigation history
+            const testInterview = _cloneDeep(interview);
+            // FIXME The type of the _sections is not quite right, this should be valid but it is not
+            testInterview.response._sections = {
+                home: { _startedAt: 1, _isCompleted: true },
+                householdMembers: { _startedAt: 2 },
+                _actions: [
+                    { section: 'home', action: 'start' as const, ts: 1 },
+                    { section: 'householdMembers', action: 'start' as const, ts: 2 },
+                ]
+            } as any;
+
+            // Navigate to requested section
+            const nextSectionResult = navigationService.initNavigationState({ interview: testInterview, requestedSection });
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: undefined
+                }
+            });
+            // The completion conditional of the previous section should have been called
+            expect(hhSectionCompleted).toHaveBeenCalledWith(testInterview, undefined);
+        });
+
+    });
+
+    describe('Navigate function', () => {
+        
+        test('should navigate to the next section forward', () => {
+            const currentSection = 'home';
+            const expectedSection = 'householdMembers';
+
+            // Prepare the interview with section navigation history
+            const testInterview = _cloneDeep(interview);
+            // FIXME The type of the _sections is not quite right, this should be valid but it is not
+            testInterview.response._sections = {
+                home: { _startedAt: 1, _isCompleted: true },
+                _actions: [
+                    { section: 'home', action: 'start' as const, ts: 1 },
+                ]
+            } as any;
+
+            // Prepare the previous navigation state
+            const currentSectionData = {
+                sectionShortname: currentSection,
+                iterationContext: undefined
+            }
+
+            // Navigate to specific section
+            const nextSectionResult = navigationService.navigate({
+                interview: testInterview,
+                currentSection: _cloneDeep(currentSectionData),
+                direction: 'forward'
+            });
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: undefined
+                }
+            });
+        });
+
+        test('should stay on page if navigating forward but section incomplete', () => {
+            const currentSection = 'home';
+            const expectedSection = 'home';
+            homeSectionCompleted.mockReturnValueOnce(false);
+
+            // Prepare the interview with section navigation history
+            const testInterview = _cloneDeep(interview);
+            // FIXME The type of the _sections is not quite right, this should be valid but it is not
+            testInterview.response._sections = {
+                home: { _startedAt: 1, _isCompleted: true },
+                _actions: [
+                    { section: 'home', action: 'start' as const, ts: 1 },
+                ]
+            } as any;
+
+            // Prepare the previous navigation state
+            const currentSectionData = {
+                sectionShortname: currentSection,
+                iterationContext: undefined
+            }
+
+            // Navigate to specific section
+            const nextSectionResult = navigationService.navigate({
+                interview: testInterview,
+                currentSection: _cloneDeep(currentSectionData),
+                direction: 'forward'
+            });
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: undefined
+                }
+            });
+        });
+
+        test('should navigate to the next section backward', () => {
+            const currentSection = 'householdMembers';
+            const expectedSection = 'home';
+
+            // Prepare the interview with section navigation history
+            const testInterview = _cloneDeep(interview);
+            // FIXME The type of the _sections is not quite right, this should be valid but it is not
+            testInterview.response._sections = {
+                home: { _startedAt: 1, _isCompleted: true },
+                householdMembers: { _startedAt: 2 },
+                _actions: [
+                    { section: 'home', action: 'start' as const, ts: 1 },
+                    { section: 'householdMembers', action: 'start' as const, ts: 2 },
+                ]
+            } as any;
+
+            // Prepare the previous navigation state
+            const currentSectionData = {
+                sectionShortname: currentSection,
+                iterationContext: undefined
+            }
+
+            // Navigate to specific section
+            const nextSectionResult = navigationService.navigate({
+                interview: testInterview,
+                currentSection: _cloneDeep(currentSectionData),
+                direction: 'backward'
+            });
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: undefined
+                }
+            });
+        });
+
+        test('should navigate to the next section backward, even if current section is incomplete', () => {
+            const currentSection = 'householdMembers';
+            const expectedSection = 'home';
+
+            // Prepare the interview with section navigation history
+            const testInterview = _cloneDeep(interview);
+            // FIXME The type of the _sections is not quite right, this should be valid but it is not
+            testInterview.response._sections = {
+                home: { _startedAt: 1, _isCompleted: true },
+                householdMembers: { _startedAt: 2 },
+                _actions: [
+                    { section: 'home', action: 'start' as const, ts: 1 },
+                    { section: 'householdMembers', action: 'start' as const, ts: 2 },
+                ]
+            } as any;
+
+            // Prepare the previous navigation state
+            const currentSectionData = {
+                sectionShortname: currentSection,
+                iterationContext: undefined
+            }
+
+            // Navigate to specific section
+            const nextSectionResult = navigationService.navigate({
+                interview: testInterview,
+                currentSection: _cloneDeep(currentSectionData),
+                direction: 'backward'
+            });
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: undefined
+                }
+            });
+            // Should not verify completion is going to previous section
+            expect(hhSectionCompleted).not.toHaveBeenCalled();
+        });
+
+        test('should remain in last section when navigating forward in last section', () => {
+            const currentSection = 'end';
+            const expectedSection = 'end';
+
+            // Prepare the interview with section navigation history
+            const testInterview = _cloneDeep(interview);
+            // FIXME The type of the _sections is not quite right, this should be valid but it is not
+            testInterview.response._sections = {
+                home: { _startedAt: 1, _isCompleted: true },
+                householdMembers: { _startedAt: 2, _isCompleted: true },
+                end: { _startedAt: 4 },
+                _actions: [
+                    { section: 'home', action: 'start' as const, ts: 1 },
+                    { section: 'householdMembers', action: 'start' as const, ts: 2 },
+                    { section: 'end', action: 'start' as const, ts: 4 },
+                ]
+            } as any;
+
+            // Prepare the previous navigation state
+            const currentSectionData = {
+                sectionShortname: currentSection,
+                iterationContext: undefined
+            }
+
+            // Navigate to specific section
+            const nextSectionResult = navigationService.navigate({
+                interview: testInterview,
+                currentSection: _cloneDeep(currentSectionData),
+                direction: 'forward'
+            });
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: undefined
+                }
+            });
+        });
+
+        test('should skip section if section is marked as such', () => {
+            const currentSection = 'home';
+            const expectedSection = 'end';
+            // HouseholdMembers section should be skipped
+            hhShouldSectionBeVisible.mockReturnValueOnce(false);
+
+             // Prepare the interview with section navigation history
+            const testInterview = _cloneDeep(interview);
+            // FIXME The type of the _sections is not quite right, this should be valid but it is not
+            testInterview.response._sections = {
+                home: { _startedAt: 1, _isCompleted: true },
+                householdMembers: { _startedAt: 2, _isCompleted: true },
+                end: { _startedAt: 4 },
+                _actions: [
+                    { section: 'home', action: 'start' as const, ts: 1 },
+                    { section: 'householdMembers', action: 'start' as const, ts: 2 },
+                    { section: 'end', action: 'start' as const, ts: 4 },
+                    { section: 'home', action: 'start' as const, ts: 8 },
+                ]
+            } as any;
+
+            // Prepare the previous navigation state
+            const currentSectionData = {
+                sectionShortname: currentSection,
+                iterationContext: undefined
+            }
+
+            // Navigate to specific section
+            const nextSectionResult = navigationService.navigate({
+                interview: testInterview,
+                currentSection: _cloneDeep(currentSectionData),
+                direction: 'forward'
+            });
+            expect(hhShouldSectionBeVisible).toHaveBeenCalledWith(testInterview, undefined);
+            expect(hhSectionCompleted).toHaveBeenCalledWith(testInterview, undefined);
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: undefined
+                }
+            });
+        });
+    })
+
+});
+
+describe('With repeated sections per household members, skipping select in natural flow', () => {
+
+    const navigationService = createNavigationService(complexSectionsConfig);
+
+    describe('initNavigationState',() => {
+        test('should navigate to first section when no previous navigation', () => {
+            const expectedSection = 'home';
+
+            // Navigate to the first section
+            const nextSectionResult = navigationService.initNavigationState({ interview });
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: undefined
+                }
+            });
+        });
+
+        test('should navigate to last visited section if there are previous navigations, section not repeated', () => {
+            const expectedSection = 'end';
+            
+            // Prepare the interview with section navigation history
+            const testInterview = _cloneDeep(interview);
+            // FIXME The type of the _sections is not quite right, this should be valid but it is not
+            testInterview.response._sections = {
+                home: { _startedAt: 1, _isCompleted: true },
+                householdMembers: { _startedAt: 2, _isCompleted: true },
+                personsTrips: {
+                    _startedAt: 6,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 6, _isCompleted: true },
+                    personId2: { _startedAt: 22, _isCompleted: true }
+                },
+                selectPerson: {
+                    _startedAt: 9,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 9, _isCompleted: true },
+                    personId2: { _startedAt: 24, _isCompleted: true }
+                },
+                visitedPlaces: {
+                    _startedAt: 12,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 12, _isCompleted: true },
+                    personId2: { _startedAt: 28, _isCompleted: true }
+                },
+                travelBehavior: {
+                    _startedAt: 20,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 20, _isCompleted: true },
+                    personId2: { _startedAt: 32, _isCompleted: true }
+                },
+                end: { startedAt: 50 },
+                _actions: [
+                    { section: 'home', action: 'start' as const, ts: 1 },
+                    { section: 'householdMembers', action: 'start' as const, ts: 2 },
+                    { section: 'personsTrips', iterationContext: ['personId1'], action: 'start' as const, ts: 6 },
+                    { section: 'selectPerson', iterationContext: ['personId1'], action: 'start' as const, ts: 9 },
+                    { section: 'visitedPlaces', iterationContext: ['personId1'], action: 'start' as const, ts: 12 },
+                    { section: 'travelBehavior', iterationContext: ['personId1'], action: 'start' as const, ts: 20 },
+                    { section: 'personsTrips', iterationContext: ['personId2'], action: 'start' as const, ts: 22 },
+                    { section: 'selectPerson', iterationContext: ['personId2'], action: 'start' as const, ts: 24 },
+                    { section: 'visitedPlaces', iterationContext: ['personId2'], action: 'start' as const, ts: 28 },
+                    { section: 'travelBehavior', iterationContext: ['personId2'], action: 'start' as const, ts: 32 },
+                    { section: 'end', action: 'start' as const, ts: 50 },
+                ]
+            } as any;
+            Object.assign(testInterview.response, hhWithPersonsResponse);
+
+            // Navigate to last visited section
+            const nextSectionResult = navigationService.initNavigationState({ interview: testInterview });
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: undefined
+                }
+            });
+        });
+
+        test('should navigate to last visited section with correctly activated object if there are previous navigations', () => {
+            const expectedSection = 'visitedPlaces';
+            
+            // Prepare the interview with section navigation history
+            const testInterview = _cloneDeep(interview);
+            // FIXME The type of the _sections is not quite right, this should be valid but it is not
+            testInterview.response._sections = {
+                home: { _startedAt: 1, _isCompleted: true },
+                householdMembers: { _startedAt: 2, _isCompleted: true },
+                personsTrips: {
+                    _startedAt: 6,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 6, _isCompleted: true },
+                    personId2: { _startedAt: 22, _isCompleted: true }
+                },
+                selectPerson: {
+                    _startedAt: 9,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 9, _isCompleted: true },
+                    personId2: { _startedAt: 24, _isCompleted: true }
+                },
+                visitedPlaces: {
+                    _startedAt: 12,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 12, _isCompleted: true },
+                    personId2: { _startedAt: 28 }
+                },
+                travelBehavior: {
+                    _startedAt: 20,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 20, _isCompleted: true }
+                },
+                _actions: [
+                    { section: 'home', action: 'start' as const, ts: 1 },
+                    { section: 'householdMembers', action: 'start' as const, ts: 2 },
+                    { section: 'personsTrips', iterationContext: ['personId1'], action: 'start' as const, ts: 6 },
+                    { section: 'selectPerson', iterationContext: ['personId1'], action: 'start' as const, ts: 9 },
+                    { section: 'visitedPlaces', iterationContext: ['personId1'], action: 'start' as const, ts: 12 },
+                    { section: 'travelBehavior', iterationContext: ['personId1'], action: 'start' as const, ts: 20 },
+                    { section: 'personsTrips', iterationContext: ['personId2'], action: 'start' as const, ts: 22 },
+                    { section: 'selectPerson', iterationContext: ['personId2'], action: 'start' as const, ts: 24 },
+                    { section: 'visitedPlaces', iterationContext: ['personId2'], action: 'start' as const, ts: 28 }
+                ]
+            } as any;
+            Object.assign(testInterview.response, hhWithPersonsResponse);
+
+            // Navigate to last visited section
+            const nextSectionResult = navigationService.initNavigationState({ interview: testInterview });
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: ['personId2']
+                },
+                valuesByPath: { 'response._activePersonId': 'personId2' }
+            });
+        });
+
+        test('should navigate to last incomplete section for activated object if requested section in a repeated block but not enabled', () => {
+            const requestedSection = 'travelBehavior';
+            const expectedSection = 'visitedPlaces';
+            
+            // Prepare the interview with section navigation history and a household
+            const testInterview = _cloneDeep(interview);
+            // FIXME The type of the _sections is not quite right, this should be valid but it is not
+            testInterview.response._sections = {
+                home: { _startedAt: 1, _isCompleted: true },
+                householdMembers: { _startedAt: 2, _isCompleted: true },
+                personsTrips: {
+                    _startedAt: 6,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 6, _isCompleted: true },
+                    personId2: { _startedAt: 22, _isCompleted: true }
+                },
+                selectPerson: {
+                    _startedAt: 9,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 9, _isCompleted: true },
+                    personId2: { _startedAt: 24, _isCompleted: true }
+                },
+                visitedPlaces: {
+                    _startedAt: 12,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 12, _isCompleted: true },
+                    personId2: { _startedAt: 28 }
+                },
+                travelBehavior: {
+                    _startedAt: 20,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 20, _isCompleted: true }
+                },
+                _actions: [
+                    { section: 'home', action: 'start' as const, ts: 1 },
+                    { section: 'householdMembers', action: 'start' as const, ts: 2 },
+                    { section: 'personsTrips', iterationContext: ['personId1'], action: 'start' as const, ts: 6 },
+                    { section: 'selectPerson', iterationContext: ['personId1'], action: 'start' as const, ts: 9 },
+                    { section: 'visitedPlaces', iterationContext: ['personId1'], action: 'start' as const, ts: 12 },
+                    { section: 'travelBehavior', iterationContext: ['personId1'], action: 'start' as const, ts: 20 },
+                    { section: 'personsTrips', iterationContext: ['personId2'], action: 'start' as const, ts: 22 },
+                    { section: 'selectPerson', iterationContext: ['personId2'], action: 'start' as const, ts: 24 },
+                    { section: 'visitedPlaces', iterationContext: ['personId2'], action: 'start' as const, ts: 28 }
+                ]
+            } as any;
+            Object.assign(testInterview.response, hhWithPersonsResponse);
+            testInterview.response._activePersonId = 'personId2';
+            tbIsSectionEnabled.mockReturnValueOnce(false); // Simulate that the section is not visible
+
+            // Navigate to requested section
+            const nextSectionResult = navigationService.initNavigationState({ interview: testInterview, requestedSection });
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: ['personId2']
+                }
+            });
+        });
+
+        test('should navigate to last section for activated object if requested section in a repeated block but not visible', () => {
+            const requestedSection = 'travelBehavior';
+            const expectedSection = 'visitedPlaces';
+            
+            // Prepare the interview with section navigation history and a household
+            const testInterview = _cloneDeep(interview);
+            // FIXME The type of the _sections is not quite right, this should be valid but it is not
+            testInterview.response._sections = {
+                home: { _startedAt: 1, _isCompleted: true },
+                householdMembers: { _startedAt: 2, _isCompleted: true },
+                personsTrips: {
+                    _startedAt: 6,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 6, _isCompleted: true },
+                    personId2: { _startedAt: 22, _isCompleted: true }
+                },
+                selectPerson: {
+                    _startedAt: 9,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 9, _isCompleted: true },
+                    personId2: { _startedAt: 24, _isCompleted: true }
+                },
+                visitedPlaces: {
+                    _startedAt: 12,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 12, _isCompleted: true },
+                    personId2: { _startedAt: 28 }
+                },
+                travelBehavior: {
+                    _startedAt: 20,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 20, _isCompleted: true }
+                },
+                _actions: [
+                    { section: 'home', action: 'start' as const, ts: 1 },
+                    { section: 'householdMembers', action: 'start' as const, ts: 2 },
+                    { section: 'personsTrips', iterationContext: ['personId1'], action: 'start' as const, ts: 6 },
+                    { section: 'selectPerson', iterationContext: ['personId1'], action: 'start' as const, ts: 9 },
+                    { section: 'visitedPlaces', iterationContext: ['personId1'], action: 'start' as const, ts: 12 },
+                    { section: 'travelBehavior', iterationContext: ['personId1'], action: 'start' as const, ts: 20 },
+                    { section: 'personsTrips', iterationContext: ['personId2'], action: 'start' as const, ts: 22 },
+                    { section: 'selectPerson', iterationContext: ['personId2'], action: 'start' as const, ts: 24 },
+                    { section: 'visitedPlaces', iterationContext: ['personId2'], action: 'start' as const, ts: 28 }
+                ]
+            } as any;
+            Object.assign(testInterview.response, hhWithPersonsResponse);
+            testInterview.response._activePersonId = 'personId2';
+            tbIsSectionVisible.mockReturnValueOnce(false); // Simulate that the section is not visible
+
+            // Navigate to requested section
+            const nextSectionResult = navigationService.initNavigationState({ interview: testInterview, requestedSection });
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: ['personId2']
+                }
+            });
+        });
+
+        test('should navigate to object selection section if requested section in a repeated block but no active object', () => {
+            const requestedSection = 'travelBehavior';
+            const expectedSection = 'selectPerson';
+            
+            // Prepare the interview with section navigation history and a household
+            const testInterview = _cloneDeep(interview);
+            // FIXME The type of the _sections is not quite right, this should be valid but it is not
+            testInterview.response._sections = {
+                home: { _startedAt: 1, _isCompleted: true },
+                householdMembers: { _startedAt: 2, _isCompleted: true },
+                personsTrips: {
+                    _startedAt: 6,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 6, _isCompleted: true },
+                    personId2: { _startedAt: 22, _isCompleted: true }
+                },
+                selectPerson: {
+                    _startedAt: 9,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 9, _isCompleted: true },
+                    personId2: { _startedAt: 24, _isCompleted: true }
+                },
+                visitedPlaces: {
+                    _startedAt: 12,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 12, _isCompleted: true },
+                    personId2: { _startedAt: 28,  _isCompleted: true }
+                },
+                travelBehavior: {
+                    _startedAt: 20,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 20, _isCompleted: true },
+                    personId2: { _startedAt: 30 }
+                },
+                _actions: [
+                    { section: 'home', action: 'start' as const, ts: 1 },
+                    { section: 'householdMembers', action: 'start' as const, ts: 2 },
+                    { section: 'personsTrips', iterationContext: ['personId1'], action: 'start' as const, ts: 6 },
+                    { section: 'selectPerson', iterationContext: ['personId1'], action: 'start' as const, ts: 9 },
+                    { section: 'visitedPlaces', iterationContext: ['personId1'], action: 'start' as const, ts: 12 },
+                    { section: 'travelBehavior', iterationContext: ['personId1'], action: 'start' as const, ts: 20 },
+                    { section: 'personsTrips', iterationContext: ['personId2'], action: 'start' as const, ts: 22 },
+                    { section: 'selectPerson', iterationContext: ['personId2'], action: 'start' as const, ts: 24 },
+                    { section: 'visitedPlaces', iterationContext: ['personId2'], action: 'start' as const, ts: 28 },
+                    { section: 'travelBehavior', iterationContext: ['personId2'], action: 'start' as const, ts: 30 }
+                ]
+            } as any;
+            Object.assign(testInterview.response, hhWithPersonsResponse);
+
+            // Navigate to requested section
+            const nextSectionResult = navigationService.initNavigationState({ interview: testInterview, requestedSection });
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: undefined
+                }
+            });
+        });
+
+        test('should navigate to first section of repeated block with first iteration if the main repeated block section is requested', () => {
+            const requestedSection = 'personsTrips';
+            const expectedSection = 'selectPerson';
+            const expectedContext = ['personId1'];
+            
+            // Prepare the interview with section navigation history and a household
+            const testInterview = _cloneDeep(interview);
+            // FIXME The type of the _sections is not quite right, this should be valid but it is not
+            testInterview.response._sections = {
+                home: { _startedAt: 1, _isCompleted: true },
+                householdMembers: { _startedAt: 2, _isCompleted: true },
+                personsTrips: {
+                    _startedAt: 6,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 6, _isCompleted: true },
+                    personId2: { _startedAt: 22, _isCompleted: true }
+                },
+                selectPerson: {
+                    _startedAt: 9,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 9, _isCompleted: true },
+                    personId2: { _startedAt: 24, _isCompleted: true }
+                },
+                visitedPlaces: {
+                    _startedAt: 12,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 12, _isCompleted: true },
+                    personId2: { _startedAt: 28 }
+                },
+                travelBehavior: {
+                    _startedAt: 20,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 20, _isCompleted: true }
+                },
+                _actions: [
+                    { section: 'home', action: 'start' as const, ts: 1 },
+                    { section: 'householdMembers', action: 'start' as const, ts: 2 },
+                    { section: 'personsTrips', iterationContext: ['personId1'], action: 'start' as const, ts: 6 },
+                    { section: 'selectPerson', iterationContext: ['personId1'], action: 'start' as const, ts: 9 },
+                    { section: 'visitedPlaces', iterationContext: ['personId1'], action: 'start' as const, ts: 12 },
+                    { section: 'travelBehavior', iterationContext: ['personId1'], action: 'start' as const, ts: 20 },
+                    { section: 'personsTrips', iterationContext: ['personId2'], action: 'start' as const, ts: 22 },
+                    { section: 'selectPerson', iterationContext: ['personId2'], action: 'start' as const, ts: 24 },
+                    { section: 'visitedPlaces', iterationContext: ['personId2'], action: 'start' as const, ts: 28 }
+                ]
+            } as any;
+            Object.assign(testInterview.response, hhWithPersonsResponse);
+            testInterview.response._activePersonId = 'personId2';
+
+            // Navigate to requested section
+            const nextSectionResult = navigationService.initNavigationState({ interview: testInterview, requestedSection });
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: expectedContext
+                },
+                valuesByPath: { 'response._activePersonId': 'personId1' }
+            });
+        });
+
+        test('should skip selection section if only one iteration', () => {
+            const requestedSection = 'personsTrips';
+            const expectedSection = 'visitedPlaces';
+            const expectedContext = ['personId1'];
+            
+            // Prepare the interview with section navigation history and a household with only one person
+            const testInterview = _cloneDeep(interview);
+            const testHhWithPersons = _cloneDeep(hhWithPersonsResponse) as any;
+            delete testHhWithPersons.household.persons.personId2;
+            delete testHhWithPersons.household.persons.personId3;
+            // FIXME The type of the _sections is not quite right, this should be valid but it is not
+            testInterview.response._sections = {
+                home: { _startedAt: 1, _isCompleted: true },
+                householdMembers: { _startedAt: 2, _isCompleted: true },
+                personsTrips: {
+                    _startedAt: 6,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 6, _isCompleted: true },
+                },
+                visitedPlaces: {
+                    _startedAt: 12,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 12, _isCompleted: true },
+                },
+                travelBehavior: {
+                    _startedAt: 20,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 20, _isCompleted: true }
+                },
+                _actions: [
+                    { section: 'home', action: 'start' as const, ts: 1 },
+                    { section: 'householdMembers', action: 'start' as const, ts: 2 },
+                    { section: 'personsTrips', iterationContext: ['personId1'], action: 'start' as const, ts: 6 },
+                    { section: 'visitedPlaces', iterationContext: ['personId1'], action: 'start' as const, ts: 12 },
+                    { section: 'travelBehavior', iterationContext: ['personId1'], action: 'start' as const, ts: 20 }
+                ]
+            } as any;
+            Object.assign(testInterview.response, testHhWithPersons);
+
+            // Navigate to requested section
+            const nextSectionResult = navigationService.initNavigationState({ interview: testInterview, requestedSection });
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: expectedContext
+                },
+                valuesByPath: { 'response._activePersonId': 'personId1' }
+            });
+        });
+    });
+
+    describe('Navigate function', () => {
+
+        test('should skip selection section when coming from previous section the first time', () => {
+            const currentSection = 'householdMembers';
+            const expectedSection = 'visitedPlaces';
+
+            // Prepare the interview with section navigation history and a household
+            const testInterview = _cloneDeep(interview);
+            // FIXME The type of the _sections is not quite right, this should be valid but it is not
+            testInterview.response._sections = {
+                home: { _startedAt: 1, _isCompleted: true },
+                householdMembers: { _startedAt: 2, _isCompleted: true },
+                _actions: [
+                    { section: 'home', action: 'start' as const, ts: 1 },
+                    { section: 'householdMembers', action: 'start' as const, ts: 2 }
+                ]
+            } as any;
+            Object.assign(testInterview.response, hhWithPersonsResponse);
+
+            // Prepare the previous navigation state
+            const currentSectionData = {
+                sectionShortname: currentSection,
+                iterationContext: undefined
+            }
+
+            // Navigate to specific section
+            const nextSectionResult = navigationService.navigate({
+                interview: testInterview,
+                currentSection: _cloneDeep(currentSectionData),
+                direction: 'forward'
+            });
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: ['personId1']
+                },
+                valuesByPath: { 'response._activePersonId': 'personId1' }
+            });
+        });
+
+        test('should skip selection section when coming from end of first iteration', () => {
+            const currentSection = 'travelBehavior';
+            const expectedSection = 'visitedPlaces';
+
+            // Prepare the interview with section navigation history and a household
+            const testInterview = _cloneDeep(interview);
+            // FIXME The type of the _sections is not quite right, this should be valid but it is not
+            testInterview.response._sections = {
+                home: { _startedAt: 1, _isCompleted: true },
+                householdMembers: { _startedAt: 2, _isCompleted: true },
+                personsTrips: {
+                    _startedAt: 6,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 6, _isCompleted: true }
+                },
+                selectPerson: {
+                    _startedAt: 9,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 9, _isCompleted: true }
+                },
+                visitedPlaces: {
+                    _startedAt: 12,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 12, _isCompleted: true }
+                },
+                travelBehavior: {
+                    _startedAt: 20,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 20, _isCompleted: true }
+                },
+                _actions: [
+                    { section: 'home', action: 'start' as const, ts: 1 },
+                    { section: 'householdMembers', action: 'start' as const, ts: 2 },
+                    { section: 'personsTrips', iterationContext: ['personId1'], action: 'start' as const, ts: 6 },
+                    { section: 'selectPerson', iterationContext: ['personId1'], action: 'start' as const, ts: 9 },
+                    { section: 'visitedPlaces', iterationContext: ['personId1'], action: 'start' as const, ts: 12 },
+                    { section: 'travelBehavior', iterationContext: ['personId1'], action: 'start' as const, ts: 20 }
+                ]
+            } as any;
+            Object.assign(testInterview.response, hhWithPersonsResponse);
+
+            // Prepare the previous navigation state
+            const currentSectionData = {
+                sectionShortname: currentSection,
+                iterationContext: ['personId1']
+            }
+
+            // Navigate to specific section
+            const nextSectionResult = navigationService.navigate({
+                interview: testInterview,
+                currentSection: _cloneDeep(currentSectionData),
+                direction: 'forward'
+            });
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: ['personId2']
+                },
+                valuesByPath: { 'response._activePersonId': 'personId2' }
+            });
+        });
+
+        test('should show selection section when coming from previous, but sections already visited', () => {          
+            const currentSection = 'householdMembers';
+            const expectedSection = 'selectPerson';
+
+            // Prepare the interview with section navigation history and a household
+            const testInterview = _cloneDeep(interview);
+            // FIXME The type of the _sections is not quite right, this should be valid but it is not
+            testInterview.response._sections = {
+                home: { _startedAt: 1, _isCompleted: true },
+                householdMembers: { _startedAt: 2, _isCompleted: true },
+                personsTrips: {
+                    _startedAt: 6,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 6, _isCompleted: true }
+                },
+                selectPerson: {
+                    _startedAt: 9,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 9, _isCompleted: true }
+                },
+                visitedPlaces: {
+                    _startedAt: 12,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 12, _isCompleted: true }
+                },
+                travelBehavior: {
+                    _startedAt: 20,
+                    _isCompleted: true
+                },
+                _actions: [
+                    { section: 'home', action: 'start' as const, ts: 1 },
+                    { section: 'householdMembers', action: 'start' as const, ts: 2 },
+                    { section: 'personsTrips', iterationContext: ['personId1'], action: 'start' as const, ts: 6 },
+                    { section: 'selectPerson', iterationContext: ['personId1'], action: 'start' as const, ts: 9 },
+                    { section: 'visitedPlaces', iterationContext: ['personId1'], action: 'start' as const, ts: 12 },
+                    { section: 'householdMembers', action: 'start' as const, ts: 20 }
+                ]
+            } as any;
+            Object.assign(testInterview.response, hhWithPersonsResponse);
+
+            // Prepare the previous navigation state
+            const currentSectionData = {
+                sectionShortname: currentSection,
+                iterationContext: undefined
+            }
+
+            // Navigate to specific section
+            const nextSectionResult = navigationService.navigate({
+                interview: testInterview,
+                currentSection: _cloneDeep(currentSectionData),
+                direction: 'forward'
+            });
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: ['personId1']
+                },
+                valuesByPath: { 'response._activePersonId': 'personId1' }
+            });
+        });
+
+        test('should navigate to the "end" section when all repeated blocks completed', () => {
+            const currentSection = 'travelBehavior';
+            const expectedSection = 'end';
+            
+            // Prepare the interview with section navigation history and a household
+            const testInterview = _cloneDeep(interview);
+            // FIXME The type of the _sections is not quite right, this should be valid but it is not
+            testInterview.response._sections = {
+                home: { _startedAt: 1, _isCompleted: true },
+                householdMembers: { _startedAt: 2, _isCompleted: true },
+                personsTrips: {
+                    _startedAt: 6,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 6, _isCompleted: true },
+                    personId2: { _startedAt: 22, _isCompleted: true }
+                },
+                selectPerson: {
+                    _startedAt: 9,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 9, _isCompleted: true },
+                    personId2: { _startedAt: 24, _isCompleted: true }
+                },
+                visitedPlaces: {
+                    _startedAt: 12,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 12, _isCompleted: true },
+                    personId2: { _startedAt: 28,  _isCompleted: true }
+                },
+                travelBehavior: {
+                    _startedAt: 20,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 20, _isCompleted: true },
+                    personId2: { _startedAt: 30, _isCompleted: true }
+                },
+                _actions: [
+                    { section: 'home', action: 'start' as const, ts: 1 },
+                    { section: 'householdMembers', action: 'start' as const, ts: 2 },
+                    { section: 'personsTrips', iterationContext: ['personId1'], action: 'start' as const, ts: 6 },
+                    { section: 'selectPerson', iterationContext: ['personId1'], action: 'start' as const, ts: 9 },
+                    { section: 'visitedPlaces', iterationContext: ['personId1'], action: 'start' as const, ts: 12 },
+                    { section: 'travelBehavior', iterationContext: ['personId1'], action: 'start' as const, ts: 20 },
+                    { section: 'personsTrips', iterationContext: ['personId2'], action: 'start' as const, ts: 22 },
+                    { section: 'selectPerson', iterationContext: ['personId2'], action: 'start' as const, ts: 24 },
+                    { section: 'visitedPlaces', iterationContext: ['personId2'], action: 'start' as const, ts: 28 },
+                    { section: 'travelBehavior', iterationContext: ['personId2'], action: 'start' as const, ts: 30 }
+                ]
+            } as any;
+            Object.assign(testInterview.response, hhWithPersonsResponse);
+
+            // Prepare the previous navigation state
+            const currentSectionData = {
+                sectionShortname: currentSection,
+                iterationContext: ['personId2']
+            }
+
+            // Navigate to specific section
+            const nextSectionResult = navigationService.navigate({
+                interview: testInterview,
+                currentSection: _cloneDeep(currentSectionData),
+                direction: 'forward'
+            });
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: undefined
+                },
+                valuesByPath: { 'response._activePersonId': undefined }
+            });
+        });
+
+        test('should show selection section when entering repeated block, even if interview is completed', () => {
+            const currentSection = 'householdMembers';
+            const expectedSection = 'selectPerson';
+            
+            // Prepare the interview with section navigation history and a household
+            const testInterview = _cloneDeep(interview);
+            // FIXME The type of the _sections is not quite right, this should be valid but it is not
+            testInterview.response._sections = {
+                home: { _startedAt: 1, _isCompleted: true },
+                householdMembers: { _startedAt: 2, _isCompleted: true },
+                personsTrips: {
+                    _startedAt: 6,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 6, _isCompleted: true },
+                    personId2: { _startedAt: 22, _isCompleted: true }
+                },
+                selectPerson: {
+                    _startedAt: 9,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 9, _isCompleted: true },
+                    personId2: { _startedAt: 24, _isCompleted: true }
+                },
+                visitedPlaces: {
+                    _startedAt: 12,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 12, _isCompleted: true },
+                    personId2: { _startedAt: 28,  _isCompleted: true }
+                },
+                travelBehavior: {
+                    _startedAt: 20,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 20, _isCompleted: true },
+                    personId2: { _startedAt: 30, _isCompleted: true }
+                },
+                end: { _startedAt: 40, _isCompleted: true },
+                _actions: [
+                    { section: 'home', action: 'start' as const, ts: 1 },
+                    { section: 'householdMembers', action: 'start' as const, ts: 2 },
+                    { section: 'personsTrips', iterationContext: ['personId1'], action: 'start' as const, ts: 6 },
+                    { section: 'selectPerson', iterationContext: ['personId1'], action: 'start' as const, ts: 9 },
+                    { section: 'visitedPlaces', iterationContext: ['personId1'], action: 'start' as const, ts: 12 },
+                    { section: 'travelBehavior', iterationContext: ['personId1'], action: 'start' as const, ts: 20 },
+                    { section: 'personsTrips', iterationContext: ['personId2'], action: 'start' as const, ts: 22 },
+                    { section: 'selectPerson', iterationContext: ['personId2'], action: 'start' as const, ts: 24 },
+                    { section: 'visitedPlaces', iterationContext: ['personId2'], action: 'start' as const, ts: 28 },
+                    { section: 'travelBehavior', iterationContext: ['personId2'], action: 'start' as const, ts: 30 },
+                    { section: 'end', action: 'start' as const, ts: 40 }
+                ]
+            } as any;
+            Object.assign(testInterview.response, hhWithPersonsResponse);
+
+            // Prepare the previous navigation state
+            const currentSectionData = {
+                sectionShortname: currentSection,
+                iterationContext: undefined
+            }
+
+            // Navigate to specific section
+            const nextSectionResult = navigationService.navigate({
+                interview: testInterview,
+                currentSection: _cloneDeep(currentSectionData),
+                direction: 'forward'
+            });
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: ['personId1']
+                },
+                valuesByPath: { 'response._activePersonId': 'personId1' }
+            });
+        });
+
+        test('should go to previous iteration if navigating backward from an iteration that is not the first', () => {
+            const currentSection = 'selectPerson';
+            const currentIterationContext = ['personId2'];
+            const expectedSection = 'selectPerson';
+            const expectedIterationContext = ['personId1'];
+            
+            // Prepare the interview with section navigation history and a household
+            const testInterview = _cloneDeep(interview);
+            // FIXME The type of the _sections is not quite right, this should be valid but it is not
+            testInterview.response._sections = {
+                home: { _startedAt: 1, _isCompleted: true },
+                householdMembers: { _startedAt: 2, _isCompleted: true },
+                personsTrips: {
+                    _startedAt: 6,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 6, _isCompleted: true },
+                    personId2: { _startedAt: 22, _isCompleted: true }
+                },
+                selectPerson: {
+                    _startedAt: 9,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 9, _isCompleted: true },
+                    personId2: { _startedAt: 24, _isCompleted: true }
+                },
+                visitedPlaces: {
+                    _startedAt: 12,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 12, _isCompleted: true },
+                    personId2: { _startedAt: 28,  _isCompleted: true }
+                },
+                travelBehavior: {
+                    _startedAt: 20,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 20, _isCompleted: true },
+                    personId2: { _startedAt: 30, _isCompleted: true }
+                },
+                end: { _startedAt: 40, _isCompleted: true },
+                _actions: [
+                    { section: 'home', action: 'start' as const, ts: 1 },
+                    { section: 'householdMembers', action: 'start' as const, ts: 2 },
+                    { section: 'personsTrips', iterationContext: ['personId1'], action: 'start' as const, ts: 6 },
+                    { section: 'selectPerson', iterationContext: ['personId1'], action: 'start' as const, ts: 9 },
+                    { section: 'visitedPlaces', iterationContext: ['personId1'], action: 'start' as const, ts: 12 },
+                    { section: 'travelBehavior', iterationContext: ['personId1'], action: 'start' as const, ts: 20 },
+                    { section: 'personsTrips', iterationContext: ['personId2'], action: 'start' as const, ts: 22 },
+                    { section: 'selectPerson', iterationContext: ['personId2'], action: 'start' as const, ts: 24 },
+                    { section: 'visitedPlaces', iterationContext: ['personId2'], action: 'start' as const, ts: 28 },
+                    { section: 'travelBehavior', iterationContext: ['personId2'], action: 'start' as const, ts: 30 },
+                    { section: 'end', action: 'start' as const, ts: 40 }
+                ]
+            } as any;
+            Object.assign(testInterview.response, hhWithPersonsResponse);
+
+            // Prepare the previous navigation state
+            const currentSectionData = {
+                sectionShortname: currentSection,
+                iterationContext: currentIterationContext
+            }
+
+            // Navigate to specific section
+            const nextSectionResult = navigationService.navigate({
+                interview: testInterview,
+                currentSection: _cloneDeep(currentSectionData),
+                direction: 'backward'
+            });
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: expectedIterationContext
+                },
+                valuesByPath: { 'response._activePersonId': 'personId1' }
+            });
+        });
+
+        test('should go to previous section, without iteration, if navigating backward from first block iteration', () => {
+            const currentSection = 'selectPerson';
+            const currentIterationContext = ['personId1'];
+            const expectedSection = 'householdMembers';
+            
+            // Prepare the interview with section navigation history and a household
+            const testInterview = _cloneDeep(interview);
+            // FIXME The type of the _sections is not quite right, this should be valid but it is not
+            testInterview.response._sections = {
+                home: { _startedAt: 1, _isCompleted: true },
+                householdMembers: { _startedAt: 2, _isCompleted: true },
+                personsTrips: {
+                    _startedAt: 6,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 6, _isCompleted: true },
+                    personId2: { _startedAt: 22, _isCompleted: true }
+                },
+                selectPerson: {
+                    _startedAt: 9,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 9, _isCompleted: true },
+                    personId2: { _startedAt: 24, _isCompleted: true }
+                },
+                visitedPlaces: {
+                    _startedAt: 12,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 12, _isCompleted: true },
+                    personId2: { _startedAt: 28,  _isCompleted: true }
+                },
+                travelBehavior: {
+                    _startedAt: 20,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 20, _isCompleted: true },
+                    personId2: { _startedAt: 30, _isCompleted: true }
+                },
+                end: { _startedAt: 40, _isCompleted: true },
+                _actions: [
+                    { section: 'home', action: 'start' as const, ts: 1 },
+                    { section: 'householdMembers', action: 'start' as const, ts: 2 },
+                    { section: 'personsTrips', iterationContext: ['personId1'], action: 'start' as const, ts: 6 },
+                    { section: 'selectPerson', iterationContext: ['personId1'], action: 'start' as const, ts: 9 },
+                    { section: 'visitedPlaces', iterationContext: ['personId1'], action: 'start' as const, ts: 12 },
+                    { section: 'travelBehavior', iterationContext: ['personId1'], action: 'start' as const, ts: 20 },
+                    { section: 'personsTrips', iterationContext: ['personId2'], action: 'start' as const, ts: 22 },
+                    { section: 'selectPerson', iterationContext: ['personId2'], action: 'start' as const, ts: 24 },
+                    { section: 'visitedPlaces', iterationContext: ['personId2'], action: 'start' as const, ts: 28 },
+                    { section: 'travelBehavior', iterationContext: ['personId2'], action: 'start' as const, ts: 30 },
+                    { section: 'end', action: 'start' as const, ts: 40 }
+                ]
+            } as any;
+            Object.assign(testInterview.response, hhWithPersonsResponse);
+
+            // Prepare the previous navigation state
+            const currentSectionData = {
+                sectionShortname: currentSection,
+                iterationContext: currentIterationContext
+            }
+
+            // Navigate to specific section
+            const nextSectionResult = navigationService.navigate({
+                interview: testInterview,
+                currentSection: _cloneDeep(currentSectionData),
+                direction: 'backward'
+            });
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: undefined
+                },
+                valuesByPath: { 'response._activePersonId': undefined }
+            });
+        });
+
+        test('should go to next section in block with same iteration if not skipped', () => {           
+            const currentSection = 'visitedPlaces';
+            const currentIterationContext = ['personId1'];
+            const expectedSection = 'travelBehavior';
+            const expectedIterationContext = ['personId1'];
+            
+            // Prepare the interview with section navigation history and a household
+            const testInterview = _cloneDeep(interview);
+            // FIXME The type of the _sections is not quite right, this should be valid but it is not
+            testInterview.response._sections = {
+                home: { _startedAt: 1, _isCompleted: true },
+                householdMembers: { _startedAt: 2, _isCompleted: true },
+                personsTrips: {
+                    _startedAt: 6,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 6, _isCompleted: true }
+                },
+                selectPerson: {
+                    _startedAt: 9,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 9, _isCompleted: true }
+                },
+                visitedPlaces: {
+                    _startedAt: 12,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 12, _isCompleted: true }
+                },
+                travelBehavior: {
+                    _startedAt: 20,
+                    _isCompleted: true
+                },
+                end: { _startedAt: 40, _isCompleted: true },
+                _actions: [
+                    { section: 'home', action: 'start' as const, ts: 1 },
+                    { section: 'householdMembers', action: 'start' as const, ts: 2 },
+                    { section: 'personsTrips', iterationContext: ['personId1'], action: 'start' as const, ts: 6 },
+                    { section: 'selectPerson', iterationContext: ['personId1'], action: 'start' as const, ts: 9 },
+                    { section: 'visitedPlaces', iterationContext: ['personId1'], action: 'start' as const, ts: 12 }
+                ]
+            } as any;
+            Object.assign(testInterview.response, hhWithPersonsResponse);
+            testInterview.response._activePersonId = 'personId1';
+
+            // Prepare the previous navigation state
+            const currentSectionData = {
+                sectionShortname: currentSection,
+                iterationContext: currentIterationContext
+            }
+
+            // Navigate to specific section
+            const nextSectionResult = navigationService.navigate({
+                interview: testInterview,
+                currentSection: _cloneDeep(currentSectionData),
+                direction: 'forward'
+            });
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: expectedIterationContext
+                },
+                valuesByPath: undefined
+            });
+            expect(tbIsSectionVisible).toHaveBeenCalledWith(testInterview, ['personId1']);
+        });
+
+        test('should go to next iteration if last section of block is skipped in natural flow', () => {           
+            const currentSection = 'visitedPlaces';
+            const currentIterationContext = ['personId1'];
+            const expectedSection = 'visitedPlaces';
+            const expectedIterationContext = ['personId2'];
+            tbIsSectionVisible.mockReturnValueOnce(false);
+            
+            // Prepare the interview with section navigation history and a household
+            const testInterview = _cloneDeep(interview);
+            // FIXME The type of the _sections is not quite right, this should be valid but it is not
+            testInterview.response._sections = {
+                home: { _startedAt: 1, _isCompleted: true },
+                householdMembers: { _startedAt: 2, _isCompleted: true },
+                personsTrips: {
+                    _startedAt: 6,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 6, _isCompleted: true }
+                },
+                selectPerson: {
+                    _startedAt: 9,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 9, _isCompleted: true }
+                },
+                visitedPlaces: {
+                    _startedAt: 12,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 12, _isCompleted: true }
+                },
+                travelBehavior: {
+                    _startedAt: 20,
+                    _isCompleted: true
+                },
+                end: { _startedAt: 40, _isCompleted: true },
+                _actions: [
+                    { section: 'home', action: 'start' as const, ts: 1 },
+                    { section: 'householdMembers', action: 'start' as const, ts: 2 },
+                    { section: 'personsTrips', iterationContext: ['personId1'], action: 'start' as const, ts: 6 },
+                    { section: 'selectPerson', iterationContext: ['personId1'], action: 'start' as const, ts: 9 },
+                    { section: 'visitedPlaces', iterationContext: ['personId1'], action: 'start' as const, ts: 12 }
+                ]
+            } as any;
+            Object.assign(testInterview.response, hhWithPersonsResponse);
+
+            // Prepare the previous navigation state
+            const currentSectionData = {
+                sectionShortname: currentSection,
+                iterationContext: currentIterationContext
+            }
+
+            // Navigate to specific section
+            const nextSectionResult = navigationService.navigate({
+                interview: testInterview,
+                currentSection: _cloneDeep(currentSectionData),
+                direction: 'forward'
+            });
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: expectedIterationContext
+                },
+                valuesByPath: { 'response._activePersonId': expectedIterationContext[0] }
+            });
+            expect(tbIsSectionVisible).toHaveBeenCalledWith(testInterview, ['personId1']);
+        });
+
+        test('should always select the correct next section for a completed interview', () => {
+            // This is the expected sequence of sections
+            const expectedSectionSequence = [
+                { sectionShortname: 'home' },
+                { sectionShortname: 'householdMembers' },
+                { sectionShortname: 'visitedPlaces', iterationContext: ['personId1'] },
+                { sectionShortname: 'travelBehavior', iterationContext: ['personId1']},
+                { sectionShortname: 'visitedPlaces', iterationContext: ['personId2']},
+                { sectionShortname: 'end' }
+            ];
+            // Skip travelBehavior at second call
+            tbIsSectionVisible.mockReturnValueOnce(true);
+            tbIsSectionVisible.mockReturnValueOnce(false);
+
+            // Prepare the interview with section navigation history and a household
+            const testInterview = _cloneDeep(interview);
+            // Initialize sections, they will be filled as needed, prefill responses
+            testInterview.response._sections = {
+                _actions: []
+            } as any;
+            Object.assign(testInterview.response, hhWithPersonsResponse);
+
+            const initialNavigation = navigationService.initNavigationState({ interview: testInterview });
+            expect(initialNavigation).toEqual({
+                targetSection: expectedSectionSequence[0]
+            });
+
+            // Prepare the previous navigation state
+            let currentSection = initialNavigation.targetSection;
+
+            for (let i = 1; i < expectedSectionSequence.length; i++) {
+                // Add section completion data to the interview
+                (testInterview.response._sections as any)[currentSection.sectionShortname] = {
+                    _startedAt: i * 10,
+                    _isCompleted: true,
+                };
+                if (currentSection.iterationContext) { 
+                    (testInterview.response._sections as any)[currentSection.sectionShortname][currentSection.iterationContext[0]] = {
+                        _startedAt: i * 10,
+                        _isCompleted: true,
+                    };
+                }
+                (testInterview.response._sections as any)._actions.push({
+                    section: currentSection.sectionShortname,
+                    iterationContext: currentSection.iterationContext,
+                    action: 'start' as const,
+                    ts: 6
+                });
+
+                const expectedSection = expectedSectionSequence[i];
+
+                // Navigate to specific section
+                const nextSectionResult = navigationService.navigate({
+                    interview: testInterview,
+                    currentSection: _cloneDeep(currentSection),
+                    direction: 'forward'
+                });
+                expect(nextSectionResult).toEqual({
+                    targetSection: expectedSection,
+                    valuesByPath: expectedSection.iterationContext === undefined && currentSection.iterationContext === undefined ? undefined : { 'response._activePersonId': expectedSection.iterationContext ? expectedSection.iterationContext[0] : undefined }
+                });
+                currentSection = nextSectionResult.targetSection;
+            }
+        });
+
+        test('should navigate to the "end" if repeated block is disabled', () => {
+            const currentSection = 'householdMembers';
+            const expectedSection = 'end';
+            tripsIsEnabled.mockReturnValueOnce(false);
+            
+            // Prepare the interview with section navigation history and a household
+            const testInterview = _cloneDeep(interview);
+            // FIXME The type of the _sections is not quite right, this should be valid but it is not
+            testInterview.response._sections = {
+                home: { _startedAt: 1, _isCompleted: true },
+                householdMembers: { _startedAt: 2, _isCompleted: true },
+                _actions: [
+                    { section: 'home', action: 'start' as const, ts: 1 },
+                    { section: 'householdMembers', action: 'start' as const, ts: 2 }
+                ]
+            } as any;
+            Object.assign(testInterview.response, hhWithPersonsResponse);
+
+            // Prepare the previous navigation state
+            const currentSectionData = {
+                sectionShortname: currentSection
+            }
+
+            // Navigate to specific section
+            const nextSectionResult = navigationService.navigate({
+                interview: testInterview,
+                currentSection: _cloneDeep(currentSectionData),
+                direction: 'forward'
+            });
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: undefined
+                },
+                valuesByPath: undefined
+            });
+        });
+
+        test('should select iteration with active survey object ID of interview if current section is selection section', () => {
+            const currentSection = 'selectPerson';
+            const currentIterationContext = ['personId2'];
+            const expectedSection = 'visitedPlaces';
+            const expectedIterationContext = ['personId1'];
+
+            // Prepare the interview with section navigation history and a household
+            const testInterview = _cloneDeep(interview);
+            // FIXME The type of the _sections is not quite right, this should be valid but it is not
+            testInterview.response._activePersonId = 'personId1';
+            testInterview.response._sections = {
+                home: { _startedAt: 1, _isCompleted: true },
+                householdMembers: { _startedAt: 2, _isCompleted: true },
+                personsTrips: {
+                    _startedAt: 6,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 6, _isCompleted: true },
+                    personId2: { _startedAt: 22, _isCompleted: true }
+                },
+                selectPerson: {
+                    _startedAt: 9,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 9, _isCompleted: true },
+                    personId2: { _startedAt: 24, _isCompleted: true }
+                },
+                visitedPlaces: {
+                    _startedAt: 12,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 12, _isCompleted: true },
+                    personId2: { _startedAt: 28,  _isCompleted: true }
+                },
+                travelBehavior: {
+                    _startedAt: 20,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 20, _isCompleted: true },
+                    personId2: { _startedAt: 30, _isCompleted: true }
+                },
+                end: { _startedAt: 40, _isCompleted: true },
+                _actions: [
+                    { section: 'home', action: 'start' as const, ts: 1 },
+                    { section: 'householdMembers', action: 'start' as const, ts: 2 },
+                    { section: 'personsTrips', iterationContext: ['personId1'], action: 'start' as const, ts: 6 },
+                    { section: 'selectPerson', iterationContext: ['personId1'], action: 'start' as const, ts: 9 },
+                    { section: 'visitedPlaces', iterationContext: ['personId1'], action: 'start' as const, ts: 12 },
+                    { section: 'travelBehavior', iterationContext: ['personId1'], action: 'start' as const, ts: 20 },
+                    { section: 'personsTrips', iterationContext: ['personId2'], action: 'start' as const, ts: 22 },
+                    { section: 'selectPerson', iterationContext: ['personId2'], action: 'start' as const, ts: 24 },
+                    { section: 'visitedPlaces', iterationContext: ['personId2'], action: 'start' as const, ts: 28 },
+                    { section: 'travelBehavior', iterationContext: ['personId2'], action: 'start' as const, ts: 30 },
+                    { section: 'end', action: 'start' as const, ts: 40 }
+                ]
+            } as any;
+            Object.assign(testInterview.response, hhWithPersonsResponse);
+
+            // Prepare the previous navigation state
+            const currentSectionData = {
+                sectionShortname: currentSection,
+                iterationContext: currentIterationContext
+            }
+
+            // Navigate to specific section
+            const nextSectionResult = navigationService.navigate({ interview: testInterview, currentSection: _cloneDeep(currentSectionData), direction: 'forward' });
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: expectedIterationContext
+                }
+            });
+        });
+
+    });
+
+});
+
+describe('navigate function, further use cases', () => {
+
+    describe('test iteration context order', () => {
+        // Prepare the interview with section navigation history and a household
+        const testInterview = _cloneDeep(interview);
+        // FIXME The type of the _sections is not quite right, this should be valid but it is not
+        testInterview.response._sections = {
+            home: { _startedAt: 1, _isCompleted: true },
+            householdMembers: { _startedAt: 2, _isCompleted: true },
+            _actions: [
+                { section: 'home', action: 'start' as const, ts: 1 },
+                { section: 'householdMembers', action: 'start' as const, ts: 2 }
+            ]
+        } as any;
+        Object.assign(testInterview.response, hhWithPersonsResponse);
+
+        test('random', () => {
+            const currentSection = 'householdMembers';
+            const expectedSection = 'visitedPlaces';
+            const expectedIterationContext = ['personId2'];
+
+            // Set the order of the iteration contexts to randomize and mock the result
+            const sectionConfig = _cloneDeep(complexSectionsConfig);
+            (sectionConfig['personsTrips'] as SectionConfigWithDefaultsBlock).repeatedBlock.order = 'random';
+            mockShuffle.mockReturnValueOnce(['personId2', 'personId1']);
+            const navigationService = createNavigationService(sectionConfig);
+
+            // Prepare the previous navigation state
+            const currentSectionData = {
+                sectionShortname: currentSection,
+                iterationContext: undefined
+            }
+
+            // Navigate to specific section
+            const nextSectionResult = navigationService.navigate({ interview: testInterview, currentSection: _cloneDeep(currentSectionData), direction: 'forward'});
+            expect(mockShuffle).toHaveBeenCalledWith(['personId1', 'personId2']);
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: expectedIterationContext
+                },
+                valuesByPath: { 'response._activePersonId': expectedIterationContext[0], 'response._RandomSequence': ['personId2', 'personId1'] }
+            });
+        });
+
+        test('random with path prefix', () => {
+            const currentSection = 'householdMembers';
+            const expectedSection = 'visitedPlaces';
+            const expectedIterationContext = ['person', 'personId2'];
+
+            // Set the order of the iteration contexts to randomize and mock shuffle order
+            const sectionConfig = _cloneDeep(complexSectionsConfig);
+            const pathPrefix = 'person';
+            (sectionConfig['personsTrips'] as SectionConfigWithDefaultsBlock).repeatedBlock.order = 'random';
+            (sectionConfig['personsTrips'] as SectionConfigWithDefaultsBlock).repeatedBlock.pathPrefix = pathPrefix;
+            mockShuffle.mockReturnValueOnce(['personId2', 'personId1']);
+            
+            const navigationService = createNavigationService(sectionConfig);
+
+            // Prepare the previous navigation state
+            const currentSectionData = {
+                sectionShortname: currentSection,
+                iterationContext: undefined
+            }
+
+            // Navigate to specific section
+            const nextSectionResult = navigationService.navigate({ interview: testInterview, currentSection: _cloneDeep(currentSectionData), direction: 'forward' });
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: expectedIterationContext
+                },
+                valuesByPath: { 'response._activePersonId': expectedIterationContext[1], 'response._personRandomSequence': ['personId2', 'personId1'] }
+            });
+            expect(mockShuffle).toHaveBeenCalledWith(['personId1', 'personId2']);
+        });
+
+        test('random, with random sequence already set', () => {
+            const currentSection = 'householdMembers';
+            const expectedSection = 'visitedPlaces';
+            const expectedIterationContext = ['personId2'];
+
+            // Set the order of the iteration contexts to randomize and mock the result
+            const sectionConfig = _cloneDeep(complexSectionsConfig);
+            (sectionConfig['personsTrips'] as SectionConfigWithDefaultsBlock).repeatedBlock.order = 'random';
+            const navigationService = createNavigationService(sectionConfig);
+
+            const testInterviewWithRandomSequence = _cloneDeep(testInterview);
+            testInterviewWithRandomSequence.response._RandomSequence = ['personId2', 'personId1'];
+
+            // Prepare the previous navigation state
+            const currentSectionData = {
+                sectionShortname: currentSection,
+                iterationContext: undefined
+            }
+
+            // Navigate to specific section
+            const nextSectionResult = navigationService.navigate({ interview: testInterviewWithRandomSequence, currentSection: _cloneDeep(currentSectionData), direction: 'forward' });
+            expect(mockShuffle).not.toHaveBeenCalled();
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: expectedIterationContext
+                },
+                valuesByPath: { 'response._activePersonId': expectedIterationContext[0] }
+            });
+        });
+
+        test('random, with random sequence already set, but now invalid (same length)', () => {
+            const currentSection = 'householdMembers';
+            const expectedSection = 'visitedPlaces';
+            const expectedIterationContext = ['personId2'];
+
+            // Set the order of the iteration contexts to randomize and mock the result
+            const sectionConfig = _cloneDeep(complexSectionsConfig);
+            (sectionConfig['personsTrips'] as SectionConfigWithDefaultsBlock).repeatedBlock.order = 'random';
+            const navigationService = createNavigationService(sectionConfig);
+            mockShuffle.mockReturnValueOnce(['personId2', 'personId1']);
+
+            const testInterviewWithRandomSequence = _cloneDeep(testInterview);
+            testInterviewWithRandomSequence.response._RandomSequence = ['personId2', 'personId3'];
+
+            // Prepare the previous navigation state
+            const currentSectionData = {
+                sectionShortname: currentSection,
+                iterationContext: undefined
+            }
+
+            // Navigate to specific section
+            const nextSectionResult = navigationService.navigate({ interview: testInterviewWithRandomSequence, currentSection: _cloneDeep(currentSectionData), direction: 'forward'});
+            expect(mockShuffle).toHaveBeenCalledWith(['personId1', 'personId2']);
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: expectedIterationContext
+                },
+                valuesByPath: { 'response._activePersonId': expectedIterationContext[0], 'response._RandomSequence': ['personId2', 'personId1'] }
+            });
+        });
+
+        test('random, with random sequence already set, but now invalid (different length)', () => {
+            const currentSection = 'householdMembers';
+            const expectedSection = 'visitedPlaces';
+            const expectedIterationContext = ['personId2'];
+
+            // Set the order of the iteration contexts to randomize and mock the result
+            const sectionConfig = _cloneDeep(complexSectionsConfig);
+            (sectionConfig['personsTrips'] as SectionConfigWithDefaultsBlock).repeatedBlock.order = 'random';
+            const navigationService = createNavigationService(sectionConfig);
+            mockShuffle.mockReturnValueOnce(['personId2', 'personId1']);
+
+            const testInterviewWithRandomSequence = _cloneDeep(testInterview);
+            testInterviewWithRandomSequence.response._RandomSequence = ['personId2', 'personId3', 'personId1'];
+
+            // Prepare the previous navigation state
+            const currentSectionData = {
+                sectionShortname: currentSection,
+                iterationContext: undefined
+            }
+
+            // Navigate to specific section
+            const nextSectionResult = navigationService.navigate({ interview: testInterviewWithRandomSequence, currentSection: _cloneDeep(currentSectionData), direction: 'forward' });
+            expect(mockShuffle).toHaveBeenCalledWith(['personId1', 'personId2']);
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: expectedIterationContext
+                },
+                valuesByPath: { 'response._activePersonId': expectedIterationContext[0], 'response._RandomSequence': ['personId2', 'personId1'] }
+            });
+        });
+
+        test('random with path prefix, with random sequence already set', () => {
+            const currentSection = 'householdMembers';
+            const expectedSection = 'visitedPlaces';
+            const expectedIterationContext = ['person', 'personId2'];
+
+            // Set the order of the iteration contexts to randomize
+            const sectionConfig = _cloneDeep(complexSectionsConfig);
+            const pathPrefix = 'person';
+            (sectionConfig['personsTrips'] as SectionConfigWithDefaultsBlock).repeatedBlock.order = 'random';
+            (sectionConfig['personsTrips'] as SectionConfigWithDefaultsBlock).repeatedBlock.pathPrefix = pathPrefix;
+            // Set random order
+            const testInterviewWithRandomSequence = _cloneDeep(testInterview);
+            testInterviewWithRandomSequence.response._personRandomSequence = ['personId2', 'personId1'];
+            
+            const navigationService = createNavigationService(sectionConfig);
+
+            // Prepare the previous navigation state
+            const currentSectionData = {
+                sectionShortname: currentSection,
+                iterationContext: undefined
+            }
+
+            // Navigate to specific section
+            const nextSectionResult = navigationService.navigate({ interview: testInterviewWithRandomSequence, currentSection: _cloneDeep(currentSectionData), direction: 'forward' });
+            expect(mockShuffle).not.toHaveBeenCalled();
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: expectedIterationContext
+                },
+                valuesByPath: { 'response._activePersonId': expectedIterationContext[1] }
+            });
+        });
+
+        test('sequential', () => {
+            const currentSection = 'householdMembers';
+            const expectedSection = 'visitedPlaces';
+            const expectedIterationContext = ['personId1'];
+
+            // Set the order of the iteration contexts to sequential and make sure mock is not called
+            const sectionConfig = _cloneDeep(complexSectionsConfig);
+            (sectionConfig['personsTrips'] as SectionConfigWithDefaultsBlock).repeatedBlock.order = 'sequential';
+            mockShuffle.mockReturnValueOnce(['personId2', 'personId1']);
+            
+            const navigationService = createNavigationService(sectionConfig);
+
+            // Prepare the previous navigation state
+            const currentSectionData = {
+                sectionShortname: currentSection,
+                iterationContext: undefined
+            }
+
+            // Navigate to specific section
+            const nextSectionResult = navigationService.navigate({ interview: testInterview, currentSection: _cloneDeep(currentSectionData), direction: 'forward' });
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: expectedIterationContext
+                },
+                valuesByPath: { 'response._activePersonId': expectedIterationContext[0] }
+            });
+            expect(mockShuffle).not.toHaveBeenCalled();
+        });
+    });
+
+    test('iteration with path prefix', () => {           
+        const currentSection = 'visitedPlaces';
+        const currentIterationContext = ['person', 'personId1'];
+        const expectedSection = 'travelBehavior';
+        const expectedIterationContext = ['person', 'personId1'];
+        
+        // Prepare the interview with section navigation history and a household
+        const testInterview = _cloneDeep(interview);
+        // FIXME The type of the _sections is not quite right, this should be valid but it is not
+        testInterview.response._sections = {
+            home: { _startedAt: 1, _isCompleted: true },
+            householdMembers: { _startedAt: 2, _isCompleted: true },
+            personsTrips: {
+                _startedAt: 6,
+                _isCompleted: true,
+                personId1: { _startedAt: 6, _isCompleted: true }
+            },
+            selectPerson: {
+                _startedAt: 9,
+                _isCompleted: true,
+                personId1: { _startedAt: 9, _isCompleted: true }
+            },
+            visitedPlaces: {
+                _startedAt: 12,
+                _isCompleted: true,
+                personId1: { _startedAt: 12, _isCompleted: true }
+            },
+            travelBehavior: {
+                _startedAt: 20,
+                _isCompleted: true
+            },
+            end: { _startedAt: 40, _isCompleted: true },
+            _actions: [
+                { section: 'home', action: 'start' as const, ts: 1 },
+                { section: 'householdMembers', action: 'start' as const, ts: 2 },
+                { section: 'personsTrips', iterationContext: ['personId1'], action: 'start' as const, ts: 6 },
+                { section: 'selectPerson', iterationContext: ['personId1'], action: 'start' as const, ts: 9 },
+                { section: 'visitedPlaces', iterationContext: ['personId1'], action: 'start' as const, ts: 12 }
+            ]
+        } as any;
+        Object.assign(testInterview.response, hhWithPersonsResponse);
+        testInterview.response._activePersonId = 'personId1';
+
+        // Prepare the previous navigation state
+        const currentSectionData = {
+            sectionShortname: currentSection,
+            iterationContext: currentIterationContext
+        }
+
+        // Prepare section configuration with a path prefix and create navigation service
+        const sectionConfig = _cloneDeep(complexSectionsConfig);
+        const pathPrefix = 'person';
+        (sectionConfig['personsTrips'] as SectionConfigWithDefaultsBlock).repeatedBlock.pathPrefix = pathPrefix; 
+        const navigationService = createNavigationService(sectionConfig);
+
+        // Navigate to specific section
+        const nextSectionResult = navigationService.navigate({ interview: testInterview, currentSection: _cloneDeep(currentSectionData), direction: 'forward' });
+        expect(nextSectionResult).toEqual({
+            targetSection: {
+                sectionShortname: expectedSection,
+                iterationContext: expectedIterationContext
+            },
+            valuesByPath: undefined
+        });
+        expect(tbIsSectionVisible).toHaveBeenCalledWith(testInterview, ['person', 'personId1']);
+    });
+
+    test('iteration with path prefix on selection section', () => {           
+        const currentSection = 'selectPerson';
+        const currentIterationContext = ['person', 'personId1'];
+        const expectedSection = 'visitedPlaces';
+        const expectedIterationContext = ['person', 'personId1'];
+        
+        // Prepare the interview with section navigation history and a household
+        const testInterview = _cloneDeep(interview);
+        // FIXME The type of the _sections is not quite right, this should be valid but it is not
+        testInterview.response._sections = {
+            home: { _startedAt: 1, _isCompleted: true },
+            householdMembers: { _startedAt: 2, _isCompleted: true },
+            personsTrips: {
+                _startedAt: 6,
+                _isCompleted: true,
+                personId1: { _startedAt: 6, _isCompleted: true }
+            },
+            selectPerson: {
+                _startedAt: 9,
+                _isCompleted: true,
+                personId1: { _startedAt: 9, _isCompleted: true }
+            },
+            visitedPlaces: {
+                _startedAt: 12,
+                _isCompleted: true,
+            },
+            _actions: [
+                { section: 'home', action: 'start' as const, ts: 1 },
+                { section: 'householdMembers', action: 'start' as const, ts: 2 },
+                { section: 'personsTrips', iterationContext: ['personId1'], action: 'start' as const, ts: 6 },
+                { section: 'selectPerson', iterationContext: ['personId1'], action: 'start' as const, ts: 9 },
+            ]
+        } as any;
+        Object.assign(testInterview.response, hhWithPersonsResponse);
+        testInterview.response._activePersonId = 'personId1';
+
+        // Prepare the previous navigation state
+        const currentSectionData = {
+            sectionShortname: currentSection,
+            iterationContext: currentIterationContext
+        }
+
+        // Prepare section configuration with a path prefix and create navigation service
+        const sectionConfig = _cloneDeep(complexSectionsConfig);
+        const pathPrefix = 'person';
+        (sectionConfig['personsTrips'] as SectionConfigWithDefaultsBlock).repeatedBlock.pathPrefix = pathPrefix; 
+        const navigationService = createNavigationService(sectionConfig);
+
+        // Navigate to specific section
+        const nextSectionResult = navigationService.navigate({ interview: testInterview, currentSection: _cloneDeep(currentSectionData), direction: 'forward' });
+        expect(nextSectionResult).toEqual({
+            targetSection: {
+                sectionShortname: expectedSection,
+                iterationContext: expectedIterationContext
+            },
+            valuesByPath: undefined
+        });
+    });
+    
+});

--- a/packages/evolution-common/src/services/questionnaire/sections/__tests__/NavigationService.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/__tests__/NavigationService.test.ts
@@ -1938,10 +1938,9 @@ describe('navigate function, further use cases', () => {
             const expectedSection = 'visitedPlaces';
             const expectedIterationContext = ['personId1'];
 
-            // Set the order of the iteration contexts to sequential and make sure mock is not called
+            // Set the order of the iteration contexts to sequential and make sure mockShuffle is not called
             const sectionConfig = _cloneDeep(complexSectionsConfig);
             (sectionConfig['personsTrips'] as SectionConfigWithDefaultsBlock).repeatedBlock.order = 'sequential';
-            mockShuffle.mockReturnValueOnce(['personId2', 'personId1']);
             
             const navigationService = createNavigationService(sectionConfig);
 
@@ -1964,129 +1963,351 @@ describe('navigate function, further use cases', () => {
         });
     });
 
-    test('iteration with path prefix', () => {           
-        const currentSection = 'visitedPlaces';
-        const currentIterationContext = ['person', 'personId1'];
-        const expectedSection = 'travelBehavior';
-        const expectedIterationContext = ['person', 'personId1'];
-        
-        // Prepare the interview with section navigation history and a household
-        const testInterview = _cloneDeep(interview);
-        // FIXME The type of the _sections is not quite right, this should be valid but it is not
-        testInterview.response._sections = {
-            home: { _startedAt: 1, _isCompleted: true },
-            householdMembers: { _startedAt: 2, _isCompleted: true },
-            personsTrips: {
-                _startedAt: 6,
-                _isCompleted: true,
-                personId1: { _startedAt: 6, _isCompleted: true }
-            },
-            selectPerson: {
-                _startedAt: 9,
-                _isCompleted: true,
-                personId1: { _startedAt: 9, _isCompleted: true }
-            },
-            visitedPlaces: {
-                _startedAt: 12,
-                _isCompleted: true,
-                personId1: { _startedAt: 12, _isCompleted: true }
-            },
-            travelBehavior: {
-                _startedAt: 20,
-                _isCompleted: true
-            },
-            end: { _startedAt: 40, _isCompleted: true },
-            _actions: [
-                { section: 'home', action: 'start' as const, ts: 1 },
-                { section: 'householdMembers', action: 'start' as const, ts: 2 },
-                { section: 'personsTrips', iterationContext: ['personId1'], action: 'start' as const, ts: 6 },
-                { section: 'selectPerson', iterationContext: ['personId1'], action: 'start' as const, ts: 9 },
-                { section: 'visitedPlaces', iterationContext: ['personId1'], action: 'start' as const, ts: 12 }
-            ]
-        } as any;
-        Object.assign(testInterview.response, hhWithPersonsResponse);
-        testInterview.response._activePersonId = 'personId1';
+    describe('with path prefix', () => {
+        test('iteration with path prefix', () => {
+            const currentSection = 'visitedPlaces';
+            const currentIterationContext = ['person', 'personId1'];
+            const expectedSection = 'travelBehavior';
+            const expectedIterationContext = ['person', 'personId1'];
 
-        // Prepare the previous navigation state
-        const currentSectionData = {
-            sectionShortname: currentSection,
-            iterationContext: currentIterationContext
-        }
+            // Prepare the interview with section navigation history and a household
+            const testInterview = _cloneDeep(interview);
+            // FIXME The type of the _sections is not quite right, this should be valid but it is not
+            testInterview.response._sections = {
+                home: { _startedAt: 1, _isCompleted: true },
+                householdMembers: { _startedAt: 2, _isCompleted: true },
+                personsTrips: {
+                    _startedAt: 6,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 6, _isCompleted: true }
+                },
+                selectPerson: {
+                    _startedAt: 9,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 9, _isCompleted: true }
+                },
+                visitedPlaces: {
+                    _startedAt: 12,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 12, _isCompleted: true }
+                },
+                travelBehavior: {
+                    _startedAt: 20,
+                    _isCompleted: true
+                },
+                end: { _startedAt: 40, _isCompleted: true },
+                _actions: [
+                    { section: 'home', action: 'start' as const, ts: 1 },
+                    { section: 'householdMembers', action: 'start' as const, ts: 2 },
+                    { section: 'personsTrips', iterationContext: ['personId1'], action: 'start' as const, ts: 6 },
+                    { section: 'selectPerson', iterationContext: ['personId1'], action: 'start' as const, ts: 9 },
+                    { section: 'visitedPlaces', iterationContext: ['personId1'], action: 'start' as const, ts: 12 }
+                ]
+            } as any;
+            Object.assign(testInterview.response, hhWithPersonsResponse);
+            testInterview.response._activePersonId = 'personId1';
 
-        // Prepare section configuration with a path prefix and create navigation service
-        const sectionConfig = _cloneDeep(complexSectionsConfig);
-        const pathPrefix = 'person';
-        (sectionConfig['personsTrips'] as SectionConfigWithDefaultsBlock).repeatedBlock.pathPrefix = pathPrefix; 
-        const navigationService = createNavigationService(sectionConfig);
+            // Prepare the previous navigation state
+            const currentSectionData = {
+                sectionShortname: currentSection,
+                iterationContext: currentIterationContext
+            }
 
-        // Navigate to specific section
-        const nextSectionResult = navigationService.navigate({ interview: testInterview, currentSection: _cloneDeep(currentSectionData), direction: 'forward' });
-        expect(nextSectionResult).toEqual({
-            targetSection: {
-                sectionShortname: expectedSection,
-                iterationContext: expectedIterationContext
-            },
-            valuesByPath: undefined
+            // Prepare section configuration with a path prefix and create navigation service
+            const sectionConfig = _cloneDeep(complexSectionsConfig);
+            const pathPrefix = 'person';
+            (sectionConfig['personsTrips'] as SectionConfigWithDefaultsBlock).repeatedBlock.pathPrefix = pathPrefix;
+            const navigationService = createNavigationService(sectionConfig);
+
+            // Navigate to specific section
+            const nextSectionResult = navigationService.navigate({ interview: testInterview, currentSection: _cloneDeep(currentSectionData), direction: 'forward' });
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: expectedIterationContext
+                },
+                valuesByPath: undefined
+            });
+            expect(tbIsSectionVisible).toHaveBeenCalledWith(testInterview, ['person', 'personId1']);
         });
-        expect(tbIsSectionVisible).toHaveBeenCalledWith(testInterview, ['person', 'personId1']);
+
+        test('iteration with path prefix on selection section', () => {
+            const currentSection = 'selectPerson';
+            const currentIterationContext = ['person', 'personId1'];
+            const expectedSection = 'visitedPlaces';
+            const expectedIterationContext = ['person', 'personId1'];
+
+            // Prepare the interview with section navigation history and a household
+            const testInterview = _cloneDeep(interview);
+            // FIXME The type of the _sections is not quite right, this should be valid but it is not
+            testInterview.response._sections = {
+                home: { _startedAt: 1, _isCompleted: true },
+                householdMembers: { _startedAt: 2, _isCompleted: true },
+                personsTrips: {
+                    _startedAt: 6,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 6, _isCompleted: true }
+                },
+                selectPerson: {
+                    _startedAt: 9,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 9, _isCompleted: true }
+                },
+                visitedPlaces: {
+                    _startedAt: 12,
+                    _isCompleted: true,
+                },
+                _actions: [
+                    { section: 'home', action: 'start' as const, ts: 1 },
+                    { section: 'householdMembers', action: 'start' as const, ts: 2 },
+                    { section: 'personsTrips', iterationContext: ['personId1'], action: 'start' as const, ts: 6 },
+                    { section: 'selectPerson', iterationContext: ['personId1'], action: 'start' as const, ts: 9 },
+                ]
+            } as any;
+            Object.assign(testInterview.response, hhWithPersonsResponse);
+            testInterview.response._activePersonId = 'personId1';
+
+            // Prepare the previous navigation state
+            const currentSectionData = {
+                sectionShortname: currentSection,
+                iterationContext: currentIterationContext
+            }
+
+            // Prepare section configuration with a path prefix and create navigation service
+            const sectionConfig = _cloneDeep(complexSectionsConfig);
+            const pathPrefix = 'person';
+            (sectionConfig['personsTrips'] as SectionConfigWithDefaultsBlock).repeatedBlock.pathPrefix = pathPrefix;
+            const navigationService = createNavigationService(sectionConfig);
+
+            // Navigate to specific section
+            const nextSectionResult = navigationService.navigate({ interview: testInterview, currentSection: _cloneDeep(currentSectionData), direction: 'forward' });
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: expectedIterationContext
+                },
+                valuesByPath: undefined
+            });
+        });
     });
 
-    test('iteration with path prefix on selection section', () => {           
-        const currentSection = 'selectPerson';
-        const currentIterationContext = ['person', 'personId1'];
-        const expectedSection = 'visitedPlaces';
-        const expectedIterationContext = ['person', 'personId1'];
-        
-        // Prepare the interview with section navigation history and a household
-        const testInterview = _cloneDeep(interview);
-        // FIXME The type of the _sections is not quite right, this should be valid but it is not
-        testInterview.response._sections = {
-            home: { _startedAt: 1, _isCompleted: true },
-            householdMembers: { _startedAt: 2, _isCompleted: true },
-            personsTrips: {
-                _startedAt: 6,
-                _isCompleted: true,
-                personId1: { _startedAt: 6, _isCompleted: true }
-            },
-            selectPerson: {
-                _startedAt: 9,
-                _isCompleted: true,
-                personId1: { _startedAt: 9, _isCompleted: true }
-            },
-            visitedPlaces: {
-                _startedAt: 12,
-                _isCompleted: true,
-            },
-            _actions: [
-                { section: 'home', action: 'start' as const, ts: 1 },
-                { section: 'householdMembers', action: 'start' as const, ts: 2 },
-                { section: 'personsTrips', iterationContext: ['personId1'], action: 'start' as const, ts: 6 },
-                { section: 'selectPerson', iterationContext: ['personId1'], action: 'start' as const, ts: 9 },
-            ]
-        } as any;
-        Object.assign(testInterview.response, hhWithPersonsResponse);
-        testInterview.response._activePersonId = 'personId1';
-
-        // Prepare the previous navigation state
-        const currentSectionData = {
-            sectionShortname: currentSection,
-            iterationContext: currentIterationContext
-        }
-
-        // Prepare section configuration with a path prefix and create navigation service
+    describe('isIterationValid', () => {
+        // Set the `isIterationValid` function of the block
         const sectionConfig = _cloneDeep(complexSectionsConfig);
-        const pathPrefix = 'person';
-        (sectionConfig['personsTrips'] as SectionConfigWithDefaultsBlock).repeatedBlock.pathPrefix = pathPrefix; 
+        const mockIsIterationValid = jest.fn().mockReturnValue(true);
+        (sectionConfig['personsTrips'] as SectionConfigWithDefaultsBlock).repeatedBlock.isIterationValid = mockIsIterationValid;
+
         const navigationService = createNavigationService(sectionConfig);
 
-        // Navigate to specific section
-        const nextSectionResult = navigationService.navigate({ interview: testInterview, currentSection: _cloneDeep(currentSectionData), direction: 'forward' });
-        expect(nextSectionResult).toEqual({
-            targetSection: {
-                sectionShortname: expectedSection,
-                iterationContext: expectedIterationContext
-            },
-            valuesByPath: undefined
+        beforeEach(() => {
+            mockIsIterationValid.mockReset();
+            mockIsIterationValid.mockReturnValue(true);
+        })
+
+        test('Last iteration, all iterations valid', () => {
+            const currentSection = 'travelBehavior';
+            const currentIterationContext = ['personId2'];
+            const expectedSection = 'end';
+            const expectedIterationContext = undefined;
+
+            // Prepare the interview with section navigation history and a household
+            const testInterview = _cloneDeep(interview);
+            // FIXME The type of the _sections is not quite right, this should be valid but it is not
+            testInterview.response._sections = {
+                home: { _startedAt: 1, _isCompleted: true },
+                householdMembers: { _startedAt: 2, _isCompleted: true },
+                personsTrips: {
+                    _startedAt: 6,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 6, _isCompleted: true },
+                    personId2: { _startedAt: 18, _isCompleted: true }
+                },
+                selectPerson: {
+                    _startedAt: 9,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 9, _isCompleted: true },
+                    personId2: { _startedAt: 20, _isCompleted: true }
+                },
+                visitedPlaces: {
+                    _startedAt: 12,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 12, _isCompleted: true },
+                    personId2: { _startedAt: 22, _isCompleted: true }
+                },
+                travelBehavior: {
+                    _startedAt: 20,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 15, _isCompleted: true },
+                    personId2: { _startedAt: 24, _isCompleted: true }
+                },
+                end: { _startedAt: 40, _isCompleted: true },
+                _actions: [
+                    { section: 'home', action: 'start' as const, ts: 1 },
+                    { section: 'householdMembers', action: 'start' as const, ts: 2 },
+                    { section: 'personsTrips', iterationContext: ['personId1'], action: 'start' as const, ts: 6 },
+                    { section: 'selectPerson', iterationContext: ['personId1'], action: 'start' as const, ts: 9 },
+                    { section: 'visitedPlaces', iterationContext: ['personId1'], action: 'start' as const, ts: 12 },
+                    { section: 'travelBehavior', iterationContext: ['personId1'], action: 'start' as const, ts: 15 },
+                    { section: 'selectPerson', iterationContext: ['personId2'], action: 'start' as const, ts: 20 },
+                    { section: 'visitedPlaces', iterationContext: ['personId2'], action: 'start' as const, ts: 22 },
+                    { section: 'travelBehavior', iterationContext: ['personId2'], action: 'start' as const, ts: 24 }
+                ]
+            } as any;
+            Object.assign(testInterview.response, hhWithPersonsResponse);
+            testInterview.response._activePersonId = 'personId2';
+
+            // Prepare the previous navigation state
+            const currentSectionData = {
+                sectionShortname: currentSection,
+                iterationContext: currentIterationContext
+            }
+
+            // Navigate to specific section
+            const nextSectionResult = navigationService.navigate({ interview: testInterview, currentSection: _cloneDeep(currentSectionData), direction: 'forward' });
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: expectedIterationContext
+                },
+                valuesByPath: { 'response._activePersonId': undefined }
+            });
+            expect(mockIsIterationValid).toHaveBeenCalledWith(testInterview, ['personId1']);
+            expect(mockIsIterationValid).toHaveBeenCalledWith(testInterview, ['personId2']);
+        });
+
+        test('Last iteration, first one is invalid, should navigate to it', () => {
+            const currentSection = 'travelBehavior';
+            const currentIterationContext = ['personId2'];
+            const expectedSection = 'visitedPlaces';
+            const expectedIterationContext = ['personId1'];
+
+            mockIsIterationValid.mockReturnValueOnce(false);
+
+            // Prepare the interview with section navigation history and a household
+            const testInterview = _cloneDeep(interview);
+            // FIXME The type of the _sections is not quite right, this should be valid but it is not
+            testInterview.response._sections = {
+                home: { _startedAt: 1, _isCompleted: true },
+                householdMembers: { _startedAt: 2, _isCompleted: true },
+                personsTrips: {
+                    _startedAt: 6,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 6, _isCompleted: true },
+                    personId2: { _startedAt: 18, _isCompleted: true }
+                },
+                selectPerson: {
+                    _startedAt: 9,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 9, _isCompleted: true },
+                    personId2: { _startedAt: 20, _isCompleted: true }
+                },
+                visitedPlaces: {
+                    _startedAt: 12,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 12, _isCompleted: true },
+                    personId2: { _startedAt: 22, _isCompleted: true }
+                },
+                travelBehavior: {
+                    _startedAt: 20,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 15, _isCompleted: true },
+                    personId2: { _startedAt: 24, _isCompleted: true }
+                },
+                end: { _startedAt: 40, _isCompleted: true },
+                _actions: [
+                    { section: 'home', action: 'start' as const, ts: 1 },
+                    { section: 'householdMembers', action: 'start' as const, ts: 2 },
+                    { section: 'personsTrips', iterationContext: ['personId1'], action: 'start' as const, ts: 6 },
+                    { section: 'selectPerson', iterationContext: ['personId1'], action: 'start' as const, ts: 9 },
+                    { section: 'visitedPlaces', iterationContext: ['personId1'], action: 'start' as const, ts: 12 },
+                    { section: 'travelBehavior', iterationContext: ['personId1'], action: 'start' as const, ts: 15 },
+                    { section: 'selectPerson', iterationContext: ['personId2'], action: 'start' as const, ts: 20 },
+                    { section: 'visitedPlaces', iterationContext: ['personId2'], action: 'start' as const, ts: 22 },
+                    { section: 'travelBehavior', iterationContext: ['personId2'], action: 'start' as const, ts: 24 }
+                ]
+            } as any;
+            Object.assign(testInterview.response, hhWithPersonsResponse);
+            testInterview.response._activePersonId = 'personId2';
+
+            // Prepare the previous navigation state
+            const currentSectionData = {
+                sectionShortname: currentSection,
+                iterationContext: currentIterationContext
+            }
+
+            // Navigate to specific section
+            const nextSectionResult = navigationService.navigate({ interview: testInterview, currentSection: _cloneDeep(currentSectionData), direction: 'forward' });
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: expectedIterationContext
+                },
+                valuesByPath: { 'response._activePersonId': expectedIterationContext[0] }
+            });
+            expect(mockIsIterationValid).toHaveBeenCalledWith(testInterview, ['personId1']);
+        });
+
+        test('first iteration, should navigate to next one without calling isIterationValid', () => {
+            const currentSection = 'travelBehavior';
+            const currentIterationContext = ['personId1'];
+            const expectedSection = 'visitedPlaces';
+            const expectedIterationContext = ['personId2'];
+
+            // Prepare the interview with section navigation history and a household
+            const testInterview = _cloneDeep(interview);
+            // FIXME The type of the _sections is not quite right, this should be valid but it is not
+            testInterview.response._sections = {
+                home: { _startedAt: 1, _isCompleted: true },
+                householdMembers: { _startedAt: 2, _isCompleted: true },
+                personsTrips: {
+                    _startedAt: 6,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 6, _isCompleted: true }
+                },
+                selectPerson: {
+                    _startedAt: 9,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 9, _isCompleted: true }
+                },
+                visitedPlaces: {
+                    _startedAt: 12,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 12, _isCompleted: true }
+                },
+                travelBehavior: {
+                    _startedAt: 20,
+                    _isCompleted: true,
+                    personId1: { _startedAt: 15, _isCompleted: true }
+                },
+                end: { _startedAt: 40, _isCompleted: true },
+                _actions: [
+                    { section: 'home', action: 'start' as const, ts: 1 },
+                    { section: 'householdMembers', action: 'start' as const, ts: 2 },
+                    { section: 'personsTrips', iterationContext: ['personId1'], action: 'start' as const, ts: 6 },
+                    { section: 'selectPerson', iterationContext: ['personId1'], action: 'start' as const, ts: 9 },
+                    { section: 'visitedPlaces', iterationContext: ['personId1'], action: 'start' as const, ts: 12 },
+                    { section: 'travelBehavior', iterationContext: ['personId1'], action: 'start' as const, ts: 15 }
+                ]
+            } as any;
+            Object.assign(testInterview.response, hhWithPersonsResponse);
+            testInterview.response._activePersonId = 'personId1';
+
+            // Prepare the previous navigation state
+            const currentSectionData = {
+                sectionShortname: currentSection,
+                iterationContext: currentIterationContext
+            }
+
+            // Navigate to specific section
+            const nextSectionResult = navigationService.navigate({ interview: testInterview, currentSection: _cloneDeep(currentSectionData), direction: 'forward' });
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: expectedIterationContext
+                },
+                valuesByPath: { 'response._activePersonId': expectedIterationContext[0] }
+            });
+            expect(mockIsIterationValid).not.toHaveBeenCalled();
         });
     });
     

--- a/packages/evolution-common/src/services/questionnaire/sections/__tests__/navigationHelpers.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/__tests__/navigationHelpers.test.ts
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { getLastVisitedSection, isIterationContextStarted, isSectionCompleted } from '../navigationHelpers';
+import { UserRuntimeInterviewAttributes } from '../../types';
+
+describe('getLastVisitedSection', () => {
+    it('should return the last visited section when there are section actions', () => {
+        const interview = {
+            response: {
+                _sections: {
+                    _actions: [
+                        { section: 'section1', action: 'viewed', ts: 1 },
+                        { section: 'section2', action: 'viewed', ts: 3 }
+                    ]
+                }
+            }
+        } as unknown as UserRuntimeInterviewAttributes;
+        
+        expect(getLastVisitedSection({ interview })).toEqual({ sectionShortname: 'section2', iterationContext: undefined });
+    });
+
+    it('should return the last visited section with iteration context when there are section actions', () => {
+        const interview = {
+            response: {
+                _sections: {
+                    _actions: [
+                        { section: 'section1', action: 'viewed', ts: 1 },
+                        { section: 'section2', iterationContext: [ 'person', 'uuid' ], action: 'viewed', ts: 3 }
+                    ]
+                }
+            }
+        } as unknown as UserRuntimeInterviewAttributes;
+        
+        expect(getLastVisitedSection({ interview })).toEqual({ sectionShortname: 'section2', iterationContext: [ 'person', 'uuid' ] });
+    });
+
+    it('should return undefined when there are no section actions', () => {
+        const interview = {
+            response: {
+                _sections: {
+                    _actions: []
+                }
+            }
+        } as unknown as UserRuntimeInterviewAttributes;
+        
+        expect(getLastVisitedSection({ interview })).toBeUndefined();
+    });
+
+    it('should return undefined when _actions does not exist', () => {
+        const interview = {
+            response: {
+                _sections: {}
+            }
+        } as unknown as UserRuntimeInterviewAttributes;
+        
+        expect(getLastVisitedSection({ interview })).toBeUndefined();
+    });
+
+    it('should return undefined when _sections does not exist', () => {
+        const interview = {
+            response: {}
+        } as unknown as UserRuntimeInterviewAttributes;
+        
+        expect(getLastVisitedSection({ interview })).toBeUndefined();
+    });
+});
+
+describe('isSectionCompleted', () => {
+    it('should return true when a section is marked as completed', () => {
+        const interview = {
+            response: {
+                _sections: {
+                    'section1': {
+                        _isCompleted: true
+                    }
+                }
+            }
+        } as unknown as UserRuntimeInterviewAttributes;
+        
+        expect(isSectionCompleted({ interview, sectionName: 'section1' })).toBe(true);
+    });
+
+    it('should return false when a section is not marked as completed', () => {
+        const interview = {
+            response: {
+                _sections: {
+                    'section1': {
+                        _isCompleted: false
+                    }
+                }
+            }
+        } as unknown as UserRuntimeInterviewAttributes;
+        
+        expect(isSectionCompleted({ interview, sectionName: 'section1' })).toBe(false);
+    });
+
+    it('should return true when a section with iteration context is marked as completed', () => {
+        const interview = {
+            response: {
+                _sections: {
+                    'section1': {
+                        _isCompleted: true,
+                        'person/uuid': {
+                            _isCompleted: true
+                        },
+                        'person/uuid2': {
+                            _isCompleted: false
+                        }
+                    }
+                }
+            }
+        } as unknown as UserRuntimeInterviewAttributes;
+        
+        expect(isSectionCompleted({ interview, sectionName: 'section1', iterationContext: ['person', 'uuid'] })).toBe(true);
+    });
+
+    it('should return false when a section with iteration context is not marked as completed', () => {
+        const interview = {
+            response: {
+                _sections: {
+                    'section1': {
+                        _isCompleted: false,
+                        'person/uuid': {
+                            _isCompleted: true
+                        },
+                        'person/uuid2': {
+                            _isCompleted: false
+                        }
+                    }
+                }
+            }
+        } as unknown as UserRuntimeInterviewAttributes;
+        
+        expect(isSectionCompleted({ interview, sectionName: 'section1', iterationContext: ['person', 'uuid2'] })).toBe(false);
+    });
+
+    it('should return false when _isCompleted is undefined', () => {
+        const interview = {
+            response: {
+                _sections: {
+                    'section1': {}
+                }
+            }
+        } as unknown as UserRuntimeInterviewAttributes;
+        
+        expect(isSectionCompleted({ interview, sectionName: 'section1' })).toBe(false);
+    });
+
+    it('should return false when section does not exist', () => {
+        const interview = {
+            response: {
+                _sections: {}
+            }
+        } as unknown as UserRuntimeInterviewAttributes;
+        
+        expect(isSectionCompleted({ interview, sectionName: 'nonExistentSection' })).toBe(false);
+    });
+
+    it('should return false when _sections does not exist', () => {
+        const interview = {
+            response: {}
+        } as unknown as UserRuntimeInterviewAttributes;
+        
+        expect(isSectionCompleted({ interview, sectionName: 'section1' })).toBe(false);
+    });
+
+    it('should return false when specific iteration context is not defined', () => {
+        const interview = {
+            response: {
+                _sections: {
+                    'section1': {
+                        _isCompleted: true,
+                        'person/uuid': {
+                            _isCompleted: true
+                        }
+                    }
+                }
+            }
+        } as unknown as UserRuntimeInterviewAttributes;
+        
+        expect(isSectionCompleted({ interview, sectionName: 'section1', iterationContext: ['person', 'uuid3'] })).toBe(false);
+    });
+});
+
+describe('isIterationContextStarted', () => {
+    it('should return true when iteration context is empty', () => {
+        const interview = {
+            response: {
+                _sections: {}
+            }
+        } as unknown as UserRuntimeInterviewAttributes;
+
+        expect(isIterationContextStarted({ interview, iterationContext: [] })).toBe(true);
+    });
+
+    it('should return true when iteration context has started', () => {
+        const interview = {
+            response: {
+                _sections: {
+                    section1: {
+                        'person/uuid': {
+                            _startedAt: 1234567890
+                        }
+                    }
+                }
+            }
+        } as unknown as UserRuntimeInterviewAttributes;
+
+        expect(isIterationContextStarted({ interview, iterationContext: ['person', 'uuid'] })).toBe(true);
+    });
+
+    it('should return false when iteration context has not started', () => {
+        const interview = {
+            response: {
+                _sections: {
+                    section1: {
+                        'person/uuid': {}
+                    }
+                }
+            }
+        } as unknown as UserRuntimeInterviewAttributes;
+
+        expect(isIterationContextStarted({ interview, iterationContext: ['person', 'uuid'] })).toBe(false);
+    });
+
+    it('should return false when iteration context does not exist', () => {
+        const interview = {
+            response: {
+                _sections: {
+                    section1: {}
+                }
+            }
+        } as unknown as UserRuntimeInterviewAttributes;
+
+        expect(isIterationContextStarted({ interview, iterationContext: ['person', 'uuid'] })).toBe(false);
+    });
+
+    it('should return true when any section for the iteration context has started', () => {
+        const interview = {
+            response: {
+                _sections: {
+                    section1: {
+                        'person/uuid': {
+                            _startedAt: 1234567890
+                        }
+                    },
+                    section2: {
+                        'person/uuid2': {
+                            _startedAt: 9876543210
+                        }
+                    }
+                }
+            }
+        } as unknown as UserRuntimeInterviewAttributes;
+
+        expect(isIterationContextStarted({ interview, iterationContext: ['person', 'uuid'] })).toBe(true);
+    });
+
+    it('should return false when no sections for the iteration context have started', () => {
+        const interview = {
+            response: {
+                _sections: {
+                    section1: {
+                        'person/uuid': { _startedAt: 1234567890 }
+                    },
+                    section2: {
+                        'person/uuid2': { _startedAt: 1234567890 }
+                    }
+                }
+            }
+        } as unknown as UserRuntimeInterviewAttributes;
+
+        expect(isIterationContextStarted({ interview, iterationContext: ['person', 'uuid3'] })).toBe(false);
+    });
+});

--- a/packages/evolution-common/src/services/questionnaire/sections/common/__tests__/buttonValidateAndGotoNextSection.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/common/__tests__/buttonValidateAndGotoNextSection.test.ts
@@ -59,7 +59,7 @@ describe('getButtonValidateAndGotoNextSection button action', () => {
     test('test button action', () => {
         expect(mockButtonValidate).not.toHaveBeenCalled();
         const action = widgetConfig.action;
-        action({ startUpdateInterview: jest.fn(), startAddGroupedObjects: jest.fn(), startRemoveGroupedObjects: jest.fn() }, interviewAttributesForTestCases, 'path', 'segments', {});
+        action({ startUpdateInterview: jest.fn(), startAddGroupedObjects: jest.fn(), startRemoveGroupedObjects: jest.fn(), startNavigate: jest.fn() }, interviewAttributesForTestCases, 'path', 'segments', {});
         expect(mockButtonValidate).toHaveBeenCalled();
     })
 });

--- a/packages/evolution-common/src/services/questionnaire/sections/common/__tests__/widgetsSwitchPerson.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/common/__tests__/widgetsSwitchPerson.test.ts
@@ -136,9 +136,9 @@ describe('buttonSwitchPerson widget', () => {
     test('action', () => {
         const action = widgetConfig.action;
         expect(action).toBeDefined();
-        const callbackMocks = { startUpdateInterview: jest.fn(), startAddGroupedObjects: jest.fn(), startRemoveGroupedObjects: jest.fn() };
+        const callbackMocks = { startUpdateInterview: jest.fn(), startAddGroupedObjects: jest.fn(), startRemoveGroupedObjects: jest.fn(), startNavigate: jest.fn() };
         action(callbackMocks, interviewAttributesForTestCases, 'path', 'section', {}, jest.fn());
-        expect(callbackMocks.startUpdateInterview).toHaveBeenCalledWith({ sectionShortname: 'section', valuesByPath: { 'response._activeSection': 'selectPerson' } });
+        expect(callbackMocks.startNavigate).toHaveBeenCalledWith({ requestedSection: { sectionShortname: 'selectPerson' } });
     });
 
     test('label', () => {

--- a/packages/evolution-common/src/services/questionnaire/sections/common/widgetsSwitchPerson.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/common/widgetsSwitchPerson.ts
@@ -54,17 +54,12 @@ const buttonSwitchPerson: ButtonWidgetConfig = {
         callbacks: InterviewUpdateCallbacks,
         _interview: UserInterviewAttributes,
         _path: string,
-        section,
+        _section,
         _sections,
         _saveCallback
     ) {
         // FIXME: We navigate to the selectPerson section... That means this widget should be part of a feature that contains this section
-        callbacks.startUpdateInterview({
-            sectionShortname: section,
-            valuesByPath: {
-                'response._activeSection': 'selectPerson'
-            }
-        });
+        callbacks.startNavigate({ requestedSection: { sectionShortname: 'selectPerson' } });
     }
 };
 

--- a/packages/evolution-common/src/services/questionnaire/sections/navigationHelpers.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/navigationHelpers.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+// This file contains helper function to get the current navigation state of an
+// interview and the status of the various sections for a given interview. To be
+// updated when we update how navigation is stored.
+
+import { getResponse } from '../../../utils/helpers';
+import { InterviewResponse, UserRuntimeInterviewAttributes } from '../types';
+import { NavigationSection } from '../types/NavigationTypes';
+
+/**
+ * Get the last visited section from the interview object
+ *
+ * @param {Object} options - The options object
+ * @param {UserRuntimeInterviewAttributes} options.interview The interview object
+ * @returns The last visited section
+ */
+export const getLastVisitedSection = ({
+    interview
+}: {
+    interview: UserRuntimeInterviewAttributes;
+}): NavigationSection | undefined => {
+    const sectionActions = getResponse(interview, '_sections._actions', []) as Array<
+        InterviewResponse['_sections.actions']
+    >;
+    return sectionActions.length > 0
+        ? {
+            sectionShortname: sectionActions[sectionActions.length - 1].section,
+            iterationContext: sectionActions[sectionActions.length - 1].iterationContext
+        }
+        : undefined;
+};
+
+/**
+ * Get whether a section is marked as completed or not
+ *
+ * @param {Object} options - The options object
+ * @param {UserRuntimeInterviewAttributes} options.interview The interview
+ * object
+ * @param {string} options.section The name of the section to check
+ * @param {string[]} [options.iterationContext] The specific iteration context
+ * to check if the section is part of a repeated block
+ * @returns Whether the section is marked as completed
+ */
+export const isSectionCompleted = ({
+    interview,
+    sectionName,
+    iterationContext
+}: {
+    interview: UserRuntimeInterviewAttributes;
+    sectionName: string;
+    iterationContext?: string[];
+}): boolean => {
+    const sectionPath = iterationContext ? `${sectionName}.${iterationContext.join('/')}` : sectionName;
+    const sectionStatus = getResponse(interview, `_sections.${sectionPath}`, {}) as { _isCompleted?: boolean };
+    return sectionStatus._isCompleted === true;
+};
+
+/**
+ * Check if the iteration context has started for a given interview. It will
+ * return true if any section for that iteration context has started.
+ *
+ * @param {Object} options - The options object
+ * @param {UserRuntimeInterviewAttributes} options.interview The interview object
+ * @param {string[]} options.iterationContext The iteration context to check
+ * @returns Whether the iteration context has started
+ */
+export const isIterationContextStarted = ({
+    interview,
+    iterationContext
+}: {
+    interview: UserRuntimeInterviewAttributes;
+    iterationContext: string[];
+}): boolean => {
+    if (iterationContext.length === 0) {
+        return true;
+    }
+    const iterationString = iterationContext.join('/');
+    const sectionsStatus = getResponse(interview, '_sections', {}) as {
+        [sectionName: string]: { _startedAt?: number };
+    };
+    return Object.keys(sectionsStatus).some((sectionName) => {
+        const sectionStatus = sectionsStatus[sectionName];
+        return sectionStatus[iterationString] !== undefined && sectionStatus[iterationString]._startedAt !== undefined;
+    });
+};

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/buttonSaveTripSegments.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/buttonSaveTripSegments.test.ts
@@ -114,7 +114,7 @@ describe('getButtonSaveTripSegmentsConfig button action', () => {
     test('test button action', () => {
         expect(mockButtonValidate).not.toHaveBeenCalled();
         const action = widgetConfig.action;
-        action({ startUpdateInterview: jest.fn(), startAddGroupedObjects: jest.fn(), startRemoveGroupedObjects: jest.fn() }, interviewAttributesForTestCases, 'path', 'segments', {});
+        action({ startUpdateInterview: jest.fn(), startAddGroupedObjects: jest.fn(), startRemoveGroupedObjects: jest.fn(), startNavigate: jest.fn() }, interviewAttributesForTestCases, 'path', 'segments', {});
         expect(mockButtonValidate).toHaveBeenCalled();
     });
 });
@@ -128,7 +128,7 @@ describe('getButtonSaveTripSegmentsConfig save callback', () => {
     const buttonPath = 'path.to.trip.buttonAction';
     const saveCallback = widgetConfig.saveCallback;
     const updateCallbacks =
-        { startUpdateInterview: jest.fn(), startAddGroupedObjects: jest.fn(), startRemoveGroupedObjects: jest.fn() };
+        { startUpdateInterview: jest.fn(), startAddGroupedObjects: jest.fn(), startRemoveGroupedObjects: jest.fn(), startNavigate: jest.fn() };
 
     beforeEach(() => {
         jest.clearAllMocks();

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/sectionSegment.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/sectionSegment.test.ts
@@ -46,10 +46,6 @@ describe('getSegmentsSectionConfig', () => {
         expect(widgetConfig).toEqual({
             previousSection: 'visitedPlaces',
             nextSection: 'travelBehavior',
-            navMenu: {
-                type: 'hidden',
-                parentSection: 'tripsIntro'
-            },
             preload: expect.any(Function),
             template: 'tripsAndSegmentsWithMap',
             title: expect.any(Function),

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/sectionSegment.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/sectionSegment.test.ts
@@ -46,7 +46,10 @@ describe('getSegmentsSectionConfig', () => {
         expect(widgetConfig).toEqual({
             previousSection: 'visitedPlaces',
             nextSection: 'travelBehavior',
-            parentSection: 'tripsIntro',
+            navMenu: {
+                type: 'hidden',
+                parentSection: 'tripsIntro'
+            },
             preload: expect.any(Function),
             template: 'tripsAndSegmentsWithMap',
             title: expect.any(Function),

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/sectionSegments.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/sectionSegments.ts
@@ -25,10 +25,6 @@ export const getSegmentsSectionConfig = (
         // FIXME Navigation part, should be handled at a higher level
         previousSection: 'visitedPlaces',
         nextSection: 'travelBehavior',
-        navMenu: {
-            type: 'hidden',
-            parentSection: 'tripsIntro'
-        },
 
         // FIXME Preload part, which is more a side-effect than a configuration, part of it is navigation, part is side effects
         preload: function (interview, { startUpdateInterview, callback }) {

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/sectionSegments.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/sectionSegments.ts
@@ -25,7 +25,10 @@ export const getSegmentsSectionConfig = (
         // FIXME Navigation part, should be handled at a higher level
         previousSection: 'visitedPlaces',
         nextSection: 'travelBehavior',
-        parentSection: 'tripsIntro',
+        navMenu: {
+            type: 'hidden',
+            parentSection: 'tripsIntro'
+        },
 
         // FIXME Preload part, which is more a side-effect than a configuration, part of it is navigation, part is side effects
         preload: function (interview, { startUpdateInterview, callback }) {

--- a/packages/evolution-common/src/services/questionnaire/types/Data.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/Data.ts
@@ -14,6 +14,7 @@ import * as VPAttr from '../../baseObjects/attributeTypes/VisitedPlaceAttributes
 import { Optional } from '../../../types/Optional.type';
 import { SegmentAttributes } from '../../baseObjects/Segment';
 import { HouseholdAttributes } from '../../baseObjects/Household';
+import { NavigationSection } from './NavigationTypes';
 
 export type ParsingFunction<T> = (interview: UserInterviewAttributes, path: string, user?: CliUser) => T;
 
@@ -304,6 +305,11 @@ export type UserAction =
           widgetType: string;
           path: string;
           value: unknown;
+      }
+    | {
+          type: 'sectionChange';
+          targetSection: NavigationSection;
+          previousSection?: NavigationSection;
       };
 
 /**

--- a/packages/evolution-common/src/services/questionnaire/types/Data.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/Data.ts
@@ -175,11 +175,12 @@ export type InterviewResponse = {
 
     _sections?: {
         [sectionName: string]: SectionStatus & {
-            [subSection: string]: SectionStatus;
+            [iterationContextString: string]: SectionStatus;
         };
     } & {
         _actions: {
             section: string;
+            iterationContext?: string[];
             action: 'start';
             ts: number;
         }[];

--- a/packages/evolution-common/src/services/questionnaire/types/Data.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/Data.ts
@@ -162,6 +162,10 @@ export type InterviewResponse = {
     _activeTripId?: string;
     _activeJourneyId?: string;
     _activeVisitedPlaceId?: string;
+    /**
+     * @deprecated Navigation service now handles the current section and other
+     * navigation
+     * */
     _activeSection?: string;
 
     // Participant/web interview data
@@ -361,10 +365,32 @@ export type StartRemoveGroupedObjects = (
     returnOnly?: boolean
 ) => any;
 
+/**
+ * Type of the callback to trigger navigation in the current interview
+ *
+ * @param {Object} options
+ * @param {NavigationSection} [options.requestedSection] The section to navigate
+ * to, if any. If not provided, the next section will be determined by the
+ * navigation service.
+ * @param {{ [path: string]: unknown }} [options.valuesByPath] The values to
+ * update in the interview.  The key is the path to update and the value is the
+ * new value. A dot-separated path will be exploded to the corresponding nested
+ * object path.
+ * @param {(interview: UserRuntimeInterviewAttributes) => void} [callback] An
+ * optional function to call after the interview has been updated and navigation
+ * is complete
+ * @returns The dispatched action
+ */
+export type StartNavigate = (
+    options?: { requestedSection?: NavigationSection; valuesByPath?: { [path: string]: unknown } },
+    callback?: (interview: UserRuntimeInterviewAttributes, targetSection: NavigationSection) => void
+) => any;
+
 export type InterviewUpdateCallbacks = {
     startUpdateInterview: StartUpdateInterview;
     startAddGroupedObjects: StartAddGroupedObjects;
     startRemoveGroupedObjects: StartRemoveGroupedObjects;
+    startNavigate: StartNavigate;
 };
 
 export type ParsingFunctionWithCallbacks<T> = (

--- a/packages/evolution-common/src/services/questionnaire/types/NavigationTypes.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/NavigationTypes.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+/**
+ * Represents a section path that includes iteration information
+ * Format: sectionShortname[(/iterationContextParts)*]
+ * Examples: 'home', 'visitedPlaces/person/123', 'segments/person/123/journey/456'
+ */
+export type NavigationSection = {
+    /**
+     * The section shortname, e.g. 'home', 'visitedPlaces', 'segments'
+     */
+    sectionShortname: string;
+    /**
+     * Optional iteration context, to be appended to the section shortname to
+     * get the full path with the current iteration context. It may include many
+     * elements to create the URL.
+     */
+    iterationContext?: string[];
+};
+
+export const sectionToUrlPath = (section: NavigationSection): string => {
+    if (!section.iterationContext || section.iterationContext.length === 0) {
+        return section.sectionShortname;
+    }
+    return `${section.sectionShortname}/${section.iterationContext.join('/')}`;
+};
+
+/**
+ * Represents the result of navigating to the next section. It includes the new
+ * navigation state and optional values by path that needs to be updated by this
+ * navigation (like the active survey object update)
+ */
+export type TargetSectionResult = {
+    /**
+     * The new navigation state after the navigation
+     */
+    targetSection: NavigationSection;
+    /**
+     * Optional values that need to be updated by this navigation
+     */
+    valuesByPath?: { [path: string]: unknown };
+};

--- a/packages/evolution-common/src/services/questionnaire/types/SectionConfig.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/SectionConfig.ts
@@ -136,6 +136,11 @@ type SectionConditionalFunction = (
     iterationContext: string[] | undefined
 ) => boolean;
 
+type SectionEventFunction = (
+    interview: UserRuntimeInterviewAttributes,
+    iterationContext: string[] | undefined
+) => Record<string, unknown> | undefined;
+
 export type SectionConfig = {
     /**
      * The title of the section. This will be displayed as the header on the
@@ -189,9 +194,13 @@ export type SectionConfig = {
     /**
      * If set, this function will be executed whenever the section is entered.
      *
-     * FIXME: As we are moving towards a config-only section definition, this
-     * preload function should be replaced with something that can be defined in
-     * config
+     * @deprecated The preloading catch-all mechanism that can do everything and
+     * anything should now be moved to the more appropriate functions in the
+     * section config. To initialize stuff at the beginning of a section the
+     * `onSectionEntry` and `onSectionExit` functions should be used. For
+     * skipping sections or direction navigating to sections according to
+     * various conditions, use the `isSectionVisible`, `isSectionCompleted` or,
+     * if in a repeated block, the repeated block's `isIterationValid` function.
      */
     preload?: SectionPreload;
     /**
@@ -278,6 +287,34 @@ export type SectionConfig = {
      * repeated block
      */
     repeatedBlock?: RepeatedBlockSectionConfig;
+
+    /**
+     * This function will be executed once each time the section is being
+     * navigated to, before the widgets are displayed. This is the place to
+     * define all side effects of entering the section, such as initializing
+     * group objects, pre-setting some answers. It returns the values to update
+     * in the interview response.
+     *
+     * This function, and the `onSectionExit` function are meant to replace the
+     * `preload` function of the section. It should not call the update
+     * callbacks or anything else, just return the side effects of the section
+     * for the current iteration.
+     */
+    onSectionEntry?: SectionEventFunction;
+
+    /**
+     * This function will be executed once each time the section is being
+     * navigated away from, before navigating to the next section. This is the
+     * place to define all side effects of exiting the section, such as making
+     * sure related values in other sections match the ones from the current
+     * section (for example household size)
+     *
+     * This function, and the `onSectionEntry` function are meant to replace the
+     * `preload` function of the section. It should not call the update
+     * callbacks or anything else, just return the side effects of the section
+     * for the current iteration.
+     */
+    onSectionExit?: SectionEventFunction;
 };
 
 /**

--- a/packages/evolution-common/src/services/questionnaire/types/SectionConfig.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/SectionConfig.ts
@@ -13,7 +13,8 @@ import {
     StartAddGroupedObjects,
     StartRemoveGroupedObjects,
     StartUpdateInterview,
-    UserInterviewAttributes
+    UserInterviewAttributes,
+    UserRuntimeInterviewAttributes
 } from './Data';
 import { WidgetConfig } from './WidgetConfig';
 
@@ -30,12 +31,158 @@ export type SectionPreload = (
 
 export type BuiltinSectionTemplates = 'tripsAndSegmentsWithMap';
 
+/**
+ * Configuration for a repeated block of sections
+ */
+export type RepeatedBlockSectionConfig = {
+    /**
+     * Describes what this block will iterate over.
+     *
+     * FIXME: This type may not be complete, we may want to support a fixed
+     * number of iterations, or the kind of iterations where the respondent can
+     * dynamically add a new iteration (does not only depend on previous
+     * answers). But it covers the current use cases
+     */
+    iterationRule:
+        | {
+              /**
+               * Iterate over a collection of objects in the interview response. This
+               * object collection won't be modified during the repeated block
+               * sections, they typically depend on answers in previous sections.
+               *
+               * FIXME: Add a filter on the objects if required
+               */
+              type: 'surveyObjectPath';
+              /**
+               * The path in the interview response that contains a key/value element
+               * where the keys are the ID of the objects and the values are the
+               * objects for which to iterate.
+               *
+               * eg. 'household.persons'
+               */
+              path: string;
+          }
+        | {
+              /**
+               * Iterate over a collection of objects received from a builtin function
+               * in Evolution. Useful for more complex iterations, with additional
+               * conditions on the objects, but that are common enough to be part of
+               * the Evolution framework.
+               */
+              type: 'builtin';
+              /**
+               * The name of the builtin function to call.
+               *
+               * `interviewablePersons` will iterate over the persons in the household
+               * that are of interviewable age.
+               */
+              path: 'interviewablePersons';
+          };
+
+    /**
+     * Determines order of iteration through the collection
+     * 'sequential', 'random'
+     */
+    order?: 'sequential' | 'random';
+
+    /**
+     * ID of the section that selects the current object for iteration. Should
+     * be set if the `skipSelectionInNaturalFlow` is `true`, otherwise it will
+     * default to the first listed section.
+     */
+    selectionSectionId?: string;
+
+    /**
+     * Whether to skip the selection section in natural navigation flow.
+     * Defaults to `false`
+     */
+    skipSelectionInNaturalFlow?: boolean;
+
+    /**
+     * Path where to store the currently selected object ID
+     * e.g., '_activePersonId'
+     */
+    activeSurveyObjectPath: string;
+
+    /**
+     * Prefix to prepend to the active survey object ID in the iteration
+     * context, for more conviviality in the iteration context, to avoid brutal
+     * uuids. For example, if the survey object is a person, the path prefix can
+     * be 'person' and tne iteration context will be `['person', <uuid of
+     * object>]` and the resulting URL would be
+     * `/survey/sectionShortname/person/uuid`. If not set, the uuid only will be
+     * used as iteration context.
+     */
+    pathPrefix?: string;
+
+    /**
+     * Sections that are part of this repeated block
+     */
+    sections: string[];
+};
+
+type SectionConditionalFunction = (
+    interview: UserRuntimeInterviewAttributes,
+    iterationContext: string[] | undefined
+) => boolean;
+
 export type SectionConfig = {
-    widgets: string[];
-    previousSection: string | null;
-    nextSection: string | null;
+    /**
+     * The title of the section. This will be displayed as the header on the
+     * page when this section is active.
+     */
     title?: I18nData;
-    menuName?: I18nData;
+    /**
+     * The section to navigate to when the user clicks the "previous" button.
+     * If set to null, it is the first section
+     */
+    previousSection: string | null;
+    /**
+     * The section to navigate to when the user clicks the "next" button.
+     * If set to null, the survey will end.
+     */
+    nextSection: string | null;
+    /**
+     * How to display this section in the survey navigation menu, at the top of
+     * the survey page. Defaults to `inNav` with `menuName` identical to `title`
+     * if the section is a top-level one, or `hiddenInNav` with the section with
+     * repeated block as parent if it is part of a block of repeated sections.
+     */
+    navMenu?:
+        | {
+              /**
+               * Display this section in the survey navigation menu
+               */
+              type: 'inNav';
+              /**
+               * The title of the section that will be displayed in the survey
+               * navigation menu. It should be short to avoid cluttering the menu, and
+               * possibly different from the `title`.
+               */
+              menuName: I18nData;
+          }
+        | {
+              /**
+               * Do not display this section in the navigation menu
+               */
+              type: 'hidden';
+              /**
+               * Title of the section that should be set as active in the survey
+               * navigation menu when this section is the one active
+               */
+              parentSection: string;
+          };
+    /**
+     * List of widgets to be displayed in this section.
+     */
+    widgets: string[];
+    /**
+     * If set, this function will be executed whenever the section is entered.
+     *
+     * FIXME: As we are moving towards a config-only section definition, this
+     * preload function should be replaced with something that can be defined in
+     * config
+     */
     preload?: SectionPreload;
     /**
      * The name of the template to use for this section. Surveys should provide
@@ -44,17 +191,239 @@ export type SectionConfig = {
      * `evolution`, but can be overridden by the survey.
      */
     template?: BuiltinSectionTemplates | string;
-    /**
-     * If set, this section is a sub-section of the parent section. It will not
-     * be displayed in the section navigation.
-     */
-    parentSection?: string;
     // FIXME Type this
     customStyle?: any;
+
+    /**
+     * Whether this section is enabled or not. If `false`, it won't be possible
+     * to navigate to this section from the navigation menu. By default, a
+     * section will be enabled if the previous section is completed.
+     *
+     * FIXME: As we are moving towards a config-only section definition, this
+     * function should be replaced with something that can be defined in config
+     */
     enableConditional?: boolean | ParsingFunction<boolean>;
+
+    /**
+     * Whether this section and all its iterations should be considered
+     * completed or not. If `true`, the section will have a different style in
+     * the navigation menu. If the section is not in a menu, this will be ignored
+     *
+     * FIXME: As we are moving towards a config-only section definition, this
+     * function should be replaced with something that can be defined in config
+     */
     completionConditional?: boolean | ParsingFunction<boolean>;
+
+    /**
+     * Whether this section or a specific iteration of it, if it is part of a
+     * repeated block, is completed or not. This function is used during
+     * navigation to determine if the next section should be available. If the
+     * section should be skipped, use the `isSectionVisible` instead.
+     *
+     * FIXME: As we are moving towards a config-only section definition, this
+     * function should be replaced with something that can be defined in config
+     *
+     * NOTE: It is purposefully not the same as the `completionConditional` as
+     * they are used in different contexts (navigation menu vs actual survey
+     * navigation with possible iteration contexts). Both contexts will have
+     * different default implementations if not set, so we keep both, but
+     * hopefully this one will be deprecated in the future.
+     *
+     * @param interview The interview object
+     * @param iterationContext The current iteration context of the section.
+     * Undefined if the section is not part of a repeated block
+     * @returns Whether this section is completed or skipped
+     */
+    isSectionCompleted?: SectionConditionalFunction;
+
+    /**
+     * Whether this section should be visible or skipped. If this section should
+     * be skipped on some conditions, for example if there are no widgets to
+     * show, this function should return `false`. If not set, the section will
+     * always be present.
+     *
+     * FIXME: As we are moving towards a config-only section definition, this
+     * function should be replaced with something that can be defined in config
+     *
+     * FIXME: At first, instead of this function, there was a property called
+     * `skipIfNoVisibleQuestionWidgets` that would skip the section if there are
+     * no visible question widgets. But currently, to determine if a widget is
+     * visible requires calling a redux action in the frontend and it's harder
+     * to access from the navigation. When
+     * https://github.com/chairemobilite/evolution/issues/858 is implemented, it
+     * may be simpler to use a property instead of a function.
+     */
+    isSectionVisible?: SectionConditionalFunction;
+
+    /**
+     * Configuration for a repeated block of sections Only defined for the first
+     * section of a repeated block. The other sections of the block are ordinary
+     * sections. The last one should point back to the section defining the
+     * repeated block. A section with a repeated block should not have any
+     * widgets and will not be navigated to. But it can still be seen in the
+     * menus to contain its sub-sections or have its enablement and completion
+     * conditions set.
+     *
+     * TODO Support nested repeated blocks, currently, it only works with one
+     * repeated block
+     */
+    repeatedBlock?: RepeatedBlockSectionConfig;
 };
-export type SurveySections = { [sectionName: string]: SectionConfig };
+
+/**
+ * Survey section configuration type, as should be entered in a survey
+ * configuration
+ */
+export type SurveySectionsConfig = { [sectionName: string]: SectionConfig };
+
+export type SectionConfigWithDefaults = Omit<SectionConfig, 'navMenu' | 'repeatedBlock'> & {
+    type: 'section';
+    navMenu: Exclude<SectionConfig['navMenu'], undefined>;
+    /**
+     * If this section is part of a repeated block, this is the section that
+     * defines the repeated block.
+     */
+    repeatedBlockSection?: string;
+};
+
+export type SectionConfigWithDefaultsBlock = Omit<SectionConfig, 'navMenu' | 'repeatedBlock' | 'nextSection'> & {
+    type: 'repeatedBlock';
+    navMenu: Exclude<SectionConfig['navMenu'], undefined>;
+    repeatedBlock: Exclude<SectionConfig['repeatedBlock'], undefined>;
+    // It should not be possible to terminate a survey on a repeated block,
+    // there should at least be a next section with a text
+    nextSection: Exclude<SectionConfig['nextSection'], null>;
+};
+
+export type SectionConfigWithDefaultsSet = SectionConfigWithDefaults | SectionConfigWithDefaultsBlock;
+
+/**
+ * Get the complete SurveySections object from the configuration. This sets the
+ * default values of the configuration when not specified so that all values are
+ * specific.
+ *
+ * @param {SurveySectionsConfig} sections The survey sections configuration
+ * @returns {SurveySections} The complete SurveySections object
+ */
+export const getAndValidateSurveySections = (sections: SurveySectionsConfig): SurveySections => {
+    // Map the sections that are in a repeated block to the section that define this block
+    const sectionsInRepeatedBlock: { [sectionName: string]: string } = {};
+    Object.keys(sections).forEach((sectionName) => {
+        const sectionConfig = sections[sectionName];
+        if (sectionConfig.repeatedBlock) {
+            const repeatedSections = sectionConfig.repeatedBlock.sections;
+            repeatedSections.forEach((repeatedSectionName) => {
+                sectionsInRepeatedBlock[repeatedSectionName] = sectionName;
+            });
+        }
+    });
+
+    const sectionsWithDefaults: SurveySections = {};
+    // Make sure the navMenu is defined for each section
+    Object.keys(sections).forEach((sectionName) => {
+        const sectionConfig = sections[sectionName];
+        if (sectionConfig.repeatedBlock !== undefined) {
+            if (sectionConfig.nextSection === null) {
+                throw new Error(
+                    `Section "${sectionName}" cannot have a nextSection set to null when it is a repeated block.`
+                );
+            }
+            sectionsWithDefaults[sectionName] = {
+                ...sectionConfig,
+                type: 'repeatedBlock',
+                nextSection: sectionConfig.nextSection!,
+                navMenu: sectionConfig.navMenu ?? { type: 'inNav', menuName: sectionConfig.title ?? '' },
+                repeatedBlock: sectionConfig.repeatedBlock
+            };
+        } else if (sectionsInRepeatedBlock[sectionName]) {
+            sectionsWithDefaults[sectionName] = {
+                ...sectionConfig,
+                type: 'section',
+                navMenu: sectionConfig.navMenu ?? {
+                    type: 'hidden',
+                    parentSection: sectionsInRepeatedBlock[sectionName]
+                },
+                repeatedBlockSection: sectionsInRepeatedBlock[sectionName]
+            };
+        } else {
+            sectionsWithDefaults[sectionName] = {
+                ...sectionConfig,
+                type: 'section',
+                navMenu: sectionConfig.navMenu ?? { type: 'inNav', menuName: sectionConfig.title ?? '' }
+            };
+        }
+    });
+
+    // Validate each section to make sure every configuration is correct
+    Object.entries(sectionsWithDefaults).forEach(([sectionName, sectionConfig]) => {
+        // Give warnings if there are undefined sections in the configuration
+        if (sectionConfig.previousSection && !sectionsWithDefaults[sectionConfig.previousSection]) {
+            throw new Error(
+                `Section "${sectionConfig.previousSection}" is referenced in "previousSection" of section "${sectionName}", but it is not defined in the sections config.`
+            );
+        }
+        if (sectionConfig.nextSection && !sectionsWithDefaults[sectionConfig.nextSection]) {
+            throw new Error(
+                `Section "${sectionConfig.nextSection}" is referenced in "nextSection" of section "${sectionName}", but it is not defined in the sections config.`
+            );
+        }
+
+        if (sectionConfig.type === 'repeatedBlock') {
+            // All repeated sections should exist
+            const repeatedSections = sectionConfig.repeatedBlock.sections;
+            repeatedSections.forEach((repeatedSectionName) => {
+                if (!sectionsWithDefaults[repeatedSectionName]) {
+                    throw new Error(
+                        `Section "${repeatedSectionName}" is referenced in "repeatedBlock" of section "${sectionName}", but it is not defined in the sections config.`
+                    );
+                }
+            });
+            // The selectionSection should exist if specified
+            if (sectionConfig.repeatedBlock.selectionSectionId) {
+                if (!sectionsWithDefaults[sectionConfig.repeatedBlock.selectionSectionId]) {
+                    throw new Error(
+                        `Section "${sectionConfig.repeatedBlock.selectionSectionId}" is referenced in "selectionSectionId" of section "${sectionName}", but it is not defined in the sections config.`
+                    );
+                }
+            }
+        }
+        // Validate that the section in the navMenu exists
+        if (sectionConfig.navMenu.type === 'hidden') {
+            const parentSection = sectionConfig.navMenu.parentSection;
+            if (!sectionsWithDefaults[parentSection]) {
+                throw new Error(
+                    `Parent section "${parentSection}" is referenced in "navMenu" of section "${sectionName}", but it is not defined in the sections config.`
+                );
+            } else if (sectionsWithDefaults[parentSection].navMenu.type !== 'inNav') {
+                throw new Error(
+                    `Parent section "${parentSection}" referenced in "navMenu" of section "${sectionName}" is not visible in the navigation menu.`
+                );
+            }
+        }
+    });
+    // Make sure there is a first and last section
+    const firstSection = Object.keys(sectionsWithDefaults).find(
+        (sectionName) => sectionsWithDefaults[sectionName].previousSection === null
+    );
+    if (!firstSection) {
+        throw new Error('No first section defined. Make sure at least one section has "previousSection" set to null.');
+    }
+    const lastSection = Object.keys(sectionsWithDefaults).find(
+        (sectionName) => sectionsWithDefaults[sectionName].nextSection === null
+    );
+    if (!lastSection) {
+        throw new Error('No last section defined. Make sure at least one section has "nextSection" set to null.');
+    }
+    // FIXME Make further check? Do we have cycles? Are all sections used? are there many first or last sections?
+    return sectionsWithDefaults;
+};
+
+/**
+ * A survey section configuration type where all unset and default values have
+ * been set to avoid having to check for undefined values in the code.
+ */
+export type SurveySections = { [sectionName: string]: SectionConfigWithDefaultsSet };
+
 export type SurveyWidgets = {
     [widgetName: string]: WidgetConfig;
 };

--- a/packages/evolution-common/src/services/questionnaire/types/SectionConfig.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/SectionConfig.ts
@@ -11,6 +11,7 @@ import {
     I18nData,
     ParsingFunction,
     StartAddGroupedObjects,
+    StartNavigate,
     StartRemoveGroupedObjects,
     StartUpdateInterview,
     UserInterviewAttributes,
@@ -24,6 +25,7 @@ export type SectionPreload = (
         startUpdateInterview: StartUpdateInterview;
         startAddGroupedObjects: StartAddGroupedObjects;
         startRemoveGroupedObjects: StartRemoveGroupedObjects;
+        startNavigate: StartNavigate;
         callback: (interview: UserInterviewAttributes) => void;
         user: CliUser;
     }

--- a/packages/evolution-common/src/services/questionnaire/types/SectionConfig.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/SectionConfig.ts
@@ -121,6 +121,14 @@ export type RepeatedBlockSectionConfig = {
      * Sections that are part of this repeated block
      */
     sections: string[];
+
+    /**
+     * Determine whether a given iteration of the block is valid or not. This
+     * function will be used to automatically select an incomplete iteration.
+     * The participant may have a non-linear navigation through the iteration. A
+     * previous one may be incomplete even if the last one is.
+     */
+    isIterationValid?: SectionConditionalFunction;
 };
 
 type SectionConditionalFunction = (

--- a/packages/evolution-common/src/services/questionnaire/types/__tests__/NavigationTypes.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/__tests__/NavigationTypes.test.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { sectionToUrlPath, NavigationSection } from '../NavigationTypes';
+
+describe('sectionToUrlPath', () => {
+    it('should return the section shortname when iterationContext is undefined', () => {
+        const section: NavigationSection = { sectionShortname: 'home' };
+        expect(sectionToUrlPath(section)).toBe('home');
+    });
+
+    it('should return the section shortname when iterationContext is an empty array', () => {
+        const section: NavigationSection = { sectionShortname: 'home', iterationContext: [] };
+        expect(sectionToUrlPath(section)).toBe('home');
+    });
+
+    it('should return the full path with iterationContext', () => {
+        const section: NavigationSection = {
+            sectionShortname: 'visitedPlaces',
+            iterationContext: ['person', '123']
+        };
+        expect(sectionToUrlPath(section)).toBe('visitedPlaces/person/123');
+    });
+
+    it('should handle iterationContext with multiple parts', () => {
+        const section: NavigationSection = {
+            sectionShortname: 'segments',
+            iterationContext: ['person', '123', 'journey', '456']
+        };
+        expect(sectionToUrlPath(section)).toBe('segments/person/123/journey/456');
+    });
+});

--- a/packages/evolution-common/src/services/questionnaire/types/__tests__/SectionConfig.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/__tests__/SectionConfig.test.ts
@@ -1,0 +1,389 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import each from 'jest-each';
+import { getAndValidateSurveySections, SurveySectionsConfig } from '../SectionConfig';
+
+describe('getAndValidateSurveySections', () => {
+
+    afterEach(() => {    
+        jest.clearAllMocks();
+    });
+
+    test('should set default values for minimal section config', () => {
+        const minimalSection: SurveySectionsConfig = {
+            section1: {
+                previousSection: null,
+                nextSection: null,
+                widgets: []
+            }
+        };
+        
+        const result = getAndValidateSurveySections(minimalSection);
+        
+        expect(result.section1).toEqual({
+            type: 'section',
+            previousSection: null,
+            nextSection: null,
+            widgets: [],
+            navMenu: { type: 'inNav', menuName: '' }
+        });
+    });
+    
+    test('should set default values when title is provided', () => {
+        const sectionWithTitle: SurveySectionsConfig = {
+            section1: {
+                title: { en: 'Test Section', fr: 'Section de test' },
+                previousSection: null,
+                nextSection: null,
+                widgets: ['widget1']
+            }
+        };
+        
+        const result = getAndValidateSurveySections(sectionWithTitle);
+        
+        expect(result.section1).toEqual({
+            type: 'section',
+            title: { en: 'Test Section', fr: 'Section de test' },
+            previousSection: null,
+            nextSection: null,
+            widgets: ['widget1'],
+            navMenu: { 
+                type: 'inNav', 
+                menuName: { en: 'Test Section', fr: 'Section de test' } 
+            }
+        });
+    });
+    
+    test('should preserve custom navMenu when provided', () => {
+        const sectionWithCustomNavMenu: SurveySectionsConfig = {
+            mainSection: {
+                title: { en: 'Main Section', fr: 'Section principale' },
+                previousSection: null,
+                nextSection: 'section1',
+                widgets: ['widget1']
+            },
+            section1: {
+                title: { en: 'Test Section', fr: 'Section de test' },
+                previousSection: 'mainSection',
+                nextSection: null,
+                widgets: ['widget1'],
+                navMenu: { 
+                    type: 'hidden', 
+                    parentSection: 'mainSection' 
+                }
+            }
+        };
+        
+        const result = getAndValidateSurveySections(sectionWithCustomNavMenu);
+        
+        expect(result.section1.navMenu).toEqual({ 
+            type: 'hidden', 
+            parentSection: 'mainSection' 
+        });
+    });
+    
+    test('should handle multiple sections correctly', () => {
+        const multipleSections: SurveySectionsConfig = {
+            section1: {
+                title: { en: 'Section 1', fr: 'Section 1' },
+                previousSection: null,
+                nextSection: 'section2',
+                widgets: ['widget1']
+            },
+            section2: {
+                title: { en: 'Section 2', fr: 'Section 2' },
+                previousSection: 'section1',
+                nextSection: null,
+                widgets: ['widget2'],
+                navMenu: {
+                    type: 'inNav',
+                    menuName: { en: 'Custom Menu Name', fr: 'Nom de menu personnalisé' }
+                }
+            }
+        };
+        
+        const result = getAndValidateSurveySections(multipleSections);
+        
+        expect(Object.keys(result)).toHaveLength(2);
+        expect(result.section1.navMenu).toEqual({ 
+            type: 'inNav', 
+            menuName: { en: 'Section 1', fr: 'Section 1' } 
+        });
+        expect(result.section2.navMenu).toEqual({ 
+            type: 'inNav', 
+            menuName: { en: 'Custom Menu Name', fr: 'Nom de menu personnalisé' } 
+        });
+    });
+    
+    test('should preserve all properties in a complete section config', () => {
+        const mockPreload = jest.fn();
+        const mockConditionalFn = () => true;
+        const completeSection: SurveySectionsConfig = {
+            intro: {
+                title: { en: 'Introduction', fr: 'Introduction' },
+                previousSection: null,
+                nextSection: 'section1',
+                widgets: ['widget1']
+            },
+            section1: {
+                title: { en: 'Complete Section', fr: 'Section complète' },
+                previousSection: 'intro',
+                nextSection: 'outro',
+                widgets: ['widget1', 'widget2'],
+                navMenu: {
+                    type: 'hidden',
+                    parentSection: 'intro'
+                },
+                enableConditional: mockConditionalFn,
+                completionConditional: true,
+                template: 'tripsAndSegmentsWithMap',
+                preload: mockPreload,
+                customStyle: { background: 'red' },
+                isSectionVisible: jest.fn(),
+                isSectionCompleted: jest.fn()
+            },
+            outro: {
+                title: { en: 'Outro', fr: 'Conclusion' },
+                previousSection: 'section1',
+                nextSection: null,
+                widgets: ['widget3']
+            }
+        };
+        
+        const result = getAndValidateSurveySections(completeSection);
+        
+        expect(result.section1).toEqual({
+            ...completeSection.section1,
+            type: 'section'
+        });
+    });
+
+    test('should set default nav menu hidden and repeated block section when in a repeated block', () => {
+        const sectionsWithoutNav: SurveySectionsConfig = {
+            section1: {
+                title: { en: 'Test Section', fr: 'Section de test' },
+                previousSection: null,
+                nextSection: 'end',
+                widgets: ['widget1'],
+                repeatedBlock: {
+                    iterationRule: { type: 'builtin', path: 'interviewablePersons' },
+                    activeSurveyObjectPath: '_activePersonId',
+                    sections: ['section3'],
+                }
+            },
+            section3: {
+                title: { en: 'Test Section 3', fr: 'Section de test 3' },
+                previousSection: null,
+                widgets: ['widget2'],
+                nextSection: 'section1'
+            },
+            end: {
+                title: { en: 'Test Section 3', fr: 'Section de test 3' },
+                previousSection: 'section1',
+                nextSection: null,
+                widgets: []
+            }
+        };
+        
+        const result = getAndValidateSurveySections(sectionsWithoutNav);
+
+        expect(result).toEqual(expect.objectContaining({
+            section3: expect.objectContaining({
+                type: 'section',
+                navMenu: { 
+                    type: 'hidden', 
+                    parentSection: 'section1' 
+                },
+                repeatedBlockSection: 'section1'
+            }),
+            section1: expect.objectContaining({
+                type: 'repeatedBlock',
+                navMenu: {
+                    type: 'inNav',
+                    menuName: { en: 'Test Section', fr: 'Section de test' }
+                },
+                repeatedBlock: sectionsWithoutNav.section1.repeatedBlock
+            })
+        }));
+        
+    });
+
+    test('should preserve nav menu when in a repeated block', () => {
+        const sectionWithCustomNavMenu: SurveySectionsConfig = {
+            section1: {
+                title: { en: 'Test Section', fr: 'Section de test' },
+                previousSection: null,
+                nextSection: 'end',
+                widgets: ['widget1'],
+                repeatedBlock: {
+                    iterationRule: { type: 'builtin', path: 'interviewablePersons' },
+                    activeSurveyObjectPath: '_activePersonId',
+                    sections: ['section3'],
+                }
+            },
+            section3: {
+                title: { en: 'Test Section 3', fr: 'Section de test 3' },
+                previousSection: null,
+                nextSection: 'section1',
+                widgets: ['widget2'],
+                navMenu: { type: 'inNav', menuName: 'Test nav menu' }
+            },
+            end: {
+                title: { en: 'Test Section 3', fr: 'Section de test 3' },
+                previousSection: 'section1',
+                nextSection: null,
+                widgets: []
+            }
+        };
+        
+        const result = getAndValidateSurveySections(sectionWithCustomNavMenu);
+        
+        expect(result.section3.navMenu).toEqual({ type: 'inNav', menuName: 'Test nav menu' });
+    });
+
+    describe('should throw errors for undefined sections/errors in configuration', () => {
+        each([
+            ['nextSection', {
+                section1: {
+                    title: { en: 'Test Section', fr: 'Section de test' },
+                    previousSection: null,
+                    nextSection: 'section2',
+                    widgets: ['widget1']
+                }
+            },
+            'Section "section2" is referenced in "nextSection" of section "section1", but it is not defined in the sections config.'],
+            ['previousSection', {
+                section1: {
+                    title: { en: 'Test Section', fr: 'Section de test' },
+                    previousSection: 'section2',
+                    nextSection: null,
+                    widgets: ['widget1']
+                }
+            },
+            'Section "section2" is referenced in "previousSection" of section "section1", but it is not defined in the sections config.'],
+            ['repeatedBlock, missing section', {
+                section1: {
+                    title: { en: 'Test Section', fr: 'Section de test' },
+                    previousSection: null,
+                    nextSection: 'section3',
+                    widgets: ['widget1'],
+                    repeatedBlock: {
+                        iterationRule: { type: 'builtin', path: 'interviewablePersons' },
+                        activeSurveyObjectPath: '_activePersonId',
+                        sections: ['section2', 'section3'],
+                    }
+                },
+                section3: {
+                    title: { en: 'Test Section 3', fr: 'Section de test 3' },
+                    previousSection: null,
+                    nextSection: 'section1'
+                }
+            },
+            'Section "section2" is referenced in "repeatedBlock" of section "section1", but it is not defined in the sections config.'],
+            ['repeatedBlock, undefined selectionSectionId', {
+                section1: {
+                    title: { en: 'Test Section', fr: 'Section de test' },
+                    previousSection: null,
+                    nextSection: 'section3',
+                    widgets: ['widget1'],
+                    repeatedBlock: {
+                        iterationRule: { type: 'builtin', path: 'interviewablePersons' },
+                        activeSurveyObjectPath: '_activePersonId',
+                        selectionSectionId: 'section2',
+                        sections: ['section3'],
+                    }
+                },
+                section3: {
+                    title: { en: 'Test Section 3', fr: 'Section de test 3' },
+                    previousSection: null,
+                    nextSection: 'section1'
+                }
+            },
+            'Section "section2" is referenced in "selectionSectionId" of section "section1", but it is not defined in the sections config.'],
+            ['navMenu parent does not exists', {
+                section1: {
+                    title: { en: 'Test Section', fr: 'Section de test' },
+                    previousSection: null,
+                    nextSection: null,
+                    widgets: ['widget1'],
+                    navMenu: { type: 'hidden', parentSection: 'mainSection' }
+                }
+            },
+            'Parent section "mainSection" is referenced in "navMenu" of section "section1", but it is not defined in the sections config.'],
+            ['navMenu parent not in nav', {
+                section1: {
+                    title: { en: 'Test Section', fr: 'Section de test' },
+                    previousSection: null,
+                    nextSection: 'section3',
+                    widgets: ['widget1'],
+                    navMenu: { type: 'hidden', parentSection: 'section3' }
+                },
+                section3: {
+                    title: { en: 'Test Section 3', fr: 'Section de test 3' },
+                    previousSection: 'section1',
+                    nextSection: null,
+                    navMenu: { type: 'hidden', parentSection: 'section3' }
+                }
+            },
+            'Parent section "section3" referenced in "navMenu" of section "section1" is not visible in the navigation menu.'],
+            ['No first section', {
+                section1: {
+                    title: { en: 'Test Section', fr: 'Section de test' },
+                    previousSection: 'section2',
+                    nextSection: 'section2',
+                    widgets: ['widget1']
+                },
+                section2: {
+                    title: { en: 'Test Section', fr: 'Section de test' },
+                    previousSection: 'section1',
+                    nextSection: null,
+                    widgets: ['widget1']
+                }
+            },
+            'No first section defined. Make sure at least one section has "previousSection" set to null.'],
+            ['No last section', {
+                section1: {
+                    title: { en: 'Test Section', fr: 'Section de test' },
+                    previousSection: null,
+                    nextSection: 'section2',
+                    widgets: ['widget1']
+                },
+                section2: {
+                    title: { en: 'Test Section', fr: 'Section de test' },
+                    previousSection: 'section1',
+                    nextSection: 'section1',
+                    widgets: ['widget1']
+                }
+            },
+            'No last section defined. Make sure at least one section has "nextSection" set to null.'],
+            ['No next section for repeated block', {
+                section1: {
+                    title: { en: 'Test Section', fr: 'Section de test' },
+                    previousSection: null,
+                    nextSection: null,
+                    widgets: ['widget1'],
+                    repeatedBlock: {
+                        iterationRule: { type: 'builtin' as const, path: 'interviewablePersons' as const },
+                        activeSurveyObjectPath: '_activePersonId',
+                        selectionSectionId: 'section2',
+                        sections: ['section3'],
+                    }
+                },
+                section3: {
+                    title: { en: 'Test Section 3', fr: 'Section de test 3' },
+                    previousSection: null,
+                    nextSection: 'section1',
+                    widgets: []
+                }
+            },
+            'Section "section1" cannot have a nextSection set to null when it is a repeated block.']
+        ]).test('%s', (_location, sections, expectedError) => {
+            expect(() => getAndValidateSurveySections(sections)).toThrow(expectedError);
+        });
+    });
+
+});

--- a/packages/evolution-common/src/services/questionnaire/types/index.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/index.ts
@@ -11,5 +11,6 @@ import { WidgetConfig } from './WidgetConfig';
 export * from './Data';
 export * from './WidgetConfig';
 export * from './SectionConfig';
+export * from './NavigationTypes';
 
 export const isWidgetModal = (widgetConfig: WidgetConfig): boolean => (widgetConfig as any).isModal === true;

--- a/packages/evolution-common/src/utils/helpers.ts
+++ b/packages/evolution-common/src/utils/helpers.ts
@@ -633,9 +633,13 @@ export const getWidgetChoiceFromValue = ({
  * @param {Object} options - The options object.
  * @param {UserInterviewAttributes} options.interview - The interview object.
  * @param {string} options.sectionName - The name of the section to check.
- * @returns {boolean | null} - Returns true if the section is complete, false if not, or null if the section is not found.
+ * @returns {boolean | null} - Returns true if the section is complete, false if
+ * not, or null if the section is not found.
  *
- * @description This function checks if the section is complete by looking at the `interview.response._sections.${sectionName}._isCompleted` field.
+ * @description This function checks if the section is complete by looking at
+ * the `interview.response._sections.${sectionName}._isCompleted` field.
+ * @deprecated Use the `isSectionCompleted` function in the `navigationHelpers`
+ * module instead, which accounts for the iteration context as well.
  */
 export const isSectionComplete = ({
     interview,

--- a/packages/evolution-frontend/src/actions/Survey.ts
+++ b/packages/evolution-frontend/src/actions/Survey.ts
@@ -507,7 +507,8 @@ export const startNavigateWithUpdateCallback =
                     if (requestedSection || navigation === undefined) {
                         return navigationService.initNavigationState({
                             interview,
-                            requestedSection: requestedSection?.sectionShortname
+                            requestedSection: requestedSection?.sectionShortname,
+                            currentSection: navigation?.currentSection
                         });
                     }
                     // Otherwise, navigate forward
@@ -518,7 +519,7 @@ export const startNavigateWithUpdateCallback =
                 // Prepare the values by path for next section
                 if (targetSectionResult.valuesByPath) {
                 // If the target section has values by path, prepare them
-                    Object.assign(allValuesByPath, targetSectionResult.valuesByPath || {});
+                    Object.assign(allValuesByPath, targetSectionResult.valuesByPath);
                 }
 
                 // Call the update interview to update to the new section

--- a/packages/evolution-frontend/src/actions/__tests__/Survey.test.ts
+++ b/packages/evolution-frontend/src/actions/__tests__/Survey.test.ts
@@ -620,13 +620,21 @@ describe('startSetInterview', () => {
     // Prepare minimal questionnaire section config
     const applicationSections = {
         sectionLast:  {
+            type: 'section' as const,
             widgets: [],
             previousSection: 'sectionFirst',
-            nextSection: null
+            nextSection: null,
+            enableConditional: true,
+            completionConditional: true,
+            navMenu: { type: 'inNav' as const, menuName: 'sectionLast' }
         }, sectionFirst:  {
+            type: 'section' as const,
             widgets: [],
             previousSection: null,
-            nextSection: 'sectionLast'
+            nextSection: 'sectionLast',
+            enableConditional: true,
+            completionConditional: true,
+            navMenu: { type: 'inNav' as const, menuName: 'sectionFirst' }
         }
     };
 

--- a/packages/evolution-frontend/src/actions/__tests__/Survey.test.ts
+++ b/packages/evolution-frontend/src/actions/__tests__/Survey.test.ts
@@ -542,7 +542,7 @@ describe('startNavigate', () => {
 
         // Verify call to navigation service
         expect(mockInitNavigationState).toHaveBeenCalledTimes(1);
-        expect(mockInitNavigationState).toHaveBeenCalledWith({ interview: interviewAttributes, requestedSection: undefined});
+        expect(mockInitNavigationState).toHaveBeenCalledWith({ interview: interviewAttributes, requestedSection: undefined, currentSection: undefined });
 
         // Verify dispatch calls
         expect(mockDispatch).toHaveBeenCalledTimes(4);
@@ -610,7 +610,7 @@ describe('startNavigate', () => {
         mockGetState.mockImplementationOnce(mockStateWithNav);
 
         // Do the actual test
-        const callback = SurveyActions.startNavigate({ requestedSection});
+        const callback = SurveyActions.startNavigate({ requestedSection });
         await callback(mockDispatch, mockGetState);
 
         // validation function should not have been called
@@ -619,7 +619,7 @@ describe('startNavigate', () => {
         // Verify call to navigation service
         expect(mockNavigate).not.toHaveBeenCalled();
         expect(mockInitNavigationState).toHaveBeenCalledTimes(1);
-        expect(mockInitNavigationState).toHaveBeenCalledWith({ interview: interviewAttributes, requestedSection: requestedSection.sectionShortname });
+        expect(mockInitNavigationState).toHaveBeenCalledWith({ interview: interviewAttributes, requestedSection: requestedSection.sectionShortname, currentSection });
 
         // Verify dispatch calls
         expect(mockDispatch).toHaveBeenCalledTimes(4);

--- a/packages/evolution-frontend/src/components/hoc/__tests__/WithSurveyContextHoc.test.tsx
+++ b/packages/evolution-frontend/src/components/hoc/__tests__/WithSurveyContextHoc.test.tsx
@@ -14,10 +14,31 @@ interface TestProps {
     foo: string;
 }
 
+const testSections = {
+    key1: {
+        type: 'section' as const,
+        previousSection: null,
+        nextSection: null,
+        widgets: ['a'],
+        enableConditional: true,
+        completionConditional: true,
+        navMenu: { type: 'inNav' as const, menuName: 'key1' }
+    },
+    key2: {
+        type: 'section' as const,
+        previousSection: null,
+        nextSection: null,
+        widgets: [],
+        enableConditional: true,
+        completionConditional: true,
+        navMenu: { type: 'inNav' as const, menuName: 'key2' }
+    }
+};
+
 export const BaseTestComponent: React.FunctionComponent<{}> = (props: {}) => {
     const [devMode, dispatchSurvey] = React.useReducer(surveyReducer, { devMode: false });
     return (
-        <SurveyContext.Provider value={{ sections: { key1: { previousSection: null, nextSection: null, widgets: ['a'] }, key2: { previousSection: null, nextSection: null, widgets: [] }}, widgets: {}, ...devMode, dispatch: dispatchSurvey }}>
+        <SurveyContext.Provider value={{ sections: testSections, widgets: {}, ...devMode, dispatch: dispatchSurvey }}>
             <TestComponentWithContext foo='This is a test component'/>
         </SurveyContext.Provider>
     );

--- a/packages/evolution-frontend/src/components/hooks/__tests__/useSectionTemplate.test.ts
+++ b/packages/evolution-frontend/src/components/hooks/__tests__/useSectionTemplate.test.ts
@@ -30,6 +30,7 @@ describe('useSectionTemplate', () => {
             startUpdateInterview: jest.fn(),
             startAddGroupedObjects: jest.fn(),
             startRemoveGroupedObjects: jest.fn(),
+            startNavigate: jest.fn(),
             allWidgetsValid: true,
             submitted: false,
             loadingState: 0
@@ -43,6 +44,7 @@ describe('useSectionTemplate', () => {
                 startUpdateInterview: props.startUpdateInterview,
                 startAddGroupedObjects: props.startAddGroupedObjects,
                 startRemoveGroupedObjects: props.startRemoveGroupedObjects,
+                startNavigate: props.startNavigate,
                 callback: expect.any(Function),
                 user: props.user
             }

--- a/packages/evolution-frontend/src/components/hooks/useSectionTemplate.ts
+++ b/packages/evolution-frontend/src/components/hooks/useSectionTemplate.ts
@@ -34,6 +34,7 @@ export function useSectionTemplate(props: SectionProps) {
                 startUpdateInterview: props.startUpdateInterview,
                 startAddGroupedObjects: props.startAddGroupedObjects,
                 startRemoveGroupedObjects: props.startRemoveGroupedObjects,
+                startNavigate: props.startNavigate,
                 callback: () => setPreloaded(true),
                 user: props.user
             });

--- a/packages/evolution-frontend/src/components/pageParts/Section.tsx
+++ b/packages/evolution-frontend/src/components/pageParts/Section.tsx
@@ -91,6 +91,7 @@ export const Section: React.FC<SectionProps & WithSurveyContextProps> = (
                 startUpdateInterview={props.startUpdateInterview}
                 startAddGroupedObjects={props.startAddGroupedObjects}
                 startRemoveGroupedObjects={props.startRemoveGroupedObjects}
+                startNavigate={props.startNavigate}
             />
         );
     }

--- a/packages/evolution-frontend/src/components/pages/SurveyParticipant.tsx
+++ b/packages/evolution-frontend/src/components/pages/SurveyParticipant.tsx
@@ -67,9 +67,12 @@ const SurveyParticipant: React.FC<WithSurveyContextProps> = (props: WithSurveyCo
         const existingActiveSection: string | null = interview
             ? (surveyHelperNew.getResponse(interview, '_activeSection', null) as string | null)
             : null;
+        // FIXME This will have to be updated when the new navigation is implemented, not sure it works correctly
         const pathSectionParentSection: string | undefined =
-            pathSectionShortname && props.surveyContext.sections[pathSectionShortname]
-                ? (props.surveyContext.sections[pathSectionShortname].parentSection as string | undefined)
+            pathSectionShortname &&
+            props.surveyContext.sections[pathSectionShortname] &&
+            props.surveyContext.sections[pathSectionShortname].navMenu.type === 'hidden'
+                ? props.surveyContext.sections[pathSectionShortname].navMenu.parentSection
                 : undefined;
         startSetInterviewAction(
             existingActiveSection || pathSectionParentSection,

--- a/packages/evolution-frontend/src/components/survey/Button.tsx
+++ b/packages/evolution-frontend/src/components/survey/Button.tsx
@@ -90,7 +90,8 @@ const Button: React.FC<ButtonProps & WithSurveyContextProps & WithTranslation> =
                 // matter, but a solution would need to be found if not.
                 startUpdateInterview: startUpdateInterviewForButtonClick,
                 startAddGroupedObjects: props.startAddGroupedObjects,
-                startRemoveGroupedObjects: props.startRemoveGroupedObjects
+                startRemoveGroupedObjects: props.startRemoveGroupedObjects,
+                startNavigate: props.startNavigate
             },
             props.interview,
             props.path,

--- a/packages/evolution-frontend/src/components/survey/GroupWidgets.tsx
+++ b/packages/evolution-frontend/src/components/survey/GroupWidgets.tsx
@@ -69,6 +69,7 @@ export const BaseGroupedObject: React.FC<GroupedObjectProps & WithTranslation & 
             startUpdateInterview={props.startUpdateInterview}
             startAddGroupedObjects={props.startAddGroupedObjects}
             startRemoveGroupedObjects={props.startRemoveGroupedObjects}
+            startNavigate={props.startNavigate}
         />
     ));
 
@@ -108,6 +109,7 @@ export const BaseGroupedObject: React.FC<GroupedObjectProps & WithTranslation & 
                         startRemoveGroupedObjects={props.startRemoveGroupedObjects}
                         startUpdateInterview={props.startUpdateInterview}
                         startAddGroupedObjects={props.startAddGroupedObjects}
+                        startNavigate={props.startNavigate}
                     />
                     {widgetsComponents}
                 </div>
@@ -204,6 +206,7 @@ const BaseGroup: FunctionComponent<GroupProps & WithTranslation & WithSurveyCont
                     startUpdateInterview={props.startUpdateInterview}
                     startAddGroupedObjects={props.startAddGroupedObjects}
                     startRemoveGroupedObjects={props.startRemoveGroupedObjects}
+                    startNavigate={props.startNavigate}
                 />
             );
         }

--- a/packages/evolution-frontend/src/components/survey/Question.tsx
+++ b/packages/evolution-frontend/src/components/survey/Question.tsx
@@ -141,10 +141,7 @@ export class Question extends React.Component<QuestionProps & WithSurveyContextP
             if (isValid && typeof (widgetConfig as any).saveCallback === 'function') {
                 saveCallback = (widgetConfig as any).saveCallback;
             }
-            this.props.startUpdateInterview(
-                { sectionShortname: this.props.section, valuesByPath, userAction },
-                saveCallback
-            );
+            this.props.startUpdateInterview({ valuesByPath, userAction }, saveCallback);
         }
 
         if (isWidgetModal(widgetConfig) && this.state.modalIsOpen && isValid) {

--- a/packages/evolution-frontend/src/components/survey/Widget.tsx
+++ b/packages/evolution-frontend/src/components/survey/Widget.tsx
@@ -146,7 +146,8 @@ const BaseSingleWidget: React.FC<
         user: props.user,
         startUpdateInterview: props.startUpdateInterview,
         startAddGroupedObjects: props.startAddGroupedObjects,
-        startRemoveGroupedObjects: props.startRemoveGroupedObjects
+        startRemoveGroupedObjects: props.startRemoveGroupedObjects,
+        startNavigate: props.startNavigate
     };
 
     switch (widgetConfig.type) {

--- a/packages/evolution-frontend/src/components/survey/sectionTemplates/TripsAndSegmentsSection.tsx
+++ b/packages/evolution-frontend/src/components/survey/sectionTemplates/TripsAndSegmentsSection.tsx
@@ -97,6 +97,7 @@ export const SegmentsSection: React.FC<SectionProps & WithTranslation & WithSurv
                 startUpdateInterview={props.startUpdateInterview}
                 startAddGroupedObjects={props.startAddGroupedObjects}
                 startRemoveGroupedObjects={props.startRemoveGroupedObjects}
+                startNavigate={props.startNavigate}
             />
         );
     }
@@ -301,6 +302,7 @@ export const SegmentsSection: React.FC<SectionProps & WithTranslation & WithSurv
                         startUpdateInterview={props.startUpdateInterview}
                         startAddGroupedObjects={props.startAddGroupedObjects}
                         startRemoveGroupedObjects={props.startRemoveGroupedObjects}
+                        startNavigate={props.startNavigate}
                     />
                 </li>
             );

--- a/packages/evolution-frontend/src/components/survey/sectionTemplates/__tests__/TripsAndSegmentsSection.test.tsx
+++ b/packages/evolution-frontend/src/components/survey/sectionTemplates/__tests__/TripsAndSegmentsSection.test.tsx
@@ -91,7 +91,8 @@ beforeEach(() => {
         loadingState: 0,
         startUpdateInterview: jest.fn(),
         startAddGroupedObjects: jest.fn(),
-        startRemoveGroupedObjects: jest.fn()
+        startRemoveGroupedObjects: jest.fn(),
+        startNavigate: jest.fn()
     };
 });
 

--- a/packages/evolution-frontend/src/store/survey/__tests__/reducer.test.ts
+++ b/packages/evolution-frontend/src/store/survey/__tests__/reducer.test.ts
@@ -7,6 +7,7 @@
 import { UserRuntimeInterviewAttributes } from 'evolution-common/lib/services/questionnaire/types';
 import { surveyReducer } from '../reducer';
 import { SurveyActionTypes } from '../types';
+import { createNavigationService } from 'evolution-common/lib/services/questionnaire/sections/NavigationService';
 
 const testInterview: UserRuntimeInterviewAttributes = {
     id: 1,
@@ -37,16 +38,17 @@ const testInterview: UserRuntimeInterviewAttributes = {
     visibleWidgets: [],
     allWidgetsValid: true
 };
+
 test('Test setting an interview', () => {
     const action = {
         type: SurveyActionTypes.SET_INTERVIEW as const,
         interview: testInterview,
-        interviewLoaded:true
+        interviewLoaded: true
     };
 
     const result =  {
         interview: testInterview,
-        interviewLoaded:true
+        interviewLoaded: true
     };
 
     expect(surveyReducer({ }, action)).toEqual(result);
@@ -56,14 +58,14 @@ test('Test updating an interview', () => {
     const action = {
         type: SurveyActionTypes.UPDATE_INTERVIEW as const,
         interview: testInterview,
-        interviewLoaded:true,
+        interviewLoaded: true,
         submitted: true,
         errors: {field: { 'en': 'something' }}
     };
 
     const result =  {
         interview: testInterview,
-        interviewLoaded:true,
+        interviewLoaded: true,
         submitted: true,
         errors: {field: { 'en': 'something' }}
     };
@@ -72,4 +74,93 @@ test('Test updating an interview', () => {
         interview: testInterview,
         interviewLoaded: false
     }, action)).toEqual(result);
+});
+
+describe('Navigate action', () => {
+    const action = {
+        type: SurveyActionTypes.NAVIGATE as const,
+        targetSection: { sectionShortname: 'next' }
+    };
+
+    test('Test initial navigation state', () => {
+        const initialState = {
+            interview: testInterview,
+            interviewLoaded: true
+        }
+        const result =  {
+            interview: testInterview,
+            interviewLoaded: true,
+            navigation: {
+                currentSection: action.targetSection,
+                navigationHistory: []
+            }
+        };
+
+        expect(surveyReducer(initialState, action)).toEqual(result);
+    });
+
+    test('Test initial navigation state', () => {
+        const initialState = {
+            interview: testInterview,
+            interviewLoaded: true,
+            navigation: {
+                currentSection: { sectionShortname: 'previous', iterationContext: ['1234'] },
+                navigationHistory: []
+            }
+        }
+        const result =  {
+            interview: testInterview,
+            interviewLoaded: true,
+            navigation: {
+                currentSection: action.targetSection,
+                navigationHistory: [initialState.navigation.currentSection]
+            }
+        };
+
+        expect(surveyReducer(initialState, action)).toEqual(result);
+    });
+
+    test('Test with previous navigation history', () => {
+        const initialState = {
+            interview: testInterview,
+            interviewLoaded: true,
+            navigation: {
+                currentSection: { sectionShortname: 'previous', iterationContext: ['1234'] },
+                navigationHistory: [{ sectionShortname: 'previous3' }, { sectionShortname: 'previous2', iterationContext: ['1234'] }]
+            }
+        }
+        const result =  {
+            interview: testInterview,
+            interviewLoaded: true,
+            navigation: {
+                currentSection: action.targetSection,
+                navigationHistory: [...initialState.navigation.navigationHistory, initialState.navigation.currentSection]
+            }
+        };
+
+        expect(surveyReducer(initialState, action)).toEqual(result);
+    });
+
+});
+
+describe('Init navigate action', () => {
+    const action = {
+        type: SurveyActionTypes.INIT_NAVIGATE as const,
+        navigationService: createNavigationService({})
+    };
+
+    test('Test initial navigation state', () => {
+        const initialState = {
+            interview: testInterview,
+            interviewLoaded: true
+        }
+        const result =  {
+            interview: testInterview,
+            interviewLoaded: true,
+            navigationService: action.navigationService
+        };
+
+        expect(surveyReducer(initialState, action)).toEqual(result);
+    });
+
 });

--- a/packages/evolution-frontend/src/store/survey/reducer.ts
+++ b/packages/evolution-frontend/src/store/survey/reducer.ts
@@ -13,11 +13,13 @@ const reducer: Reducer<SurveyState, SurveyAction> = (state = initialState, actio
     switch (action.type) {
     case SurveyActionTypes.SET_INTERVIEW:
         return {
+            ...state,
             interview: action.interview,
             interviewLoaded: action.interviewLoaded
         };
     case SurveyActionTypes.UPDATE_INTERVIEW:
         return {
+            ...state,
             interview: action.interview,
             interviewLoaded: action.interviewLoaded,
             errors: action.errors,
@@ -28,6 +30,25 @@ const reducer: Reducer<SurveyState, SurveyAction> = (state = initialState, actio
             ...state,
             hasConsent: action.consented
         };
+    case SurveyActionTypes.NAVIGATE: {
+        const { targetSection } = action;
+        return {
+            ...state,
+            navigation: {
+                currentSection: targetSection,
+                navigationHistory: state.navigation
+                    ? [...state.navigation.navigationHistory, state.navigation.currentSection]
+                    : []
+            }
+        };
+    }
+    case SurveyActionTypes.INIT_NAVIGATE: {
+        const { navigationService } = action;
+        return {
+            ...state,
+            navigationService: navigationService
+        };
+    }
     default:
         return state;
     }

--- a/packages/evolution-frontend/src/store/survey/types.ts
+++ b/packages/evolution-frontend/src/store/survey/types.ts
@@ -4,25 +4,26 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import { UserRuntimeInterviewAttributes } from 'evolution-common/lib/services/questionnaire/types';
+import { UserRuntimeInterviewAttributes, NavigationSection } from 'evolution-common/lib/services/questionnaire/types';
+import { NavigationService } from 'evolution-common/lib/services/questionnaire/sections/NavigationService';
 
 export enum SurveyActionTypes {
     SET_INTERVIEW = 'SET_INTERVIEW',
     UPDATE_INTERVIEW = 'UPDATE_INTERVIEW',
-    ADD_CONSENT = 'ADD_CONSENT'
+    ADD_CONSENT = 'ADD_CONSENT',
+    NAVIGATE = 'NAVIGATE',
+    INIT_NAVIGATE = 'INIT_NAVIGATE'
 }
 
 export type SurveyAction =
     | {
           type: SurveyActionTypes.SET_INTERVIEW;
-          // TODO Properly type the interview
-          interview: any;
+          interview: UserRuntimeInterviewAttributes;
           interviewLoaded: boolean;
       }
     | {
           type: SurveyActionTypes.UPDATE_INTERVIEW;
-          // TODO Properly type the interview
-          interview: any;
+          interview: UserRuntimeInterviewAttributes;
           interviewLoaded: boolean;
           errors: {
               [key: string]: {
@@ -34,7 +35,27 @@ export type SurveyAction =
     | {
           type: SurveyActionTypes.ADD_CONSENT;
           consented: boolean;
+      }
+    | {
+          type: SurveyActionTypes.NAVIGATE;
+          targetSection: NavigationSection;
+      }
+    | {
+          type: SurveyActionTypes.INIT_NAVIGATE;
+          navigationService: NavigationService;
       };
+
+export type NavigationState = {
+    /**
+     * The current section path including iteration context
+     */
+    currentSection: NavigationSection;
+
+    /**
+     * Stack of sections previously visited, to enable back navigation
+     */
+    navigationHistory: NavigationSection[];
+};
 
 export interface SurveyState {
     readonly interview?: UserRuntimeInterviewAttributes;
@@ -46,4 +67,6 @@ export interface SurveyState {
     };
     readonly submitted?: boolean;
     readonly hasConsent?: boolean;
+    readonly navigation?: NavigationState;
+    readonly navigationService?: NavigationService;
 }

--- a/packages/evolution-generator/src/scripts/generate_section_configs.py
+++ b/packages/evolution-generator/src/scripts/generate_section_configs.py
@@ -140,26 +140,37 @@ def generate_section_configs(excel_file_path: str, section_config_output_folder:
                         "const nextSectionName: SectionConfig['nextSection'] = null;\n"
                     )
 
-                # Generate parentSectionName
-                if parent_section is not None:
-                    ts_section_code += f"const parentSectionName: SectionConfig['parentSection'] = '{parent_section}';\n"
+                # FIXME Add an official warning if both in_nav and parent_section are set
+                if in_nav and parent_section is not None:
+                    print(
+                        f"Warning: both in_nav and parent_section are set for section '{section}'. in_nav will have precedence."
+                    )
 
                 # Generate config for the section
                 ts_section_code += f"\n// Config for the section\n"
                 ts_section_code += f"export const sectionConfig: SectionConfig = {{\n"
                 ts_section_code += f"{INDENT}previousSection: previousSectionName,\n"
                 ts_section_code += f"{INDENT}nextSection: nextSectionName,\n"
-                if parent_section is not None:
-                    ts_section_code += f"{INDENT}parentSection: parentSectionName,\n"
                 if title_en and title_fr is not None:
                     ts_section_code += f"{INDENT}title: {{\n"
                     ts_section_code += f"{INDENT}{INDENT}fr: '{title_fr}',\n"
                     ts_section_code += f"{INDENT}{INDENT}en: '{title_en}'\n"
                     ts_section_code += f"{INDENT}}},\n"
+                # Generate the navigation menu item, either in nav with title or hidden with parent
                 if title_en and title_fr is not None and in_nav == True:
-                    ts_section_code += f"{INDENT}menuName: {{\n"
-                    ts_section_code += f"{INDENT}{INDENT}fr: '{title_fr}',\n"
-                    ts_section_code += f"{INDENT}{INDENT}en: '{title_en}'\n"
+                    ts_section_code += f"{INDENT}navMenu: {{\n"
+                    ts_section_code += f"{INDENT}{INDENT}type: 'inNav',\n"
+                    ts_section_code += f"{INDENT}{INDENT}menuName: {{\n"
+                    ts_section_code += f"{INDENT}{INDENT}{INDENT}fr: '{title_fr}',\n"
+                    ts_section_code += f"{INDENT}{INDENT}{INDENT}en: '{title_en}'\n"
+                    ts_section_code += f"{INDENT}{INDENT}}}\n"
+                    ts_section_code += f"{INDENT}}},\n"
+                elif parent_section is not None:
+                    ts_section_code += f"{INDENT}navMenu: {{\n"
+                    ts_section_code += f"{INDENT}{INDENT}type: 'hidden',\n"
+                    ts_section_code += (
+                        f"{INDENT}{INDENT}parentSection: '{parent_section}'\n"
+                    )
                     ts_section_code += f"{INDENT}}},\n"
                 if has_custom_template:
                     ts_section_code += f"{INDENT}// The template to fill is in the 'template.tsx' file of this section\n"

--- a/packages/evolution-generator/src/scripts/generate_sections.py
+++ b/packages/evolution-generator/src/scripts/generate_sections.py
@@ -28,7 +28,7 @@ def generate_sections(excel_file_path: str, sections_output_file_path: str):
         ts_code += add_generator_comment()
 
         # Generate the import statements
-        ts_code += f"import {{ SurveySections }} from 'evolution-common/lib/services/questionnaire/types';\n"
+        ts_code += f"import {{ getAndValidateSurveySections, SurveySectionsConfig }} from 'evolution-common/lib/services/questionnaire/types';\n"
         # Loop through each section and generate an import statement
         for section in sections_names:
             ts_code += (
@@ -37,12 +37,12 @@ def generate_sections(excel_file_path: str, sections_output_file_path: str):
 
         # Generate the export statement
         ts_code += "\n// Export all the sections configs\n"
-        ts_code += "const sectionsConfigs: SurveySections = {\n"
+        ts_code += "const sectionsConfigs: SurveySectionsConfig = {\n"
         # Loop through each section and generate an export statement
         for section in sections_names:
             ts_code += f"{INDENT}{section}: {section}Configs,\n"
         ts_code += "};\n"
-        ts_code += "export default sectionsConfigs;\n"
+        ts_code += "export default getAndValidateSurveySections(sectionsConfigs);\n"
 
         # Write TypeScript code to a file
         with open(


### PR DESCRIPTION
part of #968

Add a `skipIfNoVisibleQuestionWidgets` property to the `SectionConfig` type to automatically skip a section if no widget of type `Question` is visible on the page.

Add a `repeatedBlock` property to the `SectionConfig`. The sections that have this property defined will not be navigatable section, but will automatically generate a certain number of repeated blocks of section, depending on the block configuration. For example, some sections could be repeated for each interviewable household member in an interview. The repeated objects can be configured.

Update the `parentSection` and `menuName`, which were mutually exclusive, to show this fact. This forces a section to either be displayed in the menu or under another section, but not both or neither.

Document each property of the `SectionConfig` type.

Add an empty navigation service with pseudo-code as well as unit tests for what is the expected behavior.