### PR TITLE
Fix poetry unit test and add to worflows

### DIFF
--- a/.github/workflows/evolution-generator.yml
+++ b/.github/workflows/evolution-generator.yml
@@ -29,6 +29,10 @@ jobs:
     - name: Run Poetry
       working-directory: packages/evolution-generator
       run: poetry install
+    - name: Run Python unit tests
+      working-directory: packages/evolution-generator
+      run: |
+        poetry run pytest -v --disable-warnings --tb=short
     - name: Generate survey
       run: yarn generateSurvey:generator
     - name: Install

--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,10 @@ __pycache__/
 **/test-results/
 **/playwright.config.ts
 
+# Evolution-Genrator packages
+packages/evolution-generator/src/tests/references/
+packages/evolution-generator/src/tests/survey/common/
+
 # demo_generator example generated files
 example/demo_generator/locales/en/*
 !example/demo_generator/locales/en/survey.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -125,10 +125,6 @@ __pycache__/
 **/test-results/
 **/playwright.config.ts
 
-# Evolution-Genrator packages
-packages/evolution-generator/src/tests/references/
-packages/evolution-generator/src/tests/survey/common/
-
 # demo_generator example generated files
 example/demo_generator/locales/en/*
 !example/demo_generator/locales/en/survey.yaml

--- a/packages/evolution-generator/poetry.lock
+++ b/packages/evolution-generator/poetry.lock
@@ -322,6 +322,17 @@ files = [
 all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
+name = "iniconfig"
+version = "2.1.0"
+description = "brain-dead simple config-ini parsing"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"},
+    {file = "iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7"},
+]
+
+[[package]]
 name = "msal"
 version = "1.31.1"
 description = "The Microsoft Authentication Library (MSAL) for Python library enables your app to access the Microsoft Cloud by supporting authentication of users with Microsoft Azure Active Directory accounts (AAD) and Microsoft Accounts (MSA) using industry standard OAuth2 and OpenID Connect."
@@ -424,6 +435,21 @@ test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.3.2)", "pytest-
 type = ["mypy (>=1.11.2)"]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+description = "plugin and hook calling mechanisms for python"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
+    {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
+]
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["coverage", "pytest", "pytest-benchmark"]
+
+[[package]]
 name = "pycparser"
 version = "2.21"
 description = "C parser in Python"
@@ -453,6 +479,26 @@ crypto = ["cryptography (>=3.4.0)"]
 dev = ["coverage[toml] (==5.0.4)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=6.0.0,<7.0.0)", "sphinx (>=4.5.0,<5.0.0)", "sphinx-rtd-theme", "zope.interface"]
 docs = ["sphinx (>=4.5.0,<5.0.0)", "sphinx-rtd-theme", "zope.interface"]
 tests = ["coverage[toml] (==5.0.4)", "pytest (>=6.0.0,<7.0.0)"]
+
+[[package]]
+name = "pytest"
+version = "8.3.5"
+description = "pytest: simple powerful testing with Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820"},
+    {file = "pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=1.5,<2"
+
+[package.extras]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "python-dotenv"
@@ -668,4 +714,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12.0"
-content-hash = "dc32ceb6665faaf9554f0621560c6782a624c34bae3d5f66b8cbe65d1d0d50bc"
+content-hash = "f9a5537d56244d9554438819076fb59fba0376b7ec2054cef296a9bb2cc26c68"

--- a/packages/evolution-generator/pyproject.toml
+++ b/packages/evolution-generator/pyproject.toml
@@ -33,6 +33,7 @@ generateSurvey = "scripts.generate_survey:main"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.8.0"
+pytest = "^8.3.5"
 
 [build-system]
 requires = ["poetry-core"]

--- a/packages/evolution-generator/src/helpers/generator_helpers.py
+++ b/packages/evolution-generator/src/helpers/generator_helpers.py
@@ -9,7 +9,7 @@ from openpyxl import Workbook  # Read data from Excel, File system operations
 from typing import List, Union  # Types for Python
 
 # Define constants
-MOCKER_EXCEL_FILE = "generator/examples/test.xlsx"
+MOCKER_EXCEL_FILE = "src/tests/references/test.xlsx"
 INDENT = "    "  # 4-space indentation
 
 

--- a/packages/evolution-generator/src/scripts/generate_choices.py
+++ b/packages/evolution-generator/src/scripts/generate_choices.py
@@ -68,8 +68,9 @@ def generate_choices(input_file: str, output_file: str):
             spread_choices_name = row_dict["spreadChoicesName"]
             conditional = row_dict["conditional"]
 
+            # Check if the row is valid
             if choice_name is None or (value is None and spread_choices_name is None):
-                continue
+                raise Exception("Invalid row data in Choices sheet")
 
             # Create choice object with value and language-specific labels
             choice = {

--- a/packages/evolution-generator/src/tests/references/.gitignore
+++ b/packages/evolution-generator/src/tests/references/.gitignore
@@ -1,0 +1,5 @@
+# Ignore everything in this directory
+*
+
+# Except this file
+!.gitignore

--- a/packages/evolution-generator/src/tests/survey/common/.gitignore
+++ b/packages/evolution-generator/src/tests/survey/common/.gitignore
@@ -1,0 +1,5 @@
+# Ignore everything in this directory
+*
+
+# Except this file
+!.gitignore

--- a/packages/evolution-generator/src/tests/test_generate_choices.py
+++ b/packages/evolution-generator/src/tests/test_generate_choices.py
@@ -5,19 +5,19 @@
 # Note: This script tests the generate_choices functions.
 import os  # File system operations
 import pytest  # Testing framework
-from generator.scripts.generate_choices import generate_choices
-from generator.helpers.generator_helpers import (
+from scripts.generate_choices import generate_choices
+from helpers.generator_helpers import (
     create_mocked_excel_data,
     delete_file_if_exists,
 )
 
 
 # Define constants
-MOCKED_EXCEL_FILE = "generator/examples/test.xlsx"
-GOOD_INPUT_FILE = "generator/examples/test.xlsx"
-BAD_INPUT_FILE = "generator/examples/test.csv"
-GOOD_OUPUT_FILE = "generator/examples/survey/common/choices.tsx"
-BAD_OUTPUT_FILE = "generator/examples/survey/common/choices.txt"
+MOCKED_EXCEL_FILE = "src/tests/references/test.xlsx"
+GOOD_INPUT_FILE = "src/tests/references/test.xlsx"
+BAD_INPUT_FILE = "src/tests/references/test.csv"
+GOOD_OUPUT_FILE = "src/tests/survey/common/choices.tsx"
+BAD_OUTPUT_FILE = "src/tests/survey/common/choices.txt"
 GOOD_SHEET_NAME = "Choices"
 BAD_SHEET_NAME = "ChoicesBad"
 GOOD_HEADERS = [
@@ -111,31 +111,17 @@ GOOD_ROWS_DATA = [
     ],
 ]
 BAD_ROWS_DATA = [["badRowData"]]
-# BAD_NUMBER_OF_COLUMNS_ROW_DATA = [
-#     [
-#         "confidentInputRange",
-#         "Pas du tout confiant",
-#         "Très confiant",
-#         "Not at all confident",
-#         "Very confident",
-#         -10,
-#         100,
-#         "%",
-#         "%",
-#         "tooMuchData",
-#     ]
-# ]
 
 
 @pytest.mark.parametrize(
     "sheet_name, headers, row_data, input_file, output_file, expected_error",
     [
-        # Test that the example works great
+        # Test that the demo_generator example works great
         (
             None,  # No mocked Excel data
             None,  # No mocked Excel data
             None,  # No mocked Excel data
-            "generator/examples/Example_Generate_Survey.xlsx",
+            "../../example/demo_generator/references/Household_Travel_Generate_Survey.xlsx",
             GOOD_OUPUT_FILE,
             None,  # No error expected
         ),
@@ -164,16 +150,16 @@ BAD_ROWS_DATA = [["badRowData"]]
             GOOD_ROWS_DATA,
             GOOD_INPUT_FILE,
             BAD_OUTPUT_FILE,
-            f"Invalid output file extension for {BAD_OUTPUT_FILE} : must be an TypeScript .tsx file",
+            f"Invalid output file extension for {BAD_OUTPUT_FILE} : must be an TypeScript .ts or .tsx file",
         ),
-        # Test that the function catch bad sheet name
+        # Test that the function catch that the sheet does not exist
         (
             BAD_SHEET_NAME,
             GOOD_HEADERS,
             GOOD_ROWS_DATA,
             GOOD_INPUT_FILE,
             GOOD_OUPUT_FILE,
-            "Invalid sheet name in Choices sheet",
+            f"Sheet with name {GOOD_SHEET_NAME} does not exist",
         ),
         # Test that the function catch bad headers
         (
@@ -182,26 +168,17 @@ BAD_ROWS_DATA = [["badRowData"]]
             GOOD_ROWS_DATA,
             GOOD_INPUT_FILE,
             GOOD_OUPUT_FILE,
-            "Invalid headers in Choices sheet",
+            f"Missing expected header in {GOOD_SHEET_NAME} sheet: choicesName",
         ),
-        # # TODO: Test that the function catch bad row data
-        # (
-        #     GOOD_SHEET_NAME,
-        #     GOOD_HEADERS,
-        #     BAD_ROWS_DATA,
-        #     GOOD_INPUT_FILE,
-        #     GOOD_OUPUT_FILE,
-        #     "Invalid row data in Choices sheet",
-        # ),
-        # # TODO: Test that the function catch bad number of columns in row data
-        # (
-        #     GOOD_SHEET_NAME,
-        #     GOOD_HEADERS,
-        #     BAD_NUMBER_OF_COLUMNS_ROW_DATA,
-        #     GOOD_INPUT_FILE,
-        #     GOOD_OUPUT_FILE,
-        #     "Invalid number of column in Choices sheet",
-        # ),
+        # Test that the function catch bad row data
+        (
+            GOOD_SHEET_NAME,
+            GOOD_HEADERS,
+            BAD_ROWS_DATA,
+            GOOD_INPUT_FILE,
+            GOOD_OUPUT_FILE,
+            "Invalid row data in Choices sheet",
+        ),
     ],
 )
 def test_generate_choices(

--- a/packages/evolution-generator/src/tests/test_generate_input_range.py
+++ b/packages/evolution-generator/src/tests/test_generate_input_range.py
@@ -7,19 +7,19 @@ import os  # File system operations
 import pytest  # Testing framework
 from typing import List, Union, Optional  # Types for Python
 
-from generator.scripts.generate_input_range import generate_input_range
-from generator.helpers.generator_helpers import (
+from scripts.generate_input_range import generate_input_range
+from helpers.generator_helpers import (
     create_mocked_excel_data,
     delete_file_if_exists,
 )
 
 
 # Define constants
-MOCKED_EXCEL_FILE = "generator/examples/test.xlsx"
-GOOD_INPUT_FILE = "generator/examples/test.xlsx"
-BAD_INPUT_FILE = "generator/examples/test.csv"
-GOOD_OUPUT_FILE = "generator/examples/survey/common/inputRange.tsx"
-BAD_OUTPUT_FILE = "generator/examples/survey/common/inputRange.txt"
+MOCKED_EXCEL_FILE = "src/tests/references/test.xlsx"
+GOOD_INPUT_FILE = "src/tests/references/test.xlsx"
+BAD_INPUT_FILE = "src/tests/references/test.csv"
+GOOD_OUPUT_FILE = "src/tests/survey/common/inputRange.tsx"
+BAD_OUTPUT_FILE = "src/tests/survey/common/inputRange.txt"
 GOOD_SHEET_NAME = "InputRange"
 BAD_SHEET_NAME = "InputRangeBad"
 GOOD_HEADERS = [
@@ -58,31 +58,17 @@ GOOD_ROWS_DATA = [
     ]
 ]
 BAD_ROWS_DATA = [["badRowData"]]
-BAD_NUMBER_OF_COLUMNS_ROW_DATA = [
-    [
-        "confidentInputRange",
-        "Pas du tout confiant",
-        "Très confiant",
-        "Not at all confident",
-        "Very confident",
-        -10,
-        100,
-        "%",
-        "%",
-        "tooMuchData",
-    ]
-]
 
 
 @pytest.mark.parametrize(
     "sheet_name, headers, row_data, input_file, output_file, expected_error",
     [
-        # Test that the example works great
+        # Test that the demo_generator example works great
         (
             None,  # No mocked Excel data
             None,  # No mocked Excel data
             None,  # No mocked Excel data
-            "generator/examples/Example_Generate_Survey.xlsx",
+            "../../example/demo_generator/references/Household_Travel_Generate_Survey.xlsx",
             GOOD_OUPUT_FILE,
             None,  # No error expected
         ),
@@ -111,16 +97,16 @@ BAD_NUMBER_OF_COLUMNS_ROW_DATA = [
             GOOD_ROWS_DATA,
             GOOD_INPUT_FILE,
             BAD_OUTPUT_FILE,
-            f"Invalid output file extension for {BAD_OUTPUT_FILE} : must be an TypeScript .tsx file",
+            f"Invalid output file extension for {BAD_OUTPUT_FILE} : must be an TypeScript .ts or .tsx file",
         ),
-        # Test that the function catch bad sheet name
+        # Test that the function catch that the sheet does not exist
         (
             BAD_SHEET_NAME,
             GOOD_HEADERS,
             GOOD_ROWS_DATA,
             GOOD_INPUT_FILE,
             GOOD_OUPUT_FILE,
-            "Invalid sheet name in InputRange sheet",
+            f"Sheet with name {GOOD_SHEET_NAME} does not exist",
         ),
         # Test that the function catch bad headers
         (
@@ -129,7 +115,7 @@ BAD_NUMBER_OF_COLUMNS_ROW_DATA = [
             GOOD_ROWS_DATA,
             GOOD_INPUT_FILE,
             GOOD_OUPUT_FILE,
-            "Invalid headers in InputRange sheet",
+            f"Missing expected header in {GOOD_SHEET_NAME} sheet: inputRangeName",
         ),
         # Test that the function catch bad row data
         (
@@ -139,15 +125,6 @@ BAD_NUMBER_OF_COLUMNS_ROW_DATA = [
             GOOD_INPUT_FILE,
             GOOD_OUPUT_FILE,
             "Invalid row data in InputRange sheet",
-        ),
-        # Test that the function catch bad number of columns in row data
-        (
-            GOOD_SHEET_NAME,
-            GOOD_HEADERS,
-            BAD_NUMBER_OF_COLUMNS_ROW_DATA,
-            GOOD_INPUT_FILE,
-            GOOD_OUPUT_FILE,
-            "Invalid number of column in InputRange sheet",
         ),
     ],
 )


### PR DESCRIPTION
# Pull request

## Description
Fix Python tests for Evolution-Generator 
Update the path of all the tests from an old structure version to the new structure.
Fix all the tests, some of the error messages have been changed since the last time we tested.
Ignore some of the generated output and input of these tests.
Install pytest package in Poetry.

Run Python unit tests inside the Evolution-Generator worflows
I did add some .gitignore file because we need an empty folder to save the generated files from the tests.