### PR TITLE
BREAKING CHANGES: Rename validated_data to corrected_response

### DIFF
--- a/example/demo_survey/src/tasks/exportToMadasare.task.ts
+++ b/example/demo_survey/src/tasks/exportToMadasare.task.ts
@@ -37,7 +37,7 @@ const headers = {
   glo_deplac_mode: true
 }
 
-const exportValidAndCompletedInterviews = function() { return knex.select('id', 'uuid', 'validated_data')
+const exportValidAndCompletedInterviews = function() { return knex.select('id', 'uuid', 'corrected_response')
   .from('sv_interviews')
   .whereRaw(`is_valid IS TRUE AND is_completed IS TRUE AND is_validated IS TRUE`)
   .orderBy('id')
@@ -46,21 +46,21 @@ const exportValidAndCompletedInterviews = function() { return knex.select('id', 
     {
       
       const interview     = rows[i];
-      const validatedData = interview.validated_data;
-      const glo_domic     = validatedData.household[prefix + "glo_domic"];
+      const correctedResponse = interview.corrected_response;
+      const glo_domic     = correctedResponse.household[prefix + "glo_domic"];
 
-      if (moment(validatedData.tripsDate) <= moment('2018-12-21') && (!validatedData.accessCode || (validatedData.accessCode && !validatedData.accessCode.endsWith('?'))))
+      if (moment(correctedResponse.tripsDate) <= moment('2018-12-21') && (!correctedResponse.accessCode || (correctedResponse.accessCode && !correctedResponse.accessCode.endsWith('?'))))
       {
         glo_domic.uuid      = interview.uuid;
-        glo_domic.codeacces = validatedData.accessCode;
+        glo_domic.codeacces = correctedResponse.accessCode;
         glo_domicCsv       += json2csv(glo_domic, {header: headers.glo_domic}) + "\n";
         headers.glo_domic   = false;
         
-        const glo_local    = validatedData.household[prefix + "home__glo_local"];
+        const glo_local    = correctedResponse.household[prefix + "home__glo_local"];
         glo_localCsv      += json2csv(glo_local, {header: headers.glo_local}) + "\n";
         headers.glo_local  = false;
 
-        const personsArray = Object.values(validatedData.household.persons).sort((personA: any, personB: any) => {
+        const personsArray = Object.values(correctedResponse.household.persons).sort((personA: any, personB: any) => {
           return personA['_sequence'] - personB['_sequence'];
         });
 
@@ -154,7 +154,7 @@ const exportValidAndCompletedInterviews = function() { return knex.select('id', 
         }
       }
 
-      fs.writeFileSync(exportJsonFileDirectory + '/' + (validatedData.accessCode || glo_domic.feuillet) + '_' + interview.uuid + '.json', JSON.stringify(validatedData));
+      fs.writeFileSync(exportJsonFileDirectory + '/' + (correctedResponse.accessCode || glo_domic.feuillet) + '_' + interview.uuid + '.json', JSON.stringify(correctedResponse));
 
     }
     fs.writeFileSync(exportFileDirectory + '/glo_domic.csv', glo_domicCsv);

--- a/locales/en/admin.json
+++ b/locales/en/admin.json
@@ -43,7 +43,7 @@
   "usersPageTitle": "Users",
   "errorsCount": "{{n}} errors",
   "refreshInterview": "Get latest changes from server",
-  "resetInterview": "Reset validated data to original participant responses",
+  "resetInterview": "Reset corrected responses to original responses",
   "closeInterviewSummary": "Close",
   "editValidationInterview": "Edit survey",
   "prevInterview": "View previous survey",
@@ -132,7 +132,7 @@
   "HouseholdSize": "Household size",
   "Select": "Select",
   "export": {
-    "PrepareValidatedCsvExportFiles": "Prepare CSV files by object (validated, if available)",
+    "PrepareValidatedCsvExportFiles": "Prepare CSV files by object (corrected responses if available)",
     "PrepareParticipantCsvExportFiles": "Prepare CSV files for export by object (original responses)",
     "RefreshExportFiles": "Refresh export file list",
     "ServerErrorForExport": "Server error while preparing export files",

--- a/locales/fr/admin.json
+++ b/locales/fr/admin.json
@@ -43,7 +43,7 @@
   "usersPageTitle": "Utilisateurs",
   "errorsCount": "{{n}} erreurs",
   "refreshInterview": "Rafraîchir les données du serveur",
-  "resetInterview": "Réinitialiser les données validées aux réponses originales du répondant",
+  "resetInterview": "Réinitialiser les réponses corrigées aux réponses originales",
   "closeInterviewSummary": "Fermer",
   "editValidationInterview": "Éditer l'entrevue",
   "prevInterview": "Voir entrevue précédente",
@@ -132,7 +132,7 @@
   "HouseholdSize": "Taille du ménage",
   "Select": "Sélectionner",
   "export": {
-    "PrepareValidatedCsvExportFiles": "Préparer les fichiers CSV par objet (réponses validées si disponibles)",
+    "PrepareValidatedCsvExportFiles": "Préparer les fichiers CSV par objet (réponses corrigées si disponibles)",
     "PrepareParticipantCsvExportFiles": "Préparer les fichiers CSV par objet (réponses originales)",
     "RefreshExportFiles": "Rafraîchir la liste des fichiers d'export",
     "ServerErrorForExport": "Erreur de serveur pendant la préparation des fichiers d'export",

--- a/packages/evolution-backend/src/api/admin/__tests__/exports.routes.test.ts
+++ b/packages/evolution-backend/src/api/admin/__tests__/exports.routes.test.ts
@@ -57,27 +57,27 @@ beforeAll(() => {
 });
 
 describe('prepareCsvFileForExportBySurveyObject route', () => {
-    it('Should prepare validated data by default', async () => {
+    it('Should prepare corrected response by default', async () => {
         const response = await request(app).get('/api/admin/data/prepareCsvFileForExportBySurveyObject');
         expect(response.status).toBe(200);
         expect(response.body).toEqual({
             status: 'exportStarted'
         });
-        expect(exportAllToCsvBySurveyObjectMock).toHaveBeenCalledWith({ responseType: 'validatedIfAvailable' });
+        expect(exportAllToCsvBySurveyObjectMock).toHaveBeenCalledWith({ responseType: 'correctedIfAvailable' });
     });
 
-    it('Should prepare validated data, if specified', async () => {
+    it('Should prepare corrected response, if specified', async () => {
         const response = await request(app).get(
-            '/api/admin/data/prepareCsvFileForExportBySurveyObject?responseType=validatedIfAvailable'
+            '/api/admin/data/prepareCsvFileForExportBySurveyObject?responseType=correctedIfAvailable'
         );
         expect(response.status).toBe(200);
         expect(response.body).toEqual({
             status: 'exportStarted'
         });
-        expect(exportAllToCsvBySurveyObjectMock).toHaveBeenCalledWith({ responseType: 'validatedIfAvailable' });
+        expect(exportAllToCsvBySurveyObjectMock).toHaveBeenCalledWith({ responseType: 'correctedIfAvailable' });
     });
 
-    it('Should prepare validated data, if invalid value is specified', async () => {
+    it('Should prepare corrected response, if invalid value is specified', async () => {
         const response = await request(app).get(
             '/api/admin/data/prepareCsvFileForExportBySurveyObject?responseType=unknownType'
         );
@@ -85,7 +85,7 @@ describe('prepareCsvFileForExportBySurveyObject route', () => {
         expect(response.body).toEqual({
             status: 'exportStarted'
         });
-        expect(exportAllToCsvBySurveyObjectMock).toHaveBeenCalledWith({ responseType: 'validatedIfAvailable' });
+        expect(exportAllToCsvBySurveyObjectMock).toHaveBeenCalledWith({ responseType: 'correctedIfAvailable' });
     });
 
     it('Should prepare participant data, if specified', async () => {

--- a/packages/evolution-backend/src/api/admin/exports.routes.ts
+++ b/packages/evolution-backend/src/api/admin/exports.routes.ts
@@ -56,9 +56,9 @@ export const addExportRoutes = () => {
     router.get('/data/prepareCsvFileForExportBySurveyObject', (req, res, _next) => {
         console.log('preparing csv export files...');
         try {
-            const validatedResponse = req.query.responseType !== 'participant';
+            const correctedResponse = req.query.responseType !== 'participant';
             const taskRunning = exportAllToCsvBySurveyObject({
-                responseType: validatedResponse ? 'validatedIfAvailable' : 'participant'
+                responseType: correctedResponse ? 'correctedIfAvailable' : 'participant'
             });
             return res.status(200).json({
                 status: taskRunning

--- a/packages/evolution-backend/src/config/__tests__/projectConfig.test.ts
+++ b/packages/evolution-backend/src/config/__tests__/projectConfig.test.ts
@@ -15,7 +15,7 @@ const interview: InterviewListAttributes = {
     is_valid: true,
     is_completed: true,
     response: { accessCode: 'notsure', foo: 'bar', household: { size: 0 } } as any,
-    validated_data: {},
+    corrected_response: {},
     username: 'test',
     facebook: false,
     google: false,
@@ -29,7 +29,7 @@ const nullResponseInterview = {
     is_valid: true,
     is_completed: true,
     response: null,
-    validated_data: null,
+    corrected_response: null,
     username: 'test',
     facebook: false,
     google: false
@@ -52,7 +52,7 @@ describe('Validation List Filter', () => {
         });
     });
 
-    test('test default validation filter with null values for response and validated data', () => {
+    test('test default validation filter with null values for response and corrected response', () => {
         const interviewStatus = projectConfig.validationListFilter(nullResponseInterview as any);
         expect(interviewStatus).toEqual({
             id: interview.id,

--- a/packages/evolution-backend/src/config/projectConfig.ts
+++ b/packages/evolution-backend/src/config/projectConfig.ts
@@ -24,7 +24,7 @@ interface ProjectServerConfig {
     roleDefinitions: (() => void) | undefined;
     /**
      * This function is provided by surveys to validate and audit the complete response.
-     * It will receive the content of the validated_data and should return the
+     * It will receive the content of the corrected_response and should return the
      * individual audits. It is optional. If the survey does not require auditing, just leave blank.
      */
     auditInterview?: (attributes: InterviewAttributes) => Promise<SurveyObjectsWithAudits>;
@@ -66,7 +66,7 @@ export const defaultConfig: ProjectServerConfig = {
             facebook,
             google,
             response,
-            validated_data,
+            corrected_response,
             audits
         } = interview;
         return {
@@ -83,7 +83,7 @@ export const defaultConfig: ProjectServerConfig = {
             response: {
                 _isCompleted: response?._isCompleted,
                 household: { size: response?.household?.size },
-                _validationComment: validated_data?._validationComment
+                _validationComment: corrected_response?._validationComment
             },
             audits
         };

--- a/packages/evolution-backend/src/models/__tests__/interviews.db.test.ts
+++ b/packages/evolution-backend/src/models/__tests__/interviews.db.test.ts
@@ -125,10 +125,10 @@ const googleUserInterviewAttributes = {
         }
     },
     validations: {},
-    validated_data: {
+    corrected_response: {
         accessCode: '2222',
         home: {
-            someField: 'validated',
+            someField: 'corrected',
             otherField: 'changed',
             arrayField: ['foo', 'bar']
         }
@@ -949,11 +949,11 @@ describe('stream interviews query', () => {
             .on('data', (row) => {
                 expect(row.audits).toBeDefined();
                 expect(row.response).toBeDefined();
-                expect(row.validated_data).toBeDefined();
-                if (row.validated_data_available) {
-                    expect(row.validated_data).not.toBeNull();
+                expect(row.corrected_response).toBeDefined();
+                if (row.corrected_response_available) {
+                    expect(row.corrected_response).not.toBeNull();
                 } else {
-                    expect(row.validated_data).toBeNull();
+                    expect(row.corrected_response).toBeNull();
                 }
                 i++;
             })
@@ -973,11 +973,11 @@ describe('stream interviews query', () => {
             .on('data', (row) => {
                 expect(row.audits).not.toBeDefined();
                 expect(row.response).toBeDefined();
-                expect(row.validated_data).toBeDefined();
-                if (row.validated_data_available) {
-                    expect(row.validated_data).not.toBeNull();
+                expect(row.corrected_response).toBeDefined();
+                if (row.corrected_response_available) {
+                    expect(row.corrected_response).not.toBeNull();
                 } else {
-                    expect(row.validated_data).toBeNull();
+                    expect(row.corrected_response).toBeNull();
                 }
                 i++;
             })
@@ -997,7 +997,7 @@ describe('stream interviews query', () => {
             .on('data', (row) => {
                 expect(row.audits).toBeDefined();
                 expect(row.response).toBeDefined();
-                expect(row.validated_data).not.toBeDefined();
+                expect(row.corrected_response).not.toBeDefined();
                 i++;
             })
             .on('end', () => {
@@ -1006,8 +1006,8 @@ describe('stream interviews query', () => {
             });
     });
 
-    test('Stream with only validated_data', (done) => {
-        const queryStream = dbQueries.getInterviewsStream({ filters: {}, select: { responseType: 'validated' } });
+    test('Stream with only corrected_response', (done) => {
+        const queryStream = dbQueries.getInterviewsStream({ filters: {}, select: { responseType: 'corrected' } });
         queryStream.on('error', (error) => {
             console.error(error);
             expect(true).toBe(false);
@@ -1016,7 +1016,7 @@ describe('stream interviews query', () => {
             .on('data', (row) => {
                 expect(row.audits).toBeDefined();
                 expect(row.response).not.toBeDefined();
-                expect(row.validated_data).toBeDefined();
+                expect(row.corrected_response).toBeDefined();
                 i++;
             })
             .on('end', () => {
@@ -1025,7 +1025,7 @@ describe('stream interviews query', () => {
             });
     });
 
-    test('Stream without response or validated_data or audits', (done) => {
+    test('Stream without response or corrected_response or audits', (done) => {
         const queryStream = dbQueries.getInterviewsStream({ filters: {}, select: { includeAudits: false, responseType: 'none' } });
         queryStream.on('error', (error) => {
             console.error(error);
@@ -1035,7 +1035,7 @@ describe('stream interviews query', () => {
             .on('data', (row) => {
                 expect(row.audits).not.toBeDefined();
                 expect(row.response).not.toBeDefined();
-                expect(row.validated_data).not.toBeDefined();
+                expect(row.corrected_response).not.toBeDefined();
                 i++;
             })
             .on('end', () => {
@@ -1044,7 +1044,7 @@ describe('stream interviews query', () => {
             });
     });
 
-    test('Stream with both response and validated_data', (done) => {
+    test('Stream with both response and corrected_response', (done) => {
         const queryStream = dbQueries.getInterviewsStream({ filters: {}, select: { responseType: 'both' } });
         queryStream.on('error', (error) => {
             console.error(error);
@@ -1054,7 +1054,7 @@ describe('stream interviews query', () => {
             .on('data', (row) => {
                 expect(row.audits).toBeDefined();
                 expect(row.response).toBeDefined();
-                expect(row.validated_data).toBeDefined();
+                expect(row.corrected_response).toBeDefined();
                 i++;
             })
             .on('end', () => {
@@ -1063,8 +1063,8 @@ describe('stream interviews query', () => {
             });
     });
 
-    test('Stream with validated_data if available', (done) => {
-        const queryStream = dbQueries.getInterviewsStream({ filters: {}, select: { responseType: 'validatedIfAvailable' } });
+    test('Stream with corrected_response if available', (done) => {
+        const queryStream = dbQueries.getInterviewsStream({ filters: {}, select: { responseType: 'correctedIfAvailable' } });
         queryStream.on('error', (error) => {
             console.error(error);
             expect(true).toBe(false);
@@ -1073,12 +1073,12 @@ describe('stream interviews query', () => {
             .on('data', (row) => {
                 expect(row.audits).toBeDefined();
                 expect(row.response).toBeDefined();
-                expect(row.validated_data).not.toBeDefined();
-                if (row.validated_data_available) {
+                expect(row.corrected_response).not.toBeDefined();
+                if (row.corrected_response_available) {
                     if (row.uuid === googleUserInterviewAttributes.uuid) {
-                        expect(row.response).toEqual(googleUserInterviewAttributes.validated_data);
+                        expect(row.response).toEqual(googleUserInterviewAttributes.corrected_response);
                     } else {
-                        expect('There is a unknown row with validated_data').toEqual('Only the google participant interview should have validated_data');
+                        expect('There is a unknown row with corrected_response').toEqual('Only the google participant interview should have corrected_response');
                     }
                 } else {
                     expect(row.uuid).not.toEqual(googleUserInterviewAttributes.uuid);
@@ -1105,11 +1105,11 @@ describe('stream interviews query', () => {
             .on('data', (row) => {
                 expect(row.audits).toBeDefined();
                 expect(row.response).toBeDefined();
-                expect(row.validated_data).toBeDefined();
-                if (row.validated_data_available) {
-                    expect(row.validated_data).not.toBeNull();
+                expect(row.corrected_response).toBeDefined();
+                if (row.corrected_response_available) {
+                    expect(row.corrected_response).not.toBeNull();
                 } else {
-                    expect(row.validated_data).toBeNull();
+                    expect(row.corrected_response).toBeNull();
                 }
                 if (row.uuid === interviewerInterviewAttributes.uuid) {
                     expect(row.interviewer_created).toEqual(true);

--- a/packages/evolution-backend/src/models/migrations/20250521101800_renameValidatedData.ts
+++ b/packages/evolution-backend/src/models/migrations/20250521101800_renameValidatedData.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { Knex } from 'knex';
+
+const interviewTable = 'sv_interviews';
+
+export async function up(knex: Knex): Promise<unknown> {
+    return await knex.schema.alterTable(interviewTable, (table: Knex.TableBuilder) => {
+        table.renameColumn('validated_data', 'corrected_response');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    return await knex.schema.alterTable(interviewTable, (table: Knex.TableBuilder) => {
+        table.renameColumn('corrected_response', 'validated_data');
+    });
+}

--- a/packages/evolution-backend/src/services/adminExport/__tests__/exportAllToCsvByObject.test.ts
+++ b/packages/evolution-backend/src/services/adminExport/__tests__/exportAllToCsvByObject.test.ts
@@ -91,22 +91,22 @@ describe('exportAllToCsvBySurveyObject', () => {
                 arrayOfObjects: [{ a: 1, b: 2 }, { a: 3, b: 4 }],
                 arrayOfStrings: ['a', 'b', 'c'],
             },
-            validated_data_available: true,
+            corrected_response_available: true,
         };
 
         // Add the interview to the stream twice, for the paths and the export
         mockGetInterviewsStream.mockReturnValueOnce(new ObjectReadableMock([interviewData]) as any);
         mockGetInterviewsStream.mockReturnValueOnce(new ObjectReadableMock([interviewData]) as any);
 
-        await exportAllToCsvBySurveyObjectTask({ responseType: 'validatedIfAvailable' });
+        await exportAllToCsvBySurveyObjectTask({ responseType: 'correctedIfAvailable' });
 
         // Check the file content of the exported files, there should be one file for persons, one for the interview
         expect(mockCreateStream).toHaveBeenCalledTimes(2);
         expect(mockGetInterviewsStream).toHaveBeenCalledTimes(2);
-        expect(mockGetInterviewsStream).toHaveBeenCalledWith({ filters: {}, select: { includeAudits: false, includeInterviewerData: true, responseType: 'validatedIfAvailable' } });
+        expect(mockGetInterviewsStream).toHaveBeenCalledWith({ filters: {}, select: { includeAudits: false, includeInterviewerData: true, responseType: 'correctedIfAvailable' } });
 
         // Check the content of the interview file
-        const interviewCsvFileName = Object.keys(fileStreams).find((filename) => filename.endsWith('validated_interview_test.csv'));
+        const interviewCsvFileName = Object.keys(fileStreams).find((filename) => filename.endsWith('corrected_interview_test.csv'));
         expect(interviewCsvFileName).toBeDefined();
 
         const csvStream = fileStreams[interviewCsvFileName as string];
@@ -120,7 +120,7 @@ describe('exportAllToCsvBySurveyObject', () => {
             _interviewUuid: interviewData.uuid,
             _interviewer_count: '',
             _interviewer_created: '',
-            hasValidatedData: 'true',
+            hasCorrectedResponse: 'true',
             'household.size': String(interviewData.response.household.size),
             is_completed: String(interviewData.is_completed),
             is_questionable: '',
@@ -135,7 +135,7 @@ describe('exportAllToCsvBySurveyObject', () => {
         });
 
         // Check the content of the persons file
-        const personsCsvFileName = Object.keys(fileStreams).find((filename) => filename.endsWith('validated_household_persons_test.csv'));
+        const personsCsvFileName = Object.keys(fileStreams).find((filename) => filename.endsWith('corrected_household_persons_test.csv'));
         expect(personsCsvFileName).toBeDefined();
 
         const personsCsvStream = fileStreams[personsCsvFileName as string];
@@ -232,23 +232,23 @@ describe('exportAllToCsvBySurveyObject', () => {
                     personsDidTrips: [person1Uuid, person2Uuid]
                 }
             },
-            validated_data_available: true,
+            corrected_response_available: true,
         };
 
         // Add the interview to the stream twice, for the paths and the export
         mockGetInterviewsStream.mockReturnValueOnce(new ObjectReadableMock([interviewData]) as any);
         mockGetInterviewsStream.mockReturnValueOnce(new ObjectReadableMock([interviewData]) as any);
 
-        const filenames = await exportAllToCsvBySurveyObjectTask({ responseType: 'validatedIfAvailable' });
+        const filenames = await exportAllToCsvBySurveyObjectTask({ responseType: 'correctedIfAvailable' });
         console.log('filenames', filenames);
 
         // Check the file content of the exported files, there should be one file for persons, one for the interview
         expect(mockCreateStream).toHaveBeenCalledTimes(3);
         expect(mockGetInterviewsStream).toHaveBeenCalledTimes(2);
-        expect(mockGetInterviewsStream).toHaveBeenCalledWith({ filters: {}, select: { includeAudits: false, includeInterviewerData: true, responseType: 'validatedIfAvailable' } });
+        expect(mockGetInterviewsStream).toHaveBeenCalledWith({ filters: {}, select: { includeAudits: false, includeInterviewerData: true, responseType: 'correctedIfAvailable' } });
 
         // Check the content of the interview file
-        const interviewCsvFileName = Object.keys(fileStreams).find((filename) => filename.endsWith('validated_interview_test.csv'));
+        const interviewCsvFileName = Object.keys(fileStreams).find((filename) => filename.endsWith('corrected_interview_test.csv'));
         expect(interviewCsvFileName).toBeDefined();
 
         const csvStream = fileStreams[interviewCsvFileName as string];
@@ -262,7 +262,7 @@ describe('exportAllToCsvBySurveyObject', () => {
             _interviewUuid: interviewData.uuid,
             _interviewer_count: '',
             _interviewer_created: '',
-            hasValidatedData: 'true',
+            hasCorrectedResponse: 'true',
             'household.size': String(interviewData.response.household.size),
             is_completed: String(interviewData.is_completed),
             is_questionable: '',
@@ -272,7 +272,7 @@ describe('exportAllToCsvBySurveyObject', () => {
         });
 
         // Check the content of the persons file
-        const personsCsvFileName = Object.keys(fileStreams).find((filename) => filename.endsWith('validated_household_persons_test.csv'));
+        const personsCsvFileName = Object.keys(fileStreams).find((filename) => filename.endsWith('corrected_household_persons_test.csv'));
         expect(personsCsvFileName).toBeDefined();
 
         const personsCsvStream = fileStreams[personsCsvFileName as string];
@@ -297,7 +297,7 @@ describe('exportAllToCsvBySurveyObject', () => {
         });
 
         // Check the content of the visited places file
-        const visitedPlacesCsvFileName = Object.keys(fileStreams).find((filename) => filename.endsWith('validated_household_persons_visitedPlaces_test.csv'));
+        const visitedPlacesCsvFileName = Object.keys(fileStreams).find((filename) => filename.endsWith('corrected_household_persons_visitedPlaces_test.csv'));
         expect(visitedPlacesCsvFileName).toBeDefined();
 
         const visitedPlacesCsvStream = fileStreams[visitedPlacesCsvFileName as string];
@@ -357,7 +357,7 @@ describe('exportAllToCsvBySurveyObject', () => {
                 arrayOfStrings: ['a', 'b', 'c'],
                 arrayOrString: 'string'
             },
-            validated_data_available: true,
+            corrected_response_available: true,
         }, {
             id: 2,
             uuid: uuidV4(),
@@ -372,22 +372,22 @@ describe('exportAllToCsvBySurveyObject', () => {
                 fieldIn2: 2,
                 arrayIn2Only: ['x']
             },
-            validated_data_available: true,
+            corrected_response_available: true,
         }];
 
         // Add the interview to the stream twice, for the paths and the export
         mockGetInterviewsStream.mockReturnValueOnce(new ObjectReadableMock(interviewData) as any);
         mockGetInterviewsStream.mockReturnValueOnce(new ObjectReadableMock(interviewData) as any);
 
-        await exportAllToCsvBySurveyObjectTask({ responseType: 'validatedIfAvailable' });
+        await exportAllToCsvBySurveyObjectTask({ responseType: 'correctedIfAvailable' });
 
         // Check the file content of the exported files, there should be one file for persons, one for the interview
         expect(mockCreateStream).toHaveBeenCalledTimes(1);
         expect(mockGetInterviewsStream).toHaveBeenCalledTimes(2);
-        expect(mockGetInterviewsStream).toHaveBeenCalledWith({ filters: {}, select: { includeAudits: false, includeInterviewerData: true, responseType: 'validatedIfAvailable' } });
+        expect(mockGetInterviewsStream).toHaveBeenCalledWith({ filters: {}, select: { includeAudits: false, includeInterviewerData: true, responseType: 'correctedIfAvailable' } });
 
         // Check the content of the interview file
-        const interviewCsvFileName = Object.keys(fileStreams).find((filename) => filename.endsWith('validated_interview_test.csv'));
+        const interviewCsvFileName = Object.keys(fileStreams).find((filename) => filename.endsWith('corrected_interview_test.csv'));
         expect(interviewCsvFileName).toBeDefined();
 
         const csvStream = fileStreams[interviewCsvFileName as string];
@@ -400,7 +400,7 @@ describe('exportAllToCsvBySurveyObject', () => {
             _interviewUuid: interviewData[0].uuid,
             _interviewer_count: '',
             _interviewer_created: '',
-            hasValidatedData: 'true',
+            hasCorrectedResponse: 'true',
             is_completed: String(interviewData[0].is_completed),
             is_questionable: '',
             is_valid: String(interviewData[0].is_valid),
@@ -419,7 +419,7 @@ describe('exportAllToCsvBySurveyObject', () => {
             _interviewUuid: interviewData[1].uuid,
             _interviewer_count: '',
             _interviewer_created: '',
-            hasValidatedData: 'true',
+            hasCorrectedResponse: 'true',
             is_completed: String(interviewData[1].is_completed),
             is_questionable: '',
             is_valid: String(interviewData[1].is_valid),

--- a/packages/evolution-backend/src/services/adminExport/__tests__/exportInterviewLogs.test.ts
+++ b/packages/evolution-backend/src/services/adminExport/__tests__/exportInterviewLogs.test.ts
@@ -85,8 +85,8 @@ describe('exportInterviewLogTask', () => {
             ...commonInterviewData,
             timestamp_sec: 6,
             event_date: new Date(6 * 1000),
-            values_by_path: { 'validated_data.home.address': '6760 rue Saint-Vallier Montréal', 'validated_data.home.city': 'Montréal' },
-            unset_paths: [ 'validated_data.home.country' ]
+            values_by_path: { 'corrected_response.home.address': '6760 rue Saint-Vallier Montréal', 'corrected_response.home.city': 'Montréal' },
+            unset_paths: [ 'corrected_response.home.country' ]
         }
     ];
 

--- a/packages/evolution-backend/src/services/adminExport/exportAllToCsvBySurveyObject.ts
+++ b/packages/evolution-backend/src/services/adminExport/exportAllToCsvBySurveyObject.ts
@@ -34,7 +34,7 @@ type AttributeAndSurveyObjectPaths = {
  *
  * FIXME This won't be necessary once section logs are in a separate table
  *
- * FIXME In the case of the validated interview data, the durations will
+ * FIXME In the case of the corrected interview data, the durations will
  * probably include the time a validation may have spent looking at an interview
  * and will add up to the durations. To get the participant's duration, the file
  * with the participant data should be used. But that should not be a problem
@@ -258,7 +258,7 @@ const getPathsBySurveyObject = async (options: ExportOptions): Promise<{ [objNam
 
     const pathsBySurveyObject = {
         interview: [
-            'hasValidatedData',
+            'hasCorrectedResponse',
             'is_valid',
             'is_completed',
             'is_validated',
@@ -348,7 +348,7 @@ const formatValue = (value: unknown): unknown => {
  * @returns
  */
 export const exportAllToCsvBySurveyObjectTask = async function (
-    options: ExportOptions = { responseType: 'validatedIfAvailable' }
+    options: ExportOptions = { responseType: 'correctedIfAvailable' }
 ) {
     const pathsBySurveyObject = await getPathsBySurveyObject(options);
 
@@ -389,7 +389,7 @@ export const exportAllToCsvBySurveyObjectTask = async function (
     } = {};
     const wroteHeaderBySurveyObjectPath = {};
     const csvFilePaths: string[] = [];
-    const fileNamePrefix = options.responseType === 'validatedIfAvailable' ? 'validated' : 'participant';
+    const fileNamePrefix = options.responseType === 'correctedIfAvailable' ? 'corrected' : 'participant';
     for (const surveyObjectPath in pathsBySurveyObject) {
         const csvFilePath = `${filePathOnServer}/${fileNamePrefix}_${surveyObjectPath.replaceAll('._.', '_').replaceAll('.', '_')}_${config.projectShortname}.csv`;
         const csvStream = fs.createWriteStream(fileManager.getAbsolutePath(csvFilePath));
@@ -439,7 +439,7 @@ export const exportAllToCsvBySurveyObjectTask = async function (
                 const objectsBySurveyObjectPath = {
                     interview: exportedInterviewDataBySurveyObjectPath.interview
                 };
-                objectsBySurveyObjectPath.interview.hasValidatedData = row.validated_data_available;
+                objectsBySurveyObjectPath.interview.hasCorrectedResponse = row.corrected_response_available;
                 objectsBySurveyObjectPath.interview.is_valid = interview.is_valid;
                 objectsBySurveyObjectPath.interview.is_completed = interview.is_completed;
                 objectsBySurveyObjectPath.interview.is_validated = interview.is_validated;

--- a/packages/evolution-backend/src/services/adminExport/types.ts
+++ b/packages/evolution-backend/src/services/adminExport/types.ts
@@ -6,8 +6,8 @@
  */
 
 export type ExportOptions = {
-    /** Specifies which set of response should be exported. 'validated' means
-     * it exports the validated data if available, 'participant' is the original
+    /** Specifies which set of response should be exported. 'corrected' means
+     * it exports the corrected response if available, 'participant' is the original
      * participant response */
-    responseType: 'participant' | 'validatedIfAvailable';
+    responseType: 'participant' | 'correctedIfAvailable';
 };

--- a/packages/evolution-backend/src/services/audits/Audits.ts
+++ b/packages/evolution-backend/src/services/audits/Audits.ts
@@ -20,7 +20,7 @@ export class Audits {
     };
 
     static runAndSaveInterviewAudits = async (interview: InterviewAttributes): Promise<SurveyObjectsWithAudits> => {
-        if (!serverConfig.auditInterview || !interview.validated_data) {
+        if (!serverConfig.auditInterview || !interview.corrected_response) {
             return {
                 audits: []
             };

--- a/packages/evolution-backend/src/services/audits/__tests__/Audits.test.ts
+++ b/packages/evolution-backend/src/services/audits/__tests__/Audits.test.ts
@@ -86,7 +86,7 @@ describe('runAndSaveInterviewAudits', () => {
         } as any,
         validations: {},
         is_completed: false,
-        validated_data: {
+        corrected_response: {
             fieldA: 'modifiedA',
             fieldB: 'modifiedB',
             someObject: {
@@ -114,8 +114,8 @@ describe('runAndSaveInterviewAudits', () => {
         expect(mockInterviewAudits).not.toHaveBeenCalled();
     });
 
-    test('validated_data not set in interview', async () => {
-        const objectsAndAudits = await Audits.runAndSaveInterviewAudits(_omit(interviewAttributes, 'validated_data'));
+    test('corrected_response not set in interview', async () => {
+        const objectsAndAudits = await Audits.runAndSaveInterviewAudits(_omit(interviewAttributes, 'corrected_response'));
         expect(objectsAndAudits.audits).toEqual([]);
         expect(mockInterviewAudits).not.toHaveBeenCalled();
     });

--- a/packages/evolution-backend/src/services/interviews/__tests__/InterviewUtils.test.ts
+++ b/packages/evolution-backend/src/services/interviews/__tests__/InterviewUtils.test.ts
@@ -4,9 +4,9 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import { mapResponseToValidatedData } from '../interviewUtils';
+import { mapResponseToCorrectedResponse } from '../interviewUtils';
 
-describe('mapResponseToValidatedData', () => {
+describe('mapResponseToCorrectedResponse', () => {
     test('Response object', () => {
         const valuesByPath = {
             response: { accessCode: '2222', newField: { foo: 'bar' } },
@@ -15,13 +15,13 @@ describe('mapResponseToValidatedData', () => {
         const unsetPaths = [ 'response', 'validations' ];
 
         const { valuesByPath: updatedValues, unsetPaths: updatedUnsetPaths } =
-            mapResponseToValidatedData(valuesByPath, unsetPaths);
+            mapResponseToCorrectedResponse(valuesByPath, unsetPaths);
 
         expect(updatedValues).toEqual({
-            validated_data: { accessCode: '2222', newField: { foo: 'bar' } },
+            corrected_response: { accessCode: '2222', newField: { foo: 'bar' } },
             validations: { accessCode: { is_valid: false }, response: false }
         });
-        expect(updatedUnsetPaths).toEqual(['validated_data', 'validations']);
+        expect(updatedUnsetPaths).toEqual(['corrected_response', 'validations']);
     });
 
     test('Response depp strings', () => {
@@ -36,16 +36,16 @@ describe('mapResponseToValidatedData', () => {
         const unsetPaths = [ 'response.accessCode', 'response2', 'response2.notToBeModified' ];
 
         const { valuesByPath: updatedValues, unsetPaths: updatedUnsetPaths } =
-            mapResponseToValidatedData(valuesByPath, unsetPaths);
+            mapResponseToCorrectedResponse(valuesByPath, unsetPaths);
 
         expect(updatedValues).toEqual({
-            'validated_data.accessCode': '2222',
-            'validated_data.newField.foo': 'bar',
+            'corrected_response.accessCode': '2222',
+            'corrected_response.newField.foo': 'bar',
             'validations.accessCode.is_valid': false,
             'validations.response': false,
             'response2.notToBeModified': true,
             'response2': 'notToBeModified'
         });
-        expect(updatedUnsetPaths).toEqual(['validated_data.accessCode', 'response2', 'response2.notToBeModified']);
+        expect(updatedUnsetPaths).toEqual(['corrected_response.accessCode', 'response2', 'response2.notToBeModified']);
     });
 });

--- a/packages/evolution-backend/src/services/interviews/__tests__/serverFieldUpdate.test.ts
+++ b/packages/evolution-backend/src/services/interviews/__tests__/serverFieldUpdate.test.ts
@@ -36,7 +36,7 @@ const mockedOperation = jest.fn();
 const updateCallbacks = [
     {
         field: 'testFields.fieldA',
-        runOnValidatedData: true,
+        runOnCorrectedResponse: true,
         callback: jest.fn().mockImplementation((interview, fieldValue) =>
             fieldValue === 'foo'
                 ? { 'testFields.fieldB': 'bar' }
@@ -79,22 +79,22 @@ describe('Simple field update', () => {
         ['Values by path, but field not updated', { 'response.testFields.fieldB': 'abc' }, []],
         ['Unset path, but field not updated', { }, ['response.testFields.fieldB']],
         ['Field set, should return empty', { 'response.testFields.fieldA': '121' }, [], 0, {}],
-        ['Field set in validated data, should run for this callback', { 'validated_data.testFields.fieldA': '121' }, [], 0, {}],
+        ['Field set in corrected response, should run for this callback', { 'corrected_response.testFields.fieldA': '121' }, [], 0, {}],
         ['Field set to specific value, should return an update', { 'response.testFields.fieldA': 'foo' }, [], 0, { 'response.testFields.fieldB': 'bar' }],
-        ['Field set to specific value in validated_data, should return an update', { 'validated_data.testFields.fieldA': 'foo' }, [], 0, { 'validated_data.testFields.fieldB': 'bar' }],
+        ['Field set to specific value in corrected_response, should return an update', { 'corrected_response.testFields.fieldA': 'foo' }, [], 0, { 'corrected_response.testFields.fieldB': 'bar' }],
         ['Field updated to same value, should not be returned', { 'response.testFields.fieldA': 'same' }, [], 0, {}],
         ['Field unset, should return empty', { 'response.testFields.fieldB': 'abc' }, ['response.testFields.fieldA'], 0, {}],
         ['Field update, should return URL', { 'response._isCompleted' : true }, [], 2, {}, testRedirectUrl],
         ['Field update, no URL return', { 'response._isCompleted' : false }, [], 2, {}, undefined],
-        ['Field update in validated_data, should not run for this callback', { 'validated_data._isCompleted' : false }, [], false, {}, undefined],
-        ['Not a field in response or validated_data', { '_isCompleted' : false }, [], false, {}, undefined],
+        ['Field update in corrected_response, should not run for this callback', { 'corrected_response._isCompleted' : false }, [], false, {}, undefined],
+        ['Not a field in response or corrected_response', { '_isCompleted' : false }, [], false, {}, undefined],
         ['No data', { }, undefined],
     ]).test('%s', async (_description, valuesByPath, unsetPath, called: number | false = false, expectedFieldValues: { [path: string]: unknown } = {}, expectedUrl = undefined) => {
         expect(await updateServerFields(interviewAttributes, updateCallbacks, valuesByPath, unsetPath, deferredUpdateCallback)).toEqual([expectedFieldValues, expectedUrl]);
         if (called !== false) {
             expect(updateCallbacks[called].callback).toHaveBeenCalledTimes(1);
             if (called === 0) {
-                expect(updateCallbacks[called].callback).toHaveBeenCalledWith(interviewAttributes, valuesByPath['response.testFields.fieldA'] !== undefined ? valuesByPath['response.testFields.fieldA'] : valuesByPath['validated_data.testFields.fieldA'], 'testFields.fieldA', expect.anything());
+                expect(updateCallbacks[called].callback).toHaveBeenCalledWith(interviewAttributes, valuesByPath['response.testFields.fieldA'] !== undefined ? valuesByPath['response.testFields.fieldA'] : valuesByPath['corrected_response.testFields.fieldA'], 'testFields.fieldA', expect.anything());
             } else if (called === 2) {
                 expect(updateCallbacks[called].callback).toHaveBeenCalledWith(interviewAttributes, valuesByPath['response._isCompleted'], '_isCompleted', expect.anything());
             }

--- a/packages/evolution-backend/src/services/interviews/interview.ts
+++ b/packages/evolution-backend/src/services/interviews/interview.ts
@@ -189,15 +189,17 @@ export const updateInterview = async (
     return { interviewId: retInterview.uuid, serverValidations, serverValuesByPath, redirectUrl };
 };
 
-export const copyResponseToValidatedData = async (interview: InterviewAttributes) => {
-    // TODO The frontend code that was replaced by this method said: // TODO The copy to validated_data should include the audit
+export const copyResponseToCorrectedResponse = async (interview: InterviewAttributes) => {
+    // TODO The frontend code that was replaced by this method said: // TODO The copy to corrected_response should include the audit
 
-    // Keep the _validationComment from current validated_data, then copy original response
-    const validationComment = interview.validated_data ? interview.validated_data._validationComment : undefined;
-    interview.validated_data = _cloneDeep(interview.response);
-    interview.validated_data._validatedDataCopiedAt = moment().unix();
+    // Keep the _validationComment from current corrected_response, then copy original response
+    const validationComment = interview.corrected_response
+        ? interview.corrected_response._validationComment
+        : undefined;
+    interview.corrected_response = _cloneDeep(interview.response);
+    interview.corrected_response._correctedResponseCopiedAt = moment().unix();
     if (validationComment) {
-        interview.validated_data._validationComment = validationComment;
+        interview.corrected_response._validationComment = validationComment;
     }
-    await interviewsDbQueries.update(interview.uuid, { validated_data: interview.validated_data });
+    await interviewsDbQueries.update(interview.uuid, { corrected_response: interview.corrected_response });
 };

--- a/packages/evolution-backend/src/services/interviews/interviewUtils.ts
+++ b/packages/evolution-backend/src/services/interviews/interviewUtils.ts
@@ -8,17 +8,17 @@
 import { UserAction } from 'evolution-common/lib/services/questionnaire/types';
 
 /** Change the prefixes in the valuesByPath, unsetPaths and userAction from
- * response to validated_data. */
-export const mapResponseToValidatedData = (
+ * response to corrected_response. */
+export const mapResponseToCorrectedResponse = (
     valuesByPath: { [key: string]: unknown },
     unsetPaths: string[],
     userAction?: UserAction
 ): { valuesByPath: { [key: string]: unknown }; unsetPaths: string[]; userAction?: UserAction } => {
     // Content in valuesByPath and unsetPaths with prefix 'response' should
-    // be put in 'validated_data' instead.
+    // be put in 'corrected_response' instead.
     const renameKey = (oldKey: string): string => {
         if (oldKey.startsWith('response.') || oldKey === 'response') {
-            return oldKey.replace('response', 'validated_data');
+            return oldKey.replace('response', 'corrected_response');
         }
         return oldKey;
     };

--- a/packages/evolution-backend/src/services/interviews/interviews.ts
+++ b/packages/evolution-backend/src/services/interviews/interviews.ts
@@ -7,8 +7,8 @@
 import _cloneDeep from 'lodash/cloneDeep';
 import moment from 'moment';
 import { auditInterview, getChangesAfterCleaningInterview } from 'evolution-common/lib/services/interviews/interview';
-import { updateInterview, setInterviewFields, copyResponseToValidatedData } from './interview';
-import { mapResponseToValidatedData } from './interviewUtils';
+import { updateInterview, setInterviewFields, copyResponseToCorrectedResponse } from './interview';
+import { mapResponseToCorrectedResponse } from './interviewUtils';
 import { validateAccessCode } from '../accessCode';
 import { validate as validateUuid } from 'uuid';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
@@ -202,8 +202,8 @@ export default class Interviews {
                         console.info(`Auditing interview ${i}`);
                     }
                     i++;
-                    if (_isBlank(interview.validated_data)) {
-                        copyResponseToValidatedData(interview)
+                    if (_isBlank(interview.corrected_response)) {
+                        copyResponseToCorrectedResponse(interview)
                             .then(
                                 () =>
                                     new Promise((res1, _rej1) => {
@@ -218,7 +218,7 @@ export default class Interviews {
                                     })
                             )
                             .catch((error) => {
-                                console.error('Error copying response to validated data', error);
+                                console.error('Error copying response to corrected response', error);
                             })
                             .finally(() => {
                                 queryStream.resume();
@@ -256,9 +256,9 @@ export default class Interviews {
                     queryStream.pause();
                     // Pausing the connnection is useful if your processing involves I/O
                     const interview = row;
-                    const changesAfterCleaningInterview = mapResponseToValidatedData(
+                    const changesAfterCleaningInterview = mapResponseToCorrectedResponse(
                         getChangesAfterCleaningInterview(
-                            interview.validated_data,
+                            interview.corrected_response,
                             interview.response,
                             interview,
                             parsers,
@@ -268,7 +268,7 @@ export default class Interviews {
                     );
                     setInterviewFields(interview, changesAfterCleaningInterview);
                     const audits = auditInterview(
-                        interview.validated_data,
+                        interview.corrected_response,
                         interview.response,
                         interview,
                         validations,
@@ -316,9 +316,9 @@ export default class Interviews {
                     // Pausing the connnection is useful if your processing involves I/O
                     const interview = row;
                     updateInterview(interview, {
-                        fieldsToUpdate: ['validated_data', 'is_completed', 'is_validated', 'is_valid'],
+                        fieldsToUpdate: ['corrected_response', 'is_completed', 'is_validated', 'is_valid'],
                         valuesByPath: {
-                            validated_data: interview.response,
+                            corrected_response: interview.response,
                             is_completed: null,
                             is_validated: null,
                             is_valid: null

--- a/packages/evolution-backend/src/tasks/exportInterviewsJson.task.ts
+++ b/packages/evolution-backend/src/tasks/exportInterviewsJson.task.ts
@@ -16,7 +16,7 @@ const exportJsonFileDirectory = 'exports/interviewsJson';
  */
 const exportInterviews = function (exportJsonFileDirectory) {
     return knex
-        .select('id', 'uuid', 'response', 'validated_data')
+        .select('id', 'uuid', 'response', 'corrected_response')
         .from('sv_interviews')
         .orderBy('id')
         .then((rows) => {

--- a/packages/evolution-backend/src/tasks/resetInterviewsValidation.task.ts
+++ b/packages/evolution-backend/src/tasks/resetInterviewsValidation.task.ts
@@ -8,7 +8,7 @@ import '../config/projectConfig'; // Unused, but must be imported
 import 'chaire-lib-backend/lib/config/dotenv.config';
 import Interviews from '../services/interviews/interviews';
 
-// this task will remove all validated data from every valid interviews and replace validated data with original response (not modified by validators/admins)
+// this task will remove all corrected responses from every valid interviews and replace corrected response with original response (not modified by validators/admins)
 // You must provide this argument to confirm reset: I WANT TO DELETE ALL VALIDATION WORK
 const confirm = process.argv[2];
 

--- a/packages/evolution-common/src/services/baseObjects/interview/InterviewUnserializer.ts
+++ b/packages/evolution-common/src/services/baseObjects/interview/InterviewUnserializer.ts
@@ -18,7 +18,7 @@ export type ExtendedInterviewWithComposedAttributes = InterviewAttributes & {
 };
 
 /**
- * Validate the interview params coming from the frontend as json unvalidated data.
+ * Validate the interview params coming from the frontend as json unvalidated response.
  * This method does not audit the content, it just make sure that the values are of
  * the correct type and that required data is present.
  * @param dirtyParams the json data

--- a/packages/evolution-common/src/services/interviews/interview.ts
+++ b/packages/evolution-common/src/services/interviews/interview.ts
@@ -26,14 +26,14 @@ export const INTERVIEWER_PARTICIPANT_PREFIX = 'telephone';
  * and the value is the number of times this validation fails on the response.
  */
 export const auditInterview = function (
-    validatedData: InterviewResponse,
+    correctedResponse: InterviewResponse,
     originalResponse: InterviewResponse,
     interview: InterviewAttributes,
     validations: any,
     surveyProjectHelper: any
 ): { [validationId: string]: number } {
     const auditsCountByValidationId: { [validationId: string]: number } = {};
-    const response = validatedData ? validatedData : originalResponse;
+    const response = correctedResponse ? correctedResponse : originalResponse;
     const household = _get(response, 'household', {});
     const home = _get(response, 'home', {});
     const validatedInterview = _cloneDeep(interview);
@@ -179,10 +179,10 @@ export const auditInterview = function (
 };
 
 // this function will use parsers to clean and fix the interviews. Parsers can change any path in the interview, to normalize repsonses or clean errors or typos in some fields:
-// the input is validated_data response if available, otherwise, it will use original respondent response
+// the input is corrected_response response if available, otherwise, it will use original respondent response
 // output will be valuesByPath which are each changes made to the response, by path
 export const getChangesAfterCleaningInterview = function (
-    validatedData,
+    correctedResponse,
     originalResponse,
     interview,
     parsers,
@@ -194,7 +194,7 @@ export const getChangesAfterCleaningInterview = function (
 
     let changeModesWalk = false;
 
-    const response = validatedData || originalResponse;
+    const response = correctedResponse || originalResponse;
     const validatedInterview = _cloneDeep(interview);
     validatedInterview.response = response;
     validatedInterview._response = originalResponse;

--- a/packages/evolution-common/src/services/questionnaire/types/Data.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/Data.ts
@@ -196,7 +196,7 @@ export type InterviewResponse = {
 };
 
 type ValidatedResponse = InterviewResponse & {
-    _validatedDataCopiedAt?: number;
+    _correctedResponseCopiedAt?: number;
     _validationComment?: string;
 };
 
@@ -233,7 +233,7 @@ export interface UserInterviewAttributes {
 export interface InterviewAttributes extends UserInterviewAttributes {
     is_active?: boolean;
     is_started?: boolean;
-    validated_data?: ValidatedResponse;
+    corrected_response?: ValidatedResponse;
     audits?: InterviewAudits;
     is_validated?: boolean;
     is_questionable?: boolean;
@@ -251,7 +251,7 @@ export interface InterviewListAttributes {
     uuid: string;
     participant_id: number;
     response: InterviewResponse;
-    validated_data: ValidatedResponse;
+    corrected_response: ValidatedResponse;
     is_valid?: boolean;
     is_completed?: boolean;
     is_validated?: boolean;

--- a/packages/evolution-frontend/src/actions/SurveyAdmin.ts
+++ b/packages/evolution-frontend/src/actions/SurveyAdmin.ts
@@ -246,7 +246,7 @@ export const startSurveyValidateRemoveGroupedObjects = (
 };
 
 /**
- * Fetch an interview from server and re-initialize the validated_data to the
+ * Fetch an interview from server and re-initialize the corrected_response to the
  * participant's response, but keeping the validation comments.
  *
  * @param {*} interviewUuid The uuid of the interview to open

--- a/packages/evolution-frontend/src/components/admin/pages/ExportInterviewData.tsx
+++ b/packages/evolution-frontend/src/components/admin/pages/ExportInterviewData.tsx
@@ -27,11 +27,11 @@ const ExportInterviewData = ({ t, i18n }: WithTranslation) => {
     };
 
     const onPrepareCsvValidatedExportFiles = async () => {
-        return onPrepareCsvExportFiles('validatedIfAvailable');
+        return onPrepareCsvExportFiles('correctedIfAvailable');
     };
 
     const onPrepareCsvExportFiles = async (
-        exportType: 'validatedIfAvailable' | 'participant' = 'validatedIfAvailable'
+        exportType: 'correctedIfAvailable' | 'participant' = 'correctedIfAvailable'
     ) => {
         setIsPreparingCsvExportFiles(true);
         try {


### PR DESCRIPTION
validated_data is renamed corrected_response (see [nomenclature](docs/nomenclature.md)) You need to run yarn migrate to update column names in your database. Part of #745