### PR TITLE
auth: record participant login in the interview

### DIFF
--- a/packages/evolution-backend/src/models/migrations/20250526083900_createLoginLogTable.ts
+++ b/packages/evolution-backend/src/models/migrations/20250526083900_createLoginLogTable.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { Knex } from 'knex';
+
+const participantLoginTbl = 'sv_participant_logins';
+const participantTbl = 'sv_participants';
+
+export async function up(knex: Knex): Promise<unknown> {
+    return knex.schema.createTable(participantLoginTbl, (table: Knex.TableBuilder) => {
+        table.integer('participant_id').notNullable();
+        table.foreign('participant_id').references(`${participantTbl}.id`).onDelete('CASCADE');
+        table.timestamp('timestamp', { useTz: true }).notNullable().defaultTo(knex.fn.now());
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    return knex.schema.dropTable(participantLoginTbl);
+}

--- a/packages/evolution-backend/src/models/participants.db.queries.ts
+++ b/packages/evolution-backend/src/models/participants.db.queries.ts
@@ -11,6 +11,7 @@ import TrError from 'chaire-lib-common/lib/utils/TrError';
 import { ParticipantAttributes } from '../services/participants/participant';
 
 const tableName = 'sv_participants';
+const participantLoginTbl = 'sv_participant_logins';
 
 const create = async (newObject: Partial<ParticipantAttributes>): Promise<ParticipantAttributes> => {
     try {
@@ -110,9 +111,27 @@ const update = async (id: number, attributes: Partial<ParticipantAttributes>): P
     }
 };
 
+/**
+ * Log the last login of a participant in the database
+ * @param participantId The ID of the participant to log
+ * @returns {Promise<void>} A promise that resolves when the login is logged
+ */
+const logLastLogin = async (participantId: number): Promise<void> => {
+    try {
+        await knex(participantLoginTbl).insert({ participant_id: participantId });
+    } catch (error) {
+        throw new TrError(
+            `Cannot log login of participant with id ${participantId} in table ${participantLoginTbl} (knex error: ${error})`,
+            'EVOPART0003',
+            'DatabaseCannotInsertBecauseDatabaseError'
+        );
+    }
+};
+
 export default {
     create,
     find,
     update,
-    getById
+    getById,
+    logLastLogin
 };

--- a/packages/evolution-backend/src/services/auth/__tests__/participantAuthModel.test.ts
+++ b/packages/evolution-backend/src/services/auth/__tests__/participantAuthModel.test.ts
@@ -18,13 +18,15 @@ jest.mock('../../../models/participants.db.queries', () => ({
     update: jest.fn(),
     find: jest.fn(),
     getById: jest.fn(),
-    create: jest.fn()
+    create: jest.fn(),
+    logLastLogin: jest.fn()
 }));
 
 const mockSave = participantsDbQueries.update as jest.MockedFunction<typeof participantsDbQueries.update>;
 const mockFind = participantsDbQueries.find as jest.MockedFunction<typeof participantsDbQueries.find>
 const mockGetById = participantsDbQueries.getById as jest.MockedFunction<typeof participantsDbQueries.getById>;
-const mockCreate = participantsDbQueries.create as jest.MockedFunction<typeof participantsDbQueries.create>
+const mockCreate = participantsDbQueries.create as jest.MockedFunction<typeof participantsDbQueries.create>;
+const mockLogLastLogin = participantsDbQueries.logLastLogin as jest.MockedFunction<typeof participantsDbQueries.logLastLogin>;
 
 const defaultUserId = 5;
 
@@ -623,4 +625,11 @@ test('ParticipantModel: properties', () => {
     expect(user.passwordResetExpireAt).toEqual(defaultParticipantAttributes.password_reset_expire_at);
     expect(user.confirmationToken).toEqual(defaultParticipantAttributes.confirmation_token);
     expect(user.isConfirmed).toEqual(defaultParticipantAttributes.is_confirmed);
+});
+
+test('ParticipantModel: record login', async () => {
+    const user = new ParticipantModel(defaultParticipantAttributes);
+    await user.recordLogin();
+    expect(mockLogLastLogin).toHaveBeenCalledTimes(1);
+    expect(mockLogLastLogin).toHaveBeenCalledWith(defaultParticipantAttributes.id);
 });

--- a/packages/evolution-backend/src/services/auth/participantAuthModel.ts
+++ b/packages/evolution-backend/src/services/auth/participantAuthModel.ts
@@ -110,4 +110,9 @@ export class ParticipantModel extends UserModelBase {
     sanitize = (): BaseUser => {
         return sanitizeUserAttributes(this.attributes);
     };
+
+    recordLogin = async (): Promise<void> => {
+        // Record participant login in the database
+        return dbQueries.logLastLogin(this.attributes.id);
+    };
 }


### PR DESCRIPTION
fixes #932

Add a database table `sv_participants_logins` that tracks the participant logins in the survey. This table simply links a `participant_id` with the timestamp of the login.

Implement the `recordLogin` method in the `ParticipantModel` class to save the login timestamp in the participants' login table.