### PR TITLE
state: add root state reducer to reset interview at logout

### DIFF
--- a/packages/evolution-frontend/src/apps/admin/index.tsx
+++ b/packages/evolution-frontend/src/apps/admin/index.tsx
@@ -13,7 +13,7 @@ import { BrowserRouter } from 'react-router';
 import config from 'evolution-common/lib/config/project.config';
 import i18n from '../../config/i18n.config';
 import SurveyRouter from '../../components/admin/routers/AdminSurveyRouter';
-import configureStore from '../../store/configureStore';
+import { configureStore } from '../../store/configureStore';
 import LoadingPage from 'chaire-lib-frontend/lib/components/pages/LoadingPage';
 import { InterviewContext, interviewReducer, initialState } from '../../contexts/InterviewContext';
 import { SurveyContext, surveyReducer } from '../../contexts/SurveyContext';

--- a/packages/evolution-frontend/src/apps/participant/index.tsx
+++ b/packages/evolution-frontend/src/apps/participant/index.tsx
@@ -13,7 +13,7 @@ import { BrowserRouter } from 'react-router';
 import config from 'evolution-common/lib/config/project.config';
 import i18n from '../../config/i18n.config';
 import SurveyRouter from '../../components/routers/ParticipantSurveyRouter';
-import configureStore from '../../store/configureStore';
+import { configureStore } from '../../store/configureStore';
 import LoadingPage from 'chaire-lib-frontend/lib/components/pages/LoadingPage';
 import { InterviewContext, interviewReducer, initialState } from '../../contexts/InterviewContext';
 // TODO When the project is the root of the application (instead of evolution directly importing project files), this should go in the project

--- a/packages/evolution-frontend/src/components/pageParts/__tests__/ConsentAndStartForm.test.tsx
+++ b/packages/evolution-frontend/src/components/pageParts/__tests__/ConsentAndStartForm.test.tsx
@@ -12,7 +12,7 @@ import { Provider } from 'react-redux';
 
 import ConsentAndStartForm from '../ConsentAndStartForm';
 import { addConsent } from '../../../actions/Survey';
-import configureStore from '../../../store/configureStore';
+import { configureStore } from '../../../store/configureStore';
 
 // Mock the react-i18next's useTranslation function to control the translated string
 let translatedString = '';

--- a/packages/evolution-frontend/src/components/survey/__tests__/ErrorBoundary.test.tsx
+++ b/packages/evolution-frontend/src/components/survey/__tests__/ErrorBoundary.test.tsx
@@ -11,7 +11,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { MemoryRouter } from 'react-router';
-import configureStore from '../../../store/configureStore';
+import { configureStore } from '../../../store/configureStore';
 import { logClientSideMessage } from '../../../services/errorManagement/errorHandling';
 
 import ErrorBoundary from '../ErrorBoundary';

--- a/packages/evolution-frontend/src/store/__tests__/configureStore.test.ts
+++ b/packages/evolution-frontend/src/store/__tests__/configureStore.test.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { AuthActionTypes } from 'chaire-lib-frontend/lib/store/auth';
+import { configureStore } from '../configureStore';
+import { SurveyActionTypes } from '../survey';
+import { UserRuntimeInterviewAttributes } from 'evolution-common/lib/services/questionnaire/types';
+
+const testInterview: UserRuntimeInterviewAttributes = {
+    id: 1,
+    uuid: 'arbitrary uuid',
+    participant_id: 1,
+    is_completed: false,
+    response: {
+        section1: {
+            q1: 'abc',
+            q2: 3
+        },
+        section2: {
+            q1: 'test'
+        }
+    } as any,
+    validations: {
+        section1: {
+            q1: true,
+            q2: false
+        },
+        section2: {
+            q1: true
+        }
+    } as any,
+    is_valid: true,
+    widgets: {},
+    groups: {},
+    visibleWidgets: [],
+    allWidgetsValid: true
+};
+
+describe('configureStore', () => {
+    let store;
+
+    beforeEach(() => {
+        store = configureStore();
+    });
+
+    it('should initialize with the correct default state', () => {
+        const state = store.getState();
+        expect(state).toEqual({
+            auth: { isAuthenticated: false },
+            survey: {},
+            loadingState: { loadingState: 0 }
+        });
+    });
+
+    it('should handle actions and update state correctly', () => {
+        const loginAction = { type: AuthActionTypes.LOGIN, user: null, isAuthenticated: true, register: false, login: true };
+        store.dispatch(loginAction);
+        const state = store.getState();
+        expect(state.auth).toEqual({
+            isAuthenticated: true,
+            user: null,
+            register: false,
+            login: true
+        });
+    });
+
+    it('should reset state on logout', () => {
+        // Set interview, with an update interview action
+        const action = {
+            type: SurveyActionTypes.UPDATE_INTERVIEW as const,
+            interview: testInterview,
+            interviewLoaded:true,
+            submitted: true,
+            errors: {field: { 'en': 'something' }}
+        };
+        const result =  {
+            interview: testInterview,
+            interviewLoaded:true,
+            submitted: true,
+            errors: {field: { 'en': 'something' }}
+        };
+        store.dispatch(action);
+        const stateAfterUpdate = store.getState();
+        expect(stateAfterUpdate.survey).toEqual(result);
+
+        // Call the logout action and make sure the action is reset
+        const logoutAction = { type: AuthActionTypes.LOGOUT, isAuthenticated: false };
+        store.dispatch(logoutAction);
+        const state = store.getState();
+        expect(state).toEqual({
+            auth: { isAuthenticated: false },
+            survey: {},
+            loadingState: { loadingState: 0 }
+        });
+    });
+
+    it('should allow preloaded state to be passed', () => {
+        const preloadedState = {
+            auth: { isAuthenticated: true },
+            survey: { someSurveyData: 'test' },
+            loadingState: { loadingState: 1 }
+        };
+        const storeWithPreloadedState = configureStore(preloadedState as any);
+        const state = storeWithPreloadedState.getState();
+        expect(state).toEqual(preloadedState);
+    });
+});


### PR DESCRIPTION
fixes #999

Add a root reducer for the redux store that listens to all action and resets the state to their original value upon logout.

Add tests for the store configuration function that fails prior to the fix and makes sure the survey state is reinitialized at logout.