### PR TITLE
survey: merge interview create and activation for participants

### DIFF
--- a/packages/evolution-backend/src/api/__tests__/survey.participant.routes.test.ts
+++ b/packages/evolution-backend/src/api/__tests__/survey.participant.routes.test.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import request from 'supertest';
+import express, { Router } from 'express';
+import surveyParticipantRoutes from '../survey.participant.routes';
+import Interviews from '../../services/interviews/interviews';
+import { InterviewLoggingMiddlewares } from '../../services/logging/queryLoggingMiddleware';
+import { isLoggedIn } from 'chaire-lib-backend/lib/services/auth/authorization';
+
+jest.mock('../../services/interviews/interviews');
+jest.mock('../../services/logging/queryLoggingMiddleware');
+
+const mockUserId = 3;
+const mockAuthorizationMiddleware = jest.fn(() => (req, res, next) => next());
+const mockLoggingMiddleware: InterviewLoggingMiddlewares = {
+    getUserIdForLogging: jest.fn(() => undefined),
+    openingInterview: jest.fn().mockReturnValue(jest.fn()),
+    updatingInterview: jest.fn().mockReturnValue(jest.fn())
+};
+
+jest.mock('chaire-lib-backend/lib/services/auth/authorization', () => ({
+    isLoggedIn: jest.fn((req, res, next) => {
+        req.user = { id: mockUserId }; // Mock user object
+        next();
+    }),
+}));
+const mockIsLoggedIn = isLoggedIn as jest.MockedFunction<typeof isLoggedIn>;
+
+const app = express();
+app.use(express.json());
+app.use(
+    surveyParticipantRoutes(mockAuthorizationMiddleware, mockLoggingMiddleware)
+);
+
+describe('GET /survey/activeInterview', () => {
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('should return active interview for user', async () => {
+        const mockInterview = {
+            id: 1,
+            uuid: 'mockUuid',
+            is_valid: true,
+            is_completed: false,
+            response: {},
+            participant_id: 1,
+        };
+        (Interviews.getUserInterview as jest.Mock).mockResolvedValue(mockInterview);
+
+        const response = await request(app).get('/survey/activeInterview');
+
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual({ status: 'success', interview: mockInterview });
+        expect(Interviews.getUserInterview).toHaveBeenCalledWith(mockUserId);
+    });
+
+    test('should create interview if none exists', async () => {
+        const mockCreatedInterview = {
+            id: 1,
+            uuid: 'mockUuid',
+            is_valid: true,
+            is_completed: false,
+            response: {},
+            participant_id: 1,
+        };
+        (Interviews.getUserInterview as jest.Mock).mockResolvedValue(undefined);
+        (Interviews.createInterviewForUser as jest.Mock).mockResolvedValue(mockCreatedInterview);
+
+        const response = await request(app).get('/survey/activeInterview');
+
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual({ status: 'success', interview: mockCreatedInterview });
+        expect(Interviews.getUserInterview).toHaveBeenCalledWith(mockUserId);
+        expect(Interviews.createInterviewForUser).toHaveBeenCalledWith(
+            mockUserId,
+            {},
+            undefined,
+            ['id', 'uuid', 'is_valid', 'is_completed', 'response', 'participant_id']
+        );
+    });
+
+    test('should return 400 if user is not defined', async () => {
+        mockIsLoggedIn.mockImplementationOnce((req, res, next) => {
+            req.user = undefined; // Simulate undefined user
+            next();
+        });
+
+        const response = await request(app).get('/survey/activeInterview');
+
+        expect(response.status).toBe(400);
+        expect(response.body).toEqual({ status: 'BadRequest' });
+        expect(Interviews.getUserInterview).not.toHaveBeenCalled();
+    });
+
+    test('should handle server error', async () => {
+        (Interviews.getUserInterview as jest.Mock).mockRejectedValue(new Error('Database error'));
+
+        const response = await request(app).get('/survey/activeInterview');
+
+        expect(response.status).toBe(500);
+        expect(response.body).toEqual({
+            status: 'failed',
+            interview: null,
+            error: 'cannot fetch interview',
+        });
+        expect(Interviews.getUserInterview).toHaveBeenCalledWith(mockUserId);
+    });
+});

--- a/packages/evolution-backend/src/api/__tests__/survey.user.routes.test.ts
+++ b/packages/evolution-backend/src/api/__tests__/survey.user.routes.test.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { v4 as uuidV4 } from 'uuid';
+import request from 'supertest';
+import express, { Router } from 'express';
+import surveyUserRoutes from '../survey.user.routes';
+import { InterviewLoggingMiddlewares } from '../../services/logging/queryLoggingMiddleware';
+import Interviews from '../../services/interviews/interviews';
+import { addRolesToInterview } from '../../services/interviews/interview';
+import { isLoggedIn } from 'chaire-lib-backend/lib/services/auth/authorization';
+
+jest.mock('../../services/interviews/interviews', () => ({
+    getInterviewByUuid: jest.fn()
+}));
+const mockGetInterviewByUuid = Interviews.getInterviewByUuid as jest.MockedFunction<typeof Interviews.getInterviewByUuid>;
+jest.mock('../../services/interviews/interview', () => ({
+    addRolesToInterview: jest.fn()
+}));
+const mockAddRolesToInterview = addRolesToInterview as jest.MockedFunction<typeof addRolesToInterview>;
+jest.mock('../../services/logging/queryLoggingMiddleware');
+
+const mockUserId = 3;
+const mockAuthorizationMiddleware = jest.fn(() => (req, res, next) => next());
+const mockLoggingMiddleware: InterviewLoggingMiddlewares = {
+    getUserIdForLogging: jest.fn(() => mockUserId),
+    openingInterview: jest.fn(() => (req, res, next) => next()),
+    updatingInterview: jest.fn(() => (req, res, next) => next())
+};
+
+// Set the user in the request at the same time
+jest.mock('chaire-lib-backend/lib/services/auth/authorization', () => ({
+    isLoggedIn: jest.fn((req, res, next) => {
+        req.user = { id: mockUserId }; // Mock user object
+        next();
+    }),
+}));
+const mockIsLoggedIn = isLoggedIn as jest.MockedFunction<typeof isLoggedIn>;
+
+const app = express();
+app.use(express.json());
+app.use(
+    surveyUserRoutes(mockAuthorizationMiddleware, mockLoggingMiddleware)
+);
+
+describe('GET /survey/activeInterview/:interviewId', () => {
+
+    const interviewUuid = uuidV4();
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should return 400 if user is not defined', async () => {
+        mockIsLoggedIn.mockImplementationOnce((req, res, next) => {
+            req.user = undefined; // Simulate undefined user
+            next();
+        });
+
+        const response = await request(app).get('/survey/activeInterview/' + interviewUuid);
+        expect(response.status).toBe(400);
+        expect(response.body).toEqual({ status: 'BadRequest' });
+    });
+
+    it('should return 404 if interview is not found', async () => {
+        mockGetInterviewByUuid.mockResolvedValueOnce(undefined);
+
+        const response = await request(app)
+            .get('/survey/activeInterview/' + interviewUuid);
+
+        expect(response.status).toBe(404);
+        expect(response.body).toEqual({ status: 'notFound', interview: null });
+        expect(mockGetInterviewByUuid).toHaveBeenCalledWith(interviewUuid);
+    });
+
+    it('should return 200 with interview if found', async () => {
+        const mockInterview = { id: 1, uuid: interviewUuid };
+        mockGetInterviewByUuid.mockResolvedValueOnce(mockInterview as any);
+
+        const response = await request(app)
+            .get('/survey/activeInterview/' + interviewUuid);
+
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual({ status: 'success', interview: mockInterview });
+        expect(mockAddRolesToInterview).toHaveBeenCalledWith(mockInterview, { id: mockUserId });
+        expect(mockGetInterviewByUuid).toHaveBeenCalledWith(interviewUuid);
+    });
+
+    it('should return 500 if an error occurs', async () => {
+        mockGetInterviewByUuid.mockRejectedValueOnce(new Error('Database error'));
+
+        const response = await request(app)
+            .get('/survey/activeInterview/' + interviewUuid);
+
+        expect(response.status).toBe(500);
+        expect(response.body).toEqual({
+            status: 'failed',
+            interview: null,
+            error: 'cannot fetch interview'
+        });
+    });
+
+    it('should return failed status if uuid is not valid', async () => {
+        const response = await request(app).get('/survey/activeInterview/notAUuid');
+        expect(response.status).toBe(400);
+        expect(response.body).toEqual({ status: 'failed', error: "Invalid interview ID" });
+    });
+});

--- a/packages/evolution-backend/src/api/survey.common.routes.ts
+++ b/packages/evolution-backend/src/api/survey.common.routes.ts
@@ -11,34 +11,13 @@
 import { Request, Response, Router } from 'express';
 import _get from 'lodash/get';
 import moment from 'moment';
-import { UserAttributes } from 'chaire-lib-backend/lib/services/users/user';
 import Interviews from '../services/interviews/interviews';
 
-import { UserInterviewAttributes } from 'evolution-common/lib/services/questionnaire/types';
 import serverConfig from '../config/projectConfig';
 import { InterviewLoggingMiddlewares } from '../services/logging/queryLoggingMiddleware';
 import { logClientSide } from '../services/logging/messageLogging';
-import { addRolesToInterview, updateInterview } from '../services/interviews/interview';
+import { updateInterview } from '../services/interviews/interview';
 import { getParadataLoggingFunction } from '../services/logging/paradataLogging';
-
-export const activateInterview = async (
-    req: Request,
-    res: Response,
-    getInterview: (req: Request) => Promise<UserInterviewAttributes | undefined>
-): Promise<Response> => {
-    if (!req.user) {
-        // Sanity check, but callers should have already checked this
-        throw 'Request user is not defined, an interview cannot be activated by the user';
-    }
-    const user = req.user as UserAttributes;
-    const interview = await getInterview(req);
-    if (interview) {
-        addRolesToInterview(interview, user);
-        return res.status(200).json({ status: 'success', interview });
-    } else {
-        return res.status(200).json({ status: 'failed', interview: null });
-    }
-};
 
 /**
  * Add the common survey routes to the router

--- a/packages/evolution-backend/src/services/interviews/interviews.ts
+++ b/packages/evolution-backend/src/services/interviews/interviews.ts
@@ -102,7 +102,7 @@ export default class Interviews {
         initialResponse: { [key: string]: any },
         creatingUserId?: number | undefined,
         returning: string | string[] = 'uuid'
-    ): Promise<Partial<InterviewAttributes>> => {
+    ): Promise<InterviewAttributes> => {
         // TODO Make sure there is no active interview for this user already?
         // Create the interview for this user, make sure the start time is set
         const response = _cloneDeep(initialResponse);


### PR DESCRIPTION
The `startCreateInterview` and `startSetInterview` redux actions had a lot of code in common. Instead of duplicating them, we let the server create the interview in the `activeInterview` route of the participant app (a 404 is returned in the case of an unexisting interview in the interviewer app).

Since the function in the common routes does not have a lot to do anymore, each version of the caller route now does its own code, instead.

Add unit tests for the participant and user `activeInterview` routes.