### PR TITLE
survey: add a support form to the participant app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,8 @@ GOOGLE_OAUTH_SECRET_KEY = "<googleOauthSecretKey>"
 # Mass email service
 # SENDGRID_API_KEY = "<sendgridApiKey>"
 RESET_PASSWORD_FROM_EMAIL = "<admin@test.com>"
+# Who do send the support request emails to: format: "lang:comma-separated emails;[lang2:comma-separated emails]"
+SUPPORT_REQUEST_EMAILS = "en:example@example.org"
 # MAILCHIMP_API_KEY = "<mailchimpApiKey>"
 # MAILCHIMP_LIST_ID = "<mailchimpListId>"
 

--- a/example/demo_survey/config.js
+++ b/example/demo_survey/config.js
@@ -56,6 +56,7 @@ module.exports = {
   },
   logDatabaseUpdates: true,
   askForAccessCode: true,
+  surveySupportForm: true,
   interviewableAge: 5,
   isPartTwo: false,
   mapDefaultCenter: {

--- a/locales/en/server.json
+++ b/locales/en/server.json
@@ -8,5 +8,9 @@
     "magicLinkEmailText": "Welcome!\n\nTo connect to your questionnaire, click on the following link: {{magicLinkUrl}}.\n\nThank you",
     "magicLinkEmailSubject": "Connection to survey [do not respond]",
     "welcomeEmailText": "Hello,\n\nYou have requested access to this survey.\n\nThank you for your participation.",
-    "welcomeEmailSubject": "Welcome to the survey [do not respond]"
+    "welcomeEmailSubject": "Welcome to the survey [do not respond]",
+    "supportRequestSubject": "Support request for {{surveyName}}",
+    "supportRequestMessage": "Hello,\n\nYou have received a support request from ({{userEmail}}) for the survey {{surveyName}}.{{supportInterviewID}}{{currentPageUrl}}\n\nMessage:\n{{message}}\n\nThank you",
+    "supportInterviewID": "\n\nInterview ID: {{interviewId}}",
+    "currentPageUrl": "\n\nURL of the page: {{currentUrl}}"
 }

--- a/locales/en/survey.yml
+++ b/locales/en/survey.yml
@@ -63,3 +63,21 @@ ResponseIsRequired: "This response is required."
 
 # Section Progress Bar
 completed: 'completed'
+
+support:
+  title: "Contact Support"
+  emailLabel: "Email Address"
+  emailPlaceholder: "your.email@example.com"
+  emailHelper: "Optional. We'll use this to follow up with you if needed."
+  invalidEmail: "Please enter a valid email address"
+  messageLabel: "Message"
+  messagePlaceholder: "How can we help you?"
+  messageHelper: "Please describe your issue in detail"
+  messageRequired: "Please enter a message"
+  submitButton: "Send Message"
+  submitting: "Sending..."
+  submitSuccess: "Your message has been sent. We'll get back to you as soon as possible."
+  submitError: "There was an error sending your message. Please try again later."
+  helpButton: "Need Help?"
+  helpButtonLabel: "Open support form"
+  close: "Close"

--- a/locales/fr/server.json
+++ b/locales/fr/server.json
@@ -8,5 +8,9 @@
     "magicLinkEmailText": "Bienvenue!\n\nPour vous connecter à l'enquête, cliquer sur le lien suivant: {{magicLinkUrl}}.\n\nMerci",
     "magicLinkEmailSubject": "Connexion à l'enquête mobilité [ne pas répondre]",
     "welcomeEmailText": "Bonjour,\n\nVous avez demandé l'accès à cette enquête.\n\nMerci pour votre participation.",
-    "welcomeEmailSubject": "Bienvenue à l'enquête [ne pas répondre]"
+    "welcomeEmailSubject": "Bienvenue à l'enquête [ne pas répondre]",
+    "supportRequestSubject": "Demande d'assistance sur {{surveyName}}",
+    "supportRequestMessage": "Bonjour,\n\nVous avez reçu une demande d'assistance de la part de ({{userEmail}}) pour l'enquête {{surveyName}}.{{supportInterviewID}}{{currentPageUrl}}\n\nMessage:\n{{message}}\n\nMerci",
+    "supportInterviewID": "\n\nID de l'entrevue: {{interviewId}}",
+    "currentPageUrl": "\n\nURL de la page actuelle: {{currentUrl}}"
 }

--- a/locales/fr/survey.yml
+++ b/locales/fr/survey.yml
@@ -73,3 +73,22 @@ ResponseIsRequired: "Cette réponse est requise."
 
 # Section Progress Bar
 completed: 'complété'
+
+# Support form
+support:
+  title: "Demande de support"
+  emailLabel: "Adresse e-mail"
+  emailPlaceholder: "votre.email@example.com"
+  emailHelper: "Optionnel. Nous l'utiliserons pour vous recontacter si nécessaire."
+  invalidEmail: "Veuillez entrer une adresse e-mail valide"
+  messageLabel: "Message"
+  messagePlaceholder: "Comment pouvons-nous vous aider ?"
+  messageHelper: "Veuillez décrire votre problème en détail"
+  messageRequired: "Veuillez entrer un message"
+  submitButton: "Envoyer le message"
+  submitting: "Envoi en cours..."
+  submitSuccess: "Votre message a été envoyé. Nous vous répondrons dès que possible."
+  submitError: "Une erreur est survenue lors de l'envoi de votre message. Veuillez réessayer plus tard."
+  helpButton: "Besoin d'aide?"
+  helpButtonLabel: "Ouvrir le formulaire d'aide"
+  close: "Fermer"

--- a/packages/evolution-backend/src/api/survey.participant.routes.ts
+++ b/packages/evolution-backend/src/api/survey.participant.routes.ts
@@ -12,9 +12,44 @@ import express, { Request, Response, Router } from 'express';
 import { isLoggedIn } from 'chaire-lib-backend/lib/services/auth/authorization';
 import { UserAttributes } from 'chaire-lib-backend/lib/services/users/user';
 import Interviews from '../services/interviews/interviews';
+import { sendSupportRequestEmail } from '../services/logging/supportRequest';
 
 import { InterviewLoggingMiddlewares } from '../services/logging/queryLoggingMiddleware';
 import addCommonRoutes from './survey.common.routes';
+
+// Get a router for the routes that do not need the participant to be logged in
+export const getPublicParticipantRoutes = () => {
+    const publicRouter = express.Router();
+    publicRouter.post('/supportRequest/', async (req: Request, res: Response) => {
+        try {
+            const content = req.body;
+
+            // Get interview ID if user is logged in
+            let interviewId: number | undefined = undefined;
+            if (req.user) {
+                const interview = await Interviews.getUserInterview((req.user as UserAttributes).id);
+                if (interview) {
+                    interviewId = interview.id;
+                }
+            }
+
+            // Send support request email
+            await sendSupportRequestEmail({
+                message: content.message || 'No message provided',
+                userEmail: content.email,
+                interviewId,
+                currentUrl: content.currentUrl
+            });
+
+            return res.status(200).json({ status: 'success' });
+        } catch (error) {
+            console.error(`Error processing support request: ${error}`);
+            return res.status(500).json({ status: 'failed' });
+        }
+    });
+
+    return publicRouter;
+};
 
 export default (authorizationMiddleware, loggingMiddleware: InterviewLoggingMiddlewares): Router => {
     const router = express.Router();

--- a/packages/evolution-backend/src/api/survey.participant.routes.ts
+++ b/packages/evolution-backend/src/api/survey.participant.routes.ts
@@ -9,6 +9,7 @@
  * user's own survey
  * */
 import express, { Request, Response, Router } from 'express';
+import projectConfig from 'evolution-common/lib/config/project.config';
 import { isLoggedIn } from 'chaire-lib-backend/lib/services/auth/authorization';
 import { UserAttributes } from 'chaire-lib-backend/lib/services/users/user';
 import Interviews from '../services/interviews/interviews';
@@ -20,33 +21,36 @@ import addCommonRoutes from './survey.common.routes';
 // Get a router for the routes that do not need the participant to be logged in
 export const getPublicParticipantRoutes = () => {
     const publicRouter = express.Router();
-    publicRouter.post('/supportRequest/', async (req: Request, res: Response) => {
-        try {
-            const content = req.body;
 
-            // Get interview ID if user is logged in
-            let interviewId: number | undefined = undefined;
-            if (req.user) {
-                const interview = await Interviews.getUserInterview((req.user as UserAttributes).id);
-                if (interview) {
-                    interviewId = interview.id;
+    if (projectConfig.surveySupportForm === true) {
+        publicRouter.post('/supportRequest/', async (req: Request, res: Response) => {
+            try {
+                const content = req.body;
+
+                // Get interview ID if user is logged in
+                let interviewId: number | undefined = undefined;
+                if (req.user) {
+                    const interview = await Interviews.getUserInterview((req.user as UserAttributes).id);
+                    if (interview) {
+                        interviewId = interview.id;
+                    }
                 }
+
+                // Send support request email
+                await sendSupportRequestEmail({
+                    message: content.message || 'No message provided',
+                    userEmail: content.email,
+                    interviewId,
+                    currentUrl: content.currentUrl
+                });
+
+                return res.status(200).json({ status: 'success' });
+            } catch (error) {
+                console.error(`Error processing support request: ${error}`);
+                return res.status(500).json({ status: 'failed' });
             }
-
-            // Send support request email
-            await sendSupportRequestEmail({
-                message: content.message || 'No message provided',
-                userEmail: content.email,
-                interviewId,
-                currentUrl: content.currentUrl
-            });
-
-            return res.status(200).json({ status: 'success' });
-        } catch (error) {
-            console.error(`Error processing support request: ${error}`);
-            return res.status(500).json({ status: 'failed' });
-        }
-    });
+        });
+    }
 
     return publicRouter;
 };

--- a/packages/evolution-backend/src/apps/participant/routes.ts
+++ b/packages/evolution-backend/src/apps/participant/routes.ts
@@ -6,11 +6,15 @@
  */
 import { Application } from 'express';
 
-import getSurveyRouter from '../../api/survey.participant.routes';
+import getSurveyRouter, { getPublicParticipantRoutes } from '../../api/survey.participant.routes';
 import participantIsAuthorized from '../../services/auth/participantAuthorization';
 import { defaultMiddlewares } from '../../services/logging/queryLoggingMiddleware';
 
 export default (app: Application) => {
     const userSurveyRouter = getSurveyRouter(participantIsAuthorized, defaultMiddlewares);
     app.use('/api', userSurveyRouter);
+
+    // Add public routes for the participant
+    const participantPublicRouter = getPublicParticipantRoutes();
+    app.use('/public', participantPublicRouter);
 };

--- a/packages/evolution-backend/src/services/logging/__tests__/supportRequest.test.ts
+++ b/packages/evolution-backend/src/services/logging/__tests__/supportRequest.test.ts
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { Transporter } from 'nodemailer';
+import nodemailerMock from 'nodemailer-mock';
+import { sendSupportRequestEmail } from '../supportRequest';
+import { registerTranslationDir } from 'chaire-lib-backend/lib/config/i18next';
+
+// Register translation directory for tests
+registerTranslationDir(__dirname + '/../../../../../../locales/');
+
+// Mock email transport
+jest.mock('chaire-lib-backend/lib/services/mailer/transport', () => (nodemailerMock.createTransport({
+    sendmail: true,
+    newline: 'unix',
+    path: '/usr/sbin/sendmail'
+}) as any as Transporter));
+
+const fromEmail = 'test@support.org';
+const originalEnv = process.env;
+
+beforeEach(() => {
+    process.env = { ...originalEnv };
+    process.env.MAIL_FROM_ADDRESS = fromEmail;
+    nodemailerMock.mock.reset();
+});
+
+afterAll(() => {
+    process.env = originalEnv;
+});
+
+describe('sendSupportRequestEmail function', () => {
+    test('sends email to single support address', async () => {
+        // Setup
+        const supportEmail = 'support@example.com';
+        process.env.SUPPORT_REQUEST_EMAILS = supportEmail;
+        const message = 'Help me with my survey';
+        const userEmail = 'user@example.com';
+        const interviewId = 12345;
+        
+        // Execute
+        await sendSupportRequestEmail({
+            message,
+            userEmail,
+            interviewId
+        });
+        
+        // Verify
+        const sentEmails = nodemailerMock.mock.getSentMail();
+        expect(sentEmails.length).toBe(1);
+        expect(sentEmails[0].from).toEqual(fromEmail);
+        expect(sentEmails[0].to).toEqual(supportEmail);
+        expect(sentEmails[0].text).toContain(message);
+        expect(sentEmails[0].text).toContain(userEmail);
+        expect(sentEmails[0].text).toContain(interviewId.toString());
+        expect(sentEmails[0].html).toContain(message.replace(/\n/g, '<br/>'));
+    });
+
+    test('sends emails to multiple support addresses for same language', async () => {
+        // Setup
+        const supportEmails = 'support1@example.com,support2@example.com';
+        process.env.SUPPORT_REQUEST_EMAILS = supportEmails;
+        const message = 'Help me with my survey';
+        
+        // Execute
+        await sendSupportRequestEmail({
+            message
+        });
+        
+        // Verify
+        const sentEmails = nodemailerMock.mock.getSentMail();
+        expect(sentEmails.length).toBe(1);
+        expect(sentEmails[0].from).toEqual(fromEmail);
+        expect(sentEmails[0].to).toEqual(supportEmails);
+        expect(sentEmails[0].text).toContain(message);
+        expect(sentEmails[0].text).toContain('Unknown User');
+        expect(sentEmails[0].html).toBeDefined();
+    });
+
+    test('sends emails to different languages', async () => {
+        // Setup
+        process.env.SUPPORT_REQUEST_EMAILS = 'en:support-en@example.com;fr:support-fr@example.com';
+        const message = 'Help me with my survey';
+        const userEmail = 'user@example.com';
+        
+        // Execute
+        await sendSupportRequestEmail({
+            message,
+            userEmail
+        });
+        
+        // Verify
+        const sentEmails = nodemailerMock.mock.getSentMail();
+        expect(sentEmails.length).toBe(2);
+        
+        // Check both emails were sent to appropriate addresses with correct language content
+        const enEmail = sentEmails.find(email => email.to === 'support-en@example.com');
+        const frEmail = sentEmails.find(email => email.to === 'support-fr@example.com');
+        
+        expect(enEmail).toBeDefined();
+        expect(frEmail).toBeDefined();
+        expect(enEmail?.subject).not.toEqual(frEmail?.subject);
+        expect(enEmail?.text).toContain(message);
+        expect(frEmail?.text).toContain(message);
+        expect(enEmail?.text).toContain(userEmail);
+        expect(frEmail?.text).toContain(userEmail);
+    });
+
+    test('handles multiple emails per language', async () => {
+        // Setup
+        process.env.SUPPORT_REQUEST_EMAILS = 'en:support-en1@example.com,support-en2@example.com;fr:support-fr@example.com';
+        const message = 'Help me with my survey';
+        
+        // Execute
+        await sendSupportRequestEmail({
+            message
+        });
+        
+        // Verify
+        const sentEmails = nodemailerMock.mock.getSentMail();
+        expect(sentEmails.length).toBe(2); // One email per language group, not per recipient
+        
+        // Check emails were sent with multiple recipients for English
+        const enEmail = sentEmails.find(email => email.to === 'support-en1@example.com,support-en2@example.com');
+        const frEmail = sentEmails.find(email => email.to === 'support-fr@example.com');
+        
+        expect(enEmail).toBeDefined();
+        expect(frEmail).toBeDefined();
+    });
+
+    test('throws error when no support emails configured', async () => {
+        // Setup
+        delete process.env.SUPPORT_REQUEST_EMAILS;
+        
+        // Execute and verify
+        await expect(sendSupportRequestEmail({
+            message: 'Test message'
+        }))
+            .rejects
+            .toThrow('No support email addresses provided');
+    });
+
+    test('throws error when empty support emails string', async () => {
+        // Setup
+        process.env.SUPPORT_REQUEST_EMAILS = '';
+        
+        // Execute and verify
+        await expect(sendSupportRequestEmail({
+            message: 'Test message'
+        }))
+            .rejects
+            .toThrow('No support email addresses provided');
+    });
+
+    test('handles no interview ID gracefully', async () => {
+        // Setup
+        process.env.SUPPORT_REQUEST_EMAILS = 'support@example.com';
+        const message = 'Help me with my survey';
+        const userEmail = 'user@example.com';
+        
+        // Execute
+        await sendSupportRequestEmail({
+            message,
+            userEmail
+        });
+        
+        // Verify
+        const sentEmails = nodemailerMock.mock.getSentMail();
+        expect(sentEmails.length).toBe(1);
+        expect(sentEmails[0].text).toContain(message);
+        expect(sentEmails[0].text).toContain(userEmail);
+        expect(sentEmails[0].text).not.toContain('Interview ID');
+    });
+
+    test('handles no user email gracefully', async () => {
+        // Setup
+        process.env.SUPPORT_REQUEST_EMAILS = 'support@example.com';
+        const message = 'Help me with my survey';
+        const interviewId = 12345;
+        
+        // Execute
+        await sendSupportRequestEmail({
+            message,
+            interviewId
+        });
+        
+        // Verify
+        const sentEmails = nodemailerMock.mock.getSentMail();
+        expect(sentEmails.length).toBe(1);
+        expect(sentEmails[0].text).toContain(message);
+        expect(sentEmails[0].text).toContain('Unknown User');
+        expect(sentEmails[0].text).toContain(interviewId.toString());
+    });
+    
+    test('properly formats the survey URL', async () => {
+        // Setup
+        process.env.SUPPORT_REQUEST_EMAILS = 'support@example.com';
+        process.env.HOST = 'https://survey.example.com';
+        const message = 'Help with survey';
+        
+        // Execute
+        await sendSupportRequestEmail({
+            message
+        });
+        
+        // Verify
+        const sentEmails = nodemailerMock.mock.getSentMail();
+        expect(sentEmails.length).toBe(1);
+        expect(sentEmails[0].html).toContain('https://survey.example.com');
+    });
+
+    // New tests for currentUrl parameter
+    test('includes currentUrl in email when provided', async () => {
+        // Setup
+        process.env.SUPPORT_REQUEST_EMAILS = 'support@example.com';
+        const message = 'Help with this page';
+        const currentUrl = 'https://survey.example.com/survey/page5';
+        
+        // Execute
+        await sendSupportRequestEmail({
+            message,
+            currentUrl
+        });
+        
+        // Verify
+        const sentEmails = nodemailerMock.mock.getSentMail();
+        expect(sentEmails.length).toBe(1);
+        expect(sentEmails[0].text).toContain(currentUrl);
+        expect(sentEmails[0].html).toContain(currentUrl);
+    });
+    
+    test('includes currentUrl in emails to different language support teams', async () => {
+        // Setup
+        process.env.SUPPORT_REQUEST_EMAILS = 'en:support-en@example.com;fr:support-fr@example.com';
+        const message = 'Help with this page';
+        const currentUrl = 'https://survey.example.com/survey/page5';
+        
+        // Execute
+        await sendSupportRequestEmail({
+            message,
+            currentUrl
+        });
+        
+        // Verify
+        const sentEmails = nodemailerMock.mock.getSentMail();
+        expect(sentEmails.length).toBe(2);
+        
+        const enEmail = sentEmails.find(email => email.to === 'support-en@example.com');
+        const frEmail = sentEmails.find(email => email.to === 'support-fr@example.com');
+        
+        expect(enEmail?.text).toContain(currentUrl);
+        expect(frEmail?.text).toContain(currentUrl);
+        expect(enEmail?.html).toContain(currentUrl);
+        expect(frEmail?.html).toContain(currentUrl);
+    });
+    
+    test('includes all parameters when provided', async () => {
+        // Setup
+        process.env.SUPPORT_REQUEST_EMAILS = 'support@example.com';
+        const message = 'Help with this page';
+        const userEmail = 'user@example.com';
+        const interviewId = 12345;
+        const currentUrl = 'https://survey.example.com/survey/page5';
+        
+        // Execute
+        await sendSupportRequestEmail({
+            message,
+            userEmail,
+            interviewId,
+            currentUrl
+        });
+        
+        // Verify
+        const sentEmails = nodemailerMock.mock.getSentMail();
+        expect(sentEmails.length).toBe(1);
+        expect(sentEmails[0].text).toContain(message);
+        expect(sentEmails[0].text).toContain(userEmail);
+        expect(sentEmails[0].text).toContain(interviewId.toString());
+        expect(sentEmails[0].text).toContain(currentUrl);
+        expect(sentEmails[0].html).toContain(currentUrl);
+    });
+});

--- a/packages/evolution-backend/src/services/logging/supportRequest.ts
+++ b/packages/evolution-backend/src/services/logging/supportRequest.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import url from 'url';
+import i18n from 'chaire-lib-backend/lib/config/i18next';
+import mailTransport from 'chaire-lib-backend/lib/services/mailer/transport';
+
+// Return a key/value object where the key is the language code and the value is an array of email addresses
+const getSupportRequestRecipientsWithLanguage = (): Record<string, string[]> => {
+    // Parse the SUPPORT_REQUEST_EMAILS environment variable to support language preferences
+    const supportEmailsConfig = process.env.SUPPORT_REQUEST_EMAILS;
+    if (!supportEmailsConfig) {
+        throw new Error(
+            'No support email addresses provided. You need to specify the SUPPORT_REQUEST_EMAILS environment variable in a format containing the language followed by an array of email addresses separated by commas. For example "en:email1@example.com,email2@example.com;fr:email3@example.com"'
+        );
+    }
+
+    // Suggested format: "en:email1@example.com,email2@example.com;fr:email3@example.com"
+    const supportEmailsByLanguage: Record<string, string[]> = {};
+    supportEmailsConfig.split(';').forEach((languageGroup) => {
+        const [language, emails] = languageGroup.split(':');
+        if (language && emails) {
+            supportEmailsByLanguage[language.trim()] = emails.split(',').map((email) => email.trim());
+        } else if (language) {
+            // No ':' to specify the language, this variable thus represents the email addresses for the default language
+            const lang = i18n().language;
+            supportEmailsByLanguage[lang] = language.split(',').map((email) => email.trim());
+        }
+    });
+
+    if (Object.keys(supportEmailsByLanguage).length === 0) {
+        throw new Error(
+            'No support email addresses provided. You need to specify the SUPPORT_REQUEST_EMAILS environment variable in a format containing the language followed by an array of email addresses separated by commas. For example "en:email1@example.com,email2@example.com;fr:email3@example.com"'
+        );
+    }
+    return supportEmailsByLanguage;
+};
+
+const getSurveyUrl = (href: string = ''): URL => {
+    const host = process.env.HOST || 'http://localhost:8080';
+    return new url.URL(`${href}`, host);
+};
+
+const prepareSupportRequestEmail = (
+    lang: string,
+    {
+        message,
+        userEmail,
+        interviewId,
+        currentUrl
+    }: {
+        message: string;
+        userEmail?: string;
+        interviewId?: number;
+        currentUrl?: string;
+    }
+): { subject: string; text: string; html: string } => {
+    const translate = lang ? i18n().getFixedT(lang) : i18n().getFixedT(i18n().language);
+
+    const surveyUrl = getSurveyUrl();
+    const translateKeys = {
+        surveyName: surveyUrl.hostname,
+        userEmail: userEmail || 'Unknown User',
+        message: message,
+        supportInterviewID:
+            interviewId === undefined
+                ? ''
+                : translate(['customServer:supportInterviewID', 'server:supportInterviewID'], { interviewId }),
+        currentPageUrl:
+            currentUrl === undefined
+                ? ''
+                : translate(['customServer:currentPageUrl', 'server:currentPageUrl'], {
+                    currentUrl,
+                    interpolation: { escapeValue: false }
+                }),
+        // To avoid escaping html characters
+        interpolation: { escapeValue: false }
+    };
+
+    const textTranslateStrings = ['customServer:supportRequestMessage', 'server:supportRequestMessage'];
+    const textMsg = translate(textTranslateStrings, translateKeys);
+    const htmlTranslateKeys = Object.assign({}, translateKeys, {
+        surveyName: `<a href="${surveyUrl.href}">${surveyUrl.href}</a>`
+    });
+    const htmlMsg = translate(textTranslateStrings, htmlTranslateKeys).replace(/\n/g, '<br/>');
+
+    const subject = translate(['customServer:supportRequestSubject', 'server:supportRequestSubject'], {
+        surveyName: surveyUrl.hostname
+    });
+    return {
+        subject: subject,
+        text: textMsg,
+        html: htmlMsg
+    };
+};
+
+/**
+ * Send a support request email to support staff. The email will be send to the
+ * email addresses specified by the  SUPPORT_REQUEST_EMAILS environment variable
+ * in a format containing the language followed by an array of email addresses
+ * separated by commas. For example
+ * "en:email1@example.com,email2@example.com;fr:email3@example.com"
+ *
+ * @param options The options for the support request email
+ * @param options.message The support request message
+ * @param [options.userEmail] The email of the user who made the request
+ * @param [options.interviewId] Optional interview ID associated with the request
+ * @param [options.currentUrl] Optional current URL to include in the email
+ */
+export const sendSupportRequestEmail = async ({
+    message,
+    userEmail,
+    interviewId,
+    currentUrl
+}: {
+    message: string;
+    userEmail?: string;
+    interviewId?: number;
+    currentUrl?: string;
+}): Promise<void> => {
+    try {
+        const supportEmails = getSupportRequestRecipientsWithLanguage();
+
+        const transport = mailTransport;
+        if (transport === null) {
+            throw new Error('Mail transport configuration error. Support email cannot be sent');
+        }
+
+        const promises: Promise<void>[] = [];
+
+        for (const lang in supportEmails) {
+            const emailMessage = prepareSupportRequestEmail(lang, { message, userEmail, interviewId, currentUrl });
+
+            const mailOptions = {
+                from: process.env.MAIL_FROM_ADDRESS,
+                to: supportEmails[lang].join(','),
+                ...emailMessage
+            };
+
+            promises.push(transport.sendMail(mailOptions));
+        }
+        await Promise.all(promises);
+
+        console.log('Support request email sent successfully');
+    } catch (error) {
+        console.error('Error sending support request email: ', error);
+        console.error(
+            `Support request could not be send for interview ${interviewId === undefined ? 'unknown' : interviewId}: ${userEmail !== undefined ? `(from: ${userEmail})` : ''} ${message}`
+        );
+        throw error;
+    }
+};

--- a/packages/evolution-common/src/config/project.config.ts
+++ b/packages/evolution-common/src/config/project.config.ts
@@ -43,6 +43,18 @@ export type EvolutionProjectConfiguration = {
      * area. Defaults to 16
      * */
     drivingLicenseAge: number;
+    /**
+     * Whether to show the support form on all pages of the participant app. If
+     * set to `true`, a button will be displayed in the bottom right corner of
+     * the page, which opens a form to send a support request.  Defaults to
+     * `false`, which means the support form will not be shown.
+     *
+     * If set to `true`, the SUPPORT_REQUEST_EMAILS environment variable should
+     * be set to the emails to which to send the support request emails. This
+     * has the format "lang:comma-separated emails;[lang2:comma-separated
+     * emails]" where `lang` specifies the language in which to send the emails.
+     */
+    surveySupportForm: boolean;
     mapDefaultCenter: {
         lat: number;
         lon: number;
@@ -93,6 +105,7 @@ setProjectConfiguration<EvolutionProjectConfiguration>(
             selfResponseMinimumAge: 14,
             interviewableAge: 5,
             drivingLicenseAge: 16,
+            surveySupportForm: false,
             mapDefaultCenter: {
                 lat: 45.5,
                 lon: -73.6

--- a/packages/evolution-frontend/src/components/pageParts/FloatingSupportForm.tsx
+++ b/packages/evolution-frontend/src/components/pageParts/FloatingSupportForm.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import React, { useState, useRef, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import SupportForm from './SupportForm';
+
+const FloatingSupportForm: React.FC = () => {
+    const { t } = useTranslation(['survey', 'main']);
+    const [isExpanded, setIsExpanded] = useState(false);
+    const formRef = useRef<HTMLDivElement>(null);
+    const buttonRef = useRef<HTMLButtonElement>(null);
+
+    const toggleForm = () => {
+        setIsExpanded(!isExpanded);
+    };
+
+    // Handle clicks outside the form to close it
+    useEffect(() => {
+        const handleClickOutside = (event: MouseEvent) => {
+            if (
+                isExpanded &&
+                formRef.current &&
+                buttonRef.current &&
+                !formRef.current.contains(event.target as Node) &&
+                !buttonRef.current.contains(event.target as Node)
+            ) {
+                setIsExpanded(false);
+            }
+        };
+
+        document.addEventListener('mousedown', handleClickOutside);
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside);
+        };
+    }, [isExpanded]);
+
+    return (
+        <div className="floating-support-container">
+            {isExpanded && (
+                <div className="floating-support-panel" ref={formRef} aria-hidden={!isExpanded}>
+                    <div className="floating-support-header">
+                        <h3>{t('survey:support.title')}</h3>
+                        <button
+                            className="floating-support-close"
+                            onClick={() => setIsExpanded(false)}
+                            aria-label={t('survey:support.close')}
+                        >
+                            &times;
+                        </button>
+                    </div>
+                    <div className="floating-support-content">
+                        <SupportForm />
+                    </div>
+                </div>
+            )}
+
+            <button
+                className="floating-support-button"
+                ref={buttonRef}
+                onClick={toggleForm}
+                aria-label={t('survey:support.helpButtonLabel')}
+                aria-expanded={isExpanded}
+            >
+                {t('survey:support.helpButton')}
+            </button>
+        </div>
+    );
+};
+
+export default FloatingSupportForm;

--- a/packages/evolution-frontend/src/components/pageParts/FloatingSupportForm.tsx
+++ b/packages/evolution-frontend/src/components/pageParts/FloatingSupportForm.tsx
@@ -6,6 +6,7 @@
  */
 import React, { useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import projectConfig from 'evolution-common/lib/config/project.config';
 import SupportForm from './SupportForm';
 
 const FloatingSupportForm: React.FC = () => {
@@ -71,4 +72,6 @@ const FloatingSupportForm: React.FC = () => {
     );
 };
 
-export default FloatingSupportForm;
+const FloatingSection: React.FC = () => (projectConfig.surveySupportForm !== true ? null : <FloatingSupportForm />); // Ensure the support form is enabled
+
+export default FloatingSection;

--- a/packages/evolution-frontend/src/components/pageParts/SupportForm.tsx
+++ b/packages/evolution-frontend/src/components/pageParts/SupportForm.tsx
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface SupportFormData {
+    email: string;
+    message: string;
+    currentUrl?: string;
+}
+
+const SupportForm: React.FC = () => {
+    const { t } = useTranslation(['survey', 'main']);
+    const [formData, setFormData] = useState<SupportFormData>({
+        email: '',
+        message: ''
+    });
+    const [errors, setErrors] = useState<Partial<SupportFormData>>({});
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [submitStatus, setSubmitStatus] = useState<{
+        success: boolean;
+        message: string;
+    } | null>(null);
+
+    // Function to send the email and message to the server and receive the response
+    const sendSupportRequest = React.useCallback(
+        async (email: string, message: string) => {
+            try {
+                setIsSubmitting(true);
+                setSubmitStatus(null);
+
+                // Capture the current URL when submitting the form
+                const currentUrl = window.location.href;
+
+                const response = await fetch('/public/supportRequest', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({
+                        email,
+                        message,
+                        currentUrl
+                    })
+                });
+
+                if (response.status === 200) {
+                    const jsonData = await response.json();
+                    if (jsonData.status === 'success') {
+                        setSubmitStatus({
+                            success: true,
+                            message: t('survey:support.submitSuccess')
+                        });
+                        // Reset form after successful submission
+                        setFormData({ email: '', message: '' });
+                    } else {
+                        setSubmitStatus({
+                            success: false,
+                            message: t('survey:support.submitError')
+                        });
+                    }
+                } else {
+                    console.error('Invalid response code from server: ', response.status);
+                    setSubmitStatus({
+                        success: false,
+                        message: t('survey:support.submitError')
+                    });
+                }
+            } catch (error) {
+                console.error(`Error sending support request to server: ${error}`);
+                setSubmitStatus({
+                    success: false,
+                    message: t('survey:support.submitError')
+                });
+            } finally {
+                setIsSubmitting(false);
+            }
+        },
+        [t]
+    );
+
+    const validateForm = (): boolean => {
+        const newErrors: Partial<SupportFormData> = {};
+
+        // Message is required
+        if (!formData.message.trim()) {
+            newErrors.message = t('survey:support.messageRequired');
+        }
+
+        // Email is optional but must be valid if provided
+        if (formData.email && !/\S+@\S+\.\S+/.test(formData.email)) {
+            newErrors.email = t('survey:support.invalidEmail');
+        }
+
+        setErrors(newErrors);
+        return Object.keys(newErrors).length === 0;
+    };
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+        const { name, value } = e.target;
+        setFormData((prev) => ({
+            ...prev,
+            [name]: value
+        }));
+    };
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+
+        if (!validateForm()) {
+            return;
+        }
+
+        sendSupportRequest(formData.email, formData.message);
+    };
+
+    return (
+        <div className="support-form-container">
+            <h2 className="support-form-title">{t('survey:support.title')}</h2>
+
+            {submitStatus && (
+                <div className={`notification ${submitStatus.success ? 'success' : 'error'}`}>
+                    {submitStatus.message}
+                </div>
+            )}
+
+            {/* Only render the form if there is no successful submission */}
+            {(!submitStatus || !submitStatus.success) && (
+                <form className="apptr__form" onSubmit={handleSubmit} noValidate>
+                    <div className="apptr__form-row">
+                        <label htmlFor="email" className="apptr__form-label">
+                            {t('survey:support.emailLabel')}
+                        </label>
+                        <div className="apptr__form-field-container">
+                            <div className="apptr__form-helper-text">{t('survey:support.emailHelper')}</div>
+                            <input
+                                id="email"
+                                name="email"
+                                type="email"
+                                className={`apptr__form-input ${errors.email ? 'invalid' : ''}`}
+                                value={formData.email}
+                                onChange={handleChange}
+                                placeholder={t('survey:support.emailPlaceholder')}
+                            />
+                            {errors.email && <div className="question-invalid">{errors.email}</div>}
+                        </div>
+                    </div>
+
+                    <div className="apptr__form-row">
+                        <label htmlFor="message" className="apptr__form-label">
+                            {t('survey:support.messageLabel')}*
+                        </label>
+                        <div className="apptr__form-field-container">
+                            <div className="apptr__form-helper-text">{t('survey:support.messageHelper')}</div>
+                            <textarea
+                                id="message"
+                                name="message"
+                                className={`apptr__form-textarea ${errors.message ? 'invalid' : ''}`}
+                                rows={3}
+                                value={formData.message}
+                                onChange={handleChange}
+                                placeholder={t('survey:support.messagePlaceholder')}
+                                required
+                            />
+                            {errors.message && <div className="question-invalid">{errors.message}</div>}
+                        </div>
+                    </div>
+
+                    <div className="apptr__form-row form-buttons-container">
+                        <button type="submit" className="button blue" disabled={isSubmitting}>
+                            {isSubmitting ? t('survey:support.submitting') : t('survey:support.submitButton')}
+                        </button>
+                    </div>
+                </form>
+            )}
+        </div>
+    );
+};
+
+export default SupportForm;

--- a/packages/evolution-frontend/src/components/routers/ParticipantSurveyRouter.tsx
+++ b/packages/evolution-frontend/src/components/routers/ParticipantSurveyRouter.tsx
@@ -18,24 +18,30 @@ import PrivateRoute from 'chaire-lib-frontend/lib/components/routers/PrivateRout
 import PublicRoute from 'chaire-lib-frontend/lib/components/routers/PublicRoute';
 import ConsentedRoute from './ConsentedRoute';
 import { setShowUserInfoPerm } from 'chaire-lib-frontend/lib/actions/Auth';
+import FloatingSupportForm from '../pageParts/FloatingSupportForm';
 
 // Only show user info for users that are not simple respondents FIXME: do we still need this?
 // Seems to be obsolete now that we differenciate between participant and admin routes
 setShowUserInfoPerm({ Interviews: ['read', 'update'] });
 
 const SurveyRouter: React.FunctionComponent = () => (
-    <Routes>
-        <Route path="/login" element={<ConsentedRoute component={AuthPage} />} />
-        <Route path="/magic/verify" element={<PublicRoute component={MagicLinkVerifyPage} />} />
-        <Route path="/checkMagicEmail" element={<PublicRoute component={CheckMagicEmailPage} />} />
-        <Route path="/unauthorized" element={<PublicRoute component={UnauthorizedPage} />} />
-        <Route path="/error" element={<PublicRoute component={SurveyErrorPage} />} />
-        <Route path="/" element={<PublicRoute component={HomePage} />} />
-        <Route path="/home" element={<PublicRoute component={HomePage} />} />
-        <Route path="/survey/:sectionShortname" element={<PrivateRoute component={Survey} />} />
-        <Route path="/survey" element={<PrivateRoute component={Survey} />} />
-        <Route path="*" element={<PrivateRoute component={Survey} />} />
-    </Routes>
+    <>
+        <Routes>
+            <Route path="/login" element={<ConsentedRoute component={AuthPage} />} />
+            <Route path="/magic/verify" element={<PublicRoute component={MagicLinkVerifyPage} />} />
+            <Route path="/checkMagicEmail" element={<PublicRoute component={CheckMagicEmailPage} />} />
+            <Route path="/unauthorized" element={<PublicRoute component={UnauthorizedPage} />} />
+            <Route path="/error" element={<PublicRoute component={SurveyErrorPage} />} />
+            <Route path="/" element={<PublicRoute component={HomePage} />} />
+            <Route path="/home" element={<PublicRoute component={HomePage} />} />
+            <Route path="/survey/:sectionShortname" element={<PrivateRoute component={Survey} />} />
+            <Route path="/survey" element={<PrivateRoute component={Survey} />} />
+            <Route path="*" element={<PrivateRoute component={Survey} />} />
+        </Routes>
+
+        {/* Add the floating support form to be available on all pages */}
+        <FloatingSupportForm />
+    </>
 );
 
 export default SurveyRouter;

--- a/packages/evolution-frontend/src/styles/survey/_floating-support.scss
+++ b/packages/evolution-frontend/src/styles/survey/_floating-support.scss
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+.floating-support-container {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  z-index: 1000;
+}
+
+.floating-support-button {
+  padding: 10px 15px;
+  background-color: #2196f3;
+  color: white;
+  border: none;
+  border-radius: 30px;
+  cursor: pointer;
+  box-shadow: 0 3px 5px rgba(0,0,0,0.2);
+  font-weight: 500;
+  z-index: 1000;
+  
+  &:hover {
+    background-color: #1976d2;
+  }
+  
+  &:focus {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(33,150,243,0.3), 0 3px 5px rgba(0,0,0,0.2);
+  }
+}
+
+.floating-support-panel {
+  position: absolute;
+  bottom: 70px; // Position above the button with some spacing
+  right: 0;
+  width: 350px;
+  max-width: calc(100vw - 40px);
+  background-color: white;
+  border-radius: 8px;
+  box-shadow: 0 5px 15px rgba(0,0,0,0.3);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 120px);
+  transform-origin: bottom right;
+  animation: expandSupport 0.3s ease-out;
+  
+  @keyframes expandSupport {
+    from {
+      transform: scale(0.7);
+      opacity: 0;
+    }
+    to {
+      transform: scale(1);
+      opacity: 1;
+    }
+  }
+  
+  .floating-support-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px 16px;
+    background-color: #f5f5f5;
+    border-bottom: 1px solid #e0e0e0;
+    
+    h3 {
+      margin: 0;
+      font-size: 16px;
+      color: #333;
+      font-weight: bold;
+    }
+    
+    .floating-support-close {
+      background: none;
+      border: none;
+      font-size: 20px;
+      cursor: pointer;
+      color: #666;
+      padding: 0;
+      height: 24px;
+      width: 24px;
+      line-height: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      
+      &:hover {
+        color: #333;
+      }
+    }
+  }
+  
+  .floating-support-content {
+    overflow-y: auto;
+    padding: 0;
+    flex-grow: 1;
+    
+    .support-form-container {
+      padding: 16px;
+      
+      .support-form-title {
+        display: none; // Hide the title since we already have it in the header
+      }
+      
+      // Make form more compact to fit the panel
+      .apptr__form-row {
+        margin-bottom: 12px;
+      }
+      
+      .apptr__form-label {
+        margin-bottom: 4px;
+        font-size: 14px;
+      }
+      
+      .apptr__form-helper-text {
+        font-size: 12px;
+      }
+      
+      // Ensure input and textarea have full width
+      .apptr__form-field-container {
+        width: 100%;
+        
+        .apptr__form-input,
+        .apptr__form-textarea {
+          width: 100%;
+          box-sizing: border-box;
+        }
+        
+        .apptr__form-textarea {
+          min-height: 120px; // Increase the height of the textarea
+          resize: vertical;
+        }
+      }
+      
+      // Make sure the buttons are properly styled
+      .form-buttons-container {
+        margin-top: 16px;
+      }
+    }
+  }
+}
+
+// Responsive adjustments
+@media (max-width: 480px) {
+  .floating-support-panel {
+    width: calc(100vw - 40px);
+    max-height: 80vh;
+  }
+}

--- a/packages/evolution-frontend/src/styles/survey/styles-participant-survey.scss
+++ b/packages/evolution-frontend/src/styles/survey/styles-participant-survey.scss
@@ -1,1 +1,2 @@
 @import './styles-survey';
+@import './floating-support';


### PR DESCRIPTION
fixes #906

This form is present on every page of the participant app. A button at the bottom right corner with the text "Need help?" can be clicked by the participant. It opens a simple form where the user can enter his email address and a message explaining the support request. The support request will contain the URL of the current page the participant is on.

Upon submission, this forms sends the message to the backend, which then sends an email to the addresses specified by the `SUPPORT_REQUEST_EMAIL` environment variable. This environment variable has the following format: `lang:comma-separated-emails;lang:comme-separated-emails` to specify the emails to send the support requests to, as well as the language that those recipients want the email.

The subject of the support request contains the hostname of the survey app, to inform the support team which instance is involved. If the participant is logged in, it will also add the interview ID. The current page URL, if provided, is also part of the message.

Only the participant app has this form.