### PR TITLE
paradata: log invisible widgets at the end of sections

### DIFF
--- a/packages/evolution-backend/src/services/adminExport/exportInterviewLogs.ts
+++ b/packages/evolution-backend/src/services/adminExport/exportInterviewLogs.ts
@@ -46,20 +46,24 @@ const filterLogData = (
     };
 };
 
-const userActionToWidgetData = (userAction: UserAction | undefined): { widgetType: string; widgetPath: string } => {
+const userActionToWidgetData = (
+    userAction: UserAction | undefined
+): { widgetType: string; widgetPath: string; hiddenWidgets: string } => {
     if (userAction === undefined || _isBlank(userAction)) {
-        return { widgetType: '', widgetPath: '' };
+        return { widgetType: '', widgetPath: '', hiddenWidgets: '' };
     }
     switch (userAction.type) {
     case 'buttonClick':
         return {
             widgetType: '',
-            widgetPath: userAction.buttonId
+            widgetPath: userAction.buttonId,
+            hiddenWidgets: userAction.hiddenWidgets ? userAction.hiddenWidgets.join('|') : ''
         };
     case 'widgetInteraction':
         return {
             widgetType: userAction.widgetType,
-            widgetPath: userAction.path
+            widgetPath: userAction.path,
+            hiddenWidgets: ''
         };
     case 'sectionChange':
         return {
@@ -67,12 +71,14 @@ const userActionToWidgetData = (userAction: UserAction | undefined): { widgetTyp
             widgetPath: [
                 userAction.targetSection.sectionShortname,
                 ...(userAction.targetSection.iterationContext || [])
-            ].join('/')
+            ].join('/'),
+            hiddenWidgets: userAction.hiddenWidgets ? userAction.hiddenWidgets.join('|') : ''
         };
     default:
         return {
             widgetType: '',
-            widgetPath: ''
+            widgetPath: '',
+            hiddenWidgets: ''
         };
     }
 };
@@ -178,7 +184,7 @@ export const exportInterviewLogTask = async function ({
                     { values_by_path, unset_paths },
                     participantResponseOnly
                 );
-                if (_isBlank(filteredValuesByPath) && _isBlank(filteredUnsetPaths)) {
+                if (_isBlank(filteredValuesByPath) && _isBlank(filteredUnsetPaths) && _isBlank(logData.user_action)) {
                     // no data to export for this log
                     return;
                 }

--- a/packages/evolution-common/src/services/questionnaire/types/Data.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/Data.ts
@@ -304,6 +304,10 @@ export type UserAction =
     | {
           type: 'buttonClick';
           buttonId: string;
+          /**
+           * Widgets that were hidden in the section when the button was clicked
+           */
+          hiddenWidgets?: string[];
       }
     | {
           type: 'widgetInteraction';
@@ -315,6 +319,10 @@ export type UserAction =
           type: 'sectionChange';
           targetSection: NavigationSection;
           previousSection?: NavigationSection;
+          /**
+           * Widgets that were hidden in the previous section before navigating away
+           */
+          hiddenWidgets?: string[];
       };
 
 /**


### PR DESCRIPTION
fixes #1016

When the user navigates to another section or when a button is clicked, we save the list of hidden widgets on the current section so we can know which widgets were seen by the participant or not.

Update log export to add the hidden widgets