### PR TITLE
navigation: catch errors on section config's functions

### DIFF
--- a/packages/evolution-common/src/services/questionnaire/sections/__tests__/NavigationService.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/__tests__/NavigationService.test.ts
@@ -2473,3 +2473,186 @@ describe('navigate function, further use cases', () => {
     });
     
 });
+
+describe('Exceptions in sectionConfig\'s functions', () => {
+    test('onSectionEntry throws an error', () => {
+        // Prepare the interview with section navigation history
+        const testInterview = _cloneDeep(interview);
+        // FIXME The type of the _sections is not quite right, this should be valid but it is not
+        testInterview.response._sections = {
+            home: { _startedAt: 1, _isCompleted: true },
+            householdMembers: { _startedAt: 2 },
+            _actions: [
+                { section: 'home', action: 'start' as const, ts: 1 },
+                { section: 'householdMembers', action: 'start' as const, ts: 2 }
+            ]
+        } as any;
+
+        // Set the `onSectionEntry` to throw an error
+        const sectionConfig = _cloneDeep(simpleSectionsConfig);
+        sectionConfig.householdMembers.onSectionEntry = () => { throw new Error('Test error'); }
+        const navigationService = createNavigationService(sectionConfig);
+
+        // Navigate to last visited section
+        expect(() => navigationService.initNavigationState({ interview: testInterview })).toThrow('NavigationService: Error evaluating onSectionEntry for section householdMembers: Error: Test error');
+    });
+
+    test('onSectionExit throws an error', () => {
+        // Prepare the interview with section navigation history
+        const testInterview = _cloneDeep(interview);
+        // FIXME The type of the _sections is not quite right, this should be valid but it is not
+        testInterview.response._sections = {
+            home: { _startedAt: 1, _isCompleted: true },
+            householdMembers: { _startedAt: 2 },
+            _actions: [
+                { section: 'home', action: 'start' as const, ts: 1 },
+                { section: 'householdMembers', action: 'start' as const, ts: 2 }
+            ]
+        } as any;
+
+        // Set the `onSectionExit` to throw an error
+        const sectionConfig = _cloneDeep(simpleSectionsConfig);
+        sectionConfig.home.onSectionExit = () => { throw new Error('Test error'); }
+        const navigationService = createNavigationService(sectionConfig);
+
+        // Prepare the previous navigation state
+        const currentSectionData = {
+            sectionShortname: 'home',
+            iterationContext: undefined
+        }
+
+        // Navigate to next section
+        expect(() => navigationService.navigate({ interview: testInterview, currentSection: currentSectionData })).toThrow('NavigationService: Error evaluating onSectionExit for section home: Error: Test error');
+    });
+
+    test('isSectionVisible throws an error', () => {
+        // Prepare the interview with section navigation history
+        const testInterview = _cloneDeep(interview);
+        // FIXME The type of the _sections is not quite right, this should be valid but it is not
+        testInterview.response._sections = {
+            home: { _startedAt: 1, _isCompleted: true },
+            householdMembers: { _startedAt: 2 },
+            _actions: [
+                { section: 'home', action: 'start' as const, ts: 1 },
+                { section: 'householdMembers', action: 'start' as const, ts: 2 }
+            ]
+        } as any;
+
+        // Set the `isSectionVisible` to throw an error
+        const sectionConfig = _cloneDeep(simpleSectionsConfig);
+        sectionConfig.householdMembers.isSectionVisible = () => { throw new Error('Test error'); }
+        const navigationService = createNavigationService(sectionConfig);
+
+        // Navigate to last visited section
+        expect(() => navigationService.initNavigationState({ interview: testInterview })).toThrow('NavigationService: Error evaluating isSectionVisible for section householdMembers: Error: Test error');
+    });
+
+    test('isSectionCompleted throws an error', () => {
+        // Prepare the interview with section navigation history
+        const testInterview = _cloneDeep(interview);
+        // FIXME The type of the _sections is not quite right, this should be valid but it is not
+        testInterview.response._sections = {
+            home: { _startedAt: 1, _isCompleted: true },
+            householdMembers: { _startedAt: 2 },
+            _actions: [
+                { section: 'home', action: 'start' as const, ts: 1 },
+                { section: 'householdMembers', action: 'start' as const, ts: 2 }
+            ]
+        } as any;
+
+        // Set the `isSectionCompleted` to throw an error
+        const sectionConfig = _cloneDeep(simpleSectionsConfig);
+        sectionConfig.home.isSectionCompleted = () => { throw new Error('Test error'); }
+        const navigationService = createNavigationService(sectionConfig);
+
+        // Navigate to last visited section
+        expect(() => navigationService.navigate({ interview: testInterview, currentSection: { sectionShortname: 'home' } })).toThrow('NavigationService: Error evaluating isSectionCompleted for section home: Error: Test error');
+    });
+
+    test('enableConditional throws an error', () => {
+        // Prepare the interview with section navigation history
+        const testInterview = _cloneDeep(interview);
+        // FIXME The type of the _sections is not quite right, this should be valid but it is not
+        testInterview.response._sections = {
+            home: { _startedAt: 1, _isCompleted: true },
+            householdMembers: { _startedAt: 2 },
+            _actions: [
+                { section: 'home', action: 'start' as const, ts: 1 },
+                { section: 'householdMembers', action: 'start' as const, ts: 2 }
+            ]
+        } as any;
+
+        // Set the `enableConditional` to throw an error
+        const sectionConfig = _cloneDeep(simpleSectionsConfig);
+        sectionConfig.householdMembers.enableConditional = () => { throw new Error('Test error'); }
+        const navigationService = createNavigationService(sectionConfig);
+
+        // Navigate to last visited section
+        expect(() => navigationService.initNavigationState({ interview: testInterview })).toThrow('NavigationService: Error evaluating enableConditional for section householdMembers: Error: Test error');
+    });
+
+    test('isIterationValid throws an error', () => {
+        // Prepare the interview with section navigation history and a household
+        const testInterview = _cloneDeep(interview);
+        // FIXME The type of the _sections is not quite right, this should be valid but it is not
+        testInterview.response._sections = {
+            home: { _startedAt: 1, _isCompleted: true },
+            householdMembers: { _startedAt: 2, _isCompleted: true },
+            personsTrips: {
+                _startedAt: 6,
+                _isCompleted: true,
+                personId1: { _startedAt: 6, _isCompleted: true },
+                personId2: { _startedAt: 18, _isCompleted: true }
+            },
+            selectPerson: {
+                _startedAt: 9,
+                _isCompleted: true,
+                personId1: { _startedAt: 9, _isCompleted: true },
+                personId2: { _startedAt: 20, _isCompleted: true }
+            },
+            visitedPlaces: {
+                _startedAt: 12,
+                _isCompleted: true,
+                personId1: { _startedAt: 12, _isCompleted: true },
+                personId2: { _startedAt: 22, _isCompleted: true }
+            },
+            travelBehavior: {
+                _startedAt: 20,
+                _isCompleted: true,
+                personId1: { _startedAt: 15, _isCompleted: true },
+                personId2: { _startedAt: 24, _isCompleted: true }
+            },
+            end: { _startedAt: 40, _isCompleted: true },
+            _actions: [
+                { section: 'home', action: 'start' as const, ts: 1 },
+                { section: 'householdMembers', action: 'start' as const, ts: 2 },
+                { section: 'personsTrips', iterationContext: ['personId1'], action: 'start' as const, ts: 6 },
+                { section: 'selectPerson', iterationContext: ['personId1'], action: 'start' as const, ts: 9 },
+                { section: 'visitedPlaces', iterationContext: ['personId1'], action: 'start' as const, ts: 12 },
+                { section: 'travelBehavior', iterationContext: ['personId1'], action: 'start' as const, ts: 15 },
+                { section: 'selectPerson', iterationContext: ['personId2'], action: 'start' as const, ts: 20 },
+                { section: 'visitedPlaces', iterationContext: ['personId2'], action: 'start' as const, ts: 22 },
+                { section: 'travelBehavior', iterationContext: ['personId2'], action: 'start' as const, ts: 24 }
+            ]
+        } as any;
+        Object.assign(testInterview.response, hhWithPersonsResponse);
+        testInterview.response._activePersonId = 'personId2';
+
+        // Set the `isIterationValid` function to throw an error
+        const sectionConfig = _cloneDeep(complexSectionsConfig);
+        (sectionConfig['personsTrips'] as SectionConfigWithDefaultsBlock).repeatedBlock.isIterationValid = () => { throw new Error('Test error'); }
+        
+        const navigationService = createNavigationService(sectionConfig);
+
+        // Prepare the previous navigation state
+        const currentSection = 'travelBehavior';
+        const currentIterationContext = ['personId2'];
+        const currentSectionData = {
+            sectionShortname: currentSection,
+            iterationContext: currentIterationContext
+        }
+
+        // Navigate to specific section
+        expect(() => navigationService.navigate({ interview: testInterview, currentSection: _cloneDeep(currentSectionData), direction: 'forward' })).toThrow('NavigationService: Error evaluating isIterationValid for section personsTrips with iteration personId1: Error: Test error');
+    });
+});

--- a/packages/evolution-common/src/services/questionnaire/types/Data.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/Data.ts
@@ -384,13 +384,19 @@ export type StartRemoveGroupedObjects = (
  * update in the interview.  The key is the path to update and the value is the
  * new value. A dot-separated path will be exploded to the corresponding nested
  * object path.
+ * @param {GotoFunction} [options.gotoFunction] A function used to redirect the
+ * page to a specific URL
  * @param {(interview: UserRuntimeInterviewAttributes) => void} [callback] An
  * optional function to call after the interview has been updated and navigation
  * is complete
  * @returns The dispatched action
  */
 export type StartNavigate = (
-    options?: { requestedSection?: NavigationSection; valuesByPath?: { [path: string]: unknown } },
+    options?: {
+        requestedSection?: NavigationSection;
+        valuesByPath?: { [path: string]: unknown };
+        gotoFunction?: GotoFunction;
+    },
     callback?: (interview: UserRuntimeInterviewAttributes, targetSection: NavigationSection) => void
 ) => any;
 

--- a/packages/evolution-common/src/services/questionnaire/types/SectionConfig.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/SectionConfig.ts
@@ -324,6 +324,7 @@ export type SectionConfig = {
 export type SurveySectionsConfig = { [sectionName: string]: SectionConfig };
 
 export type SectionConfigWithDefaults = Omit<SectionConfig, 'navMenu' | 'repeatedBlock'> & {
+    sectionName: string;
     type: 'section';
     navMenu: Exclude<SectionConfig['navMenu'], undefined>;
     /**
@@ -334,6 +335,7 @@ export type SectionConfigWithDefaults = Omit<SectionConfig, 'navMenu' | 'repeate
 };
 
 export type SectionConfigWithDefaultsBlock = Omit<SectionConfig, 'navMenu' | 'repeatedBlock' | 'nextSection'> & {
+    sectionName: string;
     type: 'repeatedBlock';
     navMenu: Exclude<SectionConfig['navMenu'], undefined>;
     repeatedBlock: Exclude<SectionConfig['repeatedBlock'], undefined>;
@@ -376,6 +378,7 @@ export const getAndValidateSurveySections = (sections: SurveySectionsConfig): Su
                 );
             }
             sectionsWithDefaults[sectionName] = {
+                sectionName,
                 ...sectionConfig,
                 type: 'repeatedBlock',
                 nextSection: sectionConfig.nextSection!,
@@ -384,6 +387,7 @@ export const getAndValidateSurveySections = (sections: SurveySectionsConfig): Su
             };
         } else if (sectionsInRepeatedBlock[sectionName]) {
             sectionsWithDefaults[sectionName] = {
+                sectionName,
                 ...sectionConfig,
                 type: 'section',
                 navMenu: sectionConfig.navMenu ?? {
@@ -394,6 +398,7 @@ export const getAndValidateSurveySections = (sections: SurveySectionsConfig): Su
             };
         } else {
             sectionsWithDefaults[sectionName] = {
+                sectionName,
                 ...sectionConfig,
                 type: 'section',
                 navMenu: sectionConfig.navMenu ?? { type: 'inNav', menuName: sectionConfig.title ?? '' }

--- a/packages/evolution-common/src/services/questionnaire/types/__tests__/SectionConfig.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/__tests__/SectionConfig.test.ts
@@ -25,6 +25,7 @@ describe('getAndValidateSurveySections', () => {
         const result = getAndValidateSurveySections(minimalSection);
         
         expect(result.section1).toEqual({
+            sectionName: 'section1',
             type: 'section',
             previousSection: null,
             nextSection: null,
@@ -46,6 +47,7 @@ describe('getAndValidateSurveySections', () => {
         const result = getAndValidateSurveySections(sectionWithTitle);
         
         expect(result.section1).toEqual({
+            sectionName: 'section1',
             type: 'section',
             title: { en: 'Test Section', fr: 'Section de test' },
             previousSection: null,
@@ -157,6 +159,7 @@ describe('getAndValidateSurveySections', () => {
         const result = getAndValidateSurveySections(completeSection);
         
         expect(result.section1).toEqual({
+            sectionName: 'section1',
             ...completeSection.section1,
             type: 'section'
         });
@@ -193,6 +196,7 @@ describe('getAndValidateSurveySections', () => {
 
         expect(result).toEqual(expect.objectContaining({
             section3: expect.objectContaining({
+                sectionName: 'section3',
                 type: 'section',
                 navMenu: { 
                     type: 'hidden', 
@@ -201,6 +205,7 @@ describe('getAndValidateSurveySections', () => {
                 repeatedBlockSection: 'section1'
             }),
             section1: expect.objectContaining({
+                sectionName: 'section1',
                 type: 'repeatedBlock',
                 navMenu: {
                     type: 'inNav',

--- a/packages/evolution-frontend/src/actions/Survey.ts
+++ b/packages/evolution-frontend/src/actions/Survey.ts
@@ -491,7 +491,7 @@ const navigate = (targetSection: NavigationSection): SurveyAction => ({
 export const startNavigateWithUpdateCallback =
     (
         fctUpdateInterview: typeof startUpdateInterview,
-        { requestedSection, valuesByPath = {} }: Parameters<StartNavigate>[0] = {},
+        { requestedSection, valuesByPath = {}, gotoFunction }: Parameters<StartNavigate>[0] = {},
         callback?: Parameters<StartNavigate>[1]
     ) =>
         async (
@@ -587,6 +587,7 @@ export const startNavigateWithUpdateCallback =
             } catch (error) {
                 console.error('Error navigating to section', error);
                 handleClientError(error instanceof Error ? error : new Error(String(error)), {
+                    navigate: gotoFunction,
                     interviewId: getState().survey.interview?.id
                 });
             } finally {

--- a/packages/evolution-frontend/src/components/admin/pages/SurveyCorrection.tsx
+++ b/packages/evolution-frontend/src/components/admin/pages/SurveyCorrection.tsx
@@ -7,7 +7,7 @@
 import React, { useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { ThunkDispatch } from 'redux-thunk';
-import { useParams } from 'react-router';
+import { useNavigate, useParams } from 'react-router';
 
 import * as surveyHelperNew from 'evolution-common/lib/utils/helpers';
 import LoadingPage from 'chaire-lib-frontend/lib/components/pages/LoadingPage';
@@ -37,12 +37,14 @@ const SurveyCorrection: React.FC = () => {
     const interview = useSelector((state: RootState) => state.survey.interview);
     const interviewLoaded = useSelector((state: RootState) => state.survey.interviewLoaded);
     const dispatch = useDispatch<ThunkDispatch<RootState, unknown, SurveyAction>>();
+    const navigate = useNavigate();
     const { interviewUuid } = useParams();
     const { sections } = useContext(SurveyContext);
 
     // Use the redux actions for the corrected interview
     const startUpdateInterviewAction: StartUpdateInterview = React.useCallback(
-        (data, callback) => dispatch(startUpdateSurveyCorrectedInterview(data, callback)),
+        (data, callback) =>
+            dispatch(startUpdateSurveyCorrectedInterview({ ...data, gotoFunction: navigate }, callback)),
         []
     );
     const startAddGroupedObjectsAction: StartAddGroupedObjects = React.useCallback(
@@ -65,7 +67,8 @@ const SurveyCorrection: React.FC = () => {
         []
     );
     const startNavigateAction: StartNavigate = React.useCallback(
-        (section: Parameters<StartNavigate>[0]) => dispatch(startNavigateCorrectedInterview(section)),
+        (options: Parameters<StartNavigate>[0]) =>
+            dispatch(startNavigateCorrectedInterview({ ...options, gotoFunction: navigate })),
         [dispatch]
     );
 

--- a/packages/evolution-frontend/src/components/hoc/__tests__/WithSurveyContextHoc.test.tsx
+++ b/packages/evolution-frontend/src/components/hoc/__tests__/WithSurveyContextHoc.test.tsx
@@ -16,6 +16,7 @@ interface TestProps {
 
 const testSections = {
     key1: {
+        sectionName: 'key1',
         type: 'section' as const,
         previousSection: null,
         nextSection: null,
@@ -25,6 +26,7 @@ const testSections = {
         navMenu: { type: 'inNav' as const, menuName: 'key1' }
     },
     key2: {
+        sectionName: 'key2',
         type: 'section' as const,
         previousSection: null,
         nextSection: null,

--- a/packages/evolution-frontend/src/components/pages/SurveyParticipant.tsx
+++ b/packages/evolution-frontend/src/components/pages/SurveyParticipant.tsx
@@ -63,7 +63,7 @@ const SurveyParticipant: React.FC = () => {
         []
     );
     const startNavigateAction: StartNavigate = React.useCallback(
-        (section: Parameters<StartNavigate>[0]) => dispatch(startNavigate(section)),
+        (options: Parameters<StartNavigate>[0]) => dispatch(startNavigate({ ...options, gotoFunction: navigate })),
         [dispatch]
     );
 


### PR DESCRIPTION
fixes #1027

Each user-defined functions in the `SectionConfig` type is wrapped
around a try/catch, which allows to give a complete message on which
function/section the error occurred in. The error is thrown and should
be caught by the survey's catchAll mechanism and send to the server.