### PR TITLE
inputs: let the checkbox and multiselect parse arrays

### DIFF
--- a/packages/evolution-common/src/services/questionnaire/types/WidgetConfig.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/WidgetConfig.ts
@@ -317,6 +317,10 @@ export type QuestionWidgetConfig =
     | InputSelectType
     | InputRadioNumberType;
 
+const inputTypesWithArrayValue: QuestionWidgetConfig['inputType'][] = ['checkbox', 'multiselect'];
+export const isInputTypeWithArrayValue = (inputType: QuestionWidgetConfig['inputType']): boolean =>
+    inputTypesWithArrayValue.includes(inputType);
+
 export type TextWidgetConfig = {
     type: 'text';
     align?: WidgetDirectionAlign;

--- a/packages/evolution-common/src/services/questionnaire/types/__tests__/WidgetConfig.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/__tests__/WidgetConfig.test.ts
@@ -4,7 +4,7 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import { WidgetConfig } from '../WidgetConfig';
+import { WidgetConfig, isInputTypeWithArrayValue } from '../WidgetConfig';
 
 // Simply make sure various objects are recognize as WidgetConfig object. Any fault should result in compilation error.
 test('Test text assignation', () => {
@@ -79,4 +79,25 @@ test('Test input text assignation', () => {
     };
 
     expect(widgetConfig).toBeDefined();
+});
+
+describe('isQuestionAnswerAnArray', () => {
+    test('should return true for array input types', () => {
+        expect(isInputTypeWithArrayValue('checkbox')).toBe(true);
+        expect(isInputTypeWithArrayValue('multiselect')).toBe(true);
+    });
+
+    test('should return false for non-array input types', () => {
+        expect(isInputTypeWithArrayValue('string')).toBe(false);
+        expect(isInputTypeWithArrayValue('text')).toBe(false);
+        expect(isInputTypeWithArrayValue('radio')).toBe(false);
+        expect(isInputTypeWithArrayValue('radioNumber')).toBe(false);
+        expect(isInputTypeWithArrayValue('select')).toBe(false);
+        expect(isInputTypeWithArrayValue('button')).toBe(false);
+        expect(isInputTypeWithArrayValue('time')).toBe(false);
+        expect(isInputTypeWithArrayValue('slider')).toBe(false);
+        expect(isInputTypeWithArrayValue('datePicker')).toBe(false);
+        expect(isInputTypeWithArrayValue('mapPoint')).toBe(false);
+        expect(isInputTypeWithArrayValue('mapFindPlace')).toBe(false);
+    });
 });

--- a/packages/evolution-common/src/utils/__tests__/helpers.test.ts
+++ b/packages/evolution-common/src/utils/__tests__/helpers.test.ts
@@ -122,8 +122,9 @@ each([
     [3.4, 'integer', 3],
     [null, 'integer', null],
     [undefined, 'integer', undefined],
-    [[3], 'integer', undefined],
+    [[3], 'integer', 3],
     [{ test: 3 }, 'integer', undefined],
+    [['a', 'b'], 'integer', null, null],
     ['', 'integer', null],
     ['3', 'float', 3],
     ['3.4', 'float', 3.4],
@@ -131,9 +132,10 @@ each([
     [3.4, 'float', 3.4],
     [null, 'float', null],
     [undefined, 'float', undefined],
-    [[3], 'float', undefined],
+    [[3], 'float', 3],
     [{ test: 3 }, 'float', undefined],
     ['', 'float', null],
+    [['a', 'b'], 'float', null, null],
     ['true', 'boolean', true],
     [true, 'boolean', true],
     ['f', 'boolean', false],
@@ -147,6 +149,7 @@ each([
     [3, 'string', '3'],
     [null, 'string', null],
     [undefined, 'string', undefined],
+    [['str1', 'str2'], 'string', 'str1', ['str1', 'str2']],
     [{ type: 'Feature', geometry: { type: 'Point', coordinates: [0,0] }, properties: {} }, 'geojson', { type: 'Feature', geometry: { type: 'Point', coordinates: [0,0] }, properties: {} }],
     // Should add the properties to the feature
     [{ type: 'Feature', geometry: { type: 'Point', coordinates: [0,0] } }, 'geojson', { type: 'Feature', geometry: { type: 'Point', coordinates: [0,0] }, properties: {} }],
@@ -154,13 +157,25 @@ each([
     [3, 'geojson', null],
     ['not a feature', 'geojson', null],
     [null, 'geojson', null],
-    [[3, 4], undefined, [3, 4]],
+    [[3, 4], undefined, 3, [3, 4]],
     [{ test: 3 }, undefined, { test: 3 }],
     // TODO What about other data types? They are simply converted to string, should something else be done?
-    [[3, 4], 'string', String([3, 4])],
+    [[3, 4], 'string', '3', ['3', '4']],
     [{ test: 3 }, 'string', String({ test: 3 })]
-]).test('parseValue: %s %s', (value, type, expected) => {
-    expect(Helpers.parseValue(value, type)).toEqual(expected);
+]).describe('parseValue: %s %s', (value, type, expected, expectedAsArray) => {
+    test('asArray false', () => {
+        expect(Helpers.parseValue(value, type, false)).toEqual(expected);
+    });
+
+    test('asArray true', () => {
+        let expectedArray = expectedAsArray;
+        if (expectedAsArray === undefined && expected !== null && expected !== undefined) {
+            expectedArray = [expected];
+        } else if (expectedAsArray === undefined && expected === null) {
+            expectedArray = null;
+        }
+        expect(Helpers.parseValue(value, type, true)).toEqual(expectedArray);
+    });
 });
 
 each([

--- a/packages/evolution-frontend/src/actions/utils/WidgetOperation.ts
+++ b/packages/evolution-frontend/src/actions/utils/WidgetOperation.ts
@@ -15,7 +15,10 @@ import * as surveyHelper from 'evolution-common/lib/utils/helpers';
 import applicationConfiguration from '../../config/application.config';
 import { checkConditional, checkChoicesConditional } from './Conditional';
 import { checkValidations } from './Validation';
-import { UserRuntimeInterviewAttributes } from 'evolution-common/lib/services/questionnaire/types';
+import {
+    isInputTypeWithArrayValue,
+    UserRuntimeInterviewAttributes
+} from 'evolution-common/lib/services/questionnaire/types';
 import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
 import { GroupConfig } from 'evolution-common/lib/services/questionnaire/types';
 
@@ -143,7 +146,7 @@ const prepareSimpleWidget = (
     let customValue = customPath ? surveyHelper.getResponse(data.interview, customPath, undefined) : undefined;
 
     // convert values to number or boolean if needed:
-    value = surveyHelper.parseValue(value, widgetConfig.datatype);
+    value = surveyHelper.parseValue(value, widgetConfig.datatype, isInputTypeWithArrayValue(widgetConfig.inputType));
     let visibleValueUpdated = false;
     customValue = surveyHelper.parseValue(customValue, widgetConfig.customDatatype);
 

--- a/packages/evolution-frontend/src/components/survey/Question.tsx
+++ b/packages/evolution-frontend/src/components/survey/Question.tsx
@@ -36,7 +36,7 @@ import {
     UserInterviewAttributes
 } from 'evolution-common/lib/services/questionnaire/types';
 import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
-import { QuestionWidgetConfig } from 'evolution-common/lib/services/questionnaire/types';
+import { QuestionWidgetConfig, isInputTypeWithArrayValue } from 'evolution-common/lib/services/questionnaire/types';
 import { WidgetStatus } from 'evolution-common/lib/services/questionnaire/types';
 import InputWidgetWrapper from './widgets/InputWidgetWrapper';
 
@@ -90,7 +90,11 @@ export class Question extends React.Component<QuestionProps & WithSurveyContextP
         const previousValue = widgetStatus.value;
         const previousCustomValue = widgetStatus.customValue;
         const value = e.target ? e.target.value : e; //InputDatePicker call onValueChange with e=value
-        const parsedValue = surveyHelper.parseValue(value, (widgetConfig as any).datatype);
+        const parsedValue = surveyHelper.parseValue(
+            value,
+            (widgetConfig as any).datatype,
+            isInputTypeWithArrayValue(widgetConfig.inputType)
+        );
         const parsedCustomValue = surveyHelper.parseValue(customValue, (widgetConfig as any).customDatatype);
         const [isValid] = checkValidations(
             widgetConfig.validations,


### PR DESCRIPTION
fixes #1036

Add a `asArray` parameter to the `parseValue` function, which allows to specify if the expected value should be an array, but still convert to the correct datatype the values in the array.

Add a `isInputTypeWithArrayValue` function to determine if the input type should give an array value. checkboxes and multiselects are inputs with array values.