### PR TITLE
debug: take full page screenshots of failed UI tests

### DIFF
--- a/packages/evolution-frontend/playwright-example.config.ts
+++ b/packages/evolution-frontend/playwright-example.config.ts
@@ -28,7 +28,10 @@ export default defineConfig({
         baseURL: 'http://localhost:8080',
         // Collect trace when retrying the failed test.
         trace: 'on-first-retry',
-        screenshot: 'only-on-failure'
+        screenshot: {
+            mode: 'only-on-failure',
+            fullPage: true
+        }
     },
 
     /* Configure projects for major browsers */


### PR DESCRIPTION
This will allow to see the map whose test fails in the generator UI tests.