### PR TITLE
survey: support captcha in support form and byField

### DIFF
--- a/example/demo_survey/config.js
+++ b/example/demo_survey/config.js
@@ -58,6 +58,7 @@ module.exports = {
   logDatabaseUpdates: true,
   askForAccessCode: true,
   surveySupportForm: true,
+  captchaComponentType: 'capjs',
   interviewableAge: 5,
   isPartTwo: false,
   mapDefaultCenter: {

--- a/locales/en/auth.json
+++ b/locales/en/auth.json
@@ -70,6 +70,13 @@
   "PostalCodePlaceholder": "A1B 2C3",
   "InvalidPostalCodeFormat": "The postal code format is invalid.",
   "MissingPostalCode": "Please enter a postal code.",
-  "ConfirmCredentials": "The access code and postal code combination does not match any interview data. Please verify your information or check the checkbox to confirm the values entered."
+  "ConfirmCredentials": "The access code and postal code combination does not match any interview data. Please verify your information or check the checkbox to confirm the values entered.",
+  "CapJScaptcha": {
+    "initialLabel": "I'm a human",
+    "verifyingLabel": "Verifying...",
+    "solvedLabel": "Verified",
+    "errorLabel": "Error, please retry"    
+  },
+  "captchaRequired": "Please complete the CAPTCHA to submit your message."
 }
   

--- a/locales/en/survey.yml
+++ b/locales/en/survey.yml
@@ -85,3 +85,4 @@ support:
   helpButton: "Need Help?"
   helpButtonLabel: "Open support form"
   close: "Close"
+  captchaRequired: "Please complete the CAPTCHA to submit your message."

--- a/locales/fr/auth.json
+++ b/locales/fr/auth.json
@@ -70,5 +70,12 @@
   "PostalCodePlaceholder": "A1B 2C3",
   "InvalidPostalCodeFormat": "Le code postal est invalide.",
   "MissingPostalCode": "Veuillez entrer un code postal.",
-  "ConfirmCredentials": "La combinaison de code d'accès et code postal n'existe pas. Veuillez vérifier les informations entrées ou cocher la case pour confirmer cette information."
+  "ConfirmCredentials": "La combinaison de code d'accès et code postal n'existe pas. Veuillez vérifier les informations entrées ou cocher la case pour confirmer cette information.",
+  "CapJScaptcha": {
+    "initialLabel": "Je suis humain",
+    "verifyingLabel": "Vérification...",
+    "solvedLabel": "Vérifié",
+    "errorLabel": "Erreur, veuillez réessayer"    
+  },
+  "captchaRequired": "Veuillez confirmer que vous n'êtes pas un robot en cochant la case ci-dessous."
 }

--- a/locales/fr/survey.yml
+++ b/locales/fr/survey.yml
@@ -95,3 +95,4 @@ support:
   helpButton: "Besoin d'aide?"
   helpButtonLabel: "Ouvrir le formulaire d'aide"
   close: "Fermer"
+  captchaRequired: "Veuillez confirmer que vous n'êtes pas un robot en cochant la case ci-dessous."

--- a/packages/evolution-backend/src/api/__tests__/auth.routes.test.ts
+++ b/packages/evolution-backend/src/api/__tests__/auth.routes.test.ts
@@ -44,8 +44,16 @@ const authMockFunctions = {
 
 jest.mock('passport', () => {
     return {
-        authenticate: jest.fn().mockImplementation((authType) => {
-            return authMockFunctions[authType] || jest.fn().mockImplementation(authMockImplementation);
+        authenticate: jest.fn().mockImplementation((authType, _, callback?) => {
+            const mockImplementation = authMockFunctions[authType] || jest.fn().mockImplementation(authMockImplementation);
+            if (callback) {
+                return (req, res, next) => {
+                    mockImplementation(req, res, (error, user) => {
+                        callback(error, user);
+                    });
+                }
+            }
+            return mockImplementation;
         }),
         use: jest.fn(),
         serializeUser: jest.fn(),
@@ -53,6 +61,14 @@ jest.mock('passport', () => {
         initialize: jest.fn().mockReturnValue((req, res, next) => next()),
         session: jest.fn().mockReturnValue((req, res, next) => next())
     }
+});
+
+// Mock the captcha validation
+jest.mock('chaire-lib-backend/lib/api/captcha.routes', () => ({
+    validateCaptchaToken: jest.fn().mockImplementation(() => mockedValidateCaptchaToken)
+}));
+const mockedValidateCaptchaToken = jest.fn().mockImplementation((req, res, next) => {
+    next();
 });
 
 const validFieldValue = 'test-value';
@@ -77,13 +93,29 @@ describe('Auth by field route', () => {
     // Setup the app with byField enabled
     projectConfig.auth = { byField: true };
 
+    let failedAttempts: number | undefined = undefined;
     const app = express();
     // FIXME Since upgrading @types/node, the types are wrong and we get compilation error.
     app.use(express.json({ limit: '500mb' }) as RequestHandler);
     app.use(express.urlencoded({ extended: true }) as RequestHandler);
     const router = express.Router();
+    // Mock session middleware to simulate user session and failed attempts
+    router.use((req, res, next) => {
+        req.session = req.session || {};
+        (req.session as any).failedAuthByFieldAttempts = failedAttempts;
+        req.logIn = jest.fn((user, callback: any) => {
+            req.user = user;
+            callback(null);
+        });
+        next();
+    })
     authRoutes(router, userAuthModel, passport);
     app.use(router);
+
+    beforeEach(() => {
+        failedAttempts = undefined;
+        jest.clearAllMocks();
+    })
 
     test('Auth by field, valid credentials', async () => {
         authResponse = {
@@ -99,21 +131,61 @@ describe('Auth by field route', () => {
         expect(res.body.status).toEqual('Login successful!');
         expect(res.body.user).toEqual(validUser);
         expect(authMockFunctions['auth-by-field']).toHaveBeenCalledTimes(1);
+        expect(mockedValidateCaptchaToken).not.toHaveBeenCalled();
+    });
+
+    test('Auth by field, valid credentials after first attempt, valid catpcha', async () => {
+        failedAttempts = 1; // Simulate one failed attempt, should validate captcha
+        authResponse = {
+            error: null,
+            user: validUser
+        };
+        const res = await session(app)
+            .post('/auth-by-field')
+            .send({ field: validFieldValue })
+            .set('Accept', 'application/json')
+            .expect('Content-Type', /json/)
+            .expect(200);
+        expect(res.body.status).toEqual('Login successful!');
+        expect(res.body.user).toEqual(validUser);
+        expect(authMockFunctions['auth-by-field']).toHaveBeenCalledTimes(1);
+        expect(mockedValidateCaptchaToken).toHaveBeenCalledTimes(1);
+    });
+
+    test('Auth by field, valid credentials after first attempt, no catpcha', async () => {
+        failedAttempts = 1; // Simulate one failed attempt, should validate captcha
+        mockedValidateCaptchaToken.mockImplementationOnce((req, res, next) => {
+            return res.status(403).json({ status: 'InvalidCaptcha' });
+        })
+        authResponse = {
+            error: null,
+            user: validUser
+        };
+        const res = await session(app)
+            .post('/auth-by-field')
+            .send({ field: validFieldValue })
+            .set('Accept', 'application/json')
+            .expect('Content-Type', /json/)
+            .expect(403);
+        expect(res.body.status).toEqual('InvalidCaptcha');
+        expect(res.body.user).toBeUndefined();
+        expect(authMockFunctions['auth-by-field']).not.toHaveBeenCalled();
+        expect(mockedValidateCaptchaToken).toHaveBeenCalledTimes(1);
     });
 
     test('Auth by field, invalid credentials', async () => {
         authResponse = {
-            error: 'InvalidField',
+            error: 'InvalidData',
             user: false
         };
         const res = await session(app)
             .post('/auth-by-field')
             .send({ field: 'invalid-value' })
             .set('Accept', 'application/json')
-            .expect('Content-Type', /json/)
-            .expect(200);
+            .expect(400)
+            .expect('Content-Type', /json/);
         expect(res.body.status).toEqual('User not authenticated');
-        expect(res.body.error).toEqual('InvalidField');
+        expect(res.body.error).toEqual('InvalidData');
         expect(res.body.user).toEqual(undefined);
         expect(authMockFunctions['auth-by-field']).toHaveBeenCalledTimes(1);
     });
@@ -128,8 +200,8 @@ describe('Auth by field route', () => {
             .post('/auth-by-field')
             .send({ field: validFieldValue })
             .set('Accept', 'application/json')
-            .expect('Content-Type', /json/)
-            .expect(401);
+            .expect(401)
+            .expect('Content-Type', /json/);
         expect(res.body.status).toEqual('User not authenticated');
         expect(res.body.error).toEqual('Unauthorized');
         expect(res.body.user).toEqual(undefined);

--- a/packages/evolution-backend/src/api/auth.routes.ts
+++ b/packages/evolution-backend/src/api/auth.routes.ts
@@ -4,11 +4,12 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import { Router, Request, Response } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import authRoutes from 'chaire-lib-backend/lib/api/auth.routes';
 import { IAuthModel, IUserModel } from 'chaire-lib-backend/lib/services/auth/authModel';
 import { PassportStatic } from 'passport';
 import projectConfig from 'evolution-common/lib/config/project.config';
+import { validateCaptchaToken } from 'chaire-lib-backend/lib/api/captcha.routes';
 
 // Setup authentication routes for evolution, in a separate express router. It
 // also adds the auth-by-field route if configured
@@ -19,26 +20,56 @@ export default <U extends IUserModel>(app: Router, authModel: IAuthModel<U>, pas
     authRoutes(router, authModel, passport);
 
     if (projectConfig.auth.byField === true) {
-        router.post(
-            '/auth-by-field',
-            passport.authenticate('auth-by-field'),
-            (req, res) => {
-                return res.status(200).json({
-                    user: req.user,
-                    status: 'Login successful!'
-                });
-            },
-            (err, _req: Request, res: Response, _next) => {
-                // Handle error
-                if (!res.statusCode) {
-                    res.status(200);
-                }
-                return res.json({
-                    error: err,
-                    status: 'User not authenticated'
-                });
+        // For subsequent attempts, validate captcha token
+        const captchaMiddleware = validateCaptchaToken({
+            // This is not an error message for the user, no need to translate it
+            errorMessage: 'Captcha validation required after failed login attempt',
+            keepToken: true // Keep the token for to avoid repeated captcha at login in case or errors
+        });
+
+        // Middleware to check if captcha is required based on previous failed attempts
+        const conditionalCaptchaValidation = async (req: Request, res: Response, next: NextFunction) => {
+            // Initialize failed attempts counter in the session if it doesn't exist
+            if (!req.session.failedAuthByFieldAttempts) {
+                req.session.failedAuthByFieldAttempts = 0;
             }
-        );
+
+            // Skip captcha validation for first attempt
+            if (req.session.failedAuthByFieldAttempts === 0) {
+                return next();
+            }
+            return captchaMiddleware(req, res, next);
+        };
+
+        router.post('/auth-by-field', conditionalCaptchaValidation, (req, res, next) => {
+            passport.authenticate('auth-by-field', { session: true }, (err, user) => {
+                if (!user) {
+                    // Authentication failed
+                    req.session.failedAuthByFieldAttempts = (req.session.failedAuthByFieldAttempts || 0) + 1;
+
+                    return res.status(err === 'Unauthorized' ? 401 : 400).json({
+                        status: 'User not authenticated',
+                        error: err,
+                        requiresCaptcha: true
+                    });
+                }
+
+                // Authentication succeeded, log in user
+                req.logIn(user, (loginErr) => {
+                    if (loginErr) {
+                        return next(loginErr);
+                    }
+
+                    // Reset failed attempts counter on successful login
+                    req.session.failedAuthByFieldAttempts = 0;
+
+                    return res.status(200).json({
+                        user: req.user,
+                        status: 'Login successful!'
+                    });
+                });
+            })(req, res, next);
+        });
     }
 
     app.use(router);

--- a/packages/evolution-backend/src/api/express-session.d.ts
+++ b/packages/evolution-backend/src/api/express-session.d.ts
@@ -17,5 +17,6 @@ declare module 'express-session' {
             interviewId: string;
             updatedPaths: string[];
         };
+        failedAuthByFieldAttempts?: number; // Number of failed attempts for auth-by-field
     }
 }

--- a/packages/evolution-backend/src/api/survey.participant.routes.ts
+++ b/packages/evolution-backend/src/api/survey.participant.routes.ts
@@ -14,6 +14,7 @@ import { isLoggedIn } from 'chaire-lib-backend/lib/services/auth/authorization';
 import { UserAttributes } from 'chaire-lib-backend/lib/services/users/user';
 import Interviews from '../services/interviews/interviews';
 import { sendSupportRequestEmail } from '../services/logging/supportRequest';
+import { validateCaptchaToken } from 'chaire-lib-backend/lib/api/captcha.routes';
 
 import { InterviewLoggingMiddlewares } from '../services/logging/queryLoggingMiddleware';
 import addCommonRoutes from './survey.common.routes';
@@ -23,7 +24,7 @@ export const getPublicParticipantRoutes = () => {
     const publicRouter = express.Router();
 
     if (projectConfig.surveySupportForm === true) {
-        publicRouter.post('/supportRequest/', async (req: Request, res: Response) => {
+        publicRouter.post('/supportRequest/', validateCaptchaToken(), async (req: Request, res: Response) => {
             try {
                 const content = req.body;
 

--- a/packages/evolution-frontend/src/actions/Auth.ts
+++ b/packages/evolution-frontend/src/actions/Auth.ts
@@ -83,7 +83,12 @@ export const startRegisterWithPassword = AuthBase.startRegisterWithPassword;
 
 export const startForgotPasswordRequest = AuthBase.startForgotPasswordRequest;
 
-export type ByFieldLoginData = { accessCode: string; postalCode: string; confirmCredentials: boolean | undefined };
+export type ByFieldLoginData = {
+    accessCode: string;
+    postalCode: string;
+    confirmCredentials: boolean | undefined;
+    captchaToken?: unknown;
+};
 export const startByFieldLogin = (
     data: ByFieldLoginData,
     location: Location,

--- a/packages/evolution-frontend/src/components/pages/auth/ByFieldLoginForm.tsx
+++ b/packages/evolution-frontend/src/components/pages/auth/ByFieldLoginForm.tsx
@@ -17,6 +17,7 @@ import Button from 'chaire-lib-frontend/lib/components/input/Button';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { RootState } from 'chaire-lib-frontend/lib/store/configureStore';
 import { InterviewContext } from '../../../contexts/InterviewContext';
+import CaptchaComponent from 'chaire-lib-frontend/lib/components/captcha/CaptchaComponent';
 
 type ByFieldLoginFormProps = {
     headerText?: string;
@@ -30,6 +31,10 @@ const ByFieldLoginForm: React.FC<ByFieldLoginFormProps> = ({ headerText, buttonT
     const location = useLocation();
     const navigate = useNavigate();
     const { dispatch: interviewDispatch } = React.useContext(InterviewContext);
+    const [{ isCaptchaValid, captchaToken }, setCaptchaResult] = React.useState<{
+        isCaptchaValid: boolean;
+        captchaToken: unknown;
+    }>({ isCaptchaValid: false, captchaToken: null });
 
     const isAuthenticated = useSelector((state: RootState) => state.auth.isAuthenticated);
     const login = useSelector((state: RootState) => state.auth.login);
@@ -107,6 +112,11 @@ const ByFieldLoginForm: React.FC<ByFieldLoginFormProps> = ({ headerText, buttonT
             return;
         }
 
+        if (hasInvalidCredentials && !isCaptchaValid) {
+            setFormState((prev) => ({ ...prev, error: 'auth:captchaRequired' }));
+            return;
+        }
+
         // Pass the access code to the interview context
         interviewDispatch({ type: 'enter', queryData: new URLSearchParams(`?accessCode=${formState.accessCode}`) });
 
@@ -117,7 +127,8 @@ const ByFieldLoginForm: React.FC<ByFieldLoginFormProps> = ({ headerText, buttonT
                 {
                     accessCode: formState.accessCode,
                     postalCode: formState.postalCode,
-                    confirmCredentials: formState.confirmCredentials
+                    confirmCredentials: formState.confirmCredentials,
+                    captchaToken: captchaToken
                 },
                 location,
                 navigate
@@ -193,6 +204,11 @@ const ByFieldLoginForm: React.FC<ByFieldLoginFormProps> = ({ headerText, buttonT
                             />
                             {t('auth:ConfirmCredentials')}
                         </label>
+                        <CaptchaComponent
+                            onCaptchaValid={(isValid, captchaToken) => {
+                                setCaptchaResult({ isCaptchaValid: isValid, captchaToken });
+                            }}
+                        />
                     </div>
                 )}
             </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -271,6 +271,19 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@cap.js/server@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@cap.js/server/-/server-2.0.0.tgz#51746c5f5f85fb9051868446783e21df6fae44ea"
+  integrity sha512-CaETNf+u/+vgkzQJu3Fq3UWrd8egUFYBFLYo5Rf5j2muIVY1syqUJbwvwxLbgE5mlMmND/RUo15D/G0iKCOIYA==
+  dependencies:
+    "@types/node" "^22.14.1"
+    typescript "^5.8.3"
+
+"@cap.js/widget@^0.1.25":
+  version "0.1.25"
+  resolved "https://registry.yarnpkg.com/@cap.js/widget/-/widget-0.1.25.tgz#a8400d56cdfc74b28e5f492d13b34a9db302745b"
+  integrity sha512-OVKt1rOAzqgxuSk0j18K6KtLBwAarTn6g7kAsGXcW+DAYO++Xr32LY6sj8KS3C3gqZXkhozf50kVwmgQs7CzxA==
+
 "@carto/api-client@^0.4.4":
   version "0.4.9"
   resolved "https://registry.yarnpkg.com/@carto/api-client/-/api-client-0.4.9.tgz#c3edd0af757315a2e1f0516cd503acc57bfced76"
@@ -1758,6 +1771,13 @@
     "@parcel/watcher-win32-arm64" "2.5.0"
     "@parcel/watcher-win32-ia32" "2.5.0"
     "@parcel/watcher-win32-x64" "2.5.0"
+
+"@pitininja/cap-react-widget@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@pitininja/cap-react-widget/-/cap-react-widget-1.1.1.tgz#2d557c5745613d2defcf271dd1dddc7ad2ebb750"
+  integrity sha512-VvuW0OimPaQBRKFDbDHXUm4r8k23fg5EQlpPUHEWPUg8NW2i/+1kgPdN43Mcbxdp9DXTUcmXMP3wLwrtVmqv6A==
+  dependencies:
+    "@cap.js/widget" "^0.1.25"
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
@@ -4032,7 +4052,7 @@
   resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.34.tgz#10964ba0dee6ac4cd462e2795b6bebd407303433"
   integrity sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==
 
-"@types/node@*", "@types/node@>=10.0.0", "@types/node@>=13.7.0", "@types/node@^22.15.14", "@types/node@^22.15.3":
+"@types/node@*", "@types/node@>=10.0.0", "@types/node@>=13.7.0", "@types/node@^22.15.14", "@types/node@^22.14.1", "@types/node@^22.15.3":
   version "22.15.14"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-22.15.14.tgz#889fd356a04d003a6d5650ccc003ef4d712430d7"
   integrity sha512-BL1eyu/XWsFGTtDWOYULQEs4KR0qdtYfCxYAUYRoB7JP7h9ETYLgQTww6kH8Sj2C0pFGgrpM0XKv6/kbIzYJ1g==


### PR DESCRIPTION
fixes #1021

The support form always provides a captcha. As for `byField` login form,
it will display a captcha after the first un-successful login attempts.

The backend route for support and byField login have been updated to use
the captcha validation middleware.

Also update Evolution