### PR TITLE
navigation: fix random order list when already assigned

### DIFF
--- a/packages/evolution-common/src/services/questionnaire/sections/NavigationService.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/NavigationService.ts
@@ -282,8 +282,8 @@ export class NavigationService {
                 objectIds = _shuffle(objectIds);
                 interviewFieldsToUpdate[`response.${randomOrderPath}`] = objectIds;
             } else {
-                // Otherwise, use the random order
-                objectIds.splice(0, objectIds.length - 1, ...randomOrder);
+                // Otherwise, use the random order, don't use the array from the response directly, copy it instead
+                objectIds = [...randomOrder];
             }
         }
 

--- a/packages/evolution-common/src/services/questionnaire/sections/__tests__/NavigationService.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/__tests__/NavigationService.test.ts
@@ -1847,6 +1847,7 @@ describe('navigate function, further use cases', () => {
             mockShuffle.mockReturnValueOnce(['personId2', 'personId1']);
 
             const testInterviewWithRandomSequence = _cloneDeep(testInterview);
+            // Current random sequence has a not interviewable person (personId3)
             testInterviewWithRandomSequence.response._RandomSequence = ['personId2', 'personId3'];
 
             // Prepare the previous navigation state
@@ -1930,6 +1931,39 @@ describe('navigate function, further use cases', () => {
                     iterationContext: expectedIterationContext
                 },
                 valuesByPath: { 'response._activePersonId': expectedIterationContext[1] }
+            });
+        });
+
+        test('random, last section of last iteration', () => {
+            const currentSection = 'travelBehavior';
+            const currentIterationContext = ['personId1'];
+            const expectedSection = 'end';
+            const expectedIterationContext = undefined;
+
+            // Set the order of the iteration contexts to randomize and mock the result
+            const sectionConfig = _cloneDeep(complexSectionsConfig);
+            (sectionConfig['personsTrips'] as SectionConfigWithDefaultsBlock).repeatedBlock.order = 'random';
+            const navigationService = createNavigationService(sectionConfig);
+
+            // Set random order
+            const testInterviewWithRandomSequence = _cloneDeep(testInterview);
+            testInterviewWithRandomSequence.response._RandomSequence = ['personId2', 'personId1'];
+
+            // Prepare the previous navigation state
+            const currentSectionData = {
+                sectionShortname: currentSection,
+                iterationContext: currentIterationContext
+            };
+
+            // Navigate to specific section
+            const nextSectionResult = navigationService.navigate({ interview: testInterviewWithRandomSequence, currentSection: _cloneDeep(currentSectionData), direction: 'forward'});
+            expect(mockShuffle).not.toHaveBeenCalled();
+            expect(nextSectionResult).toEqual({
+                targetSection: {
+                    sectionShortname: expectedSection,
+                    iterationContext: expectedIterationContext
+                },
+                valuesByPath: { 'response._activePersonId': undefined }
             });
         });
 


### PR DESCRIPTION
fixes #1064

Add a unit test which shows the problem of the extra element in the iteration blocks during navigation.

Set the `objectIds` to the random order when getting the iteration contexts instead of replacing in the array directly.