### PR TITLE
authByField: use the formatters from the survey fields

### DIFF
--- a/example/demo_survey/src/survey/widgets/home.tsx
+++ b/example/demo_survey/src/survey/widgets/home.tsx
@@ -13,6 +13,7 @@ import config from 'chaire-lib-common/lib/config/shared/project.config';
 import * as surveyHelperNew from 'evolution-common/lib/utils/helpers';
 import { getHousehold } from 'evolution-common/lib/services/odSurvey/helpers';
 import waterBoundaries  from '../waterBoundaries.json';
+import { canadianPostalCodeFormatter, eightDigitsAccessCodeFormatter } from 'evolution-common/lib/utils/formatters';
 
 export const homeIntro = {
   type: "text",
@@ -60,17 +61,7 @@ export const accessCode = {
   containsHtml: true,
   keyboardInputMode: 'numeric',
   placeholder: "ex. 1234-5678",
-  inputFilter: (input: string) => {
-    input = input.replace("_", "-"); // change _ to -
-    input = input.replace(/[^-\d]/g, ''); // Remove everything but numbers and -
-    // Get only the digits. If we have 8, we can automatically format the access code.
-    const digits = input.replace(/\D+/g, '');
-    if (digits.length === 8) {
-        return digits.slice(0, 4) + "-" + digits.slice(4);
-    }
-    // Prevent entering more than 9 characters (8 digit access code and a dash)
-    return input.slice(0, 9);
-  },
+  inputFilter: eightDigitsAccessCodeFormatter,
   label: (t: TFunction) => t('survey:AccessCode')
 }
 
@@ -464,7 +455,7 @@ export const homePostalCode = {
   inputType: "string",
   path: "home.postalCode",
   datatype: "string",
-  textTransform: "uppercase",
+  inputFilter: canadianPostalCodeFormatter,
   twoColumns: true,
   label: {
     fr: "Code postal",

--- a/packages/evolution-backend/src/api/auth.routes.ts
+++ b/packages/evolution-backend/src/api/auth.routes.ts
@@ -10,6 +10,7 @@ import { IAuthModel, IUserModel } from 'chaire-lib-backend/lib/services/auth/aut
 import { PassportStatic } from 'passport';
 import projectConfig from 'evolution-common/lib/config/project.config';
 import { validateCaptchaToken } from 'chaire-lib-backend/lib/api/captcha.routes';
+import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 
 // Setup authentication routes for evolution, in a separate express router. It
 // also adds the auth-by-field route if configured
@@ -19,7 +20,7 @@ export default <U extends IUserModel>(app: Router, authModel: IAuthModel<U>, pas
     // Add other auth routes
     authRoutes(router, authModel, passport);
 
-    if (projectConfig.auth.byField === true) {
+    if (!_isBlank(projectConfig.auth.byField) && projectConfig.auth.byField !== false) {
         // For subsequent attempts, validate captcha token
         const captchaMiddleware = validateCaptchaToken({
             // This is not an error message for the user, no need to translate it

--- a/packages/evolution-backend/src/services/auth/auth.config.ts
+++ b/packages/evolution-backend/src/services/auth/auth.config.ts
@@ -4,10 +4,10 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-
+import { PassportStatic } from 'passport';
 import configurePassport from 'chaire-lib-backend/lib/config/auth';
 import { IAuthModel, IUserModel } from 'chaire-lib-backend/lib/services/auth/authModel';
-import { PassportStatic } from 'passport';
+import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import projectConfig from 'evolution-common/lib/config/project.config';
 import byFieldLogin from './authByFieldLogin';
 
@@ -15,7 +15,7 @@ export default <U extends IUserModel>(authModel: IAuthModel<U>): PassportStatic 
     // Configure passport with the auth model
     const passport = configurePassport<U>(authModel);
 
-    if (projectConfig.auth.byField === true) {
+    if (!_isBlank(projectConfig.auth.byField) && projectConfig.auth.byField !== false) {
         byFieldLogin(passport, authModel);
     }
 

--- a/packages/evolution-common/package.json
+++ b/packages/evolution-common/package.json
@@ -23,13 +23,14 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.7.1",
+    "@turf/turf": "^7.1.0",
     "chaire-lib-common": "^0.2.2",
+    "cleave-zen": "^0.0.17",
     "geojson-validation": "^1.0.2",
     "i18next": "^24.0.5",
     "lodash": "^4.17.21",
     "moment": "^2.30.1",
-    "uuid": "^11.1.0",
-    "@turf/turf": "^7.1.0"
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@types/geojson": "^7946.0.16",

--- a/packages/evolution-common/src/config/project.config.ts
+++ b/packages/evolution-common/src/config/project.config.ts
@@ -102,12 +102,24 @@ export type EvolutionProjectConfiguration = {
     // Add additional properties to the config
     auth: ProjectConfiguration<any>['auth'] & {
         /**
-         * If true, the auth model will use the combination of access code and
-         * postal code as login credentials.
+         * If true or with fields defined, the auth model will use the
+         * combination of access code and postal code as login credentials.
          *
-         * TODO Support options to specify which fields are to be used
+         * TODO Support options to specify which fields are to be used (other
+         * than access code and postal code)
          */
-        byField?: boolean;
+        byField?:
+            | boolean
+            | {
+                  /**
+                   * The field to use for the access code. Defaults to 'accessCode'
+                   */
+                  accessCodeField?: string;
+                  /**
+                   * The field to use for the postal code. Defaults to 'postalCode'
+                   */
+                  postalCodeField?: string;
+              };
     };
 
     // TODO Add more project configuration types

--- a/packages/evolution-common/src/utils/__tests__/formatters.test.ts
+++ b/packages/evolution-common/src/utils/__tests__/formatters.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { canadianPostalCodeFormatter, eightDigitsAccessCodeFormatter } from '../formatters';
+
+describe('helper', () => {
+  describe('eightDigitsAccessCodeFormatter', () => {
+    test.each([
+      // Test case format: [description, input, expected output]
+      ['formats 8 digits as XXXX-XXXX', '12345678', '1234-5678'],
+      ['converts existing dashes correctly', '1234-5678', '1234-5678'],
+      ['converts underscores to dashes', '1234_5678', '1234-5678'],
+      ['removes letters and special characters', 'ab12cd34ef56gh78', '1234-5678'],
+      ['handles mixed special characters', '12_34-ab56!78', '1234-5678'],
+      ['keeps dashes but removes other special chars', '12-34-56-78', '1234-5678'],
+      ['smaller code with dashes', '123-456', '1234-56'],
+      ['8 digits with dash at the wrong place', '123-45678', '1234-5678'],
+      ['does not format if less than 8 digits', '123456', '1234-56'],
+      ['truncates to 9 characters max', '1234567890', '1234-5678'],
+      ['handles input with spaces', '1234 5678', '1234-5678'],
+      ['handles input with spaces before and after', '   12 34 5678  ', '1234-5678'],
+      ['handles empty string', '', ''],
+      ['handles with non-numeric at the end', '1234db', '1234-'],
+      ['partial access code, 1 character', '1', '1'],
+      ['partial access code, 2 characters', '12', '12'],
+      ['partial access code, 3 characters', '123', '123'],
+      ['partial access code, 4 characters', '1234', '1234-'],
+      ['partial access code, 4 characters + dash', '1234-', '1234-'],
+      ['partial access code, 4 characters + dash + 2 characters', '1234-23', '1234-23'],
+      ['partial access code, 5 characters', '12345', '1234-5'],
+      ['partial access code, 6 characters', '123456', '1234-56'],
+      ['partial access code, 7 characters', '1234567', '1234-567'],
+    ])('%s', (_, input, expected) => {
+      expect(eightDigitsAccessCodeFormatter(input)).toBe(expected);
+    });
+  });
+
+  describe('canadianPostalCodeFormatter', () => {
+    test.each([
+      // Test case format: [description, input, expected output]
+      ['lower case no space', 'h2e1r3', 'H2E 1R3'],
+      ['correctly formatted', 'H2E 1R3', 'H2E 1R3'],
+      ['With invalid delimiters', 'H2e-1r3', 'H2E 1R3'],
+      ['Many invalid characters', 'h.2.e.1.r.3', 'H2E 1R3'],
+      ['all numeric', '123456', '123 456'],
+      ['all letters', 'abcdef', 'ABC DEF'],
+      ['handles input with many spaces', 'h   2 e     1r3', 'H2E 1R3'],
+      ['handles input with spaces before and after', '   H2E 1R3  ', 'H2E 1R3'],
+      ['handles empty string', '', ''],
+      ['partial postal code, 1 character', 'h', 'H'],
+      ['partial postal code, 2 characters', 'h2', 'H2'],
+      ['partial postal code, 3 characters', 'h2e', 'H2E '],
+      ['partial postal code, 4 characters', 'h2e1', 'H2E 1'],
+      ['partial postal code, 5 characters', 'h2e1r', 'H2E 1R'],
+      ['partial access code, 3 characters + space', 'h2e1 ', 'H2E 1'],
+    ])('%s', (_, input, expected) => {
+      expect(canadianPostalCodeFormatter(input)).toBe(expected);
+    });
+  });
+});

--- a/packages/evolution-common/src/utils/formatters.ts
+++ b/packages/evolution-common/src/utils/formatters.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { formatGeneral } from 'cleave-zen';
+
+/**
+ * Format an access code to the format "XXXX-XXXX" where X is a digit.
+ * If the input contains less than 8 digits, it will return the code as is
+ * If the input contains 8 or more digits, it will format the first 8 digits
+ * as "XXXX-XXXX".
+ * @param input The input to format
+ * @returns The formatted access code
+ */
+export const eightDigitsAccessCodeFormatter = (input: string): string =>
+    formatGeneral(input, {
+        blocks: [4, 4],
+        delimiter: '-',
+        numericOnly: true
+    });
+
+/**
+ * Formats a canadian postal code as 2 blocks of 3 characters. Note that this
+ * does not validate while writing, it just formats the input.
+ * @param input The input to format
+ * @returns The formatted canadian postal code
+ */
+export const canadianPostalCodeFormatter = (input: string): string => {
+    // Remove everything but letters and numbers
+    const strippedInput = input.replace(/[^a-zA-Z0-9]/g, '');
+    // Format with 2 blocks of 3 characters, with a space in between
+    return formatGeneral(strippedInput, {
+        blocks: [3, 3],
+        delimiter: ' ',
+        numericOnly: false,
+        uppercase: true
+    });
+};

--- a/packages/evolution-frontend/src/components/pages/auth/AuthPage.tsx
+++ b/packages/evolution-frontend/src/components/pages/auth/AuthPage.tsx
@@ -36,11 +36,14 @@ const AuthByField = (props: { authMethods: string[] }) => {
     if (!props.authMethods.includes('byField')) {
         return null;
     } else {
+        const byFieldConfig = config.auth?.byField || {};
         return (
             <div className="apptr__auth-box">
                 <ByFieldLoginForm
                     headerText={t(['survey:auth:ByFieldLoginHeader', 'auth:ByFieldLoginHeader'])}
                     buttonText={t(['survey:auth:Login', 'auth:Login'])}
+                    accessCodeField={typeof byFieldConfig === 'boolean' ? undefined : byFieldConfig.accessCodeField}
+                    postalCodeField={typeof byFieldConfig === 'boolean' ? undefined : byFieldConfig.postalCodeField}
                 />
                 <div className="apptr__separator"></div>
             </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4052,7 +4052,7 @@
   resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.34.tgz#10964ba0dee6ac4cd462e2795b6bebd407303433"
   integrity sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==
 
-"@types/node@*", "@types/node@>=10.0.0", "@types/node@>=13.7.0", "@types/node@^22.15.14", "@types/node@^22.14.1", "@types/node@^22.15.3":
+"@types/node@*", "@types/node@>=10.0.0", "@types/node@>=13.7.0", "@types/node@^22.14.1", "@types/node@^22.15.14", "@types/node@^22.15.3":
   version "22.15.14"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-22.15.14.tgz#889fd356a04d003a6d5650ccc003ef4d712430d7"
   integrity sha512-BL1eyu/XWsFGTtDWOYULQEs4KR0qdtYfCxYAUYRoB7JP7h9ETYLgQTww6kH8Sj2C0pFGgrpM0XKv6/kbIzYJ1g==
@@ -5463,6 +5463,11 @@ clean-webpack-plugin@^4.0.0:
   integrity sha512-WuWE1nyTNAyW5T7oNyys2EN0cfP2fdRxhxnIQWiAp0bMabPdHhoGxM8A6YL2GhqwgrPnnaemVE7nv5XJ2Fhh2w==
   dependencies:
     del "^4.1.1"
+
+cleave-zen@^0.0.17:
+  version "0.0.17"
+  resolved "https://registry.yarnpkg.com/cleave-zen/-/cleave-zen-0.0.17.tgz#c9ba1739531e24cb7cb522328a90c8e9f7b785d0"
+  integrity sha512-SLuad6RaACsONu3Fr4F3sE9YXxMlMv6AiaZ8qkwfdV9Ex+TJ+ip3rLFsdrqvnp0YGlslfzAfw8q8MwQJW3yHdg==
 
 cli-cursor@^3, cli-cursor@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
fixes #1053

To avoid the `ByFieldLoginForm` to hard-code formats of the fields, we
directly use fields of the survey that are defined in the widgets and use
the `inputFilter`, if any, for the corresponding field input in the auth
form.

The validations from the input are also used for the login form. Since
those validations are called in a context that does not have a valid
interview yet, the validation functions of those fields should be simple
and not depend on other answers. There may be unexpected behavior if it
is not the case.

This updates the configuration of the `byField` auth method. Instead of
a simple `true` or `false` value, it can be an object to configure the
name of the field to use for access code (`accessCodeField`) or postal
code (`postalCodeField`). By default, the auth form will look for fields
named `accessCode` and `postalCode`.