### PR TITLE
generator: support the `hidden` property of choices

### DIFF
--- a/packages/evolution-generator/src/scripts/generate_choices.py
+++ b/packages/evolution-generator/src/scripts/generate_choices.py
@@ -70,6 +70,7 @@ def generate_choices(input_file: str, output_file: str):
             label_en = process_label(row_dict["label::en"])
             spread_choices_name = row_dict["spreadChoicesName"]
             conditional = row_dict["conditional"]
+            hidden = row_dict.get("hidden", False)
 
             # Check if the row is valid
             if choice_name is None or (value is None and spread_choices_name is None):
@@ -80,6 +81,7 @@ def generate_choices(input_file: str, output_file: str):
                 "value": value,
                 "label": {"fr": label_fr, "en": label_en},
                 "spread_choices_name": spread_choices_name,
+                "hidden": hidden,
             }
 
             # Add conditional field to choice object if it exists
@@ -123,7 +125,8 @@ def generate_choices(input_file: str, output_file: str):
                         f"{INDENT}{INDENT}label: {{\n"
                         f"{INDENT}{INDENT}{INDENT}fr: '{choice['label']['fr']}',\n"
                         f"{INDENT}{INDENT}{INDENT}en: '{choice['label']['en']}'\n"
-                        f"{INDENT}{INDENT}}}{',' if choice.get("conditional", None) is not None else ''}\n"
+                        f"{INDENT}{INDENT}}}{f",\n{INDENT}{INDENT}hidden: true" if choice["hidden"] else ''}"
+                        f"{INDENT}{INDENT}{',' if choice.get("conditional", None) is not None else ''}\n"
                     )
                     # Add the 'conditional' field only if it exists
                     if choice.get("conditional", None) is not None:

--- a/packages/evolution-generator/src/tests/test_generate_choices.py
+++ b/packages/evolution-generator/src/tests/test_generate_choices.py
@@ -110,6 +110,20 @@ GOOD_ROWS_DATA = [
         None,
     ],
 ]
+# FIXME We do not actually test that the hidden choices are correctly generated, just that it works
+GOOD_HEADERS_WITH_HIDDEN = [
+    "choicesName",
+    "value",
+    "label::fr",
+    "label::en",
+    "spreadChoicesName",
+    "conditional",
+    "hidden",
+]
+GOOD_ROWS_DATA_WITH_HIDDEN = [
+    ["yesNoChoices", "yes", "Oui", "Yes", None, None, True],
+    ["yesNoChoices", "no", "Non", "No", None, None, False],
+]
 BAD_ROWS_DATA = [["badRowData"]]
 
 
@@ -130,6 +144,15 @@ BAD_ROWS_DATA = [["badRowData"]]
             GOOD_SHEET_NAME,
             GOOD_HEADERS,
             GOOD_ROWS_DATA,
+            GOOD_INPUT_FILE,
+            GOOD_OUPUT_FILE,
+            None,  # No error expected
+        ),
+        # Test that the function works correctly with 'hidden' headers
+        (
+            GOOD_SHEET_NAME,
+            GOOD_HEADERS_WITH_HIDDEN,
+            GOOD_ROWS_DATA_WITH_HIDDEN,
             GOOD_INPUT_FILE,
             GOOD_OUPUT_FILE,
             None,  # No error expected


### PR DESCRIPTION
fixes #1102

There can be an optional `hidden` boolean column in the `Choices` tab of the Excel file to say if a choice should be hidden.