### PR TITLE
generator: make the `other` gender translation the default

### DIFF
--- a/packages/evolution-generator/src/scripts/generate_labels.py
+++ b/packages/evolution-generator/src/scripts/generate_labels.py
@@ -303,13 +303,13 @@ def add_translations_from_excel(
                 else None
             )
 
-            # Expand gender context for fr_label and fr_label_one
+            # Expand gender context for labels, by language
             gender_fr = expand_gender(fr_label)
             gender_fr_one = expand_gender(fr_label_one)
             gender_en = expand_gender(en_label)
             gender_en_one = expand_gender(en_label_one)
 
-            # Delete the YAML file for the section before adding translations, but only once per (language, section) for the whole script
+            # Add section to processed section set if not already processed
             if section not in processed_sections:
                 processed_sections.add(section)  # Mark section as processed
 
@@ -331,10 +331,11 @@ def add_translations_from_excel(
                     rowNumber=rowNumber,
                     translations=translations_dict["fr"],
                 )
+                # The "other" translation will be the default one
                 add_translation(
                     language="fr",
                     section=section,
-                    path=path + "_other",
+                    path=path,
                     value=gender_fr["other"],
                     rowNumber=rowNumber,
                     translations=translations_dict["fr"],
@@ -370,7 +371,7 @@ def add_translations_from_excel(
                 add_translation(
                     language="fr",
                     section=section,
-                    path=path + "_other_one",
+                    path=path + "_one",
                     value=gender_fr_one["other"],
                     rowNumber=rowNumber,
                     translations=translations_dict["fr"],
@@ -406,7 +407,7 @@ def add_translations_from_excel(
                 add_translation(
                     language="en",
                     section=section,
-                    path=path + "_other",
+                    path=path,
                     value=gender_en["other"],
                     rowNumber=rowNumber,
                     translations=translations_dict["en"],
@@ -442,7 +443,7 @@ def add_translations_from_excel(
                 add_translation(
                     language="en",
                     section=section,
-                    path=path + "_other_one",
+                    path=path + "_one",
                     value=gender_en_one["other"],
                     rowNumber=rowNumber,
                     translations=translations_dict["en"],

--- a/packages/evolution-generator/src/scripts/generate_widgets.py
+++ b/packages/evolution-generator/src/scripts/generate_widgets.py
@@ -539,10 +539,9 @@ def generate_label(section, path, row, key_name="label"):
     if has_label_one or has_persons_count_label:
         initial_assignations += f"{INDENT}{INDENT}const countPersons = odSurveyHelpers.countPersons({{ interview }});\n"
     if has_gender_context_label:
-        initial_assignations += (
-            f"{INDENT}{INDENT}const personGender = activePerson?.gender\n"
+        additional_t_context += (
+            f"{INDENT}{INDENT}{INDENT}context: activePerson?.gender,\n"
         )
-        additional_t_context += f"{INDENT}{INDENT}{INDENT}context: personGender === 'male' || personGender === 'female' ? personGender : 'other',\n"
     if has_persons_count_label or has_label_one:
         additional_t_context += f"{INDENT}{INDENT}{INDENT}count: countPersons,\n"
     widget_label = (

--- a/packages/evolution-generator/src/tests/test_generate_widgets.py
+++ b/packages/evolution-generator/src/tests/test_generate_widgets.py
@@ -226,8 +226,7 @@ def test_generate_label_with_gender_label():
     assert "const activePerson =" in result
     assert "const nickname =" not in result
     assert "const countPersons =" not in result
-    assert "const personGender =" in result
-    assert "context: personGender =" in result
+    assert "context: activePerson?.gender" in result
 
 
 def test_generate_label_with_one_person():
@@ -262,11 +261,10 @@ def test_generate_label_with_all_contexts():
     assert "const activePerson =" in result
     assert "const nickname =" in result
     assert "const countPersons =" in result
-    assert "const personGender =" in result
     assert "nickname," in result
     assert "nickname," in result
     assert "count: countPersons" in result
-    assert "context: personGender =" in result
+    assert "context: activePerson?.gender" in result
 
 
 # TODO: Test generate_help_popup


### PR DESCRIPTION
fixes #1105

If there is no context, or the requested context does not exist, there should always be a fallback translation string to avoid untranslated text. The `other` gender should be this default one.