### PR TITLE
i18n: add common translations in Evolution

### DIFF
--- a/example/demo_survey/locales/en/survey.json
+++ b/example/demo_survey/locales/en/survey.json
@@ -17,10 +17,6 @@
         "deleteThisGroupedObject": "Delete this person",
         "addGroupedObject": "Add a person"
     },
-    "person": {
-        "dayScheduleFor": "Day schedule for",
-        "yourDaySchedule": "Your day schedule"
-    },
     "auth": {
         "UsernameOrEmail": "Email address",
         "missingUsernameOrEmail": "Please provide your email address",
@@ -33,42 +29,11 @@
         "UseAnonymousLogin": "Continue without connecting"
     },
     "visitedPlace": {
-        "deleteThisGroupedObject": "Delete this location",
-        "addGroupedObject": "Add the next location",
-        "activities": {
-            "home": "Home",
-            "workUsual": "Work at usual location",
-            "workNotUsual": "Work",
-            "schoolUsual": "School, studies at usual location",
-            "schoolNotUsual": "School, studies",
-            "schoolNotStudent": "School, studies",
-            "service": "Service",
-            "medical": "Health",
-            "workOnTheRoad": "On the road",
-            "workOnTheRoadFromHome": "On the road",
-            "workOnTheRoadFromUsualWork": "On the road",
-            "worship": "Place of worship",
-            "leisure": "Leisure",
-            "shopping": "Shopping",
-            "restaurant": "Restaurant, bar, coffee shop",
-            "dropSomeone": "Drop or accompany someone",
-            "fetchSomeone": "Pick someone up",
-            "visiting": "Visiting friends or family",
-            "secondaryHome": "Secondary home or cottage",
-            "other": "Other"
-        },
-        "editVisitedPlace": "Edit",
-        "deleteVisitedPlace": "Delete",
         "saveVisitedPlace": "Save this location",
-        "insertVisitedPlace": "Insert a location here",
         "editVisitedPlaces": "Edit, insert or delete location a location",
-        "addVisitedPlace": "Add the next location",
-        "cancelEditVisitedPlaces": "Cancel",
         "resetVisitedPlaces": "Reset visited places and trips for this person"
     },
     "trip": {
-        "trip": "Trip",
-        "editTrip": "Edit",
         "saveTrip": "Save this trip",
         "editTrips": "Edit trips",
         "cancelEditTrips": "Cancel",
@@ -76,10 +41,6 @@
             "carDriver": "Car driver",
             "carPassenger": "Car passenger"
         }
-    },
-    "segments": {
-        "deleteThisGroupedObject": "Delete this mode of transport",
-        "addGroupedObject": "Add a mode of transport"
     },
     "AccessCode": "Please enter the access code written in the letter or the email you received<br /><span class=\"_pale _oblique\">Leave blank if no access code was received</span>",
     "Age": "Age<span class=\\\"_pale _oblique\\\">Enter 0 for babies less than 1 years old</span>",

--- a/example/demo_survey/locales/fr/survey.json
+++ b/example/demo_survey/locales/fr/survey.json
@@ -17,10 +17,6 @@
         "deleteThisGroupedObject": "Supprimer cette personne",
         "addGroupedObject": "Ajouter une personne"
     },
-    "person": {
-        "dayScheduleFor": "Horaire de la journée de",
-        "yourDaySchedule": "Votre horaire de la journée"
-    },
     "auth": {
         "UsernameOrEmail": "Courriel",
         "missingUsernameOrEmail": "Veuillez indiquer votre courriel",
@@ -33,42 +29,11 @@
         "UseAnonymousLogin": "Continuer sans se connecter"
     },
     "visitedPlace": {
-        "deleteThisGroupedObject": "Supprimer ce lieu",
-        "addGroupedObject": "Ajouter le prochain lieu",
-        "activities": {
-            "home": "Domicile",
-            "workUsual": "Travail au lieu habituel",
-            "workNotUsual": "Travail",
-            "schoolUsual": "École, études au lieu habituel",
-            "schoolNotUsual": "École, études",
-            "schoolNotStudent": "École, études",
-            "service": "Service",
-            "medical": "Santé",
-            "shopping": "Magasinage",
-            "workOnTheRoad": "Sur la route",
-            "workOnTheRoadFromHome": "Sur la route",
-            "workOnTheRoadFromUsualWork": "Sur la route",
-            "worship": "Lieu de culte",
-            "leisure": "Loisirs",
-            "restaurant": "Restaurant, bar, café",
-            "dropSomeone": "Reconduire ou accompagner quelqu'un",
-            "fetchSomeone": "Aller chercher quelqu'un",
-            "visiting": "Visite d'amis ou famille",
-            "secondaryHome": "Résidence secondaire ou chalet",
-            "other": "Autre"
-        },
-        "editVisitedPlace": "Modifier",
-        "deleteVisitedPlace": "Supprimer",
-        "saveVisitedPlace": "Sauvegarder ce lieu",
-        "insertVisitedPlace": "Insérer un lieu ici",
         "editVisitedPlaces": "Modifier, insérer ou supprimer un lieu",
-        "addVisitedPlace": "Ajouter le prochain lieu",
         "cancelEditVisitedPlaces": "Annuler",
         "resetVisitedPlaces": "Réinitialiser les lieux visités et les déplacements de cette personne"
     },
     "trip": {
-        "trip": "Déplacement",
-        "editTrip": "Modifier",
         "saveTrip": "Sauvegarder ce déplacement",
         "editTrips": "Modifier un déplacement",
         "cancelEditTrips": "Annuler",
@@ -76,10 +41,6 @@
             "carDriver": "Auto conducteur",
             "carPassenger": "Auto passager"
         }
-    },
-    "segments": {
-        "deleteThisGroupedObject": "Supprimer ce mode de transport",
-        "addGroupedObject": "Ajouter un mode de transport"
     },
     "AccessCode": "Veuillez indiquer le code d'accès inscrit dans la lettre ou le courriel que vous avez reçu<br /><span class=\"_pale _oblique\">Laissez vide si aucun code d'accès reçu</span>",
     "Age": "Âge<br /><span class=\"_pale _oblique\">Inscrire 0 pour les bébés de moins de 1 an</span>",

--- a/example/demo_survey/src/survey/templates/VisitedPlacesSection.tsx
+++ b/example/demo_survey/src/survey/templates/VisitedPlacesSection.tsx
@@ -175,8 +175,7 @@ export const VisitedPlacesSection: React.FC<SectionProps> = (
       {
         const personSchedule = (
           <div className="survey-visited-places-schedule-person-container" key={_personId}>
-            {!isAlone && <p className={_personId === person._uuid ? ' _orange' : ''}>{t('survey:person:dayScheduleFor')} <span className="_strong">{_person.nickname}</span></p>}
-            {isAlone  && <p className='_orange'>{t('survey:person:yourDaySchedule')}</p>}
+            {<p className={_personId === person._uuid ? ' _orange' : ''} >{t('survey:person:dayScheduleFor', { nickname: _person.nickname, count: householdSize as number})}</p>}
             <div className="survey-visited-places-schedule-person">
               {personVisitedPlacesSchedules}
             </div>

--- a/locales/en/segments.yml
+++ b/locales/en/segments.yml
@@ -125,3 +125,5 @@ CurrentTripSegmentsIntro_leisureStroll: >-
     Please indicate all modes of transport used to complete the stroll, in chronological
     order:
 SaveTripLabel: Confirm this trip
+deleteThisGroupedObject: Delete this mode of transport
+addGroupedObject": Add a mode of transport

--- a/locales/en/survey.yml
+++ b/locales/en/survey.yml
@@ -86,3 +86,60 @@ support:
   helpButtonLabel: "Open support form"
   close: "Close"
   captchaRequired: "Please complete the CAPTCHA to submit your message."
+person:
+  dayScheduleFor: Day schedule for <strong>{{nickname}}</strong>
+  dayScheduleFor_one: Your day schedule
+visitedPlace:
+  addVisitedPlace: Add the next location
+  deleteVisitedPlace: Delete
+  addGroupedObject: Add the next location
+  deleteThisGroupedObject: Delete this location
+  cancelEditVisitedPlaces: Cancel
+  editVisitedPlace: Edit
+  insertVisitedPlace: Insert a location here
+  activities:
+    accompanySomeone: Accompany someone
+    carElectricChargingStation: Car charging station
+    carsharingStation: 'Car sharing station (ex: Communauto)'
+    dropSomeone: Drop someone off
+    fetchSomeone: Pick someone up
+    home: Home
+    leisureArtsMusicCulture: Arts, music or culture
+    leisureSports: Park, sports, training (fixed destination)
+    leisureStroll: >-
+        Stroll with no fixed destination (ex: go running/jogging, walk with
+        pet, etc.)
+    leisureTourism: Vacation, tourism
+    medical: Medical (clinic, hospital, physiotherapy, etc.)
+    other: Other
+    otherParentHome: Home of the other parent or guardian
+    pickClassifiedPurchase: Pick up a purchase from a private seller (classified ads)
+    restaurant: Restaurant, coffee shop, bar
+    schoolNotStudent: Studies
+    schoolNotUsual: Studies at a different location
+    schoolUsual: School/Studies at fixed/usual location
+    secondaryHome: Secondary home
+    service: Service (hairdresser, repairs, lawyer, bank, etc.)
+    shopping: Shopping (store, gas station, grocery, etc.)
+    veterinarian: Veterinarian (Vet)
+    visiting: Visiting friends, partner or family
+    volunteering: Volunteering
+    workNotUsual: Work not from a usual location (business meeting, conference, etc.)
+    workOnTheRoad: Work on the road
+    workUsual: Work from usual location (non-home)
+    worship: Place of worship
+  activityCategories:
+    childcare: Childcare centre
+    dropFetchSomeone: Drop someone off or pick someone up
+    home: Home
+    kindergarten: Kindergarten/Preschool
+    leisure: Leisure (stroll, sports, arts, outdoors, tourism, etc.)
+    other: Other
+    otherParentHome: Home of the other parent or guardian
+    school: School
+    schoolStudies: School / studies
+    shoppingServiceRestaurant: Shopping, service or restaurant
+    work: Work
+trip:
+  tripSeq: Trip {{seq}}
+  editTrip: Edit

--- a/locales/fr/segments.yml
+++ b/locales/fr/segments.yml
@@ -126,3 +126,5 @@ CurrentTripSegmentsIntro_leisureStroll: >-
     Veuillez indiquer tous les modes de transport utilisés pour effectuer la promenade,
     dans l'ordre chronologique:
 SaveTripLabel: Confirmer ce déplacement
+deleteThisGroupedObject: Supprimer ce mode de transport
+addGroupedObject": Ajouter un mode de transport

--- a/locales/fr/survey.yml
+++ b/locales/fr/survey.yml
@@ -96,3 +96,60 @@ support:
   helpButtonLabel: "Ouvrir le formulaire d'aide"
   close: "Fermer"
   captchaRequired: "Veuillez confirmer que vous n'êtes pas un robot en cochant la case ci-dessous."
+person:
+  dayScheduleFor: Horaire de la journée de <strong>{{nickname}}</strong>
+  dayScheduleFor_one: Votre horaire de la journée
+visitedPlace:
+  addVisitedPlace: Ajouter le prochain lieu
+  deleteVisitedPlace: Supprimer
+  addGroupedObject: Ajouter le prochain lieu
+  deleteThisGroupedObject: Supprimer ce lieu
+  cancelEditVisitedPlaces: Annuler
+  editVisitedPlace: Modifier
+  insertVisitedPlace: Insérer un lieu ici
+  activities:
+    accompanySomeone: Accompagner quelqu'un
+    carElectricChargingStation: Borne de recharge de véhicule électrique
+    carsharingStation: 'Station d''autopartage (ex: Communauto)'
+    dropSomeone: Reconduire quelqu'un
+    fetchSomeone: Aller chercher quelqu'un
+    home: Domicile
+    leisureArtsMusicCulture: Arts, musique ou culture
+    leisureSports: Parc, sports, entraînement (destination fixe)
+    leisureStroll: >-
+        Promenade sans destination fixe (ex: aller courir/jogging, aller
+        promener le chien, etc.)
+    leisureTourism: Vacances, tourisme
+    medical: Santé (clinique, hôpital, physiothérapie, etc.)
+    other: Autre
+    otherParentHome: Domicile de l'autre parent ou tuteur
+    pickClassifiedPurchase: Récupérer un achat fait chez un particulier (petites annonces)
+    restaurant: Restaurant, café, bar
+    schoolNotStudent: Études
+    schoolNotUsual: Études dans un autre lieu
+    schoolUsual: École/Études au lieu principal
+    secondaryHome: Résidence secondaire
+    service: Service (coiffeur, réparations, avocat, banque, etc.)
+    shopping: Magasinage (achats, station-service, épicerie, etc.)
+    veterinarian: Vétérinaire
+    visiting: Visite d'ami(s), conjoint ou famille
+    volunteering: Bénévolat
+    workNotUsual: Travail dans un autre lieu
+    workOnTheRoad: Travail sur la route
+    workUsual: Travail au lieu habituel
+    worship: Lieu de culte
+  activityCategories:
+    childcare: Garderie ou CPE
+    dropFetchSomeone: Reconduire ou aller chercher quelqu'un
+    home: Domicile
+    kindergarten: Maternelle
+    leisure: Loisirs (promenade, sports, arts, plein air, tourisme, etc.)
+    other: Autre
+    otherParentHome: Domicile de l'autre parent ou tuteur
+    school: École
+    schoolStudies: École / Études
+    shoppingServiceRestaurant: Magasinage, service ou restauration
+    work: Travail
+trip:
+  tripSeq: Déplacement {{seq}}
+  editTrip: Modifier

--- a/packages/evolution-frontend/src/components/survey/sectionTemplates/TripsAndSegmentsSection.tsx
+++ b/packages/evolution-frontend/src/components/survey/sectionTemplates/TripsAndSegmentsSection.tsx
@@ -147,7 +147,7 @@ export const SegmentsSection: React.FC<SectionProps & WithTranslation & WithSurv
                             <img
                                 src={iconPathsByMode[segment.mode]}
                                 style={{ height: '1.5em', marginLeft: '0.3em' }}
-                                alt={props.t(`survey:trip:modes:${segment.mode}`)}
+                                alt={props.t(`segments:mode:short:${segment.mode}`)}
                             />
                         </React.Fragment>
                     );
@@ -164,9 +164,7 @@ export const SegmentsSection: React.FC<SectionProps & WithTranslation & WithSurv
                 key={`survey-trip-item__${i}`}
             >
                 <span className="survey-trip-item-element survey-trip-item-sequence-and-icon">
-                    <em>
-                        {props.t('survey:trip:trip')} {tripSequence}
-                    </em>
+                    <em>{props.t('survey:trip:tripSeq', { seq: tripSequence })}</em>
                 </span>
                 <span className="survey-trip-item-element survey-trip-item-buttons">
                     <FontAwesomeIcon icon={faClock} style={{ marginRight: '0.3rem', marginLeft: '0.6rem' }} />

--- a/packages/evolution-frontend/src/components/survey/sectionTemplates/__tests__/__snapshots__/TripsAndSegmentsSection.test.tsx.snap
+++ b/packages/evolution-frontend/src/components/survey/sectionTemplates/__tests__/__snapshots__/TripsAndSegmentsSection.test.tsx.snap
@@ -37,9 +37,7 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
               class="survey-trip-item-element survey-trip-item-sequence-and-icon"
             >
               <em>
-                trip.trip
-                 
-                1
+                trip.tripSeq
               </em>
             </span>
             <span
@@ -160,7 +158,7 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
             class="no-bullet survey-trip-item survey-trip-item-mode-icons"
           >
             <img
-              alt="trip.modes.walk"
+              alt="mode.short.walk"
               src="/dist/images/modes_icons/walk.png"
               style="height: 1.5em; margin-left: 0.3em;"
             />
@@ -172,9 +170,7 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
               class="survey-trip-item-element survey-trip-item-sequence-and-icon"
             >
               <em>
-                trip.trip
-                 
-                2
+                trip.tripSeq
               </em>
             </span>
             <span
@@ -348,9 +344,7 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
               class="survey-trip-item-element survey-trip-item-sequence-and-icon"
             >
               <em>
-                trip.trip
-                 
-                1
+                trip.tripSeq
               </em>
             </span>
             <span
@@ -503,7 +497,7 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
             class="no-bullet survey-trip-item survey-trip-item-mode-icons"
           >
             <img
-              alt="trip.modes.walk"
+              alt="mode.short.walk"
               src="/dist/images/modes_icons/walk.png"
               style="height: 1.5em; margin-left: 0.3em;"
             />
@@ -568,9 +562,7 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
               class="survey-trip-item-element survey-trip-item-sequence-and-icon"
             >
               <em>
-                trip.trip
-                 
-                1
+                trip.tripSeq
               </em>
             </span>
             <span
@@ -691,7 +683,7 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
             class="no-bullet survey-trip-item survey-trip-item-mode-icons"
           >
             <img
-              alt="trip.modes.walk"
+              alt="mode.short.walk"
               src="/dist/images/modes_icons/walk.png"
               style="height: 1.5em; margin-left: 0.3em;"
             />
@@ -703,9 +695,7 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
               class="survey-trip-item-element survey-trip-item-sequence-and-icon"
             >
               <em>
-                trip.trip
-                 
-                2
+                trip.tripSeq
               </em>
             </span>
             <span
@@ -879,9 +869,7 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
               class="survey-trip-item-element survey-trip-item-sequence-and-icon"
             >
               <em>
-                trip.trip
-                 
-                1
+                trip.tripSeq
               </em>
             </span>
             <span
@@ -980,7 +968,7 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
             class="no-bullet survey-trip-item survey-trip-item-mode-icons survey-trip-item-selected"
           >
             <img
-              alt="trip.modes.walk"
+              alt="mode.short.walk"
               src="/dist/images/modes_icons/walk.png"
               style="height: 1.5em; margin-left: 0.3em;"
             />
@@ -1000,9 +988,7 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
               class="survey-trip-item-element survey-trip-item-sequence-and-icon"
             >
               <em>
-                trip.trip
-                 
-                2
+                trip.tripSeq
               </em>
             </span>
             <span

--- a/packages/evolution-frontend/src/components/survey/widgets/DeleteGroupedObjectButton.tsx
+++ b/packages/evolution-frontend/src/components/survey/widgets/DeleteGroupedObjectButton.tsx
@@ -61,7 +61,7 @@ const DeleteGroupedObjectButton: React.FC<DeleteGroupedObjectButton & WithTransl
     );
     const deleteButtonLabel =
         translateString(props.widgetConfig.groupedObjectDeleteButtonLabel, props.i18n, props.interview, props.path) ||
-        props.t(`survey:${props.shortname}:deleteThisGroupedObject`);
+        props.t([`${props.shortname}:deleteThisGroupedObject`, `survey:${props.shortname}:deleteThisGroupedObject`]);
 
     return showDeleteButton ? (
         <div className="center">


### PR DESCRIPTION
fixes #1104

add commonly used translations in the `TripsAndSegmentsSection` and the `VisitedPlacesSection` templates directly in the Evolution's `survey.yml` files, so that any survey making use of those templates, either directly or copying it, do not have to add all those translations again.