### PR TITLE
ui tests: add missing await before nav status check

### DIFF
--- a/packages/evolution-frontend/tests/ui-testing/testHelpers.ts
+++ b/packages/evolution-frontend/tests/ui-testing/testHelpers.ts
@@ -436,7 +436,7 @@ export const inputSelectTest: InputSelectTest = ({ context, path, value }) => {
         const newPath = context.objectDetector.replaceWithIds(path);
         const option = context.page.locator(`id=survey-question__${newPath}`);
         await option.scrollIntoViewIfNeeded();
-        option.selectOption(value);
+        await option.selectOption(value);
         await expect(option).toHaveValue(value);
         await focusOut(context.page);
     });
@@ -1099,12 +1099,12 @@ export const verifyNavBarButtonStatus: NavBarButtonStatusTest = ({ context, butt
                 break;
         }
 
-        expect(button).toHaveClass(expectedStatusClass);
+        await expect(button).toHaveClass(expectedStatusClass);
 
         if (isDisabled) {
-            await expect(button).toHaveAttribute('disabled');
+            await expect(button).toBeDisabled();
         } else {
-            await expect(button).not.toHaveAttribute('disabled');
+            await expect(button).toBeEnabled();
         }
     });
 };


### PR DESCRIPTION
This caused tests to pass, but failure to be reported outside tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved UI test stability by ensuring button selection and state assertions fully resolve before proceeding, reducing flakiness and false negatives.
  - Makes navbar-related checks more deterministic across browsers and CI environments.
  - No changes to production code or public interfaces; this only strengthens test reliability and clarity when failures occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->