### PR TITLE
Update input map find place test

### DIFF
--- a/packages/evolution-frontend/.eslintignore
+++ b/packages/evolution-frontend/.eslintignore
@@ -4,5 +4,4 @@ node_modules/
 jestSetup.ts
 // The webpack file is not used yet, so it's ignored for now, but it should not be and it should be typescript
 webpack.config.js
-tests/
 playwright-example.config.ts

--- a/packages/evolution-frontend/package.json
+++ b/packages/evolution-frontend/package.json
@@ -21,7 +21,7 @@
     "test:sequential": "echo 'cross-env NODE_ENV=test jest --config=jest.sequential.config.js --runInBand'",
     "test:ui": "echo 'cross-env NODE_ENV=test jest --config=jest.ui.config.js'",
     "lint": "eslint .",
-    "format": "prettier-eslint ./src/**/*.{ts,tsx} --write",
+    "format": "prettier-eslint \"./src/**/*.{ts,tsx}\" \"./tests/**/*.{ts,tsx}\" --write",
     "format:all": "yarn format"
   },
   "dependencies": {

--- a/packages/evolution-frontend/tests/ui-testing/SurveyObjectDetectors.ts
+++ b/packages/evolution-frontend/tests/ui-testing/SurveyObjectDetectors.ts
@@ -12,9 +12,11 @@ const uuidRegex = /[0-9a-f-]{36}/g;
 const personObjectKeyRegex = /^response\.household\.persons\.([0-9a-f-]{36})$/;
 const vehicleObjectKeyRegex = /^response\.household\.vehicles\.([0-9a-f-]{36})$/;
 const journeyObjectKeyRegex = /^response\.household\.persons\.[0-9a-f-]{36}.journeys.[0-9a-f-]{36}$/;
-const visitedPlaceObjectKeyRegex = /^response\.household\.persons\.[0-9a-f-]{36}.journeys.[0-9a-f-]{36}.visitedPlaces.[0-9a-f-]{36}$/;
+const visitedPlaceObjectKeyRegex =
+    /^response\.household\.persons\.[0-9a-f-]{36}.journeys.[0-9a-f-]{36}.visitedPlaces.[0-9a-f-]{36}$/;
 const tripObjectKeyRegex = /^response\.household\.persons\.[0-9a-f-]{36}.journeys.[0-9a-f-]{36}.trips.[0-9a-f-]{36}$/;
-const segmentObjectKeyRegex = /^response\.household\.persons\.[0-9a-f-]{36}.journeys.[0-9a-f-]{36}.trips.[0-9a-f-]{36}.segments.[0-9a-f-]{36}$/;
+const segmentObjectKeyRegex =
+    /^response\.household\.persons\.[0-9a-f-]{36}.journeys.[0-9a-f-]{36}.trips.[0-9a-f-]{36}.segments.[0-9a-f-]{36}$/;
 const activePersonKeyRegex = /^response\._activePersonId$/;
 const activeJourneyKeyRegex = /^response\._activeJourneyId$/;
 const activeVisitedPlaceKeyRegex = /^response\._activeVisitedPlaceId$/;
@@ -59,8 +61,14 @@ export class SurveyObjectDetector {
         return newString;
     }
 
-    private replaceWithActiveObjectId(str: string, activeObjectStr: string, activeObjectId: string | undefined): string {
-        return str.includes(activeObjectStr) && typeof activeObjectId === 'string' ? str.replace(activeObjectStr, activeObjectId) : str;
+    private replaceWithActiveObjectId(
+        str: string,
+        activeObjectStr: string,
+        activeObjectId: string | undefined
+    ): string {
+        return str.includes(activeObjectStr) && typeof activeObjectId === 'string'
+            ? str.replace(activeObjectStr, activeObjectId)
+            : str;
     }
 
     // Replace ${segmentId[n]} with the actual segment ID. The segment is supposed to be for the active trip (there is no activeSegment property)
@@ -140,37 +148,45 @@ export class SurveyObjectDetector {
         // Get the journey objects and store the journey ids
         const journeyObjectsKeys = Object.keys(data).filter((key) => key.match(journeyObjectKeyRegex) !== null);
         if (journeyObjectsKeys.length > 0) {
-            journeyObjectsKeys.map((key) => {
-                const matchGroups = key.match(uuidRegex);
-                if (matchGroups !== null && matchGroups.length === 2) {
-                    return { personId: matchGroups[0], journeyId: matchGroups[1], data: data[key] };
-                }
-                throw `Invalid journey found: ${key}`;
-            }).sort((a, b) => a.data['_sequence'] - b.data['_sequence']).forEach((personJourney) => {
-                if (!this.journeys[personJourney.personId]) {
-                    this.journeys[personJourney.personId] = [];
-                }
-                this.journeys[personJourney.personId].push(personJourney.journeyId);
-            });
+            journeyObjectsKeys
+                .map((key) => {
+                    const matchGroups = key.match(uuidRegex);
+                    if (matchGroups !== null && matchGroups.length === 2) {
+                        return { personId: matchGroups[0], journeyId: matchGroups[1], data: data[key] };
+                    }
+                    throw `Invalid journey found: ${key}`;
+                })
+                .sort((a, b) => a.data['_sequence'] - b.data['_sequence'])
+                .forEach((personJourney) => {
+                    if (!this.journeys[personJourney.personId]) {
+                        this.journeys[personJourney.personId] = [];
+                    }
+                    this.journeys[personJourney.personId].push(personJourney.journeyId);
+                });
         }
     }
 
     private detectVisitedPlaces(data: any) {
         // Get the visited place objects and store the visited places ids
-        const visitedPlaceObjectKeys = Object.keys(data).filter((key) => key.match(visitedPlaceObjectKeyRegex) !== null);
+        const visitedPlaceObjectKeys = Object.keys(data).filter(
+            (key) => key.match(visitedPlaceObjectKeyRegex) !== null
+        );
         if (visitedPlaceObjectKeys.length > 0) {
-            visitedPlaceObjectKeys.map((key) => {
-                const matchGroups = key.match(uuidRegex);
-                if (matchGroups !== null && matchGroups.length === 3) {
-                    return { journeyId: matchGroups[1], visitedPlaceId: matchGroups[2], data: data[key] };
-                }
-                throw `Invalid visited place found: ${key}`;
-            }).sort((a, b) => a.data['_sequence'] - b.data['_sequence']).forEach((journeyVisitedPlace) => {
-                if (!this.visitedPlaces[journeyVisitedPlace.journeyId]) {
-                    this.visitedPlaces[journeyVisitedPlace.journeyId] = [];
-                }
-                this.visitedPlaces[journeyVisitedPlace.journeyId].push(journeyVisitedPlace.visitedPlaceId);
-            });
+            visitedPlaceObjectKeys
+                .map((key) => {
+                    const matchGroups = key.match(uuidRegex);
+                    if (matchGroups !== null && matchGroups.length === 3) {
+                        return { journeyId: matchGroups[1], visitedPlaceId: matchGroups[2], data: data[key] };
+                    }
+                    throw `Invalid visited place found: ${key}`;
+                })
+                .sort((a, b) => a.data['_sequence'] - b.data['_sequence'])
+                .forEach((journeyVisitedPlace) => {
+                    if (!this.visitedPlaces[journeyVisitedPlace.journeyId]) {
+                        this.visitedPlaces[journeyVisitedPlace.journeyId] = [];
+                    }
+                    this.visitedPlaces[journeyVisitedPlace.journeyId].push(journeyVisitedPlace.visitedPlaceId);
+                });
         }
     }
 
@@ -178,18 +194,21 @@ export class SurveyObjectDetector {
         // Get the trip objects and store the trip ids
         const tripObjectKeys = Object.keys(data).filter((key) => key.match(tripObjectKeyRegex) !== null);
         if (tripObjectKeys.length > 0) {
-            tripObjectKeys.map((key) => {
-                const matchGroups = key.match(uuidRegex);
-                if (matchGroups !== null && matchGroups.length === 3) {
-                    return { journeyId: matchGroups[1], tripId: matchGroups[2], data: data[key] };
-                }
-                throw `Invalid trip found: ${key}`;
-            }).sort((a, b) => a.data['_sequence'] - b.data['_sequence']).forEach((journeyTrip) => {
-                if (!this.trips[journeyTrip.journeyId]) {
-                    this.trips[journeyTrip.journeyId] = [];
-                }
-                this.trips[journeyTrip.journeyId].push(journeyTrip.tripId);
-            });
+            tripObjectKeys
+                .map((key) => {
+                    const matchGroups = key.match(uuidRegex);
+                    if (matchGroups !== null && matchGroups.length === 3) {
+                        return { journeyId: matchGroups[1], tripId: matchGroups[2], data: data[key] };
+                    }
+                    throw `Invalid trip found: ${key}`;
+                })
+                .sort((a, b) => a.data['_sequence'] - b.data['_sequence'])
+                .forEach((journeyTrip) => {
+                    if (!this.trips[journeyTrip.journeyId]) {
+                        this.trips[journeyTrip.journeyId] = [];
+                    }
+                    this.trips[journeyTrip.journeyId].push(journeyTrip.tripId);
+                });
         }
     }
 
@@ -197,18 +216,21 @@ export class SurveyObjectDetector {
         // Get the segment objects and store their ids
         const segmentObjectKeys = Object.keys(data).filter((key) => key.match(segmentObjectKeyRegex) !== null);
         if (segmentObjectKeys.length > 0) {
-            segmentObjectKeys.map((key) => {
-                const matchGroups = key.match(uuidRegex);
-                if (matchGroups !== null && matchGroups.length === 4) {
-                    return { tripId: matchGroups[2], segmentId: matchGroups[3], data: data[key] };
-                }
-                throw `Invalid segment found: ${key}`;
-            }).sort((a, b) => a.data['_sequence'] - b.data['_sequence']).forEach((segmentTrip) => {
-                if (!this.segments[segmentTrip.tripId]) {
-                    this.segments[segmentTrip.tripId] = [];
-                }
-                this.segments[segmentTrip.tripId].push(segmentTrip.segmentId);
-            });
+            segmentObjectKeys
+                .map((key) => {
+                    const matchGroups = key.match(uuidRegex);
+                    if (matchGroups !== null && matchGroups.length === 4) {
+                        return { tripId: matchGroups[2], segmentId: matchGroups[3], data: data[key] };
+                    }
+                    throw `Invalid segment found: ${key}`;
+                })
+                .sort((a, b) => a.data['_sequence'] - b.data['_sequence'])
+                .forEach((segmentTrip) => {
+                    if (!this.segments[segmentTrip.tripId]) {
+                        this.segments[segmentTrip.tripId] = [];
+                    }
+                    this.segments[segmentTrip.tripId].push(segmentTrip.segmentId);
+                });
         }
     }
 
@@ -224,10 +246,10 @@ export class SurveyObjectDetector {
         this.detectVisitedPlaces(data);
         this.detectTrips(data);
         this.detectSegments(data);
-        this.detectActiveObject(data, activePersonKeyRegex, (activeId) => this.activePersonId = activeId);
-        this.detectActiveObject(data, activeJourneyKeyRegex, (activeId) => this.activeJourneyId = activeId);
-        this.detectActiveObject(data, activeVisitedPlaceKeyRegex, (activeId) => this.activeVisitedPlaceId = activeId);
-        this.detectActiveObject(data, activeTripKeyRegex, (activeId) => this.activeTripId = activeId);
-        this.detectActiveObject(data, activeVehicleKeyRegex, (activeId) => this.activeVehicleId = activeId);
+        this.detectActiveObject(data, activePersonKeyRegex, (activeId) => (this.activePersonId = activeId));
+        this.detectActiveObject(data, activeJourneyKeyRegex, (activeId) => (this.activeJourneyId = activeId));
+        this.detectActiveObject(data, activeVisitedPlaceKeyRegex, (activeId) => (this.activeVisitedPlaceId = activeId));
+        this.detectActiveObject(data, activeTripKeyRegex, (activeId) => (this.activeTripId = activeId));
+        this.detectActiveObject(data, activeVehicleKeyRegex, (activeId) => (this.activeVehicleId = activeId));
     }
 }

--- a/packages/evolution-frontend/tests/ui-testing/configurei18n.ts
+++ b/packages/evolution-frontend/tests/ui-testing/configurei18n.ts
@@ -9,6 +9,7 @@
 // the backend's approach. This file was copy-pasted and adapted from the
 // chaire-lib-backend/src/config/i18next.ts file.
 import i18next from 'i18next';
+// eslint-disable-next-line n/no-unpublished-import
 import Backend from 'i18next-fs-backend';
 import { join } from 'path';
 import fs from 'fs';

--- a/packages/evolution-frontend/tests/ui-testing/surveyTestHelpers.ts
+++ b/packages/evolution-frontend/tests/ui-testing/surveyTestHelpers.ts
@@ -34,10 +34,7 @@ export const startAndLoginAnonymously = ({
  * @param {testHelpers.CommonTestParameters} params.context - The test context.
  * @param {string} params.title - The expected title of the survey landing page.
  */
-export const startSurvey = ({
-    context,
-    title,
-}: { title: string; } & testHelpers.CommonTestParameters) => {
+export const startSurvey = ({ context, title }: { title: string } & testHelpers.CommonTestParameters) => {
     // Test the survey landing page
     testHelpers.hasTitleTest({ title, context });
     testHelpers.hasFrenchTest({ context });
@@ -68,12 +65,17 @@ export const startAndLoginWithAccessAndPostalCodes = ({
     postalCode,
     expectedToExist,
     nextPageUrl
-}: { title: string; accessCode: string; postalCode: string; expectedToExist?: boolean; nextPageUrl?: string } & testHelpers.CommonTestParameters) => {
+}: {
+    title: string;
+    accessCode: string;
+    postalCode: string;
+    expectedToExist?: boolean;
+    nextPageUrl?: string;
+} & testHelpers.CommonTestParameters) => {
     startSurvey({ context, title });
 
     // Test the login page
     testHelpers.registerWithAccessPostalCodeTest({ context, postalCode, accessCode, expectedToExist, nextPageUrl });
-
 };
 
 /**

--- a/packages/evolution-frontend/tests/ui-testing/testHelpers.ts
+++ b/packages/evolution-frontend/tests/ui-testing/testHelpers.ts
@@ -5,6 +5,7 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import moment from 'moment';
+// eslint-disable-next-line n/no-unpublished-import
 import { test, expect, Page, Browser, Locator } from '@playwright/test';
 import configureI18n, { registerTranslationDir } from './configurei18n';
 import { SurveyObjectDetector } from './SurveyObjectDetectors';
@@ -165,7 +166,7 @@ export const initializeTestPage = async (
 
 // Close the browser after all the tests
 test.afterAll(async ({ browser }) => {
-    browser.close;
+    await browser.close();
 });
 
 const getTestCounter = (context: CommonTestParameters['context'], testKey: string) => {
@@ -386,7 +387,7 @@ export const inputRadioInvalidTest: InputRadioTest = ({ context, path, value }) 
         const radioLocator = (await inputRadio({ context, path, value })) as Locator;
         // Filter is used to find parent container instead of locator(".."), as not all input fields are located at the same depth inside their question container
         const questionContainer = context.page
-            .locator("//div[contains(@class, 'form-container')]")
+            .locator('//div[contains(@class, \'form-container\')]')
             .filter({ has: radioLocator });
         await expect(questionContainer).toHaveClass(/question-filled question-invalid/);
     });
@@ -554,7 +555,7 @@ export const inputStringInvalidValueTest: InputStringTest = ({ context, path, va
 
         // Filter is used to find parent container instead of locator(".."), as not all input fields are located at the same depth inside their question container
         const questionContainer = context.page
-            .locator("//div[contains(@class, 'form-container')]")
+            .locator('//div[contains(@class, \'form-container\')]')
             .filter({ has: inputLocator });
         await expect(questionContainer).toHaveClass(/question-filled question-invalid/);
     });
@@ -683,7 +684,7 @@ const fetchGoogleMapsApiResponse: FetchGoogleMapsApiResponse = async ({ context,
             } catch (error) {
                 if (attempts <= maxRetries) {
                     console.log(
-                        `No response received from Google Maps, retrying in 5 seconds... (Attempt ${attempts} of ${maxRetries})`
+                        `No response received from Google Maps, retrying in 5 seconds... (Attempt ${attempts} of ${maxRetries} with error ${error?.message})`
                     );
                     attempts++;
                     await new Promise((resolve) => setTimeout(resolve, 5000)); // Wait for 5 seconds before retrying
@@ -785,8 +786,8 @@ export const inputMapFindPlaceTest: InputMapFindPlaceTest = ({ context, path }) 
  * @param {Object} options - The options for the test.
  */
 export const waitForMapToBeLoaded: WaitForMapLoadedTest = ({ context }) => {
-    test(`Wait for map to be loaded`, async () => {
-        const mapContainer = context.page.locator("//div[contains(@class, 'question-type-mapPoint')]");
+    test('Wait for map to be loaded', async () => {
+        const mapContainer = context.page.locator('//div[contains(@class, \'question-type-mapPoint\')]');
         await expect(mapContainer).toBeVisible();
         await mapContainer.scrollIntoViewIfNeeded();
         await expect(mapContainer).toHaveClass(/question-filled question-valid/);
@@ -988,7 +989,7 @@ export const tryToContinueWithInvalidInputs: ContinueWithInvalidEntriesTest = ({
 }) => {
     test(`Clicking ${text} when options are invalid should keep you on ${currentPageUrl} - ${getTestCounter(context, `${text} - ${currentPageUrl} - ${nextPageUrl}`)}`, async () => {
         await tryToContinueOnInvalidPage({ context, text, currentPageUrl, nextPageUrl });
-        const inputBoxes = context.page.locator("//div[contains(@class, 'form-container')]");
+        const inputBoxes = context.page.locator('//div[contains(@class, \'form-container\')]');
         const inputNumber = await inputBoxes.count();
         let hasInvalidClass = false;
         for (let i = 0; i < inputNumber; i++) {
@@ -1096,22 +1097,22 @@ export const pageRedirectionTest: RedirectionTest = ({ context, buttonText, expe
  */
 export const verifyNavBarButtonStatus: NavBarButtonStatusTest = ({ context, buttonText, buttonStatus, isDisabled }) => {
     test(`The ${buttonText} navigation button should have the '${buttonStatus}' status - ${getTestCounter(context, `${buttonText} - ${buttonStatus}`)}`, async () => {
-        const navBar = context.page.locator("div[class='survey-section-nav']");
+        const navBar = context.page.locator('div[class=\'survey-section-nav\']');
         const button = navBar.getByText(buttonText);
         let expectedStatusClass;
         switch (buttonStatus) {
-            case 'completed':
-                expectedStatusClass = 'nav-button completed-section';
-                break;
-            case 'active':
-                expectedStatusClass = 'nav-button active-section';
-                break;
-            case 'activeAndCompleted':
-                expectedStatusClass = 'nav-button active-section completed-section';
-                break;
-            case 'inactive':
-                expectedStatusClass = 'nav-button';
-                break;
+        case 'completed':
+            expectedStatusClass = 'nav-button completed-section';
+            break;
+        case 'active':
+            expectedStatusClass = 'nav-button active-section';
+            break;
+        case 'activeAndCompleted':
+            expectedStatusClass = 'nav-button active-section completed-section';
+            break;
+        case 'inactive':
+            expectedStatusClass = 'nav-button';
+            break;
         }
 
         await expect(button).toHaveClass(expectedStatusClass);
@@ -1133,7 +1134,7 @@ export const verifyNavBarButtonStatus: NavBarButtonStatusTest = ({ context, butt
  */
 export const changePageFromNavBar: ChangePageFromNavBarTest = ({ context, buttonText, nextPageUrl }) => {
     test(`Click ${buttonText} in the nav bar and check that it goes to ${nextPageUrl} ${getTestCounter(context, `${buttonText} - ${nextPageUrl}`)}`, async () => {
-        const navBar = context.page.locator("div[class='survey-section-nav']");
+        const navBar = context.page.locator('div[class=\'survey-section-nav\']');
         const button = navBar.getByText(buttonText);
         await button.scrollIntoViewIfNeeded();
         await button.click();
@@ -1152,7 +1153,7 @@ export const changePageFromNavBar: ChangePageFromNavBarTest = ({ context, button
 export const sectionProgressBarTest: SectionProgressBarTest = ({ context, sectionName, completionPercentage }) => {
     test(`Validate progress bar for section "${sectionName}" with ${completionPercentage}% completion ${getTestCounter(context, `${sectionName} - ${completionPercentage}`)}`, async () => {
         // Locate the progress bar section
-        const progressBarSection = context.page.locator("//div[contains(@class, 'survey-section__progress-bar')]");
+        const progressBarSection = context.page.locator('//div[contains(@class, \'survey-section__progress-bar\')]');
         await progressBarSection.scrollIntoViewIfNeeded();
 
         // Verify the section name is displayed in the progress bar
@@ -1223,7 +1224,7 @@ export const solveCaptcha = async ({ context }: CommonTestParameters): Promise<v
         });
 
         if (!clicked) {
-            throw new Error("Couldn't find captcha element to click");
+            throw new Error('Couldn\'t find captcha element to click');
         }
 
         // Wait for the captcha to be verified using JavaScript evaluation
@@ -1307,7 +1308,7 @@ export const solveCaptcha = async ({ context }: CommonTestParameters): Promise<v
                 });
 
                 if (!isVerified) {
-                    console.log("First click didn't work, trying different position");
+                    console.log('First click didn\'t work, trying different position');
                     await context.page.mouse.click(
                         boundingBox.x + boundingBox.width / 2,
                         boundingBox.y + boundingBox.height / 2

--- a/packages/evolution-frontend/tests/ui-testing/testHelpers.ts
+++ b/packages/evolution-frontend/tests/ui-testing/testHelpers.ts
@@ -756,14 +756,16 @@ export const inputMapFindPlaceTest: InputMapFindPlaceTest = ({ context, path }) 
             await refreshButton.click();
         }
 
-        if (resultsNumber >= 2) {
-            // If multiple results
-            const select = inputMap.locator(`id=survey-question__${newPath}_mapFindPlace`);
+        // If there is at least one result and the select input exists, select the first option and confirm.
+        // Note: This is necessary because sometimes the select input appears with only one available option.
+        const select = inputMap.locator(`id=survey-question__${newPath}_mapFindPlace`);
+        if (resultsNumber >= 1 && (await select.count()) > 0) {
+            // Select the first option from the dropdown
             await select.focus(); // Focus on the select element
             await select.press('ArrowDown'); // take the first option from select
             await select.press('Enter');
 
-            // Confirm place
+            // Confirm place selection
             const confirmButton = inputMap.locator(`id=survey-question__${newPath}_confirm`);
             await expect(confirmButton).toBeVisible();
             await confirmButton.click();


### PR DESCRIPTION
# Pull request

## Description
format testHelpers

Tests: Update logic to handle single result selection with inputMapFindPlaceTest
If there is at least one result and the select input exists, select the first option and confirm.
Note: This is necessary because sometimes the select input appears with only one available option.

Format: Format files in tests folder. 
Update 'yarn format' of evolution-frontend.
Fix some lint problems or ignore the one that was not true.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Map location selection now works when only a single result is available, preventing dead-ends during address lookup.
  - CAPTCHA verification improved and made more reliable (including within shadow DOM scenarios), reducing stalls during verification.

- Improvements
  - Survey start flow now includes language switching, consent handling, and a smoother survey start for better onboarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->