### PR TITLE
segments: fix icon in the trips and segment template

### DIFF
--- a/packages/evolution-frontend/src/components/survey/sectionTemplates/TripsAndSegmentsSection.tsx
+++ b/packages/evolution-frontend/src/components/survey/sectionTemplates/TripsAndSegmentsSection.tsx
@@ -23,7 +23,7 @@ import * as helpers from 'evolution-common/lib/utils/helpers';
 import { secondsSinceMidnightToTimeStrWithSuffix } from '../../../services/display/frontendHelper';
 import { loopActivities } from 'evolution-common/lib/services/odSurvey/types';
 import { VisitedPlace } from 'evolution-common/lib/services/questionnaire/types';
-import { getActivityMarkerIcon } from 'evolution-common/lib/services/questionnaire/sections/visitedPlaces/activityIconMapping';
+import { getActivityIcon } from 'evolution-common/lib/services/questionnaire/sections/visitedPlaces/activityIconMapping';
 
 export const SegmentsSection: React.FC<SectionProps & WithTranslation & WithSurveyContextProps> = (
     props: SectionProps & WithTranslation & WithSurveyContextProps
@@ -199,7 +199,7 @@ export const SegmentsSection: React.FC<SectionProps & WithTranslation & WithSurv
                 >
                     <span className="survey-trip-item-element survey-trip-item-origin-description">
                         <img
-                            src={getActivityMarkerIcon(origin.activity)}
+                            src={getActivityIcon(origin.activity)}
                             style={{ height: '4rem' }}
                             alt={props.t(`visitedPlaces/activities/${origin.activity}`)}
                         />
@@ -218,7 +218,7 @@ export const SegmentsSection: React.FC<SectionProps & WithTranslation & WithSurv
                     </span>
                     <span className="survey-trip-item-element survey-trip-item-destination-description">
                         <img
-                            src={getActivityMarkerIcon(destination.activity)}
+                            src={getActivityIcon(destination.activity)}
                             style={{ height: '4rem' }}
                             alt={props.t(`visitedPlaces/activities/${destination.activity}`)}
                         />
@@ -242,7 +242,7 @@ export const SegmentsSection: React.FC<SectionProps & WithTranslation & WithSurv
                             </span>
                             <span className="survey-trip-item-element survey-trip-item-destination-description">
                                 <img
-                                    src={getActivityMarkerIcon(nextDestination.activity)}
+                                    src={getActivityIcon(nextDestination.activity)}
                                     style={{ height: '4rem' }}
                                     alt={props.t(`visitedPlaces/activities/${nextDestination.activity}`)}
                                 />

--- a/packages/evolution-frontend/src/components/survey/sectionTemplates/__tests__/__snapshots__/TripsAndSegmentsSection.test.tsx.snap
+++ b/packages/evolution-frontend/src/components/survey/sectionTemplates/__tests__/__snapshots__/TripsAndSegmentsSection.test.tsx.snap
@@ -109,7 +109,7 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
             >
               <img
                 alt="visitedPlaces/activities/activity1"
-                src="/dist/icons/activities/other/question_mark-marker_round.svg"
+                src="/dist/icons/activities/other/question_mark.svg"
                 style="height: 4rem;"
               />
               <span>
@@ -146,7 +146,7 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
             >
               <img
                 alt="visitedPlaces/activities/activity2"
-                src="/dist/icons/activities/other/question_mark-marker_round.svg"
+                src="/dist/icons/activities/other/question_mark.svg"
                 style="height: 4rem;"
               />
               <span>
@@ -241,7 +241,7 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
             >
               <img
                 alt="visitedPlaces/activities/activity2"
-                src="/dist/icons/activities/other/question_mark-marker_round.svg"
+                src="/dist/icons/activities/other/question_mark.svg"
                 style="height: 4rem;"
               />
               <span>
@@ -273,7 +273,7 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
             >
               <img
                 alt="visitedPlaces/activities/activity3"
-                src="/dist/icons/activities/other/question_mark-marker_round.svg"
+                src="/dist/icons/activities/other/question_mark.svg"
                 style="height: 4rem;"
               />
               <span>
@@ -416,7 +416,7 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
             >
               <img
                 alt="visitedPlaces/activities/activity1"
-                src="/dist/icons/activities/other/question_mark-marker_round.svg"
+                src="/dist/icons/activities/other/question_mark.svg"
                 style="height: 4rem;"
               />
               <span>
@@ -453,7 +453,7 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
             >
               <img
                 alt="visitedPlaces/activities/workOnTheRoad"
-                src="/dist/icons/activities/work/truck_with_road-marker_round.svg"
+                src="/dist/icons/activities/work/truck_with_road.svg"
                 style="height: 4rem;"
               />
               <span>
@@ -485,7 +485,7 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
             >
               <img
                 alt="visitedPlaces/activities/activity3"
-                src="/dist/icons/activities/other/question_mark-marker_round.svg"
+                src="/dist/icons/activities/other/question_mark.svg"
                 style="height: 4rem;"
               />
               <span>
@@ -634,7 +634,7 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
             >
               <img
                 alt="visitedPlaces/activities/workOnTheRoad"
-                src="/dist/icons/activities/work/truck_with_road-marker_round.svg"
+                src="/dist/icons/activities/work/truck_with_road.svg"
                 style="height: 4rem;"
               />
               <span>
@@ -671,7 +671,7 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
             >
               <img
                 alt="visitedPlaces/activities/activity2"
-                src="/dist/icons/activities/other/question_mark-marker_round.svg"
+                src="/dist/icons/activities/other/question_mark.svg"
                 style="height: 4rem;"
               />
               <span>
@@ -766,7 +766,7 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
             >
               <img
                 alt="visitedPlaces/activities/activity2"
-                src="/dist/icons/activities/other/question_mark-marker_round.svg"
+                src="/dist/icons/activities/other/question_mark.svg"
                 style="height: 4rem;"
               />
               <span>
@@ -798,7 +798,7 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
             >
               <img
                 alt="visitedPlaces/activities/activity3"
-                src="/dist/icons/activities/other/question_mark-marker_round.svg"
+                src="/dist/icons/activities/other/question_mark.svg"
                 style="height: 4rem;"
               />
               <span>
@@ -919,7 +919,7 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
             >
               <img
                 alt="visitedPlaces/activities/activity1"
-                src="/dist/icons/activities/other/question_mark-marker_round.svg"
+                src="/dist/icons/activities/other/question_mark.svg"
                 style="height: 4rem;"
               />
               <span>
@@ -956,7 +956,7 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
             >
               <img
                 alt="visitedPlaces/activities/activity2"
-                src="/dist/icons/activities/other/question_mark-marker_round.svg"
+                src="/dist/icons/activities/other/question_mark.svg"
                 style="height: 4rem;"
               />
               <span>
@@ -1037,7 +1037,7 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
             >
               <img
                 alt="visitedPlaces/activities/activity2"
-                src="/dist/icons/activities/other/question_mark-marker_round.svg"
+                src="/dist/icons/activities/other/question_mark.svg"
                 style="height: 4rem;"
               />
               <span>
@@ -1069,7 +1069,7 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
             >
               <img
                 alt="visitedPlaces/activities/activity3"
-                src="/dist/icons/activities/other/question_mark-marker_round.svg"
+                src="/dist/icons/activities/other/question_mark.svg"
                 style="height: 4rem;"
               />
               <span>


### PR DESCRIPTION
They wrongly used the marker icons, but the icons are not in a map context so it needs to be the icon without marker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized the activity icon reference used in trip and segment visuals for origin, destination, and next destination, improving naming consistency across the interface.
  - No changes to functionality or behavior; icons render as before.
  - This is a non-user-facing update aimed at consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->