### PR TITLE
inputTime: add `datatype` property and set to integer

### DIFF
--- a/packages/evolution-common/src/services/questionnaire/types/WidgetConfig.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/WidgetConfig.ts
@@ -206,6 +206,7 @@ export type InputButtonType = BaseQuestionType & {
 
 export type InputTimeType = BaseQuestionType & {
     inputType: 'time';
+    datatype: 'integer';
     suffixTimes?: ParsingFunction<{ [timeStr: string]: string }>;
     minTimeSecondsSinceMidnight?: number | ParsingFunction<number>;
     maxTimeSecondsSinceMidnight?: number | ParsingFunction<number>;

--- a/packages/evolution-frontend/src/components/inputs/defaultInputBase.ts
+++ b/packages/evolution-frontend/src/components/inputs/defaultInputBase.ts
@@ -19,6 +19,7 @@ import {
     InputSelectType,
     InputStringType,
     InputTextType,
+    InputTimeType,
     TextWidgetConfig
 } from 'evolution-common/lib/services/questionnaire/types';
 import { validateButtonActionWithCompleteSection } from '../../services/display/frontendHelper';
@@ -88,6 +89,13 @@ export const inputSelectBase: Pick<InputSelectType, 'type' | 'inputType' | 'data
     type: 'question',
     inputType: 'select',
     datatype: 'string'
+};
+
+// InputTime default params
+export const inputTimeBase: Pick<InputTimeType, 'type' | 'inputType' | 'datatype'> = {
+    type: 'question',
+    inputType: 'time',
+    datatype: 'integer'
 };
 
 // Next button default params


### PR DESCRIPTION
fixes #1126

The `InputTime` component expects an integer value, so it should be the only datatype that such a component should take.

This also adds a base params for the inputTime widgets, with the datatype set.