### PR TITLE
admin: add the `verify/:token` link to the router

### DIFF
--- a/locales/en/auth.json
+++ b/locales/en/auth.json
@@ -77,6 +77,11 @@
     "solvedLabel": "Verified",
     "errorLabel": "Error, please retry"    
   },
-  "captchaRequired": "Please complete the CAPTCHA to submit your message."
+  "captchaRequired": "Please complete the CAPTCHA to submit your message.",
+  "ConfirmationTokenConfirming": "New account confirmation in progress...",
+  "ConfirmationTokenConfirmed": "The new account is now active!",
+  "ConfirmationTokenNotFound": "The confirmation code was not found in the database. Is the account already active?",
+  "ConfirmationTokenError": "An error occurred while confirming a new user account. If login is impossible and the error persists, contact the site's administrator for more information.",
+  "UnconfirmedUser": "You user account has not been confirmed. You or an administrator should receive an email with a link to confirm your account. Check your emails or contact the site's administrator."
 }
   

--- a/locales/en/server.json
+++ b/locales/en/server.json
@@ -14,5 +14,7 @@
     "supportRequestSubject": "Support request for {{surveyName}}",
     "supportRequestMessage": "Hello,\n\nYou have received a support request from ({{userEmail}}) for the survey {{surveyName}}.{{supportInterviewID}}{{currentPageUrl}}\n\nMessage:\n{{message}}\n\nThank you",
     "supportInterviewID": "\n\nInterview ID: {{interviewId}}",
-    "currentPageUrl": "\n\nURL of the page: {{currentUrl}}"
+    "currentPageUrl": "\n\nURL of the page: {{currentUrl}}",
+    "confirmedByAdminEmailSubject": "Evolution: account confirmed",
+    "confirmedByAdminEmailText": "Hi {{name}},\n\nyour access request to the Evolution platform has been confirmed. You can now use your account."
 }

--- a/locales/fr/auth.json
+++ b/locales/fr/auth.json
@@ -77,5 +77,10 @@
     "solvedLabel": "Vérifié",
     "errorLabel": "Erreur, veuillez réessayer"    
   },
-  "captchaRequired": "Veuillez confirmer que vous n'êtes pas un robot en cochant la case ci-dessous."
+  "captchaRequired": "Veuillez confirmer que vous n'êtes pas un robot en cochant la case ci-dessous.",
+  "ConfirmationTokenConfirming": "Confirmation du nouveau compte usager en cours...",
+  "ConfirmationTokenConfirmed": "Le compte usager est maintenant activé!",
+  "ConfirmationTokenNotFound": "Le code de confirmation n'a pas été trouvé dans la base de données. Le compte usager est peut-être déjà activé?",
+  "ConfirmationTokenError": "Une erreur est survenue lors de la confirmation du compte usager. S'il est impossible de se connecter au site et que la situation persiste, contactez l'administrateur du site pour plus d'information.",
+  "UnconfirmedUser": "Votre compte usager n'a pas été confirmé. Vous ou un administrateur recevrez un courriel avec un lien pour confirmer le compte. Vérifiez vos courriels ou contactez l'administrateur du site."
 }

--- a/locales/fr/server.json
+++ b/locales/fr/server.json
@@ -14,5 +14,7 @@
     "supportRequestSubject": "Demande d'assistance sur {{surveyName}}",
     "supportRequestMessage": "Bonjour,\n\nVous avez reçu une demande d'assistance de la part de ({{userEmail}}) pour l'enquête {{surveyName}}.{{supportInterviewID}}{{currentPageUrl}}\n\nMessage:\n{{message}}\n\nMerci",
     "supportInterviewID": "\n\nID de l'entrevue: {{interviewId}}",
-    "currentPageUrl": "\n\nURL de la page actuelle: {{currentUrl}}"
+    "currentPageUrl": "\n\nURL de la page actuelle: {{currentUrl}}",
+    "confirmedByAdminEmailSubject": "Evolution: compte confirmé",
+    "confirmedByAdminEmailText": "Bonjour {{name}},\n\nVotre accès à la plateforme d'enquête Evolution a été confirmé. Vous pouvez maintenant utiliser votre compte."
 }

--- a/packages/evolution-frontend/src/components/admin/routers/AdminSurveyRouter.tsx
+++ b/packages/evolution-frontend/src/components/admin/routers/AdminSurveyRouter.tsx
@@ -15,9 +15,11 @@ import MaintenancePage from 'chaire-lib-frontend/lib/components/pages/Maintenanc
 import { LoginPage as AdminLoginPage } from 'chaire-lib-frontend/lib/components/pages';
 import AdminRegisterPage from 'chaire-lib-frontend/lib/components/pages/RegisterPage';
 import ForgotPasswordPage from 'chaire-lib-frontend/lib/components/pages/ForgotPasswordPage';
+import VerifyPage from 'chaire-lib-frontend/lib/components/pages/VerifyPage';
 import Survey from '../../hoc/SurveyWithErrorBoundary';
 import PrivateRoute from 'chaire-lib-frontend/lib/components/routers/PrivateRoute';
 import ResetPasswordPage from 'chaire-lib-frontend/lib/components/pages/ResetPasswordPage';
+import UnconfirmedPage from 'chaire-lib-frontend/lib/components/pages/UnconfirmedPage';
 import PublicRoute from 'chaire-lib-frontend/lib/components/routers/PublicRoute';
 import AdminRoute from 'chaire-lib-frontend/lib/components/routers/AdminRoute';
 import config from 'chaire-lib-common/lib/config/shared/project.config';
@@ -47,6 +49,8 @@ const AdminSurveyRouter: React.FunctionComponent = () => (
         <Route path="/login" element={<PublicRoute component={AdminLoginPage} />} />
         <Route path="/register" element={<PublicRoute component={AdminRegisterPage} />} />
         <Route path="/forgot" element={<PublicRoute component={ForgotPasswordPage} />} />
+        <Route path="/unconfirmed" element={<PublicRoute component={UnconfirmedPage} />} />
+        <Route path="/verify/:token" element={<PublicRoute component={VerifyPage} />} />
         <Route path="/reset/:token" element={<PublicRoute component={ResetPasswordPage} />} />
         <Route path="/unauthorized" element={<PublicRoute component={UnauthorizedPage} />} />
         <Route


### PR DESCRIPTION
fixes #1144

This will allow to validate user accounts if they need confirmation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public account verification page accessible via tokenized link for confirming accounts without signing in.
  * User-facing account confirmation status messages: confirming, confirmed, not found, and error.

* **Localization**
  * Full English and French translations for all confirmation states.
  * Added English and French admin-confirmation email subject/body templates to notify users when access is approved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->