### PR TITLE
validations: validate phone number with parentheses

### DIFF
--- a/locales/en/survey.yml
+++ b/locales/en/survey.yml
@@ -148,3 +148,4 @@ errors:
   postalCodeInvalid: "Postal code is invalid."
   postalCodeInvalid_canada: "Postal code is invalid. You must live in Canada to fill this questionnaire."
   postalCodeInvalid_quebec: "Postal code is invalid. You must live in Quebec to fill this questionnaire."
+  phoneNumberInvalid: "Phone number is invalid (e.g.: 514-123-1234 or +44 20 7946 0958)."

--- a/locales/fr/survey.yml
+++ b/locales/fr/survey.yml
@@ -158,3 +158,4 @@ errors:
   postalCodeInvalid: "Le code postal est invalide."
   postalCodeInvalid_canada: "Le code postal est invalide. Vous devez résider au Canada pour compléter ce questionnaire.."
   postalCodeInvalid_quebec: "Le code postal est invalide. Vous devez résider au Québec pour compléter ce questionnaire."
+  phoneNumberInvalid: "Le numéro de téléphone est invalide. (ex.: 514-123-1234 ou +33 1 23 45 67 89)."

--- a/packages/evolution-common/src/services/widgets/validations/validations.ts
+++ b/packages/evolution-common/src/services/widgets/validations/validations.ts
@@ -286,21 +286,29 @@ export const emailValidation: ValidationFunction = (value) => {
     ];
 };
 
+// Regexes developed from discussion with AI
+const northAmericanPhoneValidationRegex =
+    /^(?:(?:\+1[-.\s]?|(?!1)?)?(?:\(?([2-9][0-9]{2})\)?[-.\s]?)?([0-9]{3})[-.\s]?([0-9]{4}))$/;
+const internationalNotNaPhoneValidationRegex = /^(?:\+(?:[\s\-.()]*\d){10,15}[\s\-.()]*$)/;
+const validateNorthAmericanOrInternationalPhoneNumber = (phoneNumber: string) =>
+    northAmericanPhoneValidationRegex.test(phoneNumber) || internationalNotNaPhoneValidationRegex.test(phoneNumber);
 /**
  * Verify if the value is a valid phone number. This validation is optional.
+ * Note if only validates the format, not the content.
  *
  * The phone number must be in the format 123-456-7890.
+ *
+ * TODO This validation is from a north american perspective, ie numbers in
+ * north america do not need the country code, other international numbers do.
+ * We should support more localizations in the future.
  *
  * @see {@link ValidationFunction}
  */
 export const phoneValidation: ValidationFunction = (value) => {
     return [
         {
-            validation: !_isBlank(value) && !/^\d{3}[-\s]?\d{3}[-\s]?\d{4}$/.test(String(value)), // Accept 3 numbers, a dash space or nothing, 3 numbers, a dash space or nothing, 4 numbers
-            errorMessage: {
-                fr: 'Le numéro de téléphone est invalide. (ex.: 514-123-1234).',
-                en: 'Phone number is invalid (e.g.: 514-123-1234).'
-            }
+            validation: !_isBlank(value) && !validateNorthAmericanOrInternationalPhoneNumber(String(value)),
+            errorMessage: (t) => t('survey:errors:phoneNumberInvalid')
         }
     ];
 };


### PR DESCRIPTION
fixes #1147

Also add unit tests for the phone number validations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved phone number validation to better accept common North American and international formats and reduce false positives/negatives; error messaging now uses localized strings.

* **Tests**
  * Added comprehensive unit tests covering many valid and invalid phone number formats (North American, international, empty input) for consistent behavior.

* **Localization**
  * Added English and French localized phone number error messages with example formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->