### PR TITLE
update activities icon mapping

### DIFF
--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/activityIconMapping.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/activityIconMapping.ts
@@ -18,20 +18,19 @@ const activityToIconPathMapping: Record<ActivityCategory | Activity | 'default',
 
     // Home activities
     home: '/dist/icons/activities/home/home',
-    otherParentHome: '/dist/icons/activities/home/home',
-    // FIXME Validate this icon, it's using the 2 persons icon, as in the previous surveys, but its name is accompany_someone
-    visiting: '/dist/icons/activities/accompany_drop_fetch_someone/accompany_someone',
+    otherParentHome: '/dist/icons/activities/home/home_secondary',
+    visiting: '/dist/icons/activities/other/two_persons',
     secondaryHome: '/dist/icons/activities/home/home_secondary',
 
     // Work/school related activities
     work: '/dist/icons/activities/work/briefcase',
     school: '/dist/icons/activities/school/graduation_cap',
     workUsual: '/dist/icons/activities/work/briefcase',
-    workNotUsual: '/dist/icons/activities/work/building_office',
-    workOnTheRoad: '/dist/icons/activities/work/truck_with_road',
+    workNotUsual: '/dist/icons/activities/work/worker_with_necktie',
+    workOnTheRoad: '/dist/icons/activities/work/truck',
     schoolUsual: '/dist/icons/activities/school/graduation_cap',
-    schoolNotUsual: '/dist/icons/activities/school/school_building_small',
-    schoolNotStudent: '/dist/icons/activities/school/graduation_cap',
+    schoolNotUsual: '/dist/icons/activities/school/school_building_large',
+    schoolNotStudent: '/dist/icons/activities/school/school_building_large',
 
     // Service and leisure activities
     shoppingServiceRestaurant: '/dist/icons/activities/shopping/shopping_cart',
@@ -56,7 +55,7 @@ const activityToIconPathMapping: Record<ActivityCategory | Activity | 'default',
     volunteering: '/dist/icons/activities/other/volunteering',
     carElectricChargingStation: '/dist/icons/activities/other/electric_charging_station',
     carsharingStation: '/dist/icons/activities/other/carsharing_station',
-    pickClassifiedPurchase: '/dist/icons/activities/shopping/shopping_basket',
+    pickClassifiedPurchase: '/dist/icons/activities/shopping/shopping_basket_with_home',
 
     // Other options
     other: '/dist/icons/activities/other/question_mark',

--- a/packages/evolution-frontend/src/components/survey/sectionTemplates/__tests__/__snapshots__/TripsAndSegmentsSection.test.tsx.snap
+++ b/packages/evolution-frontend/src/components/survey/sectionTemplates/__tests__/__snapshots__/TripsAndSegmentsSection.test.tsx.snap
@@ -453,7 +453,7 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
             >
               <img
                 alt="visitedPlaces/activities/workOnTheRoad"
-                src="/dist/icons/activities/work/truck_with_road-marker_round.svg"
+                src="/dist/icons/activities/work/truck-marker_round.svg"
                 style="height: 4rem;"
               />
               <span>
@@ -634,7 +634,7 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
             >
               <img
                 alt="visitedPlaces/activities/workOnTheRoad"
-                src="/dist/icons/activities/work/truck_with_road-marker_round.svg"
+                src="/dist/icons/activities/work/truck-marker_round.svg"
                 style="height: 4rem;"
               />
               <span>


### PR DESCRIPTION
these changes make icons more like previous surveys and are more precise

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Style
  - Refreshed activity icons in the Visited Places questionnaire for clearer visuals and consistency.
  - Updated icons for Other Parent’s Home (secondary home), Visiting (two persons), Work Not Usual (worker with necktie), Work On The Road (truck), School Not Usual and School Not Student (large school building), and Pick Classified Purchase (shopping basket with home).
  - No user flow changes; only visual updates to activity markers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->