### PR TITLE
increase icon size for segment mode

### DIFF
--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetSegmentMode.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetSegmentMode.test.ts
@@ -39,7 +39,7 @@ describe('getModeWidgetConfig', () => {
             inputType: 'radio',
             twoColumns: false,
             datatype: 'string',
-            iconSize: '1.5em',
+            iconSize: '2.25em',
             columns: 2,
             label: expect.any(Function),
             choices: modeValues.map((mode) => expect.objectContaining({

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetSegmentModePre.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetSegmentModePre.test.ts
@@ -35,7 +35,7 @@ describe('getModePreWidgetConfig', () => {
             inputType: 'radio',
             twoColumns: false,
             datatype: 'string',
-            iconSize: '1.5em',
+            iconSize: '2.25em',
             columns: 2,
             label: expect.any(Function),
             choices: expect.arrayContaining([

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/widgetSegmentMode.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/widgetSegmentMode.ts
@@ -65,7 +65,7 @@ export const getModeWidgetConfig = (
         inputType: 'radio',
         twoColumns: false,
         datatype: 'string',
-        iconSize: '1.5em',
+        iconSize: '2.25em',
         columns: 2,
         label: (t: TFunction) =>
             t(['customSurvey:segments:ModeSpecify', 'segments:ModeSpecify'], {

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/widgetSegmentModePre.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/widgetSegmentModePre.ts
@@ -100,7 +100,7 @@ export const getModePreWidgetConfig = (
         inputType: 'radio',
         twoColumns: false,
         datatype: 'string',
-        iconSize: '1.5em',
+        iconSize: '2.25em',
         columns: 2,
         label: (t: TFunction, interview, path) => {
             const person = odHelpers.getPerson({ interview });


### PR DESCRIPTION
mode icons were too small after icons update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Style
  - Increased icon size for segment mode widgets (standard and pre-mode) for improved visibility and touch targets; visual-only change with no behavioral impact.
- Tests
  - Updated test expectations to match the new icon size.
- Chores
  - Removed an internal FIXME comment related to an activity icon mapping (no runtime or API changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->