### PR TITLE
validations: support Canada or Quebec postal code validations

### DIFF
--- a/example/demo_generator/config.js
+++ b/example/demo_generator/config.js
@@ -65,6 +65,7 @@ module.exports = {
             lng: -72.9215
         }
     ],
+    postalCodeRegion: 'canada',
     detectLanguageFromUrl: true,
     detectLanguage: true,
     languages: ['fr', 'en'],

--- a/example/demo_survey/config.js
+++ b/example/demo_survey/config.js
@@ -55,6 +55,7 @@ module.exports = {
     facebook: false,
     byField: false
   },
+  postalCodeRegion: 'canada',
   logDatabaseUpdates: true,
   askForAccessCode: true,
   surveySupportForm: true,

--- a/example/demo_survey/src/survey/widgets/home.tsx
+++ b/example/demo_survey/src/survey/widgets/home.tsx
@@ -14,6 +14,7 @@ import * as surveyHelperNew from 'evolution-common/lib/utils/helpers';
 import { getHousehold } from 'evolution-common/lib/services/odSurvey/helpers';
 import waterBoundaries  from '../waterBoundaries.json';
 import { canadianPostalCodeFormatter, eightDigitsAccessCodeFormatter } from 'evolution-common/lib/utils/formatters';
+import { postalCodeValidation } from 'evolution-common/lib/services/widgets/validations/validations';
 
 export const homeIntro = {
   type: "text",
@@ -461,28 +462,7 @@ export const homePostalCode = {
     fr: "Code postal",
     en: "Postal code"
   },
-  validations: function(value, customValue, interview, path, customPath) {
-    return [
-      {
-        validation: _isBlank(value),
-        errorMessage: {
-          fr: `Veuillez spécifier votre code postal.`,
-          en: `Please specify your postal code.`
-        }
-      },
-      {
-        // To be valid in Canada, the postal code cannot have the letters D, F, I, O, Q, or U.
-        // Here, we also use G, H, J, or K in the first letter to only accept Quebec and Eastern Ontario.
-        // See: https://en.wikipedia.org/wiki/Postal_codes_in_Canada#Number_of_possible_postal_codes and https://www150.statcan.gc.ca/n1/pub/92-153-g/2011002/tech-eng.htm
-        // TODO: Instead of directly writing the validation, make a function that takes the country/region as input and returns the right regex.
-        validation: !/^[ghjk][0-9][abceghj-nprstv-z]( )?[0-9][abceghj-nprstv-z][0-9]\s*$/i.test(value),
-        errorMessage: {
-          fr: `Le code postal est invalide. Vous devez résider au Québec pour compléter ce questionnaire`,
-          en: `Postal code is invalid. You need to live in Quebec to fill this questionnaire.`
-        }
-      }
-    ];
-  }
+  validations: postalCodeValidation
 };
 
 export const homeGeography = {

--- a/locales/en/survey.yml
+++ b/locales/en/survey.yml
@@ -143,3 +143,8 @@ visitedPlace:
 trip:
   tripSeq: Trip {{seq}}
   editTrip: Edit
+errors:
+  postalCodeRequired: "Please specify your postal code."
+  postalCodeInvalid: "Postal code is invalid."
+  postalCodeInvalid_canada: "Postal code is invalid. You must live in Canada to fill this questionnaire."
+  postalCodeInvalid_quebec: "Postal code is invalid. You must live in Quebec to fill this questionnaire."

--- a/locales/fr/survey.yml
+++ b/locales/fr/survey.yml
@@ -153,3 +153,8 @@ visitedPlace:
 trip:
   tripSeq: Déplacement {{seq}}
   editTrip: Modifier
+errors:
+  postalCodeRequired: "Veuillez spécifier votre code postal."
+  postalCodeInvalid: "Le code postal est invalide."
+  postalCodeInvalid_canada: "Le code postal est invalide. Vous devez résider au Canada pour compléter ce questionnaire.."
+  postalCodeInvalid_quebec: "Le code postal est invalide. Vous devez résider au Québec pour compléter ce questionnaire."

--- a/packages/evolution-backend/src/services/auth/__tests__/authByFieldLogin.test.ts
+++ b/packages/evolution-backend/src/services/auth/__tests__/authByFieldLogin.test.ts
@@ -70,6 +70,11 @@ jest.mock('../../../models/interviewsPreFill.db.queries', () => ({
     getByReferenceValue: jest.fn()
 }));
 
+// Mock the project config to set the postalCodeRegion
+jest.mock('evolution-common/lib/config/project.config', () => ({
+    postalCodeRegion: 'canada'  // Default for tests
+}));
+
 const mockFind = participantAuthModel.find as jest.MockedFunction<typeof participantAuthModel.find>;
 const mockCreateAndSave = participantAuthModel.createAndSave as jest.MockedFunction<typeof participantAuthModel.createAndSave>;
 const mockGetByReferenceValue = interviewsPreFillQueries.getByReferenceValue as jest.MockedFunction<typeof interviewsPreFillQueries.getByReferenceValue>;

--- a/packages/evolution-backend/src/services/auth/authByFieldLogin.ts
+++ b/packages/evolution-backend/src/services/auth/authByFieldLogin.ts
@@ -11,15 +11,15 @@ import { IAuthModel, IUserModel } from 'chaire-lib-backend/lib/services/auth/aut
 import { validateAccessCode } from '../accessCode';
 import interviewsPreFillQueries from '../../models/interviewsPreFill.db.queries';
 import TrError from 'chaire-lib-common/lib/utils/TrError';
+import { getPostalCodeRegex } from 'evolution-common/lib/services/widgets/validations/validations';
 
 // Validate postal code
-// FIXME Should be moved to a common place, like the access code validation and support more countries
 const validatePostalCode = (postalCode: string): boolean => {
     if (!postalCode) {
         return false;
     }
-    // Validate a canadian postal code
-    if (!/^[ghjk][0-9][abceghj-nprstv-z]( )?[0-9][abceghj-nprstv-z][0-9]\s*$/i.test(postalCode)) {
+    // Validate the postal code with the regex for the configured region
+    if (!getPostalCodeRegex().test(postalCode)) {
         return false;
     }
 

--- a/packages/evolution-common/src/config/project.config.ts
+++ b/packages/evolution-common/src/config/project.config.ts
@@ -122,6 +122,12 @@ export type EvolutionProjectConfiguration = {
               };
     };
 
+    /**
+     * The region to use for postal code validation FIXME Also use for
+     * formatting
+     * */
+    postalCodeRegion: 'canada' | 'quebec' | 'other';
+
     // TODO Add more project configuration types
 };
 
@@ -149,7 +155,8 @@ setProjectConfiguration<EvolutionProjectConfiguration>(
             detectLanguageFromUrl: true,
             detectLanguage: false,
             languageNames: { en: 'English', fr: 'Français' },
-            title: { en: 'Survey', fr: 'Enquête' }
+            title: { en: 'Survey', fr: 'Enquête' },
+            postalCodeRegion: 'other'
         },
         projectConfig
     )

--- a/packages/evolution-common/src/services/widgets/validations/__tests__/validations.test.ts
+++ b/packages/evolution-common/src/services/widgets/validations/__tests__/validations.test.ts
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { postalCodeValidation, getPostalCodeRegex } from '../validations';
+import projectConfig from '../../../../config/project.config';
+
+// Mock the project config to be able to change the postalCodeRegion
+jest.mock('../../../../config/project.config', () => ({
+    postalCodeRegion: 'canada'  // Default for tests
+}));
+
+describe('postalCodeValidation', () => {
+    // Mock the translation function for errors
+    const mockTranslation = jest.fn().mockImplementation((key: string, _params) => key);
+
+    describe('Empty postal code validation', () => {
+        it('should return error when postal code is empty', () => {
+            const result = postalCodeValidation('', undefined, {} as any, 'postalCode');
+            expect(result.length).toBe(2);
+            expect(result[0].validation).toBe(true); // Empty validation fails
+            expect(typeof result[0].errorMessage).toEqual('function');
+            expect((result[0].errorMessage as any)(mockTranslation)).toEqual('survey:errors:postalCodeRequired');
+        });
+    });
+    
+    describe('Canadian postal code validation', () => {
+        beforeEach(() => {
+            projectConfig.postalCodeRegion = 'canada';
+        });
+        
+        test.each([
+            'A1A 1A1', 
+            'A1A1A1',
+            'H3Z 2Y7', 
+            'V8C 1A5'
+        ])('should accept valid Canadian postal code: %s', (postalCode) => {
+            const result = postalCodeValidation(postalCode, undefined, {} as any, 'postalCode');
+            expect(result[1].validation).toBe(false); // Should be valid
+        });
+        
+        test.each([
+            ['D1A 1A1', 'D is not used in Canadian postal codes'],
+            ['F1A 1A1', 'F is not used in Canadian postal codes'],
+            ['123456', 'Wrong format'],
+            ['A1A', 'Incomplete'],
+            ['W1A 1A1', 'W not allowed in first position'],
+            ['Z1A 1A1', 'Z not allowed in first position'],
+            ['A1D 1A1', 'D not allowed in third position'],
+            ['A1F 1A1', 'F not allowed in third position'],
+            ['A1I 1A1', 'I not allowed in third position'],
+            ['A1O 1A1', 'O not allowed in third position'],
+            ['A1Q 1A1', 'Q not allowed in third position'],
+            ['A1U 1A1', 'U not allowed in third position'],
+            ['ARU TAY', 'all letters'],
+            ['311 151', 'all numbers']
+        ])('should reject invalid Canadian postal code: %s (%s)', (postalCode, reason) => {
+            const result = postalCodeValidation(postalCode, undefined, {} as any, 'postalCode');
+            expect(result[1].validation).toBe(true); // Should be invalid
+            expect(typeof result[1].errorMessage).toEqual('function');
+            expect((result[1].errorMessage as any)(mockTranslation)).toEqual('survey:errors:postalCodeInvalid');
+            expect(mockTranslation).toHaveBeenLastCalledWith('survey:errors:postalCodeInvalid', { context: 'canada' });
+        });
+    });
+    
+    describe('Quebec postal code validation', () => {
+        beforeEach(() => {
+            projectConfig.postalCodeRegion = 'quebec';
+        });
+        
+        test.each([
+            'G1A 1A1',
+            'H3Z 2Y7',
+            'J7V 9Z9',
+            'K2V 1A1'
+        ])('should accept valid Quebec postal code: %s', (postalCode) => {
+            const result = postalCodeValidation(postalCode, undefined, {} as any, 'postalCode');
+            expect(result[1].validation).toBe(false); // Should be valid
+        });
+        
+        test.each([
+            ['D1A 1A1', 'D is not used in Canadian postal codes'],
+            ['F1A 1A1', 'F is not used in Canadian postal codes'],
+            ['123456', 'Wrong format'],
+            ['A1A', 'Incomplete'],
+            ['A1A 1A1', 'Newfoundland'],
+            ['B1A 1A1', 'Nova Scotia'],
+            ['C1A 1A1', 'PEI'],
+            ['E1A 1A1', 'New Brunswick'],
+            ['L1A 1A1', 'Ontario'],
+            ['M1A 1A1', 'Ontario'],
+            ['N1A 1A1', 'Ontario'],
+            ['P1A 1A1', 'Ontario'],
+            ['R1A 1A1', 'Manitoba'],
+            ['S1A 1A1', 'Saskatchewan'],
+            ['T1A 1A1', 'Alberta'],
+            ['V1A 1A1', 'British Columbia'],
+            ['ARU TAY', 'all letters'],
+            ['311 151', 'all numbers']
+        ])('should reject non-Quebec Canadian postal code: %s (%s)', (postalCode, province) => {
+            const result = postalCodeValidation(postalCode, undefined, {} as any, 'postalCode');
+            expect(result[1].validation).toBe(true); // Should be invalid
+            expect(typeof result[1].errorMessage).toEqual('function');
+            expect((result[1].errorMessage as any)(mockTranslation)).toEqual('survey:errors:postalCodeInvalid');
+            expect(mockTranslation).toHaveBeenLastCalledWith('survey:errors:postalCodeInvalid', { context: 'quebec' });
+        });
+    });
+    
+    describe('Other postal code validation', () => {
+        beforeEach(() => {
+            projectConfig.postalCodeRegion = 'other';
+        });
+        
+        test.each([
+            ['A1A 1A1', 'Canadian'],
+            ['H3Z 2Y7', 'Quebec'],
+            ['12345', 'US-style'],
+            ['12345-6789', 'US extended'],
+            ['EC1A 1BB', 'UK'],
+            ['ABC-123', 'Made up'],
+            ['XYZ', 'Made up'],
+            ['123 ABC', 'Made up with space']
+        ])('should accept %s as a valid postal code (%s)', (postalCode, description) => {
+            const result = postalCodeValidation(postalCode, undefined, {} as any, 'postalCode');
+            expect(result[1].validation).toBe(false); // Should be valid
+        });
+    });
+});
+
+describe('getPostalCodeRegex', () => {
+    test.each([
+        ['A1A 1A1', true, 'Valid Canadian postal code'],
+        ['D1A 1A1', false, 'Invalid Canadian postal code (D not allowed)']
+    ])('with Canada region: %s should be %s (%s)', (postalCode, expected, reason) => {
+        projectConfig.postalCodeRegion = 'canada';
+        const regex = getPostalCodeRegex();
+        expect(regex.test(postalCode)).toBe(expected);
+    });
+    
+    test.each([
+        ['H2X 1A1', true, 'Valid Quebec postal code'],
+        ['A1A 1A1', false, 'Not a Quebec postal code']
+    ])('with Quebec region: %s should be %s (%s)', (postalCode, expected, reason) => {
+        projectConfig.postalCodeRegion = 'quebec';
+        const regex = getPostalCodeRegex();
+        expect(regex.test(postalCode)).toBe(expected);
+    });
+    
+    test.each([
+        ['12345', true, 'US-style postal code'],
+        ['ABC-123', true, 'Made up postal code'],
+        ['H2X 1A1', true, 'Canadian postal code']
+    ])('with Other region: %s should be accepted (%s)', (postalCode, description) => {
+        projectConfig.postalCodeRegion = 'other';
+        const regex = getPostalCodeRegex();
+        expect(regex.test(postalCode)).toBe(true);
+    });
+});


### PR DESCRIPTION
fixes #1150

This extracts 2 regex for Canada and Quebec postal codes. The survey can be configured to use one of those formats and everywhere it is needed (postal code validation, authentication by access/postal codes) will use this configuration.

Add a `postalCodeRegion` configuration, which can take the value of either `quebec` or `canada`. If undefined, the postal code's content will not be validated with the builtin functions. Surveys can add their own validation functions if need be.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Region-aware postal code validation (Canada, Quebec, Other) used across surveys and auth flows.
  * Centralized postal-code validator applied in UI and backend.
  * Project configuration adds postalCodeRegion; demo examples set it to Canada.

* **Localization**
  * Added English and French error messages for required/invalid postal codes, including region-specific variants.

* **Tests**
  * Added unit tests and test-only config mocks to verify region-specific behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->