### PR TITLE
generator: make sure to generate section in order

### DIFF
--- a/packages/evolution-generator/src/scripts/generate_widgets.py
+++ b/packages/evolution-generator/src/scripts/generate_widgets.py
@@ -102,8 +102,15 @@ def generate_widgets(excel_file_path: str, widgets_output_folder: str):
 
         # Find the index of 'section' in headers
         section_index = headers.index("section")
-        # Get all unique section names
-        section_names = set(row[section_index].value for row in rows[1:])
+
+        # Get all unique section names while preserving order from the section sheet
+        seen_sections: set[str] = set()
+        section_names: list[str] = []
+        for row in rows[1:]:
+            section = row[section_index].value
+            if section and section not in seen_sections:
+                seen_sections.add(section)
+                section_names.append(section)
 
         # Track gender-related fields. It will be done one section at a time, so
         # it's not possible to use gender field in a section before it is


### PR DESCRIPTION
Widget generation may require information from previous section, like the presence or not of the gender fields, so we need to parse each section in the order they are expected to appear.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Generated widget sections now preserve the order from the source sheet, eliminating unpredictable shuffling.
  * Empty or falsy section entries are skipped, preventing blank sections from appearing.
  * Output is deterministic across environments, reducing diff noise and making reviews clearer.
  * No changes to external interfaces; improvements affect ordering and cleanliness of generated content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->