### PR TITLE
survey reducer: initialize `navigation` object in `SET_INTERVIEW`

### DIFF
--- a/packages/evolution-frontend/src/store/survey/__tests__/reducer.test.ts
+++ b/packages/evolution-frontend/src/store/survey/__tests__/reducer.test.ts
@@ -39,20 +39,49 @@ const testInterview: UserRuntimeInterviewAttributes = {
     allWidgetsValid: true
 };
 
-test('Test setting an interview', () => {
-    const action = {
-        type: SurveyActionTypes.SET_INTERVIEW as const,
-        interview: testInterview,
-        interviewLoaded: true
-    };
-
-    const result =  {
-        interview: testInterview,
-        interviewLoaded: true
-    };
-
-    expect(surveyReducer({ }, action)).toEqual(result);
-});
+describe('SET_INTERVIEW action', () => {
+    test('Test setting an interview', () => {
+        const action = {
+            type: SurveyActionTypes.SET_INTERVIEW as const,
+            interview: testInterview,
+            interviewLoaded: true
+        };
+    
+        const result =  {
+            interview: testInterview,
+            interviewLoaded: true
+        };
+    
+        expect(surveyReducer({ }, action)).toEqual(result);
+    });
+    
+    test('Test setting an interview with previous state', () => {
+        const initialState = {
+            navigation: {
+                currentSection: { sectionShortname: 'previous', iterationContext: ['1234'] },
+                navigationHistory: [{ sectionShortname: 'previous3' }, { sectionShortname: 'previous2', iterationContext: ['1234'] }]
+            },
+            submitted: true,
+            errors: { field: { 'en': 'something' } },
+            interview: { id: 2 } as UserRuntimeInterviewAttributes,
+        }
+        const action = {
+            type: SurveyActionTypes.SET_INTERVIEW as const,
+            interview: testInterview,
+            interviewLoaded: true
+        };
+    
+        const result =  {
+            interview: testInterview,
+            interviewLoaded: true,
+            navigation: undefined,
+            errors: undefined,
+            submitted: undefined
+        };
+    
+        expect(surveyReducer(initialState, action)).toEqual(result);
+    });
+})
 
 test('Test updating an interview', () => {
     const action = {

--- a/packages/evolution-frontend/src/store/survey/reducer.ts
+++ b/packages/evolution-frontend/src/store/survey/reducer.ts
@@ -15,7 +15,11 @@ const reducer: Reducer<SurveyState, SurveyAction> = (state = initialState, actio
         return {
             ...state,
             interview: action.interview,
-            interviewLoaded: action.interviewLoaded
+            interviewLoaded: action.interviewLoaded,
+            // Reset navigation and other states for this newly set interview, to not clash with previous interviews
+            navigation: undefined,
+            errors: undefined,
+            submitted: undefined
         };
     case SurveyActionTypes.UPDATE_INTERVIEW:
         return {


### PR DESCRIPTION
fixes #1163

This makes sure that whenever we reset the interview in the state, then the navigation is also reset, to avoid `undefined` loaded section when the navigation has a current section, but it is not currently loaded in the interview.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Starting a new interview now clears previous navigation, error messages, and submission status, ensuring a clean, consistent experience without leftover state from earlier sessions.

* **Tests**
  * Reorganized and added tests to validate setting a new interview, including scenarios where a prior non-empty state exists to ensure previous fields are not preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->