### PR TITLE
Fix yarn format command in macos

### DIFF
--- a/example/demo_generator/package.json
+++ b/example/demo_generator/package.json
@@ -25,7 +25,7 @@
         "start:admin:tracing": "yarn node -r ../../tracing.js lib/admin/server.js --max-old-space-size=4096",
         "start:debug": "cross-env DEBUG=express:* yarn node --trace-warnings lib/server.js --max-old-space-size=4096",
         "reset": "rimraf src/ locales/ tests/ node_modules/ lib/",
-        "format": "prettier-eslint ./**/*.{ts,tsx} --write",
+        "format": "prettier-eslint \"./**/*.{ts,tsx}\" --write",
         "format:all": "yarn format",
         "test:ui": "LOCALE_DIR=$(pwd)/locales npx playwright test"
     },

--- a/packages/evolution-backend/package.json
+++ b/packages/evolution-backend/package.json
@@ -21,7 +21,7 @@
         "test:sequential": "cross-env NODE_ENV=test jest --config=jest.sequential.config.js --runInBand",
         "test:ui": "echo 'no tests to run for this workspace'",
         "lint": "eslint .",
-        "format": "prettier-eslint ./src/**/*.{ts,tsx} --write",
+        "format": "prettier-eslint \"./src/**/*.{ts,tsx}\" --write",
         "format:all": "yarn format"
     },
     "dependencies": {

--- a/packages/evolution-common/package.json
+++ b/packages/evolution-common/package.json
@@ -17,7 +17,7 @@
     "test:sequential": "echo 'no tests to run for this workspace'",
     "test:ui": "echo 'no tests to run for this workspace'",
     "lint": "eslint .",
-    "format": "prettier-eslint ./src/**/*.{ts,tsx} --write",
+    "format": "prettier-eslint \"./src/**/*.{ts,tsx}\" --write",
     "format:all": "yarn format",
     "jsdoc": "jsdoc -c jsdoc.json"
   },

--- a/packages/evolution-generator/package.json
+++ b/packages/evolution-generator/package.json
@@ -17,7 +17,7 @@
     "test:sequential": "echo 'no tests to run for this workspace'",
     "test:ui": "echo 'no tests to run for this workspace'",
     "lint": "eslint .",
-    "format": "prettier-eslint ./src/**/*.{ts,tsx} --write",
+    "format": "prettier-eslint \"./src/**/*.{ts,tsx}\" --write",
     "format:python": "poetry run black .",
     "format:all": "yarn format && yarn format:python",
     "generateSurvey": "poetry run generateSurvey",

--- a/packages/evolution-interviewer/package.json
+++ b/packages/evolution-interviewer/package.json
@@ -20,7 +20,7 @@
         "test:sequential": "cross-env NODE_ENV=test jest --config=jest.sequential.config.js --runInBand",
         "test:ui": "echo 'no tests to run for this workspace'",
         "lint": "eslint .",
-        "format": "prettier-eslint ./src/**/*.{ts,tsx} --write",
+        "format": "prettier-eslint \"./src/**/*.{ts,tsx}\" --write",
         "format:all": "yarn format"
     },
     "dependencies": {


### PR DESCRIPTION
In macos, when there is no quotes around the prettier path, it ignores most files and will not fix formatting in several subdirectories. Using quotes seems to fix the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Standardized formatting scripts to use quoted glob patterns across packages for consistent, cross-platform behavior.
  - Prevents unintended shell expansion, ensuring the formatter targets the intended files reliably.
  - No changes to product functionality, APIs, or UI; impact limited to developer tooling and CI consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->