### PR TITLE
update the default icon marker to use the new one from chaire-lib

### DIFF
--- a/packages/evolution-frontend/src/components/inputs/InputMapPoint.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputMapPoint.tsx
@@ -24,6 +24,7 @@ import SurveyErrorMessage from '../survey/widgets/SurveyErrorMessage';
 // Default max zoom and zoom
 const defaultZoom = 13;
 const defaultMaxZoom = 18;
+const defaultMarkerUrl = '/dist/images/activities_icons/default_marker.svg';
 
 export type InputMapPointProps = CommonInputProps & {
     value?: GeoJSON.Feature<GeoJSON.Point, FeatureGeocodedProperties>;
@@ -65,8 +66,8 @@ export class InputMapPoint extends React.Component<InputMapPointProps & WithTran
                 this.props.interview,
                 this.props.path,
                 this.props.user
-            ) || '/dist/images/default_marker.svg'
-            : '/dist/images/default_marker.svg';
+            ) || defaultMarkerUrl
+            : defaultMarkerUrl;
 
         this.iconSize =
             this.props.widgetConfig.icon && this.props.widgetConfig.icon.size


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Style
  * Updated the default map marker icon for map point inputs to a new design, ensuring consistent appearance when no custom icon is set.
  * Standardized the fallback icon path across the app for improved reliability.

* Refactor
  * Centralized configuration for the default marker to reduce duplication and ease future updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->