### PR TITLE
Increase the default min zoom for map inputs

### DIFF
--- a/example/demo_generator/src/survey/common/customValidations.tsx
+++ b/example/demo_generator/src/survey/common/customValidations.tsx
@@ -21,7 +21,7 @@ export const getGeographyCustomValidation = ({ value, interview, path }) => {
                 geography.properties.lastAction &&
                 (geography.properties.lastAction === 'mapClicked' ||
                     geography.properties.lastAction === 'markerDragged') &&
-                geography.properties.zoom < 14,
+                geography.properties.zoom < 15,
             errorMessage: {
                 fr: "Le positionnement du lieu n'est pas assez précis. Utilisez le zoom + pour vous rapprocher davantage, puis précisez la localisation en déplaçant l'icône.",
                 en: 'The positioning of the place is not precise enough. Please use the + zoom and drag the icon marker to confirm the precise location.'

--- a/example/demo_generator/src/survey/sections/household/customWidgets.tsx
+++ b/example/demo_generator/src/survey/sections/household/customWidgets.tsx
@@ -115,7 +115,7 @@ export const personUsualWorkPlaceGeography: InputMapFindPlaceType = {
                     geography.properties.lastAction &&
                     (geography.properties.lastAction === 'mapClicked' ||
                         geography.properties.lastAction === 'markerDragged') &&
-                    geography.properties.zoom < 14,
+                    geography.properties.zoom < 15,
                 errorMessage: {
                     fr: "Le positionnement du lieu n'est pas assez précis. Utilisez le zoom + pour vous rapprocher davantage, puis précisez la localisation en déplaçant l'icône.",
                     en: 'Location is not precise enough. Please use the + zoom and drag the icon marker to confirm the precise location.'
@@ -195,7 +195,7 @@ export const personUsualSchoolPlaceGeography: InputMapFindPlaceType = {
                     geography.properties.lastAction &&
                     (geography.properties.lastAction === 'mapClicked' ||
                         geography.properties.lastAction === 'markerDragged') &&
-                    geography.properties.zoom < 14,
+                    geography.properties.zoom < 15,
                 errorMessage: {
                     fr: "Le positionnement du lieu n'est pas assez précis. Utilisez le zoom + pour vous rapprocher davantage, puis précisez la localisation en déplaçant l'icône.",
                     en: 'Location is not precise enough. Please use the + zoom and drag the icon marker to confirm the precise location.'

--- a/example/demo_survey/src/survey/widgets/home.tsx
+++ b/example/demo_survey/src/survey/widgets/home.tsx
@@ -514,7 +514,7 @@ export const homeGeography = {
         }
       },
       {
-        validation: geography && geography.properties.lastAction && geography.properties.lastAction === 'mapClicked' && geography.properties.zoom < 14,
+        validation: geography && geography.properties.lastAction && geography.properties.lastAction === 'mapClicked' && geography.properties.zoom < 15,
         errorMessage: {
           fr: `Le positionnement de votre domicile n'est pas assez précis.  Utilisez le zoom + pour vous rapprocher davantage, puis précisez la localisation en déplaçant l'icône.`,
           en: `Location of your home is not precise enough. Please use the + zoom and drag the icon marker to confirm the precise location.`

--- a/example/demo_survey/src/survey/widgets/householdMembers.tsx
+++ b/example/demo_survey/src/survey/widgets/householdMembers.tsx
@@ -1341,7 +1341,7 @@ export const groupedPersonUsualWorkPlaceGeography = {
         }
       },
       {
-        validation: geography && geography.properties.lastAction && geography.properties.lastAction === 'mapClicked' && geography.properties.zoom < 14,
+        validation: geography && geography.properties.lastAction && geography.properties.lastAction === 'mapClicked' && geography.properties.zoom < 15,
         errorMessage: {
           fr: `Le positionnement du lieu n'est pas assez précis. Utilisez le zoom + pour vous rapprocher davantage, puis précisez la localisation en déplaçant l'icône.`,
           en: `Location is not precise enough. Please use the + zoom and drag the icon marker to confirm the precise location.`
@@ -1436,7 +1436,7 @@ export const groupedPersonUsualSchoolPlaceGeography = {
         }
       },
       {
-        validation: geography && geography.properties.lastAction && geography.properties.lastAction === 'mapClicked' && geography.properties.zoom < 14,
+        validation: geography && geography.properties.lastAction && geography.properties.lastAction === 'mapClicked' && geography.properties.zoom < 15,
         errorMessage: {
           fr: `Le positionnement du lieu n'est pas assez précis. Utilisez le zoom + pour vous rapprocher davantage, puis précisez la localisation en déplaçant l'icône.`,
           en: `Location is not precise enough. Please use the + zoom and drag the icon marker to confirm the precise location.`

--- a/example/demo_survey/src/survey/widgets/profile.tsx
+++ b/example/demo_survey/src/survey/widgets/profile.tsx
@@ -433,7 +433,7 @@ export const personUsualWorkPlaceGeography = {
         }
       },
       {
-        validation: geography && geography.properties.lastAction && geography.properties.lastAction === 'mapClicked' && geography.properties.zoom < 14,
+        validation: geography && geography.properties.lastAction && geography.properties.lastAction === 'mapClicked' && geography.properties.zoom < 15,
         errorMessage: {
           fr: `Le positionnement du lieu n'est pas assez précis. Utilisez le zoom + pour vous rapprocher davantage, puis précisez la localisation en déplaçant l'icône.`,
           en: `Location is not precise enough. Please use the + zoom and drag the icon marker to confirm the precise location.`
@@ -558,7 +558,7 @@ export const personUsualSchoolPlaceGeography = {
         }
       },
       {
-        validation: geography && geography.properties.lastAction && geography.properties.lastAction === 'mapClicked' && geography.properties.zoom < 14,
+        validation: geography && geography.properties.lastAction && geography.properties.lastAction === 'mapClicked' && geography.properties.zoom < 15,
         errorMessage: {
           fr: `Le positionnement du lieu n'est pas assez précis. Utilisez le zoom + pour vous rapprocher davantage, puis précisez la localisation en déplaçant l'icône.`,
           en: `Location is not precise enough. Please use the + zoom and drag the icon marker to confirm the precise location.`

--- a/example/demo_survey/src/survey/widgets/visitedPlaces.tsx
+++ b/example/demo_survey/src/survey/widgets/visitedPlaces.tsx
@@ -852,7 +852,7 @@ export const visitedPlaceGeography = {
       }
     },
     {
-      validation: geography && geography.properties?.lastAction && (geography.properties.lastAction === 'mapClicked' || geography.properties.lastAction === 'markerDragged') && geography.properties.zoom < 14,
+      validation: geography && geography.properties?.lastAction && (geography.properties.lastAction === 'mapClicked' || geography.properties.lastAction === 'markerDragged') && geography.properties.zoom < 15,
       errorMessage: {
         fr: `Le positionnement du lieu n'est pas assez précis. Utilisez le zoom + pour vous rapprocher davantage, puis précisez la localisation en déplaçant l'icône.`,
         en: `Location is not precise enough. Please use the + zoom and drag the icon marker to confirm the precise location.`

--- a/packages/evolution-frontend/src/components/inputs/defaultInputBase.ts
+++ b/packages/evolution-frontend/src/components/inputs/defaultInputBase.ts
@@ -167,7 +167,7 @@ export const inputMapFindPlaceBase: Pick<
                     geography &&
                     geography.properties.lastAction &&
                     geography.properties.lastAction === 'mapClicked' &&
-                    geography.properties.zoom < 14,
+                    geography.properties.zoom < 15,
                 errorMessage: {
                     fr: 'Le positionnement du lieu n\'est pas assez précis. Utilisez le zoom + pour vous rapprocher davantage, puis précisez la localisation en déplaçant l\'icône.',
                     en: 'The positioning of the place is not precise enough. Please use the + zoom and drag the icon marker to confirm the precise location.'


### PR DESCRIPTION
According to research we did with POIs, we need to increase the default min zoom for map inputs to 15 which will be significant better than 14 which was the default.

See #849

Closes #849

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Increased map zoom requirement for location validation across the app. Users must zoom in further before locations are accepted after map clicks or marker drags.
  - Affected inputs: Home location, usual workplace, usual school, household members’ locations, and visited places.
  - Applies to both demo surveys and base map input components.
  - Error messages are unchanged; only the validation threshold is stricter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->