### PR TITLE
Add missing favicon 96x96 (usually used by android-chrome)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <link rel="apple-touch-icon" sizes="120x120" href="/dist/images/favicons/survey-apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="96x96" href="/dist/images/favicons/survey-android-chrome-96x96.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/dist/images/favicons/survey-favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/dist/images/favicons/survey-favicon-16x16.png">
     <link rel="manifest" href="/dist/images/favicons/survey-site.webmanifest">


### PR DESCRIPTION
Reorder the favison in decreasing size order, for better priority.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Added a 96×96 PNG favicon to improve visual branding in browser tabs, bookmarks, and shortcuts.
- **Chores**
  - Included new favicon metadata asset to enhance cross-platform icon coverage without affecting app behavior or performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->