### PR TITLE
Remove unused env variable from webpack and env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,16 +33,6 @@ GOOGLE_OAUTH_SECRET_KEY = "<googleOauthSecretKey>"
 RESET_PASSWORD_FROM_EMAIL = "<admin@test.com>"
 # Who do send the support request emails to: format: "lang:comma-separated emails;[lang2:comma-separated emails]"
 SUPPORT_REQUEST_EMAILS = "en:example@example.org"
-# MAILCHIMP_API_KEY = "<mailchimpApiKey>"
-# MAILCHIMP_LIST_ID = "<mailchimpListId>"
-
-# Mapbox
-# MAPBOX_ACCESS_TOKEN = "<mapboxAccessToken>"
-# MAPBOX_USER_ID = "mapbox"
-# MAPBOX_STYLE_ID = "dark-v10"
-
-# Photon
-PHOTON_OSM_SEARCH_API_URL = "<photonOsmSearchApiUrl>"
 
 # SSL
 # SSL_PRIVATE_KEY = "/path/to/privkey.pem"

--- a/example/demo_generator/webpack.admin.config.js
+++ b/example/demo_generator/webpack.admin.config.js
@@ -161,16 +161,9 @@ module.exports = (env) => {
                 'process.env': {
                     IS_BROWSER: JSON.stringify(true),
                     HOST: JSON.stringify(process.env.HOST),
-                    TRROUTING_HOST: JSON.stringify(process.env.TRROUTING_HOST),
                     APP_NAME: JSON.stringify(appIncludeName),
-                    PROJECT_SHORTNAME: JSON.stringify(config.projectShortname),
-                    PROJECT_SOURCE: JSON.stringify(process.env.PROJECT_SOURCE),
                     IS_TESTING: JSON.stringify(env === 'test'),
-                    GOOGLE_API_KEY: JSON.stringify(process.env.GOOGLE_API_KEY),
-                    PROJECT_SAMPLE: JSON.stringify(process.env.PROJECT_SAMPLE),
-                    MAILCHIMP_API_KEY: JSON.stringify(process.env.MAILCHIMP_API_KEY),
-                    MAILCHIMP_LIST_ID: JSON.stringify(process.env.MAILCHIMP_LIST_ID),
-                    PHOTON_OSM_SEARCH_API_URL: JSON.stringify(process.env.PHOTON_OSM_SEARCH_API_URL)
+                    GOOGLE_API_KEY: JSON.stringify(process.env.GOOGLE_API_KEY)
                 },
                 __CONFIG__: JSON.stringify({
                     ...config

--- a/example/demo_generator/webpack.config.js
+++ b/example/demo_generator/webpack.config.js
@@ -143,16 +143,9 @@ module.exports = (env) => {
                 'process.env': {
                     IS_BROWSER: JSON.stringify(true),
                     HOST: JSON.stringify(process.env.HOST),
-                    TRROUTING_HOST: JSON.stringify(process.env.TRROUTING_HOST),
                     APP_NAME: JSON.stringify(appIncludeName),
-                    PROJECT_SHORTNAME: JSON.stringify(config.projectShortname),
-                    PROJECT_SOURCE: JSON.stringify(process.env.PROJECT_SOURCE),
                     IS_TESTING: JSON.stringify(env === 'test'),
-                    GOOGLE_API_KEY: JSON.stringify(process.env.GOOGLE_API_KEY),
-                    PROJECT_SAMPLE: JSON.stringify(process.env.PROJECT_SAMPLE),
-                    MAILCHIMP_API_KEY: JSON.stringify(process.env.MAILCHIMP_API_KEY),
-                    MAILCHIMP_LIST_ID: JSON.stringify(process.env.MAILCHIMP_LIST_ID),
-                    PHOTON_OSM_SEARCH_API_URL: JSON.stringify(process.env.PHOTON_OSM_SEARCH_API_URL)
+                    GOOGLE_API_KEY: JSON.stringify(process.env.GOOGLE_API_KEY)
                 },
                 __CONFIG__: JSON.stringify({
                     ...config

--- a/example/demo_survey/webpack.admin.config.js
+++ b/example/demo_survey/webpack.admin.config.js
@@ -153,17 +153,9 @@ module.exports = (env) => {
         'process.env': {
           'IS_BROWSER'                  : JSON.stringify(true),
           'HOST'                        : JSON.stringify(process.env.HOST),
-          'TRROUTING_HOST'              : JSON.stringify(process.env.TRROUTING_HOST),
           'APP_NAME'                    : JSON.stringify(appIncludeName),
-          'PROJECT_SHORTNAME'           : JSON.stringify(config.projectShortname),
-          'PROJECT_SOURCE'              : JSON.stringify(process.env.PROJECT_SOURCE),
           'IS_TESTING'                  : JSON.stringify(env === 'test'),
-          'GOOGLE_API_KEY'              : JSON.stringify(process.env.GOOGLE_API_KEY),
-          'PROJECT_SAMPLE'              : JSON.stringify(process.env.PROJECT_SAMPLE),
-          'MAILCHIMP_API_KEY'           : JSON.stringify(process.env.MAILCHIMP_API_KEY),
-          'MAILCHIMP_LIST_ID'           : JSON.stringify(process.env.MAILCHIMP_LIST_ID),
-          'PHOTON_OSM_SEARCH_API_URL'   : JSON.stringify(process.env.PHOTON_OSM_SEARCH_API_URL)
-
+          'GOOGLE_API_KEY'              : JSON.stringify(process.env.GOOGLE_API_KEY)
         },
         '__CONFIG__': JSON.stringify({
             ...config

--- a/example/demo_survey/webpack.config.js
+++ b/example/demo_survey/webpack.config.js
@@ -137,16 +137,9 @@ module.exports = (env) => {
         'process.env': {
           'IS_BROWSER'                  : JSON.stringify(true),
           'HOST'                        : JSON.stringify(process.env.HOST),
-          'TRROUTING_HOST'              : JSON.stringify(process.env.TRROUTING_HOST),
           'APP_NAME'                    : JSON.stringify(appIncludeName),
-          'PROJECT_SHORTNAME'           : JSON.stringify(config.projectShortname),
-          'PROJECT_SOURCE'              : JSON.stringify(process.env.PROJECT_SOURCE),
           'IS_TESTING'                  : JSON.stringify(env === 'test'),
-          'GOOGLE_API_KEY'              : JSON.stringify(process.env.GOOGLE_API_KEY),
-          'PROJECT_SAMPLE'              : JSON.stringify(process.env.PROJECT_SAMPLE),
-          'MAILCHIMP_API_KEY'           : JSON.stringify(process.env.MAILCHIMP_API_KEY),
-          'MAILCHIMP_LIST_ID'           : JSON.stringify(process.env.MAILCHIMP_LIST_ID),
-          'PHOTON_OSM_SEARCH_API_URL'   : JSON.stringify(process.env.PHOTON_OSM_SEARCH_API_URL)
+          'GOOGLE_API_KEY'              : JSON.stringify(process.env.GOOGLE_API_KEY)
 
         },
         '__CONFIG__': JSON.stringify({


### PR DESCRIPTION
Those variables are not refered anywhere in the code in evolution, let's remove them from those demo/examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Cleaned up the sample environment file by removing outdated entries to reduce confusion and setup noise.

* **Chores**
  * Limited which environment variables are exposed to the browser in example build configurations, tightening defaults and minimizing unnecessary client-side exposure.
  * No changes to application behavior or public APIs; builds and examples continue to function as before.
  * Minor configuration streamlining for improved maintainability and clearer environment usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->