### PR TITLE
revert back to old google maps zoom control

### DIFF
--- a/packages/evolution-frontend/src/components/inputs/maps/google/InputMapGoogle.tsx
+++ b/packages/evolution-frontend/src/components/inputs/maps/google/InputMapGoogle.tsx
@@ -216,6 +216,13 @@ const InputMapGoogle: React.FunctionComponent<InputGoogleMapPointProps & WithTra
             }}
             center={center}
             zoom={props.defaultZoom || 10}
+            options={{
+                zoomControl: true,
+                cameraControl: false,
+                zoomControlOptions: {
+                    position: google.maps.ControlPosition.RIGHT_BOTTOM
+                }
+            }}
             onLoad={onLoad}
             onUnmount={onUnmount}
             onClick={(e) => onPositionChange(e, 'mapClicked')}


### PR DESCRIPTION
closes od_nationale issue https://github.com/chairemobilite/od_nationale_quebec/issues/226

The + and - button are now back and no need for panning buttons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable map UI controls added for the embedded Google Map.
  * Zoom control enabled and moved to the bottom-right for easier access.
  * Camera control disabled to reduce interface clutter.
  * Changes improve map usability without altering markers, interactions, or other behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->