### PR TITLE
authByField: add a random string to username when mismatch

### DIFF
--- a/packages/evolution-backend/src/services/auth/__tests__/authByFieldLogin.test.ts
+++ b/packages/evolution-backend/src/services/auth/__tests__/authByFieldLogin.test.ts
@@ -218,7 +218,7 @@ describe('Auth by Field Login Strategy Tests', () => {
         expect(mockGetByReferenceValue).toHaveBeenCalledTimes(1);
         expect(mockCreateAndSave).toHaveBeenCalledTimes(1);
         expect(mockCreateAndSave).toHaveBeenCalledWith({
-            username: '5555-5555-J4R5T6'
+            username: expect.stringMatching(/^5555-5555-J4R5T6-[A-Z0-9]{6}$/)
         });
         expect(mockRecordLogin).toHaveBeenCalledTimes(1);
     });


### PR DESCRIPTION
fixes #1178

If the accessCode and postalCode do not match a pair that is in the prefilled data, we add a 6 hex digits random string to the username. This will prevent leaking personal data if someone entered some invalid and easily guessed values, like 1234-1234 and 'H1H 1H1' and filled the survey.