### PR TITLE
Fixes the UI tests that input postal codes.

### DIFF
--- a/example/demo_generator/tests/common-tests-helpers.ts
+++ b/example/demo_generator/tests/common-tests-helpers.ts
@@ -76,7 +76,8 @@ export const completeHomeSectionTests = ({ context, householdSize }: CommonTestP
     testHelpers.inputStringTest({
         context,
         path: 'home.postalCode',
-        value: 'H1S1V7'
+        value: 'H1S1V7',
+        expectedValue: 'H1S 1V7'
     });
 
     testHelpers.inputMapFindPlaceTest({ context, path: 'home.geography' });

--- a/example/demo_survey/tests/test-input-validation.UI.spec.ts
+++ b/example/demo_survey/tests/test-input-validation.UI.spec.ts
@@ -26,11 +26,10 @@ surveyTestHelpers.startAndLoginAnonymously({ context, title: 'Démo', hasUser: f
 // Test the home page
 testHelpers.tryToContinueWithInvalidInputs({ context, text: 'Save and continue', currentPageUrl: '/survey/home' , nextPageUrl: '/survey/householdMembers' });
 testHelpers.inputStringInvalidValueTest({ context, path: 'household.carNumber', value: '14' });
-testHelpers.inputStringInvalidValueTest({ context, path: 'home.postalCode', value: 'H1S1V77' });
-testHelpers.inputStringInvalidValueTest({ context, path: 'home.postalCode', value: 'H1S1V' });
-testHelpers.inputStringInvalidValueTest({ context, path: 'home.postalCode', value: '1H1S7V' });
-testHelpers.inputStringInvalidValueTest({ context, path: 'home.postalCode', value: 'A1S1V7' });
-testHelpers.inputStringInvalidValueTest({ context, path: 'home.postalCode', value: 'H1D1F7' });
+testHelpers.inputStringTest({ context, path: 'home.postalCode', value: 'H1S1V77', expectedValue: 'H1S 1V7' }); // We check that the postal code doesn't accept characters past 6. This does not make the box invalid.
+testHelpers.inputStringInvalidValueTest({ context, path: 'home.postalCode', value: 'H1S1V', expectedValue: 'H1S 1V' });
+testHelpers.inputStringInvalidValueTest({ context, path: 'home.postalCode', value: '1H1S7V', expectedValue: '1H1 S7V' });
+testHelpers.inputStringInvalidValueTest({ context, path: 'home.postalCode', value: 'H1D1F7', expectedValue: 'H1D 1F7' });
 
 onePersonTestHelpers.completeHomePage(context);
 

--- a/example/demo_survey/tests/test-one-person-helpers.ts
+++ b/example/demo_survey/tests/test-one-person-helpers.ts
@@ -11,7 +11,7 @@ export function completeHomePage(context) {
     testHelpers.inputStringTest({ context, path: 'home.city', value: 'Montreal' });
     testHelpers.inputStringTest({ context, path: 'home.region', value: 'Quebec' });
     testHelpers.inputStringTest({ context, path: 'home.country', value: 'Canada' });
-    testHelpers.inputStringTest({ context, path: 'home.postalCode', value: 'H1S1V7' });
+    testHelpers.inputStringTest({ context, path: 'home.postalCode', value: 'H1S1V7', expectedValue: 'H1S 1V7' });
     //testHelpers.inputMapFindPlaceTest({ context, path: 'home.geography' });
     testHelpers.inputSelectTest({ context, path: 'home.dwellingType', value: 'tenantSingleDetachedHouse' });
     testHelpers.waitForMapToBeLoaded({ context });

--- a/example/demo_survey/tests/test-two-adults-no-trips.UI.spec.ts
+++ b/example/demo_survey/tests/test-two-adults-no-trips.UI.spec.ts
@@ -28,7 +28,7 @@ testHelpers.inputStringTest({ context, path: 'home.address', value: '7373 Langel
 testHelpers.inputStringTest({ context, path: 'home.city', value: 'Montreal' });
 testHelpers.inputStringTest({ context, path: 'home.region', value: 'Quebec' });
 testHelpers.inputStringTest({ context, path: 'home.country', value: 'Canada' });
-testHelpers.inputStringTest({ context, path: 'home.postalCode', value: 'H1S1V7' });
+testHelpers.inputStringTest({ context, path: 'home.postalCode', value: 'H1S1V7', expectedValue: 'H1S 1V7' });
 //testHelpers.inputMapFindPlaceTest({ context, path: 'home.geography' });
 testHelpers.inputSelectTest({ context, path: 'home.dwellingType', value: 'tenantSingleDetachedHouse' });
 testHelpers.waitForMapToBeLoaded({ context });


### PR DESCRIPTION
Because the postal codes fields now automatically add a space in the middle, this broke UI tests as the value read was different than the value entered. The inputString tests now have an optional expectedValue parameter, which will be  the expected value instead of the inputed value when present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Postal code input now auto-formats to the standard pattern (e.g., "H1S1V7" → "H1S 1V7") for clearer display.

- Bug Fixes
  - Validation now accepts common entry variations and displays the normalized postal code instead of rejecting entries.

- Tests
  - UI tests updated to assert formatted postal code outputs and cover diverse input cases to ensure consistent normalization and display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->