### PR TITLE
survey: fix race condition in `startUpdateInterview` redux action

### DIFF
--- a/packages/evolution-frontend/package.json
+++ b/packages/evolution-frontend/package.json
@@ -55,6 +55,7 @@
     "lodash": "^4.17.21",
     "moment": "^2.30.1",
     "node-fetch": "^2.6.7",
+    "p-queue": "^6.6.2",
     "react": "^19.0.0",
     "react-datepicker": "^7.6.0",
     "react-dom": "^19.0.0",

--- a/packages/evolution-frontend/src/actions/SurveyAdmin.ts
+++ b/packages/evolution-frontend/src/actions/SurveyAdmin.ts
@@ -37,7 +37,8 @@ import {
     validateAndPrepareSection,
     updateInterviewState,
     updateInterviewData,
-    startNavigateWithUpdateCallback
+    startNavigateWithUpdateCallback,
+    asyncDispatchQueue
 } from './Survey';
 import { ThunkDispatch } from 'redux-thunk';
 import { RootState } from '../store/configureStore';
@@ -178,7 +179,9 @@ export const startUpdateSurveyCorrectedInterview =
             dispatch: ThunkDispatch<RootState, unknown, SurveyAction | AuthAction | LoadingStateAction>,
             getState: () => RootState
         ) => {
-            await updateSurveyCorrectedInterview(dispatch, getState, data, callback);
+            return await asyncDispatchQueue.enqueueTask(async () => {
+                await updateSurveyCorrectedInterview(dispatch, getState, data, callback);
+            });
         };
 
 /**


### PR DESCRIPTION
fixes #1187

With slower connections, many concurrent update operations can be run in parallel and the result of the subsequent will override the previous results. Update operations need to be run sequentially.

We used to have the `redux-async-queue` package to do this, but it does not work with latest version of redux that we used. It is not supposed to be necessary, according to redux documentation, but they also strongly suggest using `@reduxjs/toolkit`, which we have not done yet.

In the meantime, we need to run update in sequence, so we enqueue them in a 1-concurrent p-queue. We can investigate later if our use of redux is wrong, too complex or if the a new package would solve the problem.

Add a test for concurrent update calls. This test failed with previous code, but passes with this commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Serializes concurrent interview updates to prevent race conditions, ensuring actions, updates, and navigation occur in the correct order.

- Tests
  - Added comprehensive concurrency tests and improved test state handling to validate sequencing and outcomes under simultaneous updates.

- Chores
  - Added a lightweight queuing runtime dependency to support serialized asynchronous operations and improve stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->