### PR TITLE
Add scroll to top when section is rendered

### DIFF
--- a/packages/evolution-frontend/src/components/pageParts/Section.tsx
+++ b/packages/evolution-frontend/src/components/pageParts/Section.tsx
@@ -20,6 +20,11 @@ export const Section: React.FC<SectionProps & WithSurveyContextProps> = (
 ) => {
     const { preloaded } = useSectionTemplate(props);
 
+    // Scroll to top when the section is rendered
+    React.useEffect(() => {
+        window.scrollTo(0, 0);
+    }, [props.shortname]);
+
     // TODO: This should not be done here. Wrong responsability. Move elsewhere.
     const getSortedWidgetShortnames = () => {
         let hasRandomOrderWidgets = false;


### PR DESCRIPTION
This is to avoid any new section load to not show the top of the page.

closes #1185

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * View now automatically scrolls to the top on initial section load and when switching sections, ensuring each section starts at the beginning for improved readability.
  * Applies to in-app section transitions, preventing leftover scroll positions and making navigation more predictable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->