### PR TITLE
Replace electric scooter by electric kick scooter

### DIFF
--- a/locales/en/segments.yml
+++ b/locales/en/segments.yml
@@ -25,7 +25,7 @@ mode:
     BicycleBikesharing: <strong>Bike sharing</strong>
     BicycleBikesharingElectric: <strong>Electric bike sharing</strong>
     BicyclePassenger: <strong>Passenger on bike</strong>
-    ScooterElectric: <strong>E-Scooter</strong> (electric scooter)
+    KickScooterElectric: <strong>Electric Kick Scooter</strong>
     CarDriverPersonal: <strong>Driver</strong> with personal vehicle (car/moto/scooter/truck)
     CarDriverRental: <strong>Driver</strong> with rental vehicle (car/moto/scooter/truck)
     CarDriverCarsharingStationBased: <strong>Carsharing</strong> station based
@@ -65,7 +65,7 @@ mode:
         walk: Walking
         bicycle: Bicycle
         bicycleElectric: E-Bike
-        scooterElectric: E-Scooter
+        kickScooterElectric: E-Kick Scooter
         bicyclePassenger: Passenger on bike
         carDriver: Car driver
         carPassenger: Car passenger

--- a/locales/fr/segments.yml
+++ b/locales/fr/segments.yml
@@ -25,7 +25,7 @@ mode:
     BicycleBikesharing: <strong>Vélo partage</strong>
     BicycleBikesharingElectric: <strong>Vélo partage électrique</strong>
     BicyclePassenger: <strong>Vélo passager</strong>
-    ScooterElectric: <strong>Trottinette électrique</strong>
+    KickScooterElectric: <strong>Trottinette électrique</strong>
     CarDriverPersonal: <strong>Auto conducteur</strong> avec voiture personnelle
     CarDriverRental: <strong>Auto conducteur</strong> avec voiture de location
     CarDriverCarsharingStationBased: <strong>Autopartage</strong> basé station
@@ -65,7 +65,7 @@ mode:
         walk: Marche
         bicycle: Vélo
         bicycleElectric: Vélo électrique
-        scooterElectric: Trottinette électrique
+        kickScooterElectric: Trottinette électrique
         bicyclePassenger: Vélo passager
         carDriver: Auto conducteur
         carPassenger: Auto passager

--- a/packages/evolution-common/src/services/baseObjects/attributeTypes/SegmentAttributes.ts
+++ b/packages/evolution-common/src/services/baseObjects/attributeTypes/SegmentAttributes.ts
@@ -16,7 +16,7 @@ export const modeValues = [
     'walk',
     'bicycle', // complementary type: BicycleType
     'bicyclePassenger',
-    'scooterElectric',
+    'kickScooterElectric',
     'carDriver', // complementary type: CarType
     'carPassenger',
     'transitBus', // includes Bus Transit System (BTS) category C
@@ -56,7 +56,7 @@ export const mapModeToModeCategory: { [mode in Mode]: ModeCategory } = {
     walk: 'walk',
     bicycle: 'bicycle',
     bicyclePassenger: 'bicycle',
-    scooterElectric: 'bicycle',
+    kickScooterElectric: 'bicycle',
     transitBus: 'transit',
     transitBRT: 'transit',
     transitSchoolBus: 'schoolBus', // TODO: decide  if we should use schoolBus or transit here.

--- a/packages/evolution-common/src/services/odSurvey/types.ts
+++ b/packages/evolution-common/src/services/odSurvey/types.ts
@@ -18,7 +18,7 @@ export const loopActivities = ['workOnTheRoad', 'leisureStroll'];
  * Simple modes, ie individual modes that involve no or private vehicles and are
  * often used multiple times in a journey
  */
-export const simpleModes = ['carDriver', 'walk', 'bicycle', 'bicycleElectric', 'scooterElectric'];
+export const simpleModes = ['carDriver', 'walk', 'bicycle', 'bicycleElectric', 'kickScooterElectric'];
 
 const modePreValues = [
     'carDriver',
@@ -40,7 +40,7 @@ export const modeToModePreMap: { [mode in Mode]: ModePre[] } = {
     walk: ['walk'],
     bicycle: ['bicycle'],
     bicyclePassenger: ['bicycle'],
-    scooterElectric: ['bicycle', 'other'],
+    kickScooterElectric: ['bicycle', 'other'],
     transitBus: ['transit'],
     transitBRT: ['transit'],
     transitSchoolBus: ['transit', 'other'],

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/modeIconMapping.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/modeIconMapping.ts
@@ -21,7 +21,7 @@ export const modeToIconMapping: Record<Mode, string> = {
     bicycle: '/dist/icons/modes/bicycle/bicycle_with_rider.svg',
     // FIXME Confirm this icon
     bicyclePassenger: '/dist/icons/modes/bicycle/bicycle_with_rider.svg',
-    scooterElectric: '/dist/icons/modes/scooter/scooter_electric.svg',
+    kickScooterElectric: '/dist/icons/modes/scooter/kick_scooter_electric.svg',
     // FIXME Confirm this icon
     otherActiveMode: '/dist/icons/modes/kick_scooter/kick_scooter.svg',
     motorcycle: '/dist/icons/modes/motorcycle/motorcycle.svg',


### PR DESCRIPTION
The name was incorrect, because electric scooter is not what we meant here.

Electric kick-scooter is a "Trottinette électrique" in french, which is now correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated mode name from “E‑Scooter” to “Electric Kick Scooter” in English; short label now “E‑Kick Scooter”.
  * French labels remain “Trottinette électrique” while aligning terminology internally for consistency.
  * Refreshed the electric kick scooter icon to match the updated naming.
* **Chores**
  * Standardized mode terminology across settings and surveys to ensure consistent display and selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->