### PR TITLE
modes: update path to kick scooter icon

### DIFF
--- a/packages/evolution-common/src/services/questionnaire/sections/segments/modeIconMapping.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/modeIconMapping.ts
@@ -21,7 +21,7 @@ export const modeToIconMapping: Record<Mode, string> = {
     bicycle: '/dist/icons/modes/bicycle/bicycle_with_rider.svg',
     // FIXME Confirm this icon
     bicyclePassenger: '/dist/icons/modes/bicycle/bicycle_with_rider.svg',
-    kickScooterElectric: '/dist/icons/modes/scooter/kick_scooter_electric.svg',
+    kickScooterElectric: '/dist/icons/modes/kick_scooter/kick_scooter_electric.svg',
     // FIXME Confirm this icon
     otherActiveMode: '/dist/icons/modes/kick_scooter/kick_scooter.svg',
     motorcycle: '/dist/icons/modes/motorcycle/motorcycle.svg',


### PR DESCRIPTION
It was misplaced in the `scooter` directory instead of `kick_scooter`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the icon displayed for the Electric Kick Scooter mode. Users will now see the appropriate scooter icon across questionnaires and any screens that show transport mode icons (e.g., selections, summaries, and results).
  * Visual-only update; no changes to functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->