### PR TITLE
Fix broken ui tests inputting postal codes again

### DIFF
--- a/example/demo_generator/tests/common-tests-helpers.ts
+++ b/example/demo_generator/tests/common-tests-helpers.ts
@@ -76,8 +76,7 @@ export const completeHomeSectionTests = ({ context, householdSize }: CommonTestP
     testHelpers.inputStringTest({
         context,
         path: 'home.postalCode',
-        value: 'H1S1V7',
-        expectedValue: 'H1S 1V7'
+        value: 'H1S1V7'
     });
 
     testHelpers.inputMapFindPlaceTest({ context, path: 'home.geography' });

--- a/example/demo_survey/tests/test-input-validation.UI.spec.ts
+++ b/example/demo_survey/tests/test-input-validation.UI.spec.ts
@@ -27,7 +27,7 @@ surveyTestHelpers.startAndLoginAnonymously({ context, title: 'Démo', hasUser: f
 testHelpers.tryToContinueWithInvalidInputs({ context, text: 'Save and continue', currentPageUrl: '/survey/home' , nextPageUrl: '/survey/householdMembers' });
 testHelpers.inputStringInvalidValueTest({ context, path: 'household.carNumber', value: '14' });
 testHelpers.inputStringTest({ context, path: 'home.postalCode', value: 'H1S1V77', expectedValue: 'H1S 1V7' }); // We check that the postal code doesn't accept characters past 6. This does not make the box invalid.
-testHelpers.inputStringInvalidValueTest({ context, path: 'home.postalCode', value: 'H1S1V', expectedValue: 'H1S 1V' });
+testHelpers.inputStringInvalidValueTest({ context, path: 'home.postalCode', value: 'H1S1V'}); // The space isn't added for codes with less than 6 characters
 testHelpers.inputStringInvalidValueTest({ context, path: 'home.postalCode', value: '1H1S7V', expectedValue: '1H1 S7V' });
 testHelpers.inputStringInvalidValueTest({ context, path: 'home.postalCode', value: 'H1D1F7', expectedValue: 'H1D 1F7' });
 


### PR DESCRIPTION
Codes less that 6 characters long will no longer automatically add the space, necessitating fixing a test. Aditionally, tests in demo-generator do not add the space at all, so we have to fix a test there as well.