### PR TITLE
Fix Place import of Device

### DIFF
--- a/packages/evolution-common/src/services/baseObjects/Place.ts
+++ b/packages/evolution-common/src/services/baseObjects/Place.ts
@@ -9,7 +9,7 @@ import { isFeature, isPoint } from 'geojson-validation';
 import { Optional } from '../../types/Optional.type';
 import { GeocodingPrecisionCategory, LastAction } from './attributeTypes/PlaceAttributes';
 import { Address, AddressAttributes } from './Address';
-import { Device } from './BaseInterview';
+import { Device } from './attributeTypes/InterviewParadataAttributes';
 import { Result, createErrors, createOk } from '../../types/Result.type';
 import { ParamsValidatorUtils } from '../../utils/ParamsValidatorUtils';
 import { Uuidable, UuidableAttributes } from './Uuidable';


### PR DESCRIPTION
The import was using the Base class instead of the new InterviewMetadataAttributes

Base classes are deprecated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal type dependency for device metadata to improve consistency and maintainability. No changes to behavior or public interfaces.
* **Chores**
  * Internal cleanup to align imports with current module structure. No user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->