### PR TITLE
segments: fix trip sequence when they are created

### DIFF
--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/sectionSegment.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/sectionSegment.test.ts
@@ -12,20 +12,6 @@ import { interviewAttributesForTestCases } from '../../../../../tests/surveys';
 import * as utilHelpers from '../../../../../utils/helpers';
 import * as odHelpers from '../../../../odSurvey/helpers';
 
-// Mock od helpers
-jest.mock('../../../../odSurvey/helpers', () => ({
-    getPerson: jest.fn().mockReturnValue({}),
-    getActiveJourney: jest.fn().mockReturnValue({}),
-    selectNextIncompleteTrip: jest.fn().mockReturnValue(null),
-    getVisitedPlacesArray: jest.fn().mockReturnValue([]),
-    getTripsArray: jest.fn().mockReturnValue([]),
-}));
-const mockedGetPerson = odHelpers.getPerson as jest.MockedFunction<typeof odHelpers.getPerson>;
-const mockedGetActiveJourney = odHelpers.getActiveJourney as jest.MockedFunction<typeof odHelpers.getActiveJourney>;
-const mockedSelectNextIncompleteTrip = odHelpers.selectNextIncompleteTrip as jest.MockedFunction<typeof odHelpers.selectNextIncompleteTrip>;
-const mockedGetTripsArray = odHelpers.getTripsArray as jest.MockedFunction<typeof odHelpers.getTripsArray>;
-const mockedGetVisitedPlacesArray = odHelpers.getVisitedPlacesArray as jest.MockedFunction<typeof odHelpers.getVisitedPlacesArray>;
-
 jest.mock('uuid', () => ({
     v4: jest.fn().mockReturnValue('newTripId')
 }));
@@ -34,6 +20,19 @@ const mockUuidv4 = uuidv4 as jest.MockedFunction<typeof uuidv4>;
 beforeEach(() => {
     jest.clearAllMocks();
 });
+
+// Mock the selectNextIncompleteTrip function as it is more complicated to mock an incomplete trip
+const mockedSelectNextIncompleteTrip = jest.spyOn(odHelpers, 'selectNextIncompleteTrip');
+// Set test interview with one test person for all tests. Individual tests may override if needed
+const activeJourney = { _uuid: 'testJourney1', _sequence: 1 };
+const activePerson = { _uuid: 'testPerson1', _sequence: 1, journeys: { testJourney1: activeJourney } };
+const interviewWithTestPerson = _cloneDeep(interviewAttributesForTestCases);
+interviewWithTestPerson.response.household!.persons = {
+    testPerson1: activePerson
+};
+// Set active person and journey:
+interviewWithTestPerson.response._activePersonId = activePerson._uuid;
+interviewWithTestPerson.response._activeJourneyId = activeJourney._uuid;
 
 describe('getSegmentsSectionConfig', () => {
 
@@ -70,7 +69,7 @@ describe('getSegmentsSectionConfig labels', () => {
         const mockedT = jest.fn();
         const title = widgetConfig.title;
         expect(title).toBeDefined();
-        utilHelpers.translateString(title, { t: mockedT } as any, interviewAttributesForTestCases, 'path');
+        utilHelpers.translateString(title, { t: mockedT } as any, interviewWithTestPerson, 'path');
         expect(mockedT).toHaveBeenCalledWith(['customSurvey:segments:SegmentsTitle', 'segments:SegmentsTitle']);
     });
 
@@ -85,35 +84,26 @@ describe('getSegmentsSectionConfig isSectionVisible', () => {
     });
 
     test('should return false if no iteration context', () => {
-        const result = widgetConfig.isSectionVisible!(interviewAttributesForTestCases, undefined);
+        const result = widgetConfig.isSectionVisible!(interviewWithTestPerson, undefined);
         
         expect(result).toBe(false);
-        expect(mockedGetPerson).not.toHaveBeenCalled();
     });
 
     test('should return false if no active journey', () => {
-        const testPerson = { _uuid: 'testPerson1', _sequence: 1 };
-        mockedGetPerson.mockReturnValue(testPerson);
-        mockedGetActiveJourney.mockReturnValue(null);
+        const testInterview = _cloneDeep(interviewWithTestPerson);
+        testInterview.response._activeJourneyId = undefined;
         
-        const result = widgetConfig.isSectionVisible!(interviewAttributesForTestCases, iterationContext);
+        const result = widgetConfig.isSectionVisible!(testInterview, iterationContext);
         
         expect(result).toBe(false);
-        expect(mockedGetPerson).toHaveBeenCalledWith({ interview: interviewAttributesForTestCases, personId: testPerson._uuid });
-        expect(mockedGetActiveJourney).toHaveBeenCalledWith({ interview: interviewAttributesForTestCases, person:testPerson });
     });
 
     test('should return true if there is an active journey', () => {
-        const activePerson = { _uuid: 'testPerson1', _sequence: 1 };
-        const activeJourney = { _uuid: 'journeyId1', _sequence: 1 };
-        mockedGetPerson.mockReturnValue(activePerson);
-        mockedGetActiveJourney.mockReturnValue(activeJourney);
+        const testInterview = _cloneDeep(interviewWithTestPerson);
         
-        const result = widgetConfig.isSectionVisible!(interviewAttributesForTestCases, iterationContext);
+        const result = widgetConfig.isSectionVisible!(testInterview, iterationContext);
         
         expect(result).toBe(true);
-        expect(mockedGetPerson).toHaveBeenCalledWith({ interview: interviewAttributesForTestCases, personId: 'testPerson1' });
-        expect(mockedGetActiveJourney).toHaveBeenCalledWith({ interview: interviewAttributesForTestCases, person: activePerson });
     });
 });
 
@@ -125,50 +115,37 @@ describe('getSegmentsSectionConfig isSectionCompleted', () => {
         jest.clearAllMocks();
     });
 
-    test('should return false if no active person', () => {
-        mockedGetPerson.mockReturnValue(null);
+    test('should return false if unexisting person', () => {
+        const testInterview = _cloneDeep(interviewWithTestPerson);
+        const testIterationContext = ['unexistingPerson'];
         
-        const result = widgetConfig.isSectionCompleted!(interviewAttributesForTestCases, iterationContext);
+        const result = widgetConfig.isSectionCompleted!(testInterview, testIterationContext);
         
         expect(result).toBe(false);
-        expect(mockedGetPerson).toHaveBeenCalledWith({ interview: interviewAttributesForTestCases, personId: 'testPerson1' });
     });
 
     test('should return false if no iteration context', () => {
-        const result = widgetConfig.isSectionCompleted!(interviewAttributesForTestCases, undefined);
+        const result = widgetConfig.isSectionCompleted!(interviewWithTestPerson, undefined);
         
         expect(result).toBe(false);
-        expect(mockedGetPerson).not.toHaveBeenCalled();
     });
 
     test('should return true if no next incomplete trip', () => {
-        const activePerson = { _uuid: 'testPerson1', _sequence: 1 };
-        const activeJourney = { _uuid: 'journeyId1', _sequence: 1 };
-        mockedGetPerson.mockReturnValue(activePerson);
-        mockedGetActiveJourney.mockReturnValue(activeJourney);
         mockedSelectNextIncompleteTrip.mockReturnValueOnce(null);
         
-        const result = widgetConfig.isSectionCompleted!(interviewAttributesForTestCases, iterationContext);
+        const result = widgetConfig.isSectionCompleted!(interviewWithTestPerson, iterationContext);
         
         expect(result).toBe(true);
-        expect(mockedGetPerson).toHaveBeenCalledWith({ interview: interviewAttributesForTestCases, personId: 'testPerson1' });
-        expect(mockedGetActiveJourney).toHaveBeenCalledWith({ interview: interviewAttributesForTestCases, person: activePerson });
         expect(mockedSelectNextIncompleteTrip).toHaveBeenCalledWith({ journey: activeJourney });
     });
 
     test('should return false if there is a next incomplete trip', () => {
-        const activePerson = { _uuid: 'testPerson1', _sequence: 1 };
-        const activeJourney = { _uuid: 'journeyId1', _sequence: 1 };
         const incompleteTrip = { _uuid: 'tripId1', _sequence: 1 };
-        mockedGetPerson.mockReturnValue(activePerson);
-        mockedGetActiveJourney.mockReturnValue(activeJourney);
         mockedSelectNextIncompleteTrip.mockReturnValueOnce(incompleteTrip);
         
-        const result = widgetConfig.isSectionCompleted!(interviewAttributesForTestCases, iterationContext);
+        const result = widgetConfig.isSectionCompleted!(interviewWithTestPerson, iterationContext);
         
         expect(result).toBe(false);
-        expect(mockedGetPerson).toHaveBeenCalledWith({ interview: interviewAttributesForTestCases, personId: 'testPerson1' });
-        expect(mockedGetActiveJourney).toHaveBeenCalledWith({ interview: interviewAttributesForTestCases, person: activePerson });
         expect(mockedSelectNextIncompleteTrip).toHaveBeenCalledWith({ journey: activeJourney });
     });
 });
@@ -176,75 +153,65 @@ describe('getSegmentsSectionConfig isSectionCompleted', () => {
 describe('getSegmentsSectionConfig onSectionEntry', () => {
     const widgetConfig = getSegmentsSectionConfig({});
     const iterationContext = ['testPerson1'];
-    
-    // Mock journey and person for all tests. Individual tests may override if needed
-    const activeJourney = { _uuid: 'testJourney1', _sequence: 1 };
-    const activePerson = { _uuid: 'testPerson1', _sequence: 1 };
-
-    const interviewWithTestPerson = _cloneDeep(interviewAttributesForTestCases);
-    interviewWithTestPerson.response.household!.persons = {
-        testPerson1: {
-            _uuid: 'testPerson1',
-            _sequence: 1,
-            journeys: {
-                testJourney1: activeJourney
-            }
-        }
-    }
 
     beforeEach(() => {
         jest.clearAllMocks();
-        mockedGetPerson.mockReturnValue(activePerson);
-        mockedGetActiveJourney.mockReturnValue(activeJourney);
     });
 
-    test('should return undefined if no active person', () => {
-        mockedGetPerson.mockReturnValue(null);
+    test('should return undefined if unexisting person', () => {
+        const testIterationContext = ['unexistingPerson'];
         
-        const result = widgetConfig.onSectionEntry!(interviewWithTestPerson, iterationContext);
+        const result = widgetConfig.onSectionEntry!(interviewWithTestPerson, testIterationContext);
         
         expect(result).toBeUndefined();
-        expect(mockedGetPerson).toHaveBeenCalledWith({ interview: interviewWithTestPerson, personId: 'testPerson1' });
     });
 
     test('should return undefined if no iteration context', () => {        
         const result = widgetConfig.onSectionEntry!(interviewWithTestPerson, undefined);
         
         expect(result).toBeUndefined();
-        expect(mockedGetPerson).not.toHaveBeenCalled();
     });
 
     test('should add trips when there are no trips', () => {
+        const testInterview = _cloneDeep(interviewWithTestPerson);
         // 2 places
         const places = [
             { _uuid: 'testPlace1', _sequence: 1, activity: 'home' },
             { _uuid: 'testPlace2', _sequence: 2, activity: 'workUsual' }
         ];
-        mockedGetVisitedPlacesArray.mockReturnValue(places);
+        testInterview.response.household!.persons!.testPerson1.journeys!.testJourney1.visitedPlaces = {
+            [places[0]._uuid]: places[0],
+            [places[1]._uuid]: places[1]
+        };
         // no trips
-        mockedGetTripsArray.mockReturnValue([]);
+
         // Should add a new trip
         mockUuidv4.mockReturnValueOnce('tripId1' as any);
         const newTrip = { _uuid: 'tripId1', _sequence: 1, _originVisitedPlaceUuid: 'testPlace1', _destinationVisitedPlaceUuid: 'testPlace2' };
         mockedSelectNextIncompleteTrip.mockReturnValueOnce(null);
 
-        const result = widgetConfig.onSectionEntry!(interviewWithTestPerson, iterationContext);
+        const result = widgetConfig.onSectionEntry!(testInterview, iterationContext);
         
         expect(result).toEqual({
             'response.household.persons.testPerson1.journeys.testJourney1.trips.tripId1': newTrip,
             'validations.household.persons.testPerson1.journeys.testJourney1.trips.tripId1': {},
             'response._activeTripId': 'tripId1'
         });
+        expect(mockUuidv4).toHaveBeenCalledTimes(1);
     });
 
     test('should delete trips when the number of trips is greater than the number of visited places', () => {
         const testInterview = _cloneDeep(interviewWithTestPerson);
         
         // 2 places
-        mockedGetVisitedPlacesArray.mockReturnValue([
+        const places = [
             { _uuid: 'testPlace1', _sequence: 1, activity: 'home' },
             { _uuid: 'testPlace2', _sequence: 2, activity: 'workUsual' }
-        ]);
+        ];
+        testInterview.response.household!.persons!.testPerson1.journeys!.testJourney1.visitedPlaces = {
+            [places[0]._uuid]: places[0],
+            [places[1]._uuid]: places[1]
+        };
         // 3 trips
         const trips = [
             { _uuid: 'tripId1', _sequence: 1, _originVisitedPlaceUuid: 'testPlace1', _destinationVisitedPlaceUuid: 'testPlace2' },
@@ -252,12 +219,12 @@ describe('getSegmentsSectionConfig onSectionEntry', () => {
             { _uuid: 'tripId3', _sequence: 3, _originVisitedPlaceUuid: 'testPlace3', _destinationVisitedPlaceUuid: 'testPlace4' }
         ];
         testInterview.response.household!.persons!.testPerson1.journeys!.testJourney1.trips = {
-            tripId1: trips[0],
-            tripId2: trips[1],
-            tripId3: trips[2]
+            [trips[0]._uuid]: trips[0],
+            [trips[1]._uuid]: trips[1],
+            [trips[2]._uuid]: trips[2]
         };
-        mockedGetTripsArray.mockReturnValue(trips);
         // Should remove the last 2 trips
+        mockedSelectNextIncompleteTrip.mockReturnValueOnce(null);
         
         const result = widgetConfig.onSectionEntry!(testInterview, iterationContext);
         expect(result).toEqual({
@@ -265,18 +232,21 @@ describe('getSegmentsSectionConfig onSectionEntry', () => {
             [`response.household.persons.${activePerson._uuid}.journeys.${activeJourney._uuid}.trips.tripId2`]: undefined,
             [`response.household.persons.${activePerson._uuid}.journeys.${activeJourney._uuid}.trips.tripId3`]: undefined,
             [`validations.household.persons.${activePerson._uuid}.journeys.${activeJourney._uuid}.trips.tripId2`]: undefined,
-            [`validations.household.persons.${activePerson._uuid}.journeys.${activeJourney._uuid}.trips.tripId3`]: undefined,
-
+            [`validations.household.persons.${activePerson._uuid}.journeys.${activeJourney._uuid}.trips.tripId3`]: undefined
         });
     });
 
     test('should not set an active trip if incomplete trip is to be deleted', () => {
         const testInterview = _cloneDeep(interviewWithTestPerson);
         // 2 places
-        mockedGetVisitedPlacesArray.mockReturnValue([
+        const places = [
             { _uuid: 'testPlace1', _sequence: 1, activity: 'home' },
             { _uuid: 'testPlace2', _sequence: 2, activity: 'workUsual' }
-        ]);
+        ];
+        testInterview.response.household!.persons!.testPerson1.journeys!.testJourney1.visitedPlaces = {
+            [places[0]._uuid]: places[0],
+            [places[1]._uuid]: places[1]
+        };
         // 3 trips
         const trips = [
             { _uuid: 'tripId1', _sequence: 1, _originVisitedPlaceUuid: 'testPlace1', _destinationVisitedPlaceUuid: 'testPlace2' },
@@ -288,7 +258,6 @@ describe('getSegmentsSectionConfig onSectionEntry', () => {
             tripId2: trips[1],
             tripId3: trips[2]
         };
-        mockedGetTripsArray.mockReturnValue(trips);
         // Should remove the last 2 trips
         mockedSelectNextIncompleteTrip.mockReturnValueOnce(trips[2]);
 
@@ -305,20 +274,29 @@ describe('getSegmentsSectionConfig onSectionEntry', () => {
     });
 
     test('should update trips and initialize segments when origins and destinations have changed', () => {
+        const testInterview = _cloneDeep(interviewWithTestPerson);
         // 3 places
         const places = [
             { _uuid: 'testPlace1', _sequence: 1, activity: 'home' },
             { _uuid: 'testPlace2', _sequence: 2, activity: 'workUsual' },
             { _uuid: 'testPlace3', _sequence: 3, activity: 'home' }
         ];
-        mockedGetVisitedPlacesArray.mockReturnValue(places);
+        testInterview.response.household!.persons!.testPerson1.journeys!.testJourney1.visitedPlaces = {
+            [places[0]._uuid]: places[0],
+            [places[1]._uuid]: places[1],
+            [places[2]._uuid]: places[2]
+        };
         // 2 trips, with different origins and destination
-        mockedGetTripsArray.mockReturnValue([
+        const trips = [
             { _uuid: 'tripId1', _sequence: 1, _originVisitedPlaceUuid: 'testPlace1', _destinationVisitedPlaceUuid: 'oldPlace2' },
             { _uuid: 'tripId2', _sequence: 2, _originVisitedPlaceUuid: 'oldPlace2', _destinationVisitedPlaceUuid: 'oldPlace3' }
-        ]);
+        ];
+        testInterview.response.household!.persons!.testPerson1.journeys!.testJourney1.trips = {
+            tripId1: trips[0],
+            tripId2: trips[1]
+        };
 
-        const result = widgetConfig.onSectionEntry!(interviewWithTestPerson, iterationContext);
+        const result = widgetConfig.onSectionEntry!(testInterview, iterationContext);
         
         expect(result).toEqual({
             'response.household.persons.testPerson1.journeys.testJourney1.trips.tripId1._originVisitedPlaceUuid': places[0]._uuid,
@@ -334,17 +312,21 @@ describe('getSegmentsSectionConfig onSectionEntry', () => {
     test('should set the active trip ID to the next incomplete trip', () => {
         const testInterview = _cloneDeep(interviewWithTestPerson);
         // 3 places
-        mockedGetVisitedPlacesArray.mockReturnValue([
+        const places = [
             { _uuid: 'testPlace1', _sequence: 1, activity: 'home' },
             { _uuid: 'testPlace2', _sequence: 2, activity: 'workUsual' },
             { _uuid: 'testPlace3', _sequence: 3, activity: 'home' }
-        ]);
-        // 2 trips with different origin/destination
+        ];
+        testInterview.response.household!.persons!.testPerson1.journeys!.testJourney1.visitedPlaces = {
+            [places[0]._uuid]: places[0],
+            [places[1]._uuid]: places[1],
+            [places[2]._uuid]: places[2]
+        };
+        // Trip2 is incomplete
         const trips = [
             { _uuid: 'tripId1', _sequence: 1, _originVisitedPlaceUuid: 'testPlace1', _destinationVisitedPlaceUuid: 'testPlace2' },
             { _uuid: 'tripId2', _sequence: 2, _originVisitedPlaceUuid: 'testPlace2', _destinationVisitedPlaceUuid: 'testPlace3' }
         ];
-        mockedGetTripsArray.mockReturnValue(trips);
         testInterview.response.household!.persons!.testPerson1.journeys!.testJourney1.trips = {
             tripId1: trips[0],
             tripId2: trips[1]
@@ -352,41 +334,52 @@ describe('getSegmentsSectionConfig onSectionEntry', () => {
         // Trip2 is incomplete
         const incompleteTrip = trips[1];
         mockedSelectNextIncompleteTrip.mockReturnValueOnce(incompleteTrip);
+        const expectedJourney = _cloneDeep(testInterview.response.household!.persons!.testPerson1.journeys!.testJourney1);
 
         const result = widgetConfig.onSectionEntry!(testInterview, iterationContext);
         
         expect(result).toEqual({
             'response._activeTripId': incompleteTrip._uuid
         });
-        expect(mockedSelectNextIncompleteTrip).toHaveBeenCalledWith({ journey: activeJourney });
+        expect(mockedSelectNextIncompleteTrip).toHaveBeenCalledWith({ journey: expectedJourney });
     });
 
     test('should set the active trip ID to null if no incomplete trip', () => {
+        const testInterview = _cloneDeep(interviewWithTestPerson);
         // 3 places
-        mockedGetVisitedPlacesArray.mockReturnValue([
+        const places = [
             { _uuid: 'testPlace1', _sequence: 1, activity: 'home' },
             { _uuid: 'testPlace2', _sequence: 2, activity: 'workUsual' },
             { _uuid: 'testPlace3', _sequence: 3, activity: 'home' }
-        ]);
-        // 2 trips with different origin/destination
+        ];
+        testInterview.response.household!.persons!.testPerson1.journeys!.testJourney1.visitedPlaces = {
+            [places[0]._uuid]: places[0],
+            [places[1]._uuid]: places[1],
+            [places[2]._uuid]: places[2]
+        };
+        // 2 complete trips
         const trips = [
             { _uuid: 'tripId1', _sequence: 1, _originVisitedPlaceUuid: 'testPlace1', _destinationVisitedPlaceUuid: 'testPlace2' },
             { _uuid: 'tripId2', _sequence: 2, _originVisitedPlaceUuid: 'testPlace2', _destinationVisitedPlaceUuid: 'testPlace3' }
         ];
-        mockedGetTripsArray.mockReturnValue(trips);
+        testInterview.response.household!.persons!.testPerson1.journeys!.testJourney1.trips = {
+            tripId1: trips[0],
+            tripId2: trips[1]
+        };
         mockedSelectNextIncompleteTrip.mockReturnValueOnce(null);
+        const expectedJourney = _cloneDeep(testInterview.response.household!.persons!.testPerson1.journeys!.testJourney1);
 
-        const result = widgetConfig.onSectionEntry!(interviewWithTestPerson, iterationContext);
+        const result = widgetConfig.onSectionEntry!(testInterview, iterationContext);
         
         expect(result).toEqual({
             'response._activeTripId': null
         });
-        expect(mockedSelectNextIncompleteTrip).toHaveBeenCalledWith({ journey: activeJourney });
+        expect(mockedSelectNextIncompleteTrip).toHaveBeenCalledWith({ journey: expectedJourney });
     });
 
     test('should add a new trip and select it if new trips have been added since last complete trip', () => {
         
-        // 3 places
+        // 4 places
         const places = [
             { _uuid: 'testPlace1', _sequence: 1, activity: 'home' },
             { _uuid: 'testPlace2', _sequence: 2, activity: 'workUsual' },
@@ -395,8 +388,13 @@ describe('getSegmentsSectionConfig onSectionEntry', () => {
         ];
         // Prepare interview
         const testInterview = _cloneDeep(interviewWithTestPerson);
+        testInterview.response.household!.persons!.testPerson1.journeys!.testJourney1.visitedPlaces = {
+            [places[0]._uuid]: places[0],
+            [places[1]._uuid]: places[1],
+            [places[2]._uuid]: places[2],
+            [places[3]._uuid]: places[3]
+        };
         
-        mockedGetVisitedPlacesArray.mockReturnValue(places);
         // only 1 trip, with different origins and destination, the second trip is missing
         const trips = [
             { _uuid: 'tripId1', _sequence: 1, _originVisitedPlaceUuid: 'testPlace1', _destinationVisitedPlaceUuid: 'testPlace2' }
@@ -404,8 +402,8 @@ describe('getSegmentsSectionConfig onSectionEntry', () => {
         testInterview.response.household!.persons!.testPerson1.journeys!.testJourney1.trips = {
             tripId1: trips[0]
         };
-        mockedGetTripsArray.mockReturnValue(trips);
         mockedSelectNextIncompleteTrip.mockReturnValueOnce(null);
+        const expectedJourney = _cloneDeep(testInterview.response.household!.persons!.testPerson1.journeys!.testJourney1);
 
         // Should add a new trip
         mockUuidv4.mockReturnValueOnce('tripId2' as any);
@@ -422,6 +420,7 @@ describe('getSegmentsSectionConfig onSectionEntry', () => {
             'validations.household.persons.testPerson1.journeys.testJourney1.trips.tripId3': {},
             'response._activeTripId': 'tripId2'
         });
-        expect(mockedSelectNextIncompleteTrip).toHaveBeenCalledWith({ journey: activeJourney });
+        expect(mockedSelectNextIncompleteTrip).toHaveBeenCalledWith({ journey: expectedJourney });
+        expect(mockUuidv4).toHaveBeenCalledTimes(2);
     });
 });

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/sectionSegment.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/sectionSegment.test.ts
@@ -5,12 +5,12 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import _cloneDeep from 'lodash/cloneDeep';
+import { v4 as uuidv4 } from 'uuid';
 
 import { getSegmentsSectionConfig } from '../sectionSegments';
 import { interviewAttributesForTestCases } from '../../../../../tests/surveys';
 import * as utilHelpers from '../../../../../utils/helpers';
 import * as odHelpers from '../../../../odSurvey/helpers';
-import { removeGroupedObjects, addGroupedObjects } from '../../../../../utils/helpers';
 
 // Mock od helpers
 jest.mock('../../../../odSurvey/helpers', () => ({
@@ -26,14 +26,10 @@ const mockedSelectNextIncompleteTrip = odHelpers.selectNextIncompleteTrip as jes
 const mockedGetTripsArray = odHelpers.getTripsArray as jest.MockedFunction<typeof odHelpers.getTripsArray>;
 const mockedGetVisitedPlacesArray = odHelpers.getVisitedPlacesArray as jest.MockedFunction<typeof odHelpers.getVisitedPlacesArray>;
 
-// Mock util helpers
-jest.mock('../../../../../utils/helpers', () => ({
-    ...jest.requireActual('../../../../../utils/helpers'),
-    removeGroupedObjects: jest.fn(),
-    addGroupedObjects: jest.fn()
+jest.mock('uuid', () => ({
+    v4: jest.fn().mockReturnValue('newTripId')
 }));
-const mockedAddGroupedObjects = addGroupedObjects as jest.MockedFunction<typeof addGroupedObjects>;
-const mockedRemoveGroupedObjects = removeGroupedObjects as jest.MockedFunction<typeof removeGroupedObjects>;
+const mockUuidv4 = uuidv4 as jest.MockedFunction<typeof uuidv4>;
 
 beforeEach(() => {
     jest.clearAllMocks();
@@ -185,6 +181,17 @@ describe('getSegmentsSectionConfig onSectionEntry', () => {
     const activeJourney = { _uuid: 'testJourney1', _sequence: 1 };
     const activePerson = { _uuid: 'testPerson1', _sequence: 1 };
 
+    const interviewWithTestPerson = _cloneDeep(interviewAttributesForTestCases);
+    interviewWithTestPerson.response.household!.persons = {
+        testPerson1: {
+            _uuid: 'testPerson1',
+            _sequence: 1,
+            journeys: {
+                testJourney1: activeJourney
+            }
+        }
+    }
+
     beforeEach(() => {
         jest.clearAllMocks();
         mockedGetPerson.mockReturnValue(activePerson);
@@ -194,14 +201,14 @@ describe('getSegmentsSectionConfig onSectionEntry', () => {
     test('should return undefined if no active person', () => {
         mockedGetPerson.mockReturnValue(null);
         
-        const result = widgetConfig.onSectionEntry!(interviewAttributesForTestCases, iterationContext);
+        const result = widgetConfig.onSectionEntry!(interviewWithTestPerson, iterationContext);
         
         expect(result).toBeUndefined();
-        expect(mockedGetPerson).toHaveBeenCalledWith({ interview: interviewAttributesForTestCases, personId: 'testPerson1' });
+        expect(mockedGetPerson).toHaveBeenCalledWith({ interview: interviewWithTestPerson, personId: 'testPerson1' });
     });
 
     test('should return undefined if no iteration context', () => {        
-        const result = widgetConfig.onSectionEntry!(interviewAttributesForTestCases, undefined);
+        const result = widgetConfig.onSectionEntry!(interviewWithTestPerson, undefined);
         
         expect(result).toBeUndefined();
         expect(mockedGetPerson).not.toHaveBeenCalled();
@@ -217,41 +224,42 @@ describe('getSegmentsSectionConfig onSectionEntry', () => {
         // no trips
         mockedGetTripsArray.mockReturnValue([]);
         // Should add a new trip
+        mockUuidv4.mockReturnValueOnce('tripId1' as any);
         const newTrip = { _uuid: 'tripId1', _sequence: 1, _originVisitedPlaceUuid: 'testPlace1', _destinationVisitedPlaceUuid: 'testPlace2' };
-        mockedAddGroupedObjects.mockReturnValue({ 'response.household.persons.testPerson1.journeys.testJourney1.trips.tripId1': newTrip });
         mockedSelectNextIncompleteTrip.mockReturnValueOnce(null);
 
-        const result = widgetConfig.onSectionEntry!(interviewAttributesForTestCases, iterationContext);
+        const result = widgetConfig.onSectionEntry!(interviewWithTestPerson, iterationContext);
         
-        expect(mockedAddGroupedObjects).toHaveBeenCalledWith(interviewAttributesForTestCases, 1, 1, 'household.persons.testPerson1.journeys.testJourney1.trips', [{ _originVisitedPlaceUuid: 'testPlace1', _destinationVisitedPlaceUuid: 'testPlace2' }]);
         expect(result).toEqual({
             'response.household.persons.testPerson1.journeys.testJourney1.trips.tripId1': newTrip,
+            'validations.household.persons.testPerson1.journeys.testJourney1.trips.tripId1': {},
             'response._activeTripId': 'tripId1'
         });
     });
 
     test('should delete trips when the number of trips is greater than the number of visited places', () => {
+        const testInterview = _cloneDeep(interviewWithTestPerson);
+        
         // 2 places
         mockedGetVisitedPlacesArray.mockReturnValue([
             { _uuid: 'testPlace1', _sequence: 1, activity: 'home' },
             { _uuid: 'testPlace2', _sequence: 2, activity: 'workUsual' }
         ]);
         // 3 trips
-        mockedGetTripsArray.mockReturnValue([
+        const trips = [
             { _uuid: 'tripId1', _sequence: 1, _originVisitedPlaceUuid: 'testPlace1', _destinationVisitedPlaceUuid: 'testPlace2' },
             { _uuid: 'tripId2', _sequence: 2, _originVisitedPlaceUuid: 'testPlace2', _destinationVisitedPlaceUuid: 'testPlace3' },
             { _uuid: 'tripId3', _sequence: 3, _originVisitedPlaceUuid: 'testPlace3', _destinationVisitedPlaceUuid: 'testPlace4' }
-        ]);
-        // Should remove the last 2 trips
-        mockedRemoveGroupedObjects.mockImplementation((_interview, paths) => [{}, (typeof paths === 'string' ? [paths] : paths).flatMap((path) => [ `response.${path}`, `validations.${path}` ]) ]);
-
-        const result = widgetConfig.onSectionEntry!(interviewAttributesForTestCases, iterationContext);
-        
-        const pathsToDelete = [
-            `household.persons.${activePerson._uuid}.journeys.${activeJourney._uuid}.trips.tripId2`,
-            `household.persons.${activePerson._uuid}.journeys.${activeJourney._uuid}.trips.tripId3`
         ];
-        expect(mockedRemoveGroupedObjects).toHaveBeenCalledWith(interviewAttributesForTestCases, pathsToDelete);
+        testInterview.response.household!.persons!.testPerson1.journeys!.testJourney1.trips = {
+            tripId1: trips[0],
+            tripId2: trips[1],
+            tripId3: trips[2]
+        };
+        mockedGetTripsArray.mockReturnValue(trips);
+        // Should remove the last 2 trips
+        
+        const result = widgetConfig.onSectionEntry!(testInterview, iterationContext);
         expect(result).toEqual({
             'response._activeTripId': null,
             [`response.household.persons.${activePerson._uuid}.journeys.${activeJourney._uuid}.trips.tripId2`]: undefined,
@@ -262,7 +270,8 @@ describe('getSegmentsSectionConfig onSectionEntry', () => {
         });
     });
 
-    test('should not set an active trip is incomplete trip is to be deleted', () => {
+    test('should not set an active trip if incomplete trip is to be deleted', () => {
+        const testInterview = _cloneDeep(interviewWithTestPerson);
         // 2 places
         mockedGetVisitedPlacesArray.mockReturnValue([
             { _uuid: 'testPlace1', _sequence: 1, activity: 'home' },
@@ -274,18 +283,17 @@ describe('getSegmentsSectionConfig onSectionEntry', () => {
             { _uuid: 'tripId2', _sequence: 2, _originVisitedPlaceUuid: 'testPlace2', _destinationVisitedPlaceUuid: 'testPlace3' },
             { _uuid: 'tripId3', _sequence: 3, _originVisitedPlaceUuid: 'testPlace3', _destinationVisitedPlaceUuid: 'testPlace4' }
         ]
+        testInterview.response.household!.persons!.testPerson1.journeys!.testJourney1.trips = {
+            tripId1: trips[0],
+            tripId2: trips[1],
+            tripId3: trips[2]
+        };
         mockedGetTripsArray.mockReturnValue(trips);
         // Should remove the last 2 trips
-        mockedRemoveGroupedObjects.mockImplementation((_interview, paths) => [{}, (typeof paths === 'string' ? [paths] : paths).flatMap((path) => [ `response.${path}`, `validations.${path}` ]) ]);
         mockedSelectNextIncompleteTrip.mockReturnValueOnce(trips[2]);
 
-        const result = widgetConfig.onSectionEntry!(interviewAttributesForTestCases, iterationContext);
+        const result = widgetConfig.onSectionEntry!(testInterview, iterationContext);
         
-        const pathsToDelete = [
-            `household.persons.${activePerson._uuid}.journeys.${activeJourney._uuid}.trips.tripId2`,
-            `household.persons.${activePerson._uuid}.journeys.${activeJourney._uuid}.trips.tripId3`
-        ];
-        expect(mockedRemoveGroupedObjects).toHaveBeenCalledWith(interviewAttributesForTestCases, pathsToDelete);
         expect(result).toEqual({
             'response._activeTripId': null,
             [`response.household.persons.${activePerson._uuid}.journeys.${activeJourney._uuid}.trips.tripId2`]: undefined,
@@ -310,7 +318,7 @@ describe('getSegmentsSectionConfig onSectionEntry', () => {
             { _uuid: 'tripId2', _sequence: 2, _originVisitedPlaceUuid: 'oldPlace2', _destinationVisitedPlaceUuid: 'oldPlace3' }
         ]);
 
-        const result = widgetConfig.onSectionEntry!(interviewAttributesForTestCases, iterationContext);
+        const result = widgetConfig.onSectionEntry!(interviewWithTestPerson, iterationContext);
         
         expect(result).toEqual({
             'response.household.persons.testPerson1.journeys.testJourney1.trips.tripId1._originVisitedPlaceUuid': places[0]._uuid,
@@ -321,11 +329,10 @@ describe('getSegmentsSectionConfig onSectionEntry', () => {
             'response.household.persons.testPerson1.journeys.testJourney1.trips.tripId2.segments': undefined,
             'response._activeTripId': 'tripId1'
         });
-        expect(mockedAddGroupedObjects).not.toHaveBeenCalled();
-        expect(mockedRemoveGroupedObjects).not.toHaveBeenCalled();
     });
 
     test('should set the active trip ID to the next incomplete trip', () => {
+        const testInterview = _cloneDeep(interviewWithTestPerson);
         // 3 places
         mockedGetVisitedPlacesArray.mockReturnValue([
             { _uuid: 'testPlace1', _sequence: 1, activity: 'home' },
@@ -338,11 +345,15 @@ describe('getSegmentsSectionConfig onSectionEntry', () => {
             { _uuid: 'tripId2', _sequence: 2, _originVisitedPlaceUuid: 'testPlace2', _destinationVisitedPlaceUuid: 'testPlace3' }
         ];
         mockedGetTripsArray.mockReturnValue(trips);
+        testInterview.response.household!.persons!.testPerson1.journeys!.testJourney1.trips = {
+            tripId1: trips[0],
+            tripId2: trips[1]
+        };
         // Trip2 is incomplete
         const incompleteTrip = trips[1];
         mockedSelectNextIncompleteTrip.mockReturnValueOnce(incompleteTrip);
 
-        const result = widgetConfig.onSectionEntry!(interviewAttributesForTestCases, iterationContext);
+        const result = widgetConfig.onSectionEntry!(testInterview, iterationContext);
         
         expect(result).toEqual({
             'response._activeTripId': incompleteTrip._uuid
@@ -365,7 +376,7 @@ describe('getSegmentsSectionConfig onSectionEntry', () => {
         mockedGetTripsArray.mockReturnValue(trips);
         mockedSelectNextIncompleteTrip.mockReturnValueOnce(null);
 
-        const result = widgetConfig.onSectionEntry!(interviewAttributesForTestCases, iterationContext);
+        const result = widgetConfig.onSectionEntry!(interviewWithTestPerson, iterationContext);
         
         expect(result).toEqual({
             'response._activeTripId': null
@@ -374,31 +385,43 @@ describe('getSegmentsSectionConfig onSectionEntry', () => {
     });
 
     test('should add a new trip and select it if new trips have been added since last complete trip', () => {
+        
         // 3 places
         const places = [
             { _uuid: 'testPlace1', _sequence: 1, activity: 'home' },
             { _uuid: 'testPlace2', _sequence: 2, activity: 'workUsual' },
-            { _uuid: 'testPlace3', _sequence: 3, activity: 'home' }
+            { _uuid: 'testPlace3', _sequence: 3, activity: 'shopping' },
+            { _uuid: 'testPlace4', _sequence: 4, activity: 'home' }
         ];
+        // Prepare interview
+        const testInterview = _cloneDeep(interviewWithTestPerson);
+        
         mockedGetVisitedPlacesArray.mockReturnValue(places);
         // only 1 trip, with different origins and destination, the second trip is missing
-        mockedGetTripsArray.mockReturnValue([
+        const trips = [
             { _uuid: 'tripId1', _sequence: 1, _originVisitedPlaceUuid: 'testPlace1', _destinationVisitedPlaceUuid: 'testPlace2' }
-        ]);
+        ];
+        testInterview.response.household!.persons!.testPerson1.journeys!.testJourney1.trips = {
+            tripId1: trips[0]
+        };
+        mockedGetTripsArray.mockReturnValue(trips);
         mockedSelectNextIncompleteTrip.mockReturnValueOnce(null);
 
         // Should add a new trip
-        const newTrip = { _uuid: 'tripId2', _sequence: 2, _originVisitedPlaceUuid: places[1]._uuid, _destinationVisitedPlaceUuid: places[2]._uuid };
-        mockedAddGroupedObjects.mockReturnValue({ 'response.household.persons.testPerson1.journeys.testJourney1.trips.tripId2': newTrip });
+        mockUuidv4.mockReturnValueOnce('tripId2' as any);
+        mockUuidv4.mockReturnValueOnce('tripId3' as any);
+        const newTrip2 = { _uuid: 'tripId2', _sequence: 2, _originVisitedPlaceUuid: places[1]._uuid, _destinationVisitedPlaceUuid: places[2]._uuid };
+        const newTrip3 = { _uuid: 'tripId3', _sequence: 3, _originVisitedPlaceUuid: places[2]._uuid, _destinationVisitedPlaceUuid: places[3]._uuid };
 
-        const result = widgetConfig.onSectionEntry!(interviewAttributesForTestCases, iterationContext);
+        const result = widgetConfig.onSectionEntry!(testInterview, iterationContext);
         
         expect(result).toEqual({
-            'response.household.persons.testPerson1.journeys.testJourney1.trips.tripId2': newTrip,
+            'response.household.persons.testPerson1.journeys.testJourney1.trips.tripId2': newTrip2,
+            'validations.household.persons.testPerson1.journeys.testJourney1.trips.tripId2': {},
+            'response.household.persons.testPerson1.journeys.testJourney1.trips.tripId3': newTrip3,
+            'validations.household.persons.testPerson1.journeys.testJourney1.trips.tripId3': {},
             'response._activeTripId': 'tripId2'
         });
-        expect(mockedAddGroupedObjects).toHaveBeenCalledWith(interviewAttributesForTestCases, 1, 2, 'household.persons.testPerson1.journeys.testJourney1.trips', [{ _originVisitedPlaceUuid: places[1]._uuid, _destinationVisitedPlaceUuid: places[2]._uuid }]);
-        expect(mockedRemoveGroupedObjects).not.toHaveBeenCalled();
         expect(mockedSelectNextIncompleteTrip).toHaveBeenCalledWith({ journey: activeJourney });
     });
 });


### PR DESCRIPTION
fixes #1206

Trips were added one at a time, but they were not directly added to the interview, which means the number of trips did not change, so all trips were created with the same sequence number. Instead, we keep an array of trips data to add and create all trips at once, such that they will each have a different sequence number.

Also do not mock the `addGroupedObject` function to allow to catch such errors as the one we had.

Also do not mock the odHelper functions, to better detect eventual issues in the functions under test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Batched creation of missing trips for improved performance and consistency.
  * Applies all additions in one step and determines the first invalid trip from the batch.
  * Enhances reliability of active trip selection and state/validation updates.

* **Tests**
  * Reworked tests to use explicit test interview data and deterministic UUIDs.
  * Removed broad helper mocks and added targeted spies for active-trip selection.
  * Expanded coverage for adding, deleting, and updating trips with stronger assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->