### PR TITLE
survey: unset undefined valuesByPath instead of setting undefined

### DIFF
--- a/packages/evolution-frontend/src/actions/Survey.ts
+++ b/packages/evolution-frontend/src/actions/Survey.ts
@@ -210,7 +210,11 @@ export const updateInterviewData = (
         for (const path in updatedData.valuesByPath) {
             if (path !== '_all') {
                 affectedPaths[path] = true;
-                _set(interview, path, updatedData.valuesByPath[path]);
+                if (updatedData.valuesByPath[path] === undefined) {
+                    _unset(interview, path);
+                } else {
+                    _set(interview, path, updatedData.valuesByPath[path]);
+                }
             }
         }
     }


### PR DESCRIPTION
fixes #1216

When updating the interviews, the keys in `valuesByPath` that map to an `undefined` value should be unset instead of being set to `undefined`, which effectively kept the key present in the object and caused errors in group objects like trips or visited places, which were still counted as existing.

An `undefined` value in the `valuesByPath` is the equivalent to setting it in the `unsetPaths`, as this is what is done before sending the values to the server, such that the interview, on the server side will effectively unset this value.

Also update the unit tests to use the deepEqual on the interview, as the jest equality will consider equal an undefined value for a key and the absence of the key. So it makes sure the interview as really as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Clearing a survey answer now removes the field instead of storing undefined, improving data cleanliness, validation, and server sync.

- Tests
  - Added stricter deep-equality checks to distinguish missing vs undefined properties.
  - Added a test for undefined-answer scenarios and expanded coverage verifying interview state transitions, server payloads, and dispatch sequences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->