### PR TITLE
tests: mock the `db.config` in backend tests

### DIFF
--- a/packages/evolution-backend/jest.config.js
+++ b/packages/evolution-backend/jest.config.js
@@ -11,6 +11,10 @@ const baseConfig = require('../../tests/jest.config.base');
 
 module.exports = {
     ...baseConfig,
+    setupFilesAfterEnv: [
+        ...baseConfig.setupFilesAfterEnv,
+        './jestSetup.ts'
+    ],
     'testPathIgnorePatterns': ['(/__tests__/.*(db\\.test)\\.(jsx?|tsx?))$'],
 };
 

--- a/packages/evolution-backend/jestSetup.ts
+++ b/packages/evolution-backend/jestSetup.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+jest.mock('chaire-lib-backend/lib/config/shared/db.config');


### PR DESCRIPTION
fixes #1196

Add a `jestSetup.ts` file at test startup to mock the `db.config` for all tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Introduced a global Jest setup to ensure a consistent test environment.
  * Added configuration mocking to stabilize tests and reduce flakiness.
  * Improves reliability of backend test runs without affecting production behavior.

* **Chores**
  * Updated test configuration to streamline setup and maintenance.

No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->