### PR TITLE
auth: send the welcome email asynchronously

### DIFF
--- a/packages/evolution-backend/src/services/auth/participantAuthModel.ts
+++ b/packages/evolution-backend/src/services/auth/participantAuthModel.ts
@@ -48,7 +48,8 @@ class ParticipantAuthModel extends AuthModelBase<ParticipantModel> {
 
         // Send a welcome email to the new user if the server is configured to do so
         if ((config.auth as any)?.welcomeEmail === true) {
-            await sendWelcomeEmail(user);
+            // Send welcome email, no need to wait for it
+            sendWelcomeEmail(user);
         }
 
         return user;


### PR DESCRIPTION
fixes #1244

Waiting for it increases the time to login and it is not essential to the login/registration process of the survey. If it fails, we'll know in the logs.