### PR TITLE
Disable frozen check in admin/review mode

### DIFF
--- a/packages/evolution-backend/src/api/survey.validation.routes.ts
+++ b/packages/evolution-backend/src/api/survey.validation.routes.ts
@@ -37,14 +37,6 @@ router.get(
             try {
                 const interview = await Interviews.getInterviewByUuid(req.params.interviewUuid);
                 if (interview) {
-                    // Check if interview is frozen, if so, do not allow access
-                    if (interview?.is_frozen) {
-                        console.log('activeSurvey: Interview is frozen');
-                        return res
-                            .status(403)
-                            .json({ status: 'forbidden', interview: null, error: 'interview cannot be accessed' });
-                    }
-
                     const forceCopy = _booleish(req.query.reset) === true;
                     // Copy the response in the corrected_response
                     if (forceCopy || _isBlank(interview.corrected_response)) {


### PR DESCRIPTION
It made it impossible to load or edit an interview in review mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Users can now start the interview correction flow even when an interview was previously marked as frozen; the correction copy is created and audits run as usual.
  - Eliminates unexpected “Forbidden” errors during correction, ensuring a consistent, uninterrupted workflow and successful retrieval of interview data.
  - Improves reliability of correction requests and reduces friction for users performing post-interview updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->