### PR TITLE
webpack: fix icon paths for demo projects

### DIFF
--- a/example/demo_generator/webpack.admin.config.js
+++ b/example/demo_generator/webpack.admin.config.js
@@ -144,7 +144,7 @@ module.exports = (env) => {
             new CleanWebpackPlugin({
                 dry: !isProduction,
                 verbose: true,
-                cleanAfterEveryBuildPatterns: ['**/*', '!images/**', '!*.html']
+                cleanAfterEveryBuildPatterns: ['**/*', '!images/**', '!icons/**', '!*.html']
             }),
             new HtmlWebpackPlugin({
                 title: process.env.DEFAULT_TITLE || 'Evolution - Admin',
@@ -180,6 +180,12 @@ module.exports = (env) => {
             new webpack.ContextReplacementPlugin(/moment[\/\\]locale$/, new RegExp(momentLanguagesFilter)),
             new CopyWebpackPlugin({
                 patterns: [
+                    {
+                        context: path.join(__dirname, '..', '..', 'node_modules', 'chaire-lib-frontend', 'lib', 'assets'),
+                        from: "**/*",
+                        to: "",
+                        noErrorOnMissing: true
+                    },
                     {
                         context: path.join(
                             __dirname,

--- a/example/demo_generator/webpack.config.js
+++ b/example/demo_generator/webpack.config.js
@@ -126,7 +126,7 @@ module.exports = (env) => {
             new CleanWebpackPlugin({
                 dry: !isProduction,
                 verbose: true,
-                cleanAfterEveryBuildPatterns: ['**/*', '!images/**', '!*.html']
+                cleanAfterEveryBuildPatterns: ['**/*', '!images/**', '!icons/**', '!*.html']
             }),
             new HtmlWebpackPlugin({
                 title: process.env.DEFAULT_TITLE || 'Evolution',
@@ -162,6 +162,12 @@ module.exports = (env) => {
             new webpack.ContextReplacementPlugin(/moment[\/\\]locale$/, new RegExp(momentLanguagesFilter)),
             new CopyWebpackPlugin({
                 patterns: [
+                    {
+                        context: path.join(__dirname, '..', '..', 'node_modules', 'chaire-lib-frontend', 'lib', 'assets'),
+                        from: "**/*",
+                        to: "",
+                        noErrorOnMissing: true
+                    },
                     {
                         context: path.join(
                             __dirname,

--- a/example/demo_survey/webpack.admin.config.js
+++ b/example/demo_survey/webpack.admin.config.js
@@ -138,7 +138,7 @@ module.exports = (env) => {
       new CleanWebpackPlugin({
         dry: !isProduction,
         verbose: true,
-        cleanAfterEveryBuildPatterns: ['**/*', '!images/**', '!*.html'],
+        cleanAfterEveryBuildPatterns: ['**/*', '!images/**', '!icons/**', '!*.html'],
       }),
       new HtmlWebpackPlugin({
         title: process.env.DEFAULT_TITLE || 'Evolution - Admin',
@@ -173,6 +173,12 @@ module.exports = (env) => {
       new CopyWebpackPlugin(
         {
           patterns: [
+            {
+              context: path.join(__dirname, '..', '..', 'node_modules', 'chaire-lib-frontend', 'lib', 'assets'),
+              from: "**/*",
+              to: "",
+              noErrorOnMissing: true
+            },
             {
               context: path.join(__dirname, '..', '..', 'node_modules', 'evolution-frontend', 'lib', 'assets'),
               from: "**/*",

--- a/example/demo_survey/webpack.config.js
+++ b/example/demo_survey/webpack.config.js
@@ -122,7 +122,7 @@ module.exports = (env) => {
       new CleanWebpackPlugin({
         dry: !isProduction,
         verbose: true,
-        cleanAfterEveryBuildPatterns: ['**/*', '!images/**', '!*.html'],
+        cleanAfterEveryBuildPatterns: ['**/*', '!images/**', '!icons/**', '!*.html'],
       }),
       new HtmlWebpackPlugin({
         title: process.env.DEFAULT_TITLE || 'Evolution',
@@ -159,11 +159,11 @@ module.exports = (env) => {
         {
           patterns: [
             {
-                context: path.join(__dirname, '..', '..', 'node_modules', 'chaire-lib-frontend', 'lib', 'assets'),
-                from: "**/*",
-                to: "",
-                noErrorOnMissing: true
-              },
+              context: path.join(__dirname, '..', '..', 'node_modules', 'chaire-lib-frontend', 'lib', 'assets'),
+              from: "**/*",
+              to: "",
+              noErrorOnMissing: true
+            },
             {
               context: path.join(__dirname, '..', '..', 'node_modules', 'evolution-frontend', 'lib', 'assets'),
               from: "**/*",


### PR DESCRIPTION
The icons from `chaire-lib-frontend` assets were not copied in the `demo_survey` and `demo_generator` projects. Also make sure the `icons` directory is not removed on production builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Additional shared UI assets are now bundled into the admin and demo builds, improving visual consistency and component availability.
* **Bug Fixes**
  * Icons are no longer removed during build cleanup, preventing missing or broken icon displays in the interface.
* **Chores**
  * Build pipeline refined to include shared asset copying and safer cleanup rules for more reliable builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->