### PR TITLE
refactor(DateTimeUtils)

### DIFF
--- a/packages/evolution-common/src/config/__tests__/project.config.initialized.test.ts
+++ b/packages/evolution-common/src/config/__tests__/project.config.initialized.test.ts
@@ -4,7 +4,7 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import projectConfig from "../project.config";
+import projectConfig from '../project.config';
 
 // Mock the project config from evolution-common, which might already have been
 // loaded before the first import to the evolution project config. The
@@ -16,6 +16,8 @@ jest.mock('chaire-lib-common/lib/config/shared/project.config', () => ({
         region: 'FR',
         selfResponseMinimumAge: 18,
         logDatabaseUpdates: true,
+        startDateTimeWithTimezoneOffset: '2025-03-01T08:00:00-05:00',
+        endDateTimeWithTimezoneOffset: '2025-11-30T23:59:59-05:00',
         hideStartButtonOnHomePage: true,
         introductionTwoParagraph: true,
         introBanner: true,
@@ -31,6 +33,8 @@ test('test initialized values', () => {
         region: 'FR',
         selfResponseMinimumAge: 18,
         logDatabaseUpdates: true,
+        startDateTimeWithTimezoneOffset: '2025-03-01T08:00:00-05:00',
+        endDateTimeWithTimezoneOffset: '2025-11-30T23:59:59-05:00',
         hideStartButtonOnHomePage: true,
         introductionTwoParagraph: true,
         introBanner: true,

--- a/packages/evolution-common/src/config/__tests__/project.config.test.ts
+++ b/packages/evolution-common/src/config/__tests__/project.config.test.ts
@@ -4,8 +4,9 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import { setProjectConfiguration } from "chaire-lib-common/lib/config/shared/project.config";
-import projectConfig, { EvolutionProjectConfiguration } from "../project.config";
+import { setProjectConfiguration } from 'chaire-lib-common/lib/config/shared/project.config';
+import projectConfig, { EvolutionProjectConfiguration } from '../project.config';
+import { ISODateTimeStringWithTimezoneOffset } from '../../utils/DateTimeUtils';
 
 test('Expected default', () => {
     expect(projectConfig).toEqual(expect.objectContaining({
@@ -13,6 +14,8 @@ test('Expected default', () => {
         selfResponseMinimumAge: 14,
         drivingLicenseAge: 16,
         logDatabaseUpdates: false,
+        startDateTimeWithTimezoneOffset: undefined,
+        endDateTimeWithTimezoneOffset: undefined,
         hideStartButtonOnHomePage: false,
         introductionTwoParagraph: false,
         introBanner: false,
@@ -30,6 +33,8 @@ test('set project configuration', () => {
         selfResponseMinimumAge: 18,
         drivingLicenseAge: 16,
         logDatabaseUpdates: true,
+        startDateTimeWithTimezoneOffset: '2025-01-01T00:00:00-05:00' as ISODateTimeStringWithTimezoneOffset,
+        endDateTimeWithTimezoneOffset: '2025-12-31T23:59:59-05:00' as ISODateTimeStringWithTimezoneOffset,
         hideStartButtonOnHomePage: true,
         introductionTwoParagraph: true,
         introBanner: true,
@@ -38,7 +43,7 @@ test('set project configuration', () => {
         logoPaths: { 'en': 'logo-en.png', 'fr': 'logo-fr.png' },
         languageNames: { 'en': 'English', 'fr': 'Français' },
         title: { 'en': 'Survey title', 'fr': 'Titre de l\'enquête' }
-    }
+    };
     setProjectConfiguration<EvolutionProjectConfiguration>(configToSet);
     expect(projectConfig).toEqual(expect.objectContaining(configToSet));
 });

--- a/packages/evolution-common/src/config/project.config.ts
+++ b/packages/evolution-common/src/config/project.config.ts
@@ -8,6 +8,7 @@ import projectConfig, {
     ProjectConfiguration,
     setProjectConfiguration
 } from 'chaire-lib-common/lib/config/shared/project.config';
+import { ISODateTimeStringWithTimezoneOffset } from '../utils/DateTimeUtils';
 
 /**
  * Specific configuration for the Evolution project
@@ -25,6 +26,24 @@ export type EvolutionProjectConfiguration = {
     /** Used for Google Maps localization. See
      * https://developers.google.com/maps/coverage for possible region codes */
     region: string;
+    /**
+     * Start date time for the survey in ISO date time string format with timezone offset
+     * (YYYY-MM-DDTHH:MM:SS-/+HH:MM). Example: 2025-01-01T00:00:00-05:00.
+     * Interviews started before this date and time should be invalidated and/or ignored.
+     * If both startDateTimeWithTimezoneOffset and endDateTimeWithTimezoneOffset are defined,
+     * endDateTimeWithTimezoneOffset must be after startDateTimeWithTimezoneOffset.
+     * Provide the timezone offset so we can calculate the correct unix epoch.
+     * */
+    startDateTimeWithTimezoneOffset?: ISODateTimeStringWithTimezoneOffset;
+    /**
+     * End date time for the survey in ISO date time string format with timezone offset
+     * (YYYY-MM-DDTHH:MM:SS-/+HH:MM). Example: 2025-01-01T00:00:00-05:00.
+     * Interviews started after this date and time should be invalidated and/or ignored.
+     * If both startDateTimeWithTimezoneOffset and endDateTimeWithTimezoneOffset are defined,
+     * endDateTimeWithTimezoneOffset must be after startDateTimeWithTimezoneOffset.
+     * Provide the timezone offset so we can calculate the correct unix epoch.
+     * */
+    endDateTimeWithTimezoneOffset?: ISODateTimeStringWithTimezoneOffset;
     /** Whether to log database updates. FIXME This should be server-side only
      * */
     logDatabaseUpdates: boolean;
@@ -89,7 +108,7 @@ export type EvolutionProjectConfiguration = {
      * /en, /fr, etc. or with lng=fr in the query string will be used to set the
      * language. Defaults to `true`
      */
-    detectLanguageFromUrl: true;
+    detectLanguageFromUrl: boolean;
     /**
      * If `detectLanguageFromUrl` is false, setting this will use `cookie`,
      * `localStorage` or the navigator to detect the language
@@ -97,7 +116,7 @@ export type EvolutionProjectConfiguration = {
      * FIXME Why? Why not just use the URL? This has been part of evolution
      * forever though, so there probably was a reason.
      */
-    detectLanguage: true;
+    detectLanguage: boolean;
     /**
      * The names of the languages, used in the language selector on the home page
      */
@@ -143,64 +162,67 @@ export type EvolutionProjectConfiguration = {
 };
 
 // Make sure default values are set
-setProjectConfiguration<EvolutionProjectConfiguration>(
-    Object.assign(
-        {
-            region: 'CA',
-            logDatabaseUpdates: false,
-            selfResponseMinimumAge: 14,
-            interviewableAge: 5,
-            adultAge: 18,
-            drivingLicenseAge: 16,
-            surveySupportForm: false,
-            mapDefaultCenter: {
-                lat: 45.5,
-                lon: -73.6
-            },
-            hideStartButtonOnHomePage: false,
-            introductionTwoParagraph: false,
-            introBanner: false,
-            bannerPaths: {},
-            introLogoAfterStartButton: false,
-            logoPaths: {},
-            detectLanguageFromUrl: true,
-            detectLanguage: false,
-            languageNames: { en: 'English', fr: 'Français' },
-            title: { en: 'Survey', fr: 'Enquête' },
-            postalCodeRegion: 'other',
-            personColorsPalette: [
-                // FIXME See this issue https://github.com/chairemobilite/evolution/issues/1246
-                '#FFAE70',
-                '#FFBCF2',
-                '#F2ED6A',
-                '#90E04A',
-                '#61CAD8',
-                '#9F70FF',
-                '#FF6868',
-                '#63A021',
-                '#21A09E',
-                '#4146B5',
-                '#9F41B5',
-                '#B5417B',
-                '#B5B5B5',
-                '#B59900',
-                '#9E5135',
-                '#FFAE70',
-                '#FFBCF2',
-                '#F2ED6A',
-                '#90E04A',
-                '#61CAD8',
-                '#9F70FF',
-                '#FF6868',
-                '#63A021',
-                '#21A09E',
-                '#4146B5',
-                '#9F41B5',
-                '#B5417B'
-            ]
-        },
-        projectConfig
-    )
-);
+const defaultConfig = {
+    region: 'CA',
+    logDatabaseUpdates: false,
+    selfResponseMinimumAge: 14,
+    interviewableAge: 5,
+    adultAge: 18,
+    drivingLicenseAge: 16,
+    surveySupportForm: false,
+    mapDefaultCenter: {
+        lat: 45.5,
+        lon: -73.6
+    },
+    countryCode: 'CA',
+    startDateTimeWithTimezoneOffset: undefined,
+    endDateTimeWithTimezoneOffset: undefined,
+    hideStartButtonOnHomePage: false,
+    introductionTwoParagraph: false,
+    introBanner: false,
+    bannerPaths: {},
+    introLogoAfterStartButton: false,
+    logoPaths: {},
+    detectLanguageFromUrl: true,
+    detectLanguage: false,
+    languageNames: { en: 'English', fr: 'Français' },
+    title: { en: 'Survey', fr: 'Enquête' },
+    postalCodeRegion: 'other',
+    personColorsPalette: [
+        // FIXME See this issue https://github.com/chairemobilite/evolution/issues/1246
+        '#FFAE70',
+        '#FFBCF2',
+        '#F2ED6A',
+        '#90E04A',
+        '#61CAD8',
+        '#9F70FF',
+        '#FF6868',
+        '#63A021',
+        '#21A09E',
+        '#4146B5',
+        '#9F41B5',
+        '#B5417B',
+        '#B5B5B5',
+        '#B59900',
+        '#9E5135',
+        '#FFAE70',
+        '#FFBCF2',
+        '#F2ED6A',
+        '#90E04A',
+        '#61CAD8',
+        '#9F70FF',
+        '#FF6868',
+        '#63A021',
+        '#21A09E',
+        '#4146B5',
+        '#9F41B5',
+        '#B5417B'
+    ]
+};
+
+// Validate and set the configuration
+const mergedConfig = Object.assign({}, defaultConfig, projectConfig);
+
+setProjectConfiguration<EvolutionProjectConfiguration>(mergedConfig);
 
 export default projectConfig as ProjectConfiguration<EvolutionProjectConfiguration>;

--- a/packages/evolution-common/src/utils/DateTimeUtils.ts
+++ b/packages/evolution-common/src/utils/DateTimeUtils.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+/**
+ * Branded type for ISO date time strings in YYYY-MM-DDTHH:MM:SS-/+HH:MM format with timezone offset.
+ * This prevents passing arbitrary strings where validated date times with timezones are expected.
+ */
+export type ISODateTimeStringWithTimezoneOffset = string & { readonly __brand: 'ISODateTimeStringWithTimezoneOffset' };
+
+/**
+ * Branded type for timezones.
+ * This prevents passing arbitrary strings where validated timezones are expected.
+ */
+export type Timezone = string & { readonly __brand: 'Timezone' };
+
+/**
+ * Converts a Unix epoch in seconds to a Date object.
+ * @param epochSeconds - The Unix epoch in seconds.
+ * @returns A Date object representing the given epoch time.
+ */
+export const epochToDate = (epochSeconds: number): Date => {
+    // see https://stackoverflow.com/questions/4631928/convert-utc-epoch-to-local-date
+    // to understand why we need to set Date to 0 (reset to UTC epoch)
+    const utcDate = new Date(0);
+    utcDate.setUTCSeconds(epochSeconds);
+    return utcDate;
+};
+
+/**
+ * Converts a Date object to a locale-specific string.
+ * @param date - The Date object to convert.
+ * @param locale - The locale to use for the string. Default is 'en-CA'.
+ * @param timeZone - The time zone to use for the string. Default is 'UTC'.
+ * @returns A formatted string in the specified locale and timezone.
+ */
+export const dateToString = (date: Date, locale: string = 'en-CA', timeZone: Timezone = 'UTC' as Timezone): string => {
+    return date.toLocaleString(locale, { timeZone: timeZone });
+};
+
+/**
+ * YYYY-MM-DD [HH:mm:ss] using the sv-SE locale since it produces the correct ISO8601 format
+ * See https://stackoverflow.com/questions/25050034/get-iso-8601-using-intl-datetimeformat
+ * @param date Date object
+ * @param timeZone Time zone to use for the string. Default is 'UTC'.
+ * @param withTime If true, the string will include the time. Default is false (only date).
+ * @returns A string in the format YYYY-MM-DD [HH:mm:ss] in the specified timezone.
+ */
+export const dateToIsoWithTimezone = (
+    date: Date,
+    timeZone: Timezone = 'UTC' as Timezone,
+    withTime: boolean = false
+): string => {
+    return new Intl.DateTimeFormat('sv-SE', {
+        dateStyle: 'short',
+        timeStyle: withTime ? 'medium' : undefined,
+        timeZone
+    }).format(date);
+};

--- a/packages/evolution-common/src/utils/__tests__/DateTimeUtils.test.ts
+++ b/packages/evolution-common/src/utils/__tests__/DateTimeUtils.test.ts
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import {
+    epochToDate,
+    dateToString,
+    dateToIsoWithTimezone,
+    Timezone
+} from '../DateTimeUtils';
+
+describe('DateTimeUtils', () => {
+    describe('epochToDate', () => {
+        test.each([
+            [0, new Date('1970-01-01T00:00:00.000Z')],
+            [1759948692000, new Date('2025-10-08T18:38:12.000Z')]
+        ])('should convert epoch %i to date %s', (epochMilliseconds, expectedDate) => {
+            const result = epochToDate(epochMilliseconds / 1000);
+            expect(result.getTime()).toBe(expectedDate.getTime());
+        });
+
+        test('should handle negative epoch (before 1970)', () => {
+            const epochMilliseconds = -86400000; // 1969-12-31
+            const result = epochToDate(epochMilliseconds / 1000);
+            expect(result.toISOString()).toBe('1969-12-31T00:00:00.000Z');
+        });
+
+        test('should handle fractional seconds by truncating', () => {
+            const epochMilliseconds = 1609459200000.999;
+            const result = epochToDate(epochMilliseconds / 1000);
+            // Fractional seconds should be truncated to the nearest millisecond
+            const expectedTimestamp = 1609459200000; // '2021-01-01T00:00:00.000Z'
+            expect(result.getTime()).toBe(expectedTimestamp);
+        });
+
+        test('should handle milliseconds and truncate to the nearest second', () => {
+            const epochMilliseconds = 1609459212345;
+            const result = epochToDate(epochMilliseconds / 1000);
+            expect(result.toISOString()).toBe('2021-01-01T00:00:12.000Z');
+        });
+    });
+
+    describe('dateToString', () => {
+        const testDate = new Date('2024-03-15T14:30:45.000Z');
+
+        describe('timezone handling', () => {
+            test.each([
+                ['UTC', 'en-CA', '2024-03-15, 2:30:45 p.m.'],
+                ['America/New_York', 'en-CA', '2024-03-15, 10:30:45 a.m.'],
+                ['America/Los_Angeles', 'en-CA', '2024-03-15, 7:30:45 a.m.'],
+                ['America/Toronto', 'en-CA', '2024-03-15, 10:30:45 a.m.'],
+                ['Europe/Paris', 'en-CA', '2024-03-15, 3:30:45 p.m.'],
+                ['Asia/Tokyo', 'en-CA', '2024-03-15, 11:30:45 p.m.']
+            ])('should format date in timezone %s with locale %s as %s', (timeZone, locale, expected) => {
+                const result = dateToString(testDate, locale, timeZone as Timezone);
+                expect(result).toBe(expected);
+            });
+        });
+
+        describe('daylight saving time transitions', () => {
+            test('should handle spring forward (DST start)', () => {
+                // March 10, 2024 2:00 AM - DST starts in North America
+                const springForward = new Date('2024-03-10T07:00:00.000Z'); // 2 AM EST becomes 3 AM EDT
+                const result = dateToString(springForward, 'en-CA', 'America/New_York' as Timezone);
+                expect(result).toBe('2024-03-10, 3:00:00 a.m.'); // Verify time shifted to 3 AM EDT
+            });
+
+            test('should handle fall back (DST end)', () => {
+                // November 3, 2024 2:00 AM - DST ends in North America
+                const fallBack = new Date('2024-11-03T06:00:00.000Z'); // 2 AM EDT becomes 1 AM EST
+                const result = dateToString(fallBack, 'en-CA', 'America/New_York' as Timezone);
+                expect(result).toBe('2024-11-03, 1:00:00 a.m.'); // Verify time shifted to 1 AM EST
+            });
+        });
+
+        describe('timezone handling change of day in Canada (daylight saving time, summer)', () => {
+            const testDate = epochToDate(1759982399000 / 1000);
+            test('should format date 23:59:59 local to not be on the following day even if UTC is in the next day', () => {
+                const result = dateToString(testDate, 'fr-CA', 'America/Toronto' as Timezone);
+                expect(result).toBe('2025-10-08 23 h 59 min 59 s');
+                expect(testDate.toISOString()).toBe('2025-10-09T03:59:59.000Z');
+            });
+        });
+
+        describe('timezone handling change of day in Canada (not daylight saving time, winter)', () => {
+            const testDate = epochToDate(1765256399000 / 1000);
+            test('should format date 23:59:59 local to not be on the following day even if UTC is in the next day', () => {
+                const result = dateToString(testDate, 'fr-CA', 'America/Toronto' as Timezone);
+                expect(result).toBe('2025-12-08 23 h 59 min 59 s');
+                expect(testDate.toISOString()).toBe('2025-12-09T04:59:59.000Z');
+            });
+        });
+
+        describe('locale handling', () => {
+            test.each([
+                ['en-CA', 'UTC', '2024-03-15, 2:30:45 p.m.'],
+                ['fr-CA', 'UTC', '2024-03-15 14 h 30 min 45 s'],
+                ['en-US', 'UTC', '3/15/2024, 2:30:45 PM'],
+                ['fr-FR', 'UTC', '15/03/2024 14:30:45']
+            ])('should format date with locale %s in timezone %s as %s', (locale, timeZone, expected) => {
+                const result = dateToString(testDate, locale, timeZone as Timezone);
+                expect(result).toBe(expected);
+            });
+        });
+
+        describe('default parameters', () => {
+            test('should use en-CA locale by default', () => {
+                const result = dateToString(testDate);
+                expect(result).toBe('2024-03-15, 2:30:45 p.m.');
+            });
+
+            test('should use UTC timezone by default', () => {
+                const result = dateToString(testDate, 'en-CA');
+                expect(result).toBe('2024-03-15, 2:30:45 p.m.');
+            });
+        });
+
+        describe('edge cases', () => {
+            test('should handle epoch zero', () => {
+                const epochZero = new Date(0);
+                const result = dateToString(epochZero, 'en-CA', 'UTC' as Timezone);
+                expect(result).toBe('1970-01-01, 12:00:00 a.m.');
+            });
+
+            test('should handle dates far in the future', () => {
+                const futureDate = new Date('2100-12-31T23:59:59.000Z');
+                const result = dateToString(futureDate, 'en-CA', 'UTC' as Timezone);
+                expect(result).toBe('2100-12-31, 11:59:59 p.m.');
+            });
+
+            test('should handle dates far in the past', () => {
+                const pastDate = new Date('1900-01-01T00:00:00.000Z');
+                const result = dateToString(pastDate, 'en-CA', 'UTC' as Timezone);
+                expect(result).toBe('1900-01-01, 12:00:00 a.m.');
+            });
+        });
+    });
+
+    describe('dateToIsoWithTimezone', () => {
+        test.each([
+            [1765256399000 / 1000, 'America/Toronto', true, '2025-12-08 23:59:59'],
+            [1765256399000 / 1000, 'America/Toronto', false, '2025-12-08'],
+            [1765256399000 / 1000, 'UTC', true, '2025-12-09 04:59:59'],
+            [1765256399000 / 1000, 'UTC', false, '2025-12-09']
+        ])('should format epoch %i in timezone %s with time=%s as %s', (epochSeconds, timezone, withTime, expected) => {
+            const testDate = epochToDate(epochSeconds);
+            expect(dateToIsoWithTimezone(testDate, timezone as Timezone, withTime)).toBe(expected);
+        });
+    });
+
+    describe('integration tests', () => {
+        test('should convert epoch to date and format it correctly', () => {
+            const epochMilliseconds = 1710512445000; // 2024-03-15T14:20:45Z
+            const date = epochToDate(epochMilliseconds / 1000);
+            const formatted = dateToString(date, 'en-CA', 'UTC' as Timezone);
+            expect(formatted).toBe('2024-03-15, 2:20:45 p.m.');
+        });
+
+        test('should handle round-trip conversion', () => {
+            const originalEpochMilliseconds = 1704067200000; // 2024-01-01T00:00:00Z
+            const date = epochToDate(originalEpochMilliseconds / 1000);
+            const epochMillisecondsFromDate = Math.floor(date.getTime());
+            expect(epochMillisecondsFromDate).toBe(originalEpochMilliseconds);
+        });
+
+        test('should handle timezone-aware formatting after epoch conversion', () => {
+            const epochMilliseconds = 1704067200000; // 2024-01-01T00:00:00Z
+            const date = epochToDate(epochMilliseconds / 1000);
+            const utcFormatted = dateToString(date, 'en-CA', 'UTC' as Timezone);
+            const nyFormatted = dateToString(date, 'en-CA', 'America/New_York' as Timezone);
+
+            expect(utcFormatted).toBe('2024-01-01, 12:00:00 a.m.');
+            expect(nyFormatted).toBe('2023-12-31, 7:00:00 p.m.'); // 5 hours behind UTC
+        });
+    });
+
+});


### PR DESCRIPTION
Replace string parsing with Intl.DateTimeFormat.formatToParts() in getTimeZoneOffsetMinutes() for more reliable timezone offset calculation. This eliminates locale-specific format dependencies and improves robustness.

- Use formatToParts() API instead of string parsing
- Improve function documentation with clearer behavior descriptions
- Add explicit sign convention documentation
- Enhance test assertions for exact value verification
- Fix fractional seconds test to verify truncation behavior
- project config: change format of start/end date to be ISO date time string with timezone offset

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project configuration now exposes optional start/end datetimes with timezone offsets and sets a default country code (CA).
  * New date/time utilities for ISO-with-timezone formatting, epoch conversion, and timezone-offset handling.

* **Tests**
  * Updated project config tests to cover the new datetime fields.
  * Extensive new tests validating conversions, formatting, timezone offsets, DST edge cases, and round-trip scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->