### PR TITLE
Include paradata in interview data

### DIFF
--- a/locales/en/admin.json
+++ b/locales/en/admin.json
@@ -134,6 +134,7 @@
             "uuid": "UUID",
             "accessCode": "Access Code",
             "interviewLanguage": "Interview Language",
+            "interviewLanguages": "Interview Languages",
             "travelDate": "Travel Date",
             "noComments": "No comments",
             "proxy": "Proxy",

--- a/locales/fr/admin.json
+++ b/locales/fr/admin.json
@@ -134,6 +134,7 @@
             "uuid": "UUID",
             "accessCode": "Code d'accès",
             "interviewLanguage": "Langue d'entrevue",
+            "interviewLanguages": "Langues d'entrevue",
             "travelDate": "Date de déplacements",
             "noComments": "Aucun commentaire",
             "proxy": "Proxy",

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/InterviewAuditChecks.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/InterviewAuditChecks.ts
@@ -11,16 +11,14 @@ import { InterviewAuditCheckContext, InterviewAuditCheckFunction } from '../Audi
 export const interviewAuditChecks: { [errorCode: string]: InterviewAuditCheckFunction } = {
     /**
      * Check if interview languages are missing
-     * @param context - InterviewAuditCheckContext
-     * @returns AuditForObject
      */
     I_M_Languages: (context: InterviewAuditCheckContext): AuditForObject | undefined => {
         const { interview } = context;
-        const hasLanguages = interview.languages !== undefined && interview.languages.length > 0;
+        const hasLanguages = (interview.paradata?.languages?.length ?? 0) > 0;
         if (!hasLanguages) {
             return {
                 objectType: 'interview',
-                objectUuid: interview._uuid!,
+                objectUuid: interview.uuid!,
                 errorCode: 'I_M_Languages',
                 version: 1,
                 level: 'error',

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/InterviewAuditChecks.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/InterviewAuditChecks.test.ts
@@ -10,6 +10,7 @@ import { Interview } from 'evolution-common/lib/services/baseObjects/interview/I
 import { interviewAuditChecks } from '../InterviewAuditChecks';
 import { runInterviewAuditChecks } from '../../AuditCheckRunners';
 import { InterviewAuditCheckContext } from '../../AuditCheckContexts';
+import { InterviewParadata } from 'evolution-common/lib/services/baseObjects/interview/InterviewParadata';
 
 describe('InterviewAuditChecks', () => {
     const validUuid = uuidV4();
@@ -18,6 +19,7 @@ describe('InterviewAuditChecks', () => {
     const createMockInterview = (overrides: Partial<Interview> = {}) => {
         return {
             _uuid: validUuid,
+            get uuid() { return validUuid; },
             id: validId,
             ...overrides
         } as Interview;
@@ -25,7 +27,8 @@ describe('InterviewAuditChecks', () => {
 
     describe('I_M_Languages audit check', () => {
         it('should pass when interview has languages', () => {
-            const interview = createMockInterview({ languages: ['en', 'fr'] });
+            const interview = createMockInterview();
+            interview.paradata = new InterviewParadata({ languages: [{ language: 'en' }, { language: 'fr' }] });
             const context: InterviewAuditCheckContext = { interview };
 
             const result = interviewAuditChecks.I_M_Languages(context);
@@ -34,7 +37,8 @@ describe('InterviewAuditChecks', () => {
         });
 
         it('should fail when interview missing languages', () => {
-            const interview = createMockInterview({ languages: undefined });
+            const interview = createMockInterview();
+            interview.paradata = new InterviewParadata({ languages: undefined });
             const context: InterviewAuditCheckContext = { interview };
 
             const result = interviewAuditChecks.I_M_Languages(context);
@@ -51,7 +55,8 @@ describe('InterviewAuditChecks', () => {
         });
 
         it('should fail when interview has empty languages array', () => {
-            const interview = createMockInterview({ languages: [] });
+            const interview = createMockInterview();
+            interview.paradata = new InterviewParadata({ languages: [] });
             const context: InterviewAuditCheckContext = { interview };
 
             const result = interviewAuditChecks.I_M_Languages(context);
@@ -70,7 +75,8 @@ describe('InterviewAuditChecks', () => {
 
     describe('runInterviewAuditChecks function', () => {
         it('should run all interview audits and format results with valid data', () => {
-            const interview = createMockInterview({ languages: ['en', 'fr'] });
+            const interview = createMockInterview();
+            interview.paradata = new InterviewParadata({ languages: [{ language: 'en' }, { language: 'fr' }] });
             const context: InterviewAuditCheckContext = { interview };
 
             const audits = runInterviewAuditChecks(context, interviewAuditChecks);
@@ -81,7 +87,8 @@ describe('InterviewAuditChecks', () => {
 
         it('should include failed audits when languages are missing', () => {
             // Test with missing languages
-            const interview = createMockInterview({ languages: undefined });
+            const interview = createMockInterview();
+            interview.paradata = new InterviewParadata({ languages: undefined });
             const context: InterviewAuditCheckContext = { interview };
 
             const audits = runInterviewAuditChecks(context, interviewAuditChecks);

--- a/packages/evolution-common/src/services/baseObjects/attributeTypes/InterviewParadataAttributes.ts
+++ b/packages/evolution-common/src/services/baseObjects/attributeTypes/InterviewParadataAttributes.ts
@@ -34,12 +34,32 @@ export type Browser = {
 } & StartEndTimestampable;
 
 export type WidgetMetadata = StartEndTimestampable; // TODO: should we log changed values for each widget, so add a value attribute? (any or anything else?)
+
+/* Right now, the format is not standard and has both _actions and sections shortnames, and
+inside sections, it may have objects with uuids as keys, which includes startedAt and other attributes
+for the specific object. This is a legacy format coming from interview response object.
+TODO: implement the new section metadata format and remove the _actions and sections shortnames. */
+type SectionData = {
+    _startedAt?: number;
+    _isCompleted?: boolean;
+    [personKey: string]: number | boolean | { _startedAt?: number; _isCompleted?: boolean } | undefined;
+};
 export type SectionMetadata = {
+    _actions?: Array<{ section: string; action: string; ts: number; iterationContext?: string[] }>;
+    [sectionName: string]:
+        | SectionData
+        | Array<{ section: string; action: string; ts: number; iterationContext?: string[] }>
+        | undefined;
+};
+// this will be the new version, not yet implemented:
+/*export type SectionMetadata = {
     // each time a widget is opened/focused, we add a new WidgetMetadata object with timestamps
     widgets: {
         [key: string]: WidgetMetadata[];
     };
 } & StartEndTimestampable;
+*/
+
 export type Language = {
     language?: string; // ISO 639-1 two letters language code
 } & StartEndTimestampable;

--- a/packages/evolution-common/src/services/baseObjects/interview/Interview.ts
+++ b/packages/evolution-common/src/services/baseObjects/interview/Interview.ts
@@ -11,7 +11,11 @@ import { Optional } from '../../../types/Optional.type';
 import { Uuidable, UuidableAttributes } from '../Uuidable';
 import { YesNoDontKnow } from '../attributeTypes/GenericAttributes';
 import { ConstructorUtils } from '../../../utils/ConstructorUtils';
-import { InterviewParadata, InterviewParadataAttributes } from './InterviewParadata';
+import {
+    ExtendedInterviewParadataAttributes,
+    InterviewParadata,
+    InterviewParadataAttributes
+} from './InterviewParadata';
 import { InterviewAttributes as rawInterviewAttributes } from '../../../services/questionnaire/types';
 import { SurveyObjectUnserializer } from '../SurveyObjectUnserializer';
 import { SurveyObjectsRegistry } from '../SurveyObjectsRegistry';
@@ -24,7 +28,6 @@ const interviewAttributesNames = [
     '_uuid',
     '_id',
     '_participant_id',
-    '_languages',
 
     // reviewing flags
     '_isValid',
@@ -59,7 +62,6 @@ export type InterviewAttributes = {
     _uuid?: string; // TODO: discuss whether the original and audited should have the same uuid
     _id?: number; // integer primary key from db.
     _participant_id?: number; // integer respondent/participan/user primary key id from db, TODO: update the User class to use this Interview class instead
-    _languages?: string[]; // array of ISO 639-1 two letters language codes
 
     // reviewing flags
     _isValid?: boolean; // whether the interview is valid (legit) and must be kept for export (true by default, must be set to false by a validator)
@@ -203,7 +205,19 @@ export class Interview extends Uuidable {
         this._customAttributes = {};
 
         const { attributes, customAttributes } = ConstructorUtils.initializeAttributes(
-            _omit(params, ['_paradata', 'paradata']),
+            _omit(params, [
+                '_paradata',
+                'paradata',
+                '_language', // TODO: remove this once we have migrated all interviews to the new paradata structure
+                '_languages', // TODO: remove this once we have migrated all interviews to the new paradata structure
+                '_browser', // TODO use an array instead of a single browser in survey
+                '_startedAt',
+                '_updatedAt',
+                '_completedAt',
+                '_source',
+                '_personRandomSequence',
+                '_sections'
+            ]),
             interviewAttributesNames,
             interviewAttributesWithComposedAttributes
         );
@@ -215,11 +229,16 @@ export class Interview extends Uuidable {
         this._attributes._isCompleted = interviewAttributes.is_completed;
         this._attributes._isQuestionable = interviewAttributes.is_questionable;
         this._attributes._isValidated = interviewAttributes.is_validated;
+
         this._customAttributes = customAttributes;
 
         this._paradata = ConstructorUtils.initializeComposedAttribute(
-            params._paradata,
-            (params) => InterviewParadata.unserialize(params, this._surveyObjectsRegistry),
+            params._paradata === undefined ? Interview.extractDirtyParadataParams(params) : params._paradata,
+            (_paradataParams) =>
+                InterviewParadata.unserialize(
+                    _paradataParams as ExtendedInterviewParadataAttributes,
+                    this._surveyObjectsRegistry
+                ),
             this._surveyObjectsRegistry
         );
 
@@ -244,14 +263,6 @@ export class Interview extends Uuidable {
     get participant_id(): Optional<number> {
         // no setter, comes from the db
         return this._attributes._participant_id;
-    }
-
-    get languages(): Optional<string[]> {
-        return this._attributes._languages;
-    }
-
-    set languages(value: Optional<string[]>) {
-        this._attributes._languages = value;
     }
 
     get isValid(): Optional<boolean> {
@@ -472,5 +483,31 @@ export class Interview extends Uuidable {
             rawInterviewAttributes,
             surveyObjectsRegistry
         );
+    }
+
+    /**
+     * Checks if the interview has minimum data (startedAt)
+     * @returns boolean indicating if the interview has minimum data
+     */
+    hasMinimumRequiredData(): boolean {
+        return this.paradata?.startedAt !== undefined;
+    }
+
+    /**
+     * Extract paradata params from dirty params
+     * @param dirtyParams the dirty params (not validated)
+     * @returns the paradata params (not validated)
+     */
+    static extractDirtyParadataParams(dirtyParams: { [key: string]: unknown }): { [key: string]: unknown } {
+        return {
+            languages: dirtyParams._language ? [{ language: dirtyParams._language }] : undefined,
+            browsers: dirtyParams._browser ? [dirtyParams._browser] : undefined,
+            startedAt: dirtyParams._startedAt,
+            updatedAt: dirtyParams._updatedAt,
+            completedAt: dirtyParams._completedAt,
+            source: dirtyParams._source,
+            personsRandomSequence: dirtyParams._personRandomSequence, // TODO: rename to personsRandomSequence in survey
+            sections: dirtyParams._sections
+        };
     }
 }

--- a/packages/evolution-common/src/services/baseObjects/interview/__tests__/Interview.getSet.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/interview/__tests__/Interview.getSet.test.ts
@@ -5,10 +5,12 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 
+import { v4 as uuidV4 } from 'uuid';
 import { Interview } from '../Interview';
 import { create } from '../InterviewUnserializer';
 import { Result, isOk, unwrap } from '../../../../types/Result.type';
 import { SurveyObjectsRegistry } from '../../SurveyObjectsRegistry';
+import { InterviewAttributes as RawInterviewAttributes } from '../../../../services/questionnaire/types';
 
 let registry: SurveyObjectsRegistry;
 
@@ -21,12 +23,12 @@ describe('Interview - Getters and Setters', () => {
 
     beforeEach(() => {
         const validParams = {
-            _uuid: '123e4567-e89b-12d3-a456-426614174001',
+            _uuid: uuidV4(),
             accessCode: 'ABC123',
             assignedDate: '2023-09-30',
             _startedAt: 1632929461
         };
-        const interviewResult = create(validParams, { id: 123, participant_id: 456 } as any, registry) as Result<Interview>;
+        const interviewResult = create(validParams, { id: 123, participant_id: 456 } as RawInterviewAttributes, registry) as Result<Interview>;
         if (isOk(interviewResult)) {
             interview = unwrap(interviewResult) as Interview;
         } else {
@@ -37,9 +39,9 @@ describe('Interview - Getters and Setters', () => {
     it('should allow undefined id and participant id', () => {
         let _interview: Interview;
         const validParamsWithoutIdAndParticipantId = {
-            _uuid: '123e4567-e89b-12d3-a456-426614174001',
+            _uuid: uuidV4(),
         };
-        const result = create(validParamsWithoutIdAndParticipantId, {} as any, registry) as Result<Interview>;
+        const result = create(validParamsWithoutIdAndParticipantId, {} as RawInterviewAttributes, registry) as Result<Interview>;
         if (isOk(result)) {
             _interview = unwrap(result) as Interview;
         } else {

--- a/packages/evolution-common/src/services/baseObjects/interview/__tests__/Interview.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/interview/__tests__/Interview.test.ts
@@ -5,12 +5,14 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 
+import { v4 as uuidV4 } from 'uuid';
 import { Interview, InterviewAttributes } from '../Interview';
 import { InterviewParadata, InterviewParadataAttributes } from '../InterviewParadata';
 import { create } from '../InterviewUnserializer';
-import { isOk, hasErrors } from '../../../../types/Result.type';
+import { isOk, hasErrors, unwrap } from '../../../../types/Result.type';
 import { validate as uuidValidate } from 'uuid';
 import { SurveyObjectsRegistry } from '../../SurveyObjectsRegistry';
+import { InterviewAttributes as RawInterviewAttributes } from '../../../../services/questionnaire/types';
 
 let registry: SurveyObjectsRegistry;
 
@@ -24,17 +26,29 @@ describe('Interview', () => {
         accessCode: 'ABC123',
         assignedDate: '2023-05-01',
         contactPhoneNumber: '1234567890',
-        contactEmail: 'test@example.com',
-        _languages: ['en', 'fr']
+        contactEmail: 'test@example.com'
     };
 
+    const createRawInterviewAttributes = (overrides?: Partial<RawInterviewAttributes>): RawInterviewAttributes => ({
+        id: 1,
+        participant_id: 1,
+        uuid: validParams._uuid as string,
+        is_valid: true,
+        is_completed: false,
+        is_questionable: false,
+        is_validated: false,
+        response: {},
+        validations: {},
+        ...overrides
+    });
+
     const validParadataParams: InterviewParadataAttributes = {
-        startedAt: 1625097600000,
-        updatedAt: 1625184000000,
-        completedAt: 1625270400000,
+        startedAt: 1625097600,
+        updatedAt: 1625184000,
+        completedAt: 1625270400,
         source: 'web',
         languages: [
-            { language: 'en', startTimestamp: 1625097600000, endTimestamp: 1625270400000 }
+            { language: 'en', startTimestamp: 1625097600, endTimestamp: 1625270400 }
         ],
         browsers: [
             {
@@ -42,28 +56,21 @@ describe('Interview', () => {
                 browser: { name: 'Chrome', version: '91.0.4472.124' },
                 os: { name: 'Windows', version: '10' },
                 platform: { type: 'desktop' },
-                startTimestamp: 1625097600000,
-                endTimestamp: 1625270400000
+                startTimestamp: 1625097600,
+                endTimestamp: 1625270400
             }
         ],
         sections: {
-            'home': [
-                {
-                    startTimestamp: 1625097600000,
-                    endTimestamp: 1625184000000,
-                    widgets: {
-                        'widgetShortname': [
-                            { startTimestamp: 1625097600000, endTimestamp: 1625140800000 }
-                        ]
-                    }
-                }
-            ]
+            'home': {
+                _startedAt: 1625097600,
+                _isCompleted: true
+            }
         }
     };
 
     describe('constructor', () => {
         it('should create an Interview instance with valid parameters', () => {
-            const interview = new Interview(validParams, { id: 1, participant_id: 1, uuid: validParams._uuid } as any, registry);
+            const interview = new Interview(validParams, createRawInterviewAttributes(), registry);
             expect(interview).toBeInstanceOf(Interview);
             expect(interview._uuid).toBe(validParams._uuid);
             expect(interview.accessCode).toBe(validParams.accessCode);
@@ -74,32 +81,32 @@ describe('Interview', () => {
                 ...validParams,
                 acceptToBeContactedForHelp: true
             };
-            const interview = new Interview(paramsWithAcceptContact, { id: 1, participant_id: 1, uuid: validParams._uuid } as any, registry);
+            const interview = new Interview(paramsWithAcceptContact, createRawInterviewAttributes(), registry);
             expect(interview.acceptToBeContactedForHelp).toBe(true);
         });
 
         it('should handle acceptToBeContactedForHelp as undefined by default', () => {
-            const interview = new Interview(validParams, { id: 1, participant_id: 1, uuid: validParams._uuid } as any, registry);
+            const interview = new Interview(validParams, createRawInterviewAttributes(), registry);
             expect(interview.acceptToBeContactedForHelp).toBeUndefined();
         });
 
         it('should generate a UUID if not provided', () => {
             const paramsWithoutUuid = { ...validParams };
             delete paramsWithoutUuid._uuid;
-            const interview = new Interview(paramsWithoutUuid, { id: 1, participant_id: 1 } as any, registry);
+            const interview = new Interview(paramsWithoutUuid, createRawInterviewAttributes({ uuid: undefined }), registry);
             expect(interview._uuid).toBeDefined();
             expect(typeof interview._uuid).toBe('string');
         });
 
         it('should throw an error for invalid UUID', () => {
             const invalidParams = { ...validParams, _uuid: 'invalid-uuid' };
-            expect(() => new Interview(invalidParams, { id: 1, participant_id: 1 } as any, registry)).toThrow('Uuidable: invalid uuid');
+            expect(() => new Interview(invalidParams, createRawInterviewAttributes({ uuid: 'invalid-uuid' }), registry)).toThrow('Uuidable: invalid uuid');
         });
     });
 
     describe('create', () => {
         it('should create an Interview instance with valid parameters', () => {
-            const result = create(validParams, { id: 1, participant_id: 1 } as any, registry);
+            const result = create(validParams, createRawInterviewAttributes(), registry);
             expect(isOk(result)).toBe(true);
             if (isOk(result)) {
                 expect(result.result).toBeInstanceOf(Interview);
@@ -112,7 +119,7 @@ describe('Interview', () => {
                 ...validParams,
                 acceptToBeContactedForHelp: false
             };
-            const result = create(paramsWithAcceptContact, { id: 1, participant_id: 1 } as any, registry);
+            const result = create(paramsWithAcceptContact, createRawInterviewAttributes(), registry);
             expect(isOk(result)).toBe(true);
             if (isOk(result)) {
                 expect(result.result.acceptToBeContactedForHelp).toBe(false);
@@ -124,7 +131,7 @@ describe('Interview', () => {
                 ...validParams,
                 contactEmail: 123 // other attributes are tested in validateParams test file
             };
-            const result = create(invalidParams, { id: 1, participant_id: 1 } as any, registry);
+            const result = create(invalidParams, createRawInterviewAttributes(), registry);
             expect(hasErrors(result)).toBe(true);
             if (hasErrors(result)) {
                 expect(result.errors.length).toBeGreaterThan(0);
@@ -135,20 +142,20 @@ describe('Interview', () => {
 
     describe('UUID handling', () => {
         it('should accept a valid UUID', () => {
-            const interview = new Interview(validParams, { id: 1, participant_id: 1 } as any, registry);
+            const interview = new Interview(validParams, createRawInterviewAttributes(), registry);
             expect(interview._uuid).toBe(validParams._uuid);
         });
 
         it('should generate a valid UUID if not provided', () => {
             const paramsWithoutUuid = { ...validParams };
             delete paramsWithoutUuid._uuid;
-            const interview = new Interview(paramsWithoutUuid, { id: 1, participant_id: 1 } as any, registry);
+            const interview = new Interview(paramsWithoutUuid, createRawInterviewAttributes({ uuid: undefined }), registry);
             expect(uuidValidate(interview._uuid as string)).toBe(true);
         });
 
         it('should throw an error for an invalid UUID', () => {
             const invalidUuidParams = { ...validParams, _uuid: 'invalid-uuid' };
-            expect(() => new Interview(invalidUuidParams, { id: 1, participant_id: 1 } as any, registry)).toThrow('Uuidable: invalid uuid');
+            expect(() => new Interview(invalidUuidParams, createRawInterviewAttributes({ uuid: 'invalid-uuid' }), registry)).toThrow('Uuidable: invalid uuid');
         });
     });
 
@@ -158,7 +165,7 @@ describe('Interview', () => {
                 ...validParams,
                 _paradata: validParadataParams
             };
-            const interview = new Interview(paramsWithParadata, { id: 1, participant_id: 1 } as any, registry);
+            const interview = new Interview(paramsWithParadata, createRawInterviewAttributes(), registry);
             expect(interview.paradata).toBeInstanceOf(InterviewParadata);
             expect(interview.paradata?.startedAt).toBe(validParadataParams.startedAt);
         });
@@ -168,7 +175,7 @@ describe('Interview', () => {
                 ...validParams,
                 _paradata: validParadataParams
             };
-            const result = create(paramsWithParadata, { id: 1, participant_id: 1 } as any, registry);
+            const result = create(paramsWithParadata, createRawInterviewAttributes(), registry);
             expect(isOk(result)).toBe(true);
             if (isOk(result)) {
                 expect(result.result).toBeInstanceOf(Interview);
@@ -187,7 +194,7 @@ describe('Interview', () => {
                 ...validParams,
                 _paradata: invalidParadataParams
             };
-            const result = create(paramsWithInvalidParadata, { id: 1, participant_id: 1 } as any, registry);
+            const result = create(paramsWithInvalidParadata, createRawInterviewAttributes(), registry);
             expect(hasErrors(result)).toBe(true);
             if (hasErrors(result)) {
                 expect(result.errors.length).toBeGreaterThan(0);
@@ -204,13 +211,13 @@ describe('Interview', () => {
                 customField1: 'value1',
                 customField2: 42
             };
-            const interview = new Interview(customParams, { id: 1, participant_id: 1 } as any, registry);
+            const interview = new Interview(customParams, createRawInterviewAttributes(), registry);
             expect(interview.customAttributes.customField1).toBe('value1');
             expect(interview.customAttributes.customField2).toBe(42);
         });
 
         it('should get and set paradata', () => {
-            const interview = new Interview(validParams, { id: 1, participant_id: 1 } as any, registry);
+            const interview = new Interview(validParams, createRawInterviewAttributes(), registry);
             const paradata = new InterviewParadata(validParadataParams);
             interview.paradata = paradata;
             expect(interview.paradata).toBe(paradata);
@@ -250,6 +257,201 @@ describe('Interview', () => {
             expectedConfidentialAttributes.forEach((attr) => {
                 expect(Interview._confidentialAttributes).toContain(attr);
             });
+        });
+    });
+
+    describe('hasMinimumRequiredData', () => {
+        it('should return true when paradata startedAt is defined', () => {
+            const paramsWithRequiredData = {
+                ...validParams,
+                _paradata: {
+                    ...validParadataParams,
+                    startedAt: 1625097600
+                }
+            };
+            const interview = new Interview(paramsWithRequiredData, createRawInterviewAttributes(), registry);
+            expect(interview.hasMinimumRequiredData()).toBe(true);
+        });
+
+        it('should return false when startedAt is undefined', () => {
+            const paramsWithoutStartedAt = {
+                ...validParams,
+                _paradata: {
+                    ...validParadataParams,
+                    startedAt: undefined
+                }
+            };
+            const interview = new Interview(paramsWithoutStartedAt, createRawInterviewAttributes(), registry);
+            expect(interview.hasMinimumRequiredData()).toBe(false);
+        });
+
+        it('should return false when paradata is undefined', () => {
+            const paramsWithoutParadata = {
+                ...validParams,
+            };
+            const interview = new Interview(paramsWithoutParadata, createRawInterviewAttributes(), registry);
+            expect(interview.hasMinimumRequiredData()).toBe(false);
+        });
+
+    });
+
+    describe('Interview - extractDirtyParadataParams', () => {
+        it('should extract paradata params from dirty params with single language', () => {
+            const dirtyParams = {
+                _language: 'en',
+                _startedAt: 1632929461,
+                _updatedAt: 1632929561,
+                _completedAt: 1632930461,
+                _source: 'web',
+                _personRandomSequence: [uuidV4(), uuidV4()],
+                _sections: {
+                    home: [{ startTimestamp: 1632929461, endTimestamp: 1632930461, widgets: {} }]
+                }
+            };
+
+            const result = Interview.extractDirtyParadataParams(dirtyParams);
+
+            expect(result.languages).toEqual([{ language: 'en' }]);
+            expect(result.startedAt).toBe(1632929461);
+            expect(result.updatedAt).toBe(1632929561);
+            expect(result.completedAt).toBe(1632930461);
+            expect(result.source).toBe('web');
+            expect(result.personsRandomSequence).toEqual([dirtyParams._personRandomSequence[0], dirtyParams._personRandomSequence[1]]);
+            expect(result.sections).toEqual(dirtyParams._sections);
+        });
+
+        it('should extract paradata params from dirty params with single browser', () => {
+            const dirtyParams = {
+                _browser: {
+                    _ua: 'Mozilla/5.0',
+                    browser: { name: 'Chrome', version: '93.0' },
+                    startTimestamp: 1632929461,
+                    endTimestamp: 1632930461
+                },
+                _startedAt: 1632929461
+            };
+
+            const result = Interview.extractDirtyParadataParams(dirtyParams);
+
+            expect(result.browsers).toEqual([dirtyParams._browser]);
+            expect(result.startedAt).toBe(1632929461);
+        });
+
+        it('should handle missing optional fields', () => {
+            const dirtyParams = {
+                _startedAt: 1632929461
+            };
+
+            const result = Interview.extractDirtyParadataParams(dirtyParams);
+
+            expect(result.languages).toBeUndefined();
+            expect(result.browsers).toBeUndefined();
+            expect(result.startedAt).toBe(1632929461);
+            expect(result.updatedAt).toBeUndefined();
+            expect(result.completedAt).toBeUndefined();
+            expect(result.source).toBeUndefined();
+            expect(result.personsRandomSequence).toBeUndefined();
+            expect(result.sections).toBeUndefined();
+        });
+
+        it('should handle empty params', () => {
+            const dirtyParams = {};
+
+            const result = Interview.extractDirtyParadataParams(dirtyParams);
+
+            expect(result.languages).toBeUndefined();
+            expect(result.browsers).toBeUndefined();
+            expect(result.startedAt).toBeUndefined();
+            expect(result.updatedAt).toBeUndefined();
+            expect(result.completedAt).toBeUndefined();
+            expect(result.source).toBeUndefined();
+            expect(result.personsRandomSequence).toBeUndefined();
+            expect(result.sections).toBeUndefined();
+        });
+    });
+
+    describe('Interview - Paradata extraction during creation', () => {
+        it('should use _paradata directly if provided', () => {
+            const validParams = {
+                _uuid: uuidV4(),
+                accessCode: 'ABC123',
+                assignedDate: '2023-09-30',
+                _paradata: {
+                    startedAt: 1632929461,
+                    updatedAt: 1632929561,
+                    completedAt: 1632930461,
+                    source: 'web',
+                    languages: [{ language: 'en', startTimestamp: 1632929461, endTimestamp: 1632930461 }]
+                }
+            };
+
+            const result = create(validParams, { id: 123, participant_id: 456 } as RawInterviewAttributes, registry);
+            expect(isOk(result)).toBe(true);
+            if (isOk(result)) {
+                const interview = unwrap(result) as Interview;
+                expect(interview.paradata?.startedAt).toBe(1632929461);
+                expect(interview.paradata?.updatedAt).toBe(1632929561);
+                expect(interview.paradata?.completedAt).toBe(1632930461);
+                expect(interview.paradata?.source).toBe('web');
+                expect(interview.paradata?.languages).toHaveLength(1);
+                expect(interview.paradata?.languages?.[0].language).toBe('en');
+            }
+        });
+
+
+        it('should extract paradata from dirty params when _paradata and paradata are not provided', () => {
+            const validParams = {
+                _uuid: uuidV4(),
+                accessCode: 'ABC123',
+                assignedDate: '2023-09-30',
+                _startedAt: 1632929461,
+                _updatedAt: 1632929561,
+                _completedAt: 1632930461,
+                _source: 'web',
+                _language: 'fr',
+                _browser: {
+                    _ua: 'Mozilla/5.0',
+                    browser: { name: 'Firefox', version: '92.0' },
+                    startTimestamp: 1632929461,
+                    endTimestamp: 1632930461
+                },
+                _personRandomSequence: ['uuid1', 'uuid2'],
+                _sections: {
+                    home: [{ startTimestamp: 1632929461, endTimestamp: 1632930461, widgets: {} }]
+                }
+            };
+
+            const result = create(validParams, { id: 123, participant_id: 456 } as RawInterviewAttributes, registry);
+            expect(isOk(result)).toBe(true);
+            if (isOk(result)) {
+                const interview = unwrap(result) as Interview;
+                expect(interview.paradata?.startedAt).toBe(1632929461);
+                expect(interview.paradata?.updatedAt).toBe(1632929561);
+                expect(interview.paradata?.completedAt).toBe(1632930461);
+                expect(interview.paradata?.source).toBe('web');
+                expect(interview.paradata?.languages).toHaveLength(1);
+                expect(interview.paradata?.languages?.[0].language).toBe('fr');
+                expect(interview.paradata?.browsers).toHaveLength(1);
+                expect(interview.paradata?.browsers?.[0].browser?.name).toBe('Firefox');
+                expect(interview.paradata?.personsRandomSequence).toEqual(['uuid1', 'uuid2']);
+                expect(interview.paradata?.sections?.home).toBeDefined();
+            }
+        });
+
+        it('should handle minimal dirty params without paradata fields', () => {
+            const validParams = {
+                _uuid: uuidV4(),
+                accessCode: 'ABC123',
+                assignedDate: '2023-09-30'
+            };
+
+            const result = create(validParams, { id: 123, participant_id: 456 } as RawInterviewAttributes, registry);
+            expect(isOk(result)).toBe(true);
+            if (isOk(result)) {
+                const interview = unwrap(result) as Interview;
+                expect(interview.paradata?.startedAt).toBeUndefined();
+                expect(interview.paradata?.languages).toEqual([]);
+            }
         });
     });
 });

--- a/packages/evolution-common/src/services/baseObjects/interview/__tests__/InterviewParadata.getSet.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/interview/__tests__/InterviewParadata.getSet.test.ts
@@ -19,7 +19,7 @@ describe('InterviewParadata - Getters and Setters', () => {
             personsRandomSequence: ['uuid1', 'uuid2'],
             languages: [{ language: 'en', startTimestamp: 1632929461, endTimestamp: 1632930461 }],
             browsers: [{
-                ua: 'Mozilla/5.0',
+                _ua: 'Mozilla/5.0',
                 browser: { name: 'Chrome', version: '93.0' },
                 startTimestamp: 1632929461,
                 endTimestamp: 1632930461
@@ -93,7 +93,7 @@ describe('InterviewParadata - Getters and Setters', () => {
         expect(paradata.browsers?.[0].browser?.name).toBe('Chrome');
 
         const newBrowsers = [{
-            ua: 'Mozilla/5.0',
+            _ua: 'Mozilla/5.0',
             browser: { name: 'Firefox', version: '92.0' },
             startTimestamp: 1632930462,
             endTimestamp: 1632931462
@@ -110,7 +110,18 @@ describe('InterviewParadata - Getters and Setters', () => {
         expect(paradata.sections?.section1).toHaveLength(1);
 
         const newSections = {
-            'section2': [{ startTimestamp: 1632930462, endTimestamp: 1632931462, widgets: {} }]
+            _actions: [
+                { section: 'section2', action: 'start', ts: 1632930462 },
+                { section: 'section2', action: 'end', ts: 1632931462 }
+            ],
+            'section2': {
+                _startedAt: 1632930462,
+                _isCompleted: true,
+                'person/uuid1': {
+                    _startedAt: 1632930462,
+                    _isCompleted: true
+                }
+            }
         };
         paradata.sections = newSections;
         expect(paradata.sections).toEqual(newSections);

--- a/packages/evolution-common/src/services/baseObjects/interview/__tests__/InterviewParadata.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/interview/__tests__/InterviewParadata.test.ts
@@ -10,13 +10,13 @@ import { isOk, hasErrors } from '../../../../types/Result.type';
 
 describe('InterviewParadata', () => {
     const validParams: InterviewParadataAttributes = {
-        startedAt: 1625097600000,
-        updatedAt: 1625184000000,
-        completedAt: 1625270400000,
+        startedAt: 1625097600,
+        updatedAt: 1625184000,
+        completedAt: 1625270400,
         source: 'web',
         personsRandomSequence: ['uuid1', 'uuid2'],
         languages: [
-            { language: 'en', startTimestamp: 1625097600000, endTimestamp: 1625270400000 }
+            { language: 'en', startTimestamp: 1625097600, endTimestamp: 1625270400 }
         ],
         browsers: [
             {
@@ -24,22 +24,35 @@ describe('InterviewParadata', () => {
                 browser: { name: 'Chrome', version: '91.0.4472.124' },
                 os: { name: 'Windows', version: '10' },
                 platform: { type: 'desktop' },
-                startTimestamp: 1625097600000,
-                endTimestamp: 1625270400000
+                startTimestamp: 1625097600,
+                endTimestamp: 1625270400
             }
         ],
         sections: {
-            'home': [
-                {
-                    startTimestamp: 1625097600000,
-                    endTimestamp: 1625184000000,
-                    widgets: {
-                        'widgetShortname': [
-                            { startTimestamp: 1625097600000, endTimestamp: 1625140800000 }
-                        ]
-                    }
+            _actions: [
+                { section: 'home', action: 'start', ts: 1757531067 },
+                { section: 'household', action: 'start', ts: 1757531095, iterationContext: ['1'] }
+            ],
+            'home': {
+                _startedAt: 1625097600,
+                _isCompleted: true
+            },
+            'household': {
+                _startedAt: 1625097600,
+                _isCompleted: true
+            },
+            'householdMembers': {
+                _startedAt: 1625097600,
+                _isCompleted: true,
+                'person/uuid1': {
+                    _startedAt: 1625097600,
+                    _isCompleted: true
+                },
+                'person/uuid2': {
+                    _startedAt: 1625097600,
+                    _isCompleted: true
                 }
-            ]
+            }
         }
     };
 
@@ -52,7 +65,7 @@ describe('InterviewParadata', () => {
         });
 
         it('should create an instance with minimal valid parameters', () => {
-            const minimalParams = { startedAt: 1625097600000 };
+            const minimalParams = { startedAt: 1625097600 };
             const paradata = new InterviewParadata(minimalParams);
             expect(paradata).toBeInstanceOf(InterviewParadata);
             expect(paradata.startedAt).toBe(minimalParams.startedAt);
@@ -96,11 +109,25 @@ describe('InterviewParadata', () => {
             expect(paradata.browsers?.[0].browser?.name).toBe('Chrome');
         });
 
-        it('should correctly handle sections attribute', () => {
+        it('should correctly handle sections attribute (legacy format)', () => {
             const paradata = new InterviewParadata(validParams);
-            expect(Object.keys(paradata.sections || {})).toHaveLength(1);
+            expect(Object.keys(paradata.sections || {})).toHaveLength(4); // _actions, home, household, householdMembers
+            expect(paradata.sections?._actions).toBeDefined();
+            expect(Array.isArray(paradata.sections?._actions)).toBe(true);
             expect(paradata.sections?.home).toBeDefined();
-            expect(paradata.sections?.home[0].widgets.widgetShortname).toHaveLength(1);
+            expect((paradata.sections?.home as { _startedAt?: number, _isCompleted?: boolean })?._startedAt).toBe(1625097600);
+            expect((paradata.sections?.home as { _startedAt?: number, _isCompleted?: boolean })?._isCompleted).toBe(true);
+            expect(paradata.sections?.household).toBeDefined();
+            expect((paradata.sections?.household as { _startedAt?: number, _isCompleted?: boolean })?._startedAt).toBe(1625097600);
+            expect((paradata.sections?.household as { _startedAt?: number, _isCompleted?: boolean })?._isCompleted).toBe(true);
+            expect(paradata.sections?.householdMembers).toBeDefined();
+            expect((paradata.sections?.householdMembers as { _startedAt?: number, _isCompleted?: boolean })?._startedAt).toBe(1625097600);
+            expect((paradata.sections?.householdMembers as { _startedAt?: number, _isCompleted?: boolean })?._isCompleted).toBe(true);
+            const householdMembers = paradata.sections?.householdMembers as { [key: string]: { _startedAt?: number, _isCompleted?: boolean } };
+            expect((householdMembers?.['person/uuid1'] as { _startedAt?: number, _isCompleted?: boolean })?._startedAt).toBe(1625097600);
+            expect((householdMembers?.['person/uuid1'] as { _startedAt?: number, _isCompleted?: boolean })?._isCompleted).toBe(true);
+            expect((householdMembers?.['person/uuid2'] as { _startedAt?: number, _isCompleted?: boolean })?._startedAt).toBe(1625097600);
+            expect((householdMembers?.['person/uuid2'] as { _startedAt?: number, _isCompleted?: boolean })?._isCompleted).toBe(true);
         });
 
         it('should handle empty params', () => {

--- a/packages/evolution-common/src/services/baseObjects/interview/__tests__/InterviewParadata.validateParams.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/interview/__tests__/InterviewParadata.validateParams.test.ts
@@ -16,7 +16,7 @@ describe('InterviewParadata - InterviewParadata.validateParams', () => {
         personsRandomSequence: ['uuid1', 'uuid2'],
         languages: [{ language: 'en', startTimestamp: 1632929461, endTimestamp: 1632930461 }],
         browsers: [{
-            ua: 'Mozilla/5.0',
+            _ua: 'Mozilla/5.0',
             browser: { name: 'Chrome', version: '93.0' },
             engine: { name: 'Blink', version: '93.0' },
             os: { name: 'Windows', version: '10', versionName: 'Windows 10' },
@@ -129,10 +129,10 @@ describe('InterviewParadata - InterviewParadata.validateParams', () => {
             expect(errors.some((e) => e.message.includes('browsers'))).toBe(true);
         });
 
-        it('should validate ua field', () => {
-            const params = { ...validParams, browsers: [{ ...validParams.browsers[0], ua: 123 }] };
+        it('should validate _ua field', () => {
+            const params = { ...validParams, browsers: [{ ...validParams.browsers[0], _ua: 123 }] };
             const errors = InterviewParadata.validateParams(params);
-            expect(errors.some((e) => e.message.includes('browsers.[0].ua'))).toBe(true);
+            expect(errors.some((e) => e.message.includes('browsers.[0]._ua'))).toBe(true);
         });
 
         it('should validate browser name field', () => {
@@ -208,68 +208,41 @@ describe('InterviewParadata - InterviewParadata.validateParams', () => {
         });
     });
 
-    describe('Sections validation', () => {
+    describe('Sections validation (legacy format)', () => {
 
-        it('should make sure sections content is an array', () => {
-            const params = { ...validParams, sections: { home: 'not-an-array' } };
-            const errors = InterviewParadata.validateParams(params);
-            expect(errors.some((e) => e.message.includes('sections.home'))).toBe(true);
-        });
-
-        it('should validate section startTimestamp', () => {
+        it('should accept legacy sections format with _actions and section objects', () => {
             const params = {
-                ...validParams, sections: {
-                    home: [{ ...validParams.sections.home[0], startTimestamp: 'not-a-number' }]
+                ...validParams,
+                sections: {
+                    _actions: [
+                        { section: 'home', action: 'start', ts: 1632929461 }
+                    ],
+                    home: {
+                        _startedAt: 1632929461,
+                        _isCompleted: true
+                    }
                 }
             };
             const errors = InterviewParadata.validateParams(params);
-            expect(errors.some((e) => e.message.includes('sections.home.[0].startTimestamp'))).toBe(true);
+            expect(errors).toHaveLength(0);
         });
 
-        it('should validate section endTimestamp', () => {
+        it('should accept sections with nested person keys', () => {
             const params = {
-                ...validParams, sections: {
-                    home: [{ ...validParams.sections.home[0], endTimestamp: 'not-a-number' }]
-                }
-            };
-            const errors = InterviewParadata.validateParams(params);
-            expect(errors.some((e) => e.message.includes('sections.home.[0].endTimestamp'))).toBe(true);
-        });
-
-        it('should make sure widgets is an array', () => {
-            const params = { ...validParams, sections: { home: [{ ...validParams.sections.home[0], widgets: 'not-an-array' }] } };
-            const errors = InterviewParadata.validateParams(params);
-            expect(errors.some((e) => e.message.includes('sections.home.[0].widgets'))).toBe(true);
-        });
-
-        it('should validate widget startTimestamp', () => {
-            const params = {
-                ...validParams, sections: {
-                    home: [{
-                        ...validParams.sections.home[0],
-                        widgets: {
-                            widgetShortname: [{ ...validParams.sections.home[0].widgets.widgetShortname[0], startTimestamp: 'not-a-number' }]
+                ...validParams,
+                sections: {
+                    tripsIntro: {
+                        _startedAt: 1632929461,
+                        _isCompleted: true,
+                        'person/uuid1': {
+                            _startedAt: 1632929461,
+                            _isCompleted: true
                         }
-                    }]
+                    }
                 }
             };
             const errors = InterviewParadata.validateParams(params);
-            expect(errors.some((e) => e.message.includes('sections.home.[0].widgets.widgetShortname.[0].startTimestamp'))).toBe(true);
-        });
-
-        it('should validate widget endTimestamp', () => {
-            const params = {
-                ...validParams, sections: {
-                    home: [{
-                        ...validParams.sections.home[0],
-                        widgets: {
-                            widgetShortname: [{ ...validParams.sections.home[0].widgets.widgetShortname[0], endTimestamp: 'not-a-number' }]
-                        }
-                    }]
-                }
-            };
-            const errors = InterviewParadata.validateParams(params);
-            expect(errors.some((e) => e.message.includes('sections.home.[0].widgets.widgetShortname.[0].endTimestamp'))).toBe(true);
+            expect(errors).toHaveLength(0);
         });
     });
 

--- a/packages/evolution-frontend/src/components/admin/widgets/InterviewPanel.tsx
+++ b/packages/evolution-frontend/src/components/admin/widgets/InterviewPanel.tsx
@@ -22,6 +22,9 @@ export const InterviewPanel = ({ interview, audits, showAuditErrorCode }: Interv
 
     const formattedTripsDate = interview.assignedDate ? moment(interview.assignedDate).format('LL') : '-';
 
+    const languages = interview.paradata?.languages || [];
+    const formattedLanguages = languages.map((language) => language.language || '?').join('|') || '?';
+
     return (
         <div className="admin__interview-stats" key="interview">
             <details open={true}>
@@ -36,8 +39,8 @@ export const InterviewPanel = ({ interview, audits, showAuditErrorCode }: Interv
                     <span className="_strong">{interview.accessCode || t('survey:None')}</span>
                 </span>
                 <span className="_widget">
-                    {t('interviewStats.labels.interviewLanguage')}:{' '}
-                    <span className="_strong">{interview.languages?.[0] || '?'}</span>
+                    {t(`interviewStats.labels.interviewLanguage${languages.length > 1 ? 's' : ''}`)}:{' '}
+                    <span className="_strong">{formattedLanguages}</span>
                 </span>
                 <span className="_widget">
                     {t('interviewStats.labels.travelDate')}: <span className="_strong">{formattedTripsDate}</span>


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin panel shows aggregated interview languages (pipe-separated) with singular/plural labels and '?' fallback; interviews include a minimum-required-data check.

* **Translations**
  * Added English and French labels for interview language(s) in the admin UI.

* **Compatibility**
  * Paradata sections migrated to a more structured metadata model while preserving legacy-format support.

* **Tests**
  * Expanded coverage for paradata extraction, interview creation flows, and minimum-data checks.

* **Bug Fixes**
  * Audit/backend flows now consistently read languages from paradata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->