### PR TITLE
feat: add interview timestamp audit checks and clarify timestamp units

### DIFF
--- a/locales/en/audits.json
+++ b/locales/en/audits.json
@@ -1,5 +1,8 @@
 {
     "I_M_Languages": "Interview languages are missing",
+    "I_M_StartedAt": "Interview start time is missing",
+    "I_I_StartedAtBeforeSurveyStartDate": "Interview start time is before survey start date",
+    "I_I_StartedAtAfterSurveyEndDate": "Interview start time is after survey end date",
 
     "HH_I_Size": "Household size is out of range (should be between 1 and 20)",
     "HH_M_Size": "Household size is missing",

--- a/locales/fr/audits.json
+++ b/locales/fr/audits.json
@@ -1,5 +1,8 @@
 {
     "I_M_Languages": "Les langues de l'entrevue sont manquantes",
+    "I_M_StartedAt": "La date de début de l'entrevue est manquante",
+    "I_I_StartedAtBeforeSurveyStartDate": "Le début de l'entrevue est avant la date de début de l'enquête",
+    "I_I_StartedAtAfterSurveyEndDate": "Le début de l'entrevue est après la date de fin de l'enquête",
 
     "HH_I_Size": "La taille du ménage est en dehors de la plage autorisée (devrait être entre 1 et 20)",
     "HH_M_Size": "La taille du ménage est manquante",

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/interview/I_I_StartedAtAfterSurveyEndDate.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/interview/I_I_StartedAtAfterSurveyEndDate.test.ts
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { v4 as uuidV4 } from 'uuid';
+import type { InterviewAuditCheckContext } from '../../../AuditCheckContexts';
+import { InterviewParadata } from 'evolution-common/lib/services/baseObjects/interview/InterviewParadata';
+import { ISODateTimeStringWithTimezoneOffset } from 'evolution-common/lib/utils/DateTimeUtils';
+import { createMockInterview } from './testHelper';
+
+// Note: These tests use jest.isolateModulesAsync to ensure projectConfig mutations don't leak between tests
+// running in parallel across different test files. We use await import() inside isolateModulesAsync to get
+// fresh module instances per test, ensuring each test has an isolated projectConfig state.
+describe('I_I_StartedAtAfterSurveyEndDate audit check', () => {
+    const validUuid = uuidV4();
+
+    describe('should pass in valid scenarios', () => {
+        it.each([
+            {
+                description: 'interview startedAt is before survey end date',
+                endDate: '2025-12-31T23:59:59-05:00' as ISODateTimeStringWithTimezoneOffset,
+                startedAt: new Date('2025-06-01T12:00:00-05:00').getTime() / 1000,
+                hasParadata: true
+            },
+            {
+                description: 'interview startedAt equals survey end date',
+                endDate: '2025-12-31T23:59:59-05:00' as ISODateTimeStringWithTimezoneOffset,
+                startedAt: new Date('2025-12-31T23:59:59-05:00').getTime() / 1000,
+                hasParadata: true
+            },
+            {
+                description: 'interview startedAt equals survey end date across different timezones',
+                endDate: '2025-12-31T23:59:59-05:00' as ISODateTimeStringWithTimezoneOffset,
+                startedAt: new Date('2026-01-01T04:59:59+00:00').getTime() / 1000, // Same instant as 2025-12-31T23:59:59-05:00
+                hasParadata: true
+            },
+            {
+                description: 'survey end date is not configured',
+                endDate: undefined,
+                startedAt: new Date('2026-12-31T23:59:59-05:00').getTime() / 1000,
+                hasParadata: true
+            },
+            {
+                description: 'interview startedAt is missing',
+                endDate: '2025-12-31T23:59:59-05:00' as ISODateTimeStringWithTimezoneOffset,
+                startedAt: undefined,
+                hasParadata: true
+            },
+            {
+                description: 'interview has no paradata',
+                endDate: '2025-12-31T23:59:59-05:00' as ISODateTimeStringWithTimezoneOffset,
+                startedAt: undefined,
+                hasParadata: false
+            },
+            {
+                description: 'survey end date is invalid (should be treated as not configured)',
+                endDate: 'invalid-date-string' as ISODateTimeStringWithTimezoneOffset,
+                startedAt: new Date('2026-12-31T23:59:59-05:00').getTime() / 1000,
+                hasParadata: true
+            },
+            {
+                description: 'survey end date is malformed ISO string',
+                endDate: '2025-13-45T99:99:99-05:00' as ISODateTimeStringWithTimezoneOffset,
+                startedAt: new Date('2025-06-01T12:00:00-05:00').getTime() / 1000,
+                hasParadata: true
+            },
+            {
+                description: 'interview startedAt is NaN (should be treated as missing)',
+                endDate: '2025-12-31T23:59:59-05:00' as ISODateTimeStringWithTimezoneOffset,
+                startedAt: NaN,
+                hasParadata: true
+            },
+            {
+                description: 'interview startedAt is Infinity (should be treated as missing)',
+                endDate: '2025-12-31T23:59:59-05:00' as ISODateTimeStringWithTimezoneOffset,
+                startedAt: Infinity,
+                hasParadata: true
+            },
+            {
+                description: 'interview startedAt is -Infinity (should be treated as missing)',
+                endDate: '2025-12-31T23:59:59-05:00' as ISODateTimeStringWithTimezoneOffset,
+                startedAt: -Infinity,
+                hasParadata: true
+            }
+        ])('$description', async ({ endDate, startedAt, hasParadata }) => {
+            await jest.isolateModulesAsync(async () => {
+                // Import modules inside isolateModules to get fresh instances
+                const { default: projectConfig } = await import('evolution-common/lib/config/project.config');
+                const { interviewAuditChecks } = await import('../../InterviewAuditChecks');
+
+                // Set config for this test
+                projectConfig.endDateTimeWithTimezoneOffset = endDate;
+
+                const interview = createMockInterview();
+                interview.paradata = hasParadata ? new InterviewParadata({ startedAt }) : undefined;
+                const context: InterviewAuditCheckContext = { interview };
+
+                const result = interviewAuditChecks.I_I_StartedAtAfterSurveyEndDate(context);
+
+                expect(result).toBeUndefined();
+            });
+        });
+    });
+
+    describe('should fail when interview startedAt is after survey end date', () => {
+        it.each([
+            {
+                description: 'in same timezone',
+                endDate: '2025-12-31T23:59:59-05:00' as ISODateTimeStringWithTimezoneOffset,
+                startedAt: new Date('2026-01-01T00:00:00-05:00').getTime() / 1000
+            },
+            {
+                description: 'across different timezones (UTC)',
+                endDate: '2025-12-31T23:59:59-05:00' as ISODateTimeStringWithTimezoneOffset,
+                startedAt: new Date('2026-01-01T05:00:00+00:00').getTime() / 1000 // 1 second after end date
+            },
+            {
+                description: 'across different timezones (PST)',
+                endDate: '2025-12-31T23:59:59-05:00' as ISODateTimeStringWithTimezoneOffset,
+                startedAt: new Date('2025-12-31T21:00:00-08:00').getTime() / 1000 // Same as 2026-01-01T00:00:00-05:00
+            },
+            {
+                description: 'across different timezones (JST)',
+                endDate: '2025-12-31T23:59:59-05:00' as ISODateTimeStringWithTimezoneOffset,
+                startedAt: new Date('2026-01-01T14:00:00+09:00').getTime() / 1000 // Same as 2026-01-01T00:00:00-05:00
+            },
+            {
+                description: 'with positive timezone offset',
+                endDate: '2025-12-31T23:59:59+02:00' as ISODateTimeStringWithTimezoneOffset,
+                startedAt: new Date('2026-01-01T00:00:00+02:00').getTime() / 1000
+            }
+        ])('$description', async ({ endDate, startedAt }) => {
+            await jest.isolateModulesAsync(async () => {
+                // Import modules inside isolateModules to get fresh instances
+                const { default: projectConfig } = await import('evolution-common/lib/config/project.config');
+                const { interviewAuditChecks } = await import('../../InterviewAuditChecks');
+
+                // Set config for this test
+                projectConfig.endDateTimeWithTimezoneOffset = endDate;
+
+                const interview = createMockInterview(undefined, validUuid);
+                interview.paradata = new InterviewParadata({ startedAt });
+                const context: InterviewAuditCheckContext = { interview };
+
+                const result = interviewAuditChecks.I_I_StartedAtAfterSurveyEndDate(context);
+
+                expect(result).toEqual({
+                    objectType: 'interview',
+                    objectUuid: validUuid,
+                    errorCode: 'I_I_StartedAtAfterSurveyEndDate',
+                    version: 1,
+                    level: 'error',
+                    message: 'Interview start time is after survey end date',
+                    ignore: false
+                });
+            });
+        });
+    });
+
+    describe('should pass with edge cases across timezones', () => {
+        it.each([
+            {
+                description: 'UTC to EST - same instant',
+                endDate: '2025-12-31T23:59:59-05:00' as ISODateTimeStringWithTimezoneOffset,
+                startedAt: new Date('2026-01-01T04:59:59+00:00').getTime() / 1000 // Same as end date
+            },
+            {
+                description: 'PST to EST - same instant',
+                endDate: '2025-12-31T23:59:59-05:00' as ISODateTimeStringWithTimezoneOffset,
+                startedAt: new Date('2025-12-31T20:59:59-08:00').getTime() / 1000 // Same as end date
+            },
+            {
+                description: 'JST to EST - before end date',
+                endDate: '2025-12-31T23:59:59-05:00' as ISODateTimeStringWithTimezoneOffset,
+                startedAt: new Date('2026-01-01T13:00:00+09:00').getTime() / 1000 // 23:00:00-05:00 (before)
+            },
+            {
+                description: 'positive timezone offset - before end date',
+                endDate: '2025-12-31T23:59:59+02:00' as ISODateTimeStringWithTimezoneOffset,
+                startedAt: new Date('2025-12-31T20:00:00+02:00').getTime() / 1000
+            }
+        ])('$description', async ({ endDate, startedAt }) => {
+            await jest.isolateModulesAsync(async () => {
+                // Import modules inside isolateModules to get fresh instances
+                const { default: projectConfig } = await import('evolution-common/lib/config/project.config');
+                const { interviewAuditChecks } = await import('../../InterviewAuditChecks');
+
+                // Set config for this test
+                projectConfig.endDateTimeWithTimezoneOffset = endDate;
+
+                const interview = createMockInterview();
+                interview.paradata = new InterviewParadata({ startedAt });
+                const context: InterviewAuditCheckContext = { interview };
+
+                const result = interviewAuditChecks.I_I_StartedAtAfterSurveyEndDate(context);
+
+                expect(result).toBeUndefined();
+            });
+        });
+    });
+});

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/interview/I_I_StartedAtBeforeSurveyStartDate.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/interview/I_I_StartedAtBeforeSurveyStartDate.test.ts
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { v4 as uuidV4 } from 'uuid';
+import type { InterviewAuditCheckContext } from '../../../AuditCheckContexts';
+import { InterviewParadata } from 'evolution-common/lib/services/baseObjects/interview/InterviewParadata';
+import { ISODateTimeStringWithTimezoneOffset } from 'evolution-common/lib/utils/DateTimeUtils';
+import { createMockInterview } from './testHelper';
+
+// Note: These tests use jest.isolateModules to ensure projectConfig mutations don't leak between tests
+// running in parallel across different test files. We use dynamic imports inside isolateModules to
+// ensure each test gets a fresh module instance.
+describe('I_I_StartedAtBeforeSurveyStartDate audit check', () => {
+    const validUuid = uuidV4();
+
+    describe('should pass in valid scenarios', () => {
+        it.each([
+            {
+                description: 'interview startedAt is after survey start date',
+                startDate: '2025-01-01T00:00:00-05:00' as ISODateTimeStringWithTimezoneOffset,
+                startedAt: new Date('2025-06-01T12:00:00-05:00').getTime() / 1000,
+                hasParadata: true
+            },
+            {
+                description: 'interview startedAt equals survey start date',
+                startDate: '2025-01-01T00:00:00-05:00' as ISODateTimeStringWithTimezoneOffset,
+                startedAt: new Date('2025-01-01T00:00:00-05:00').getTime() / 1000,
+                hasParadata: true
+            },
+            {
+                description: 'survey start date is not configured',
+                startDate: undefined,
+                startedAt: new Date('2024-01-01T00:00:00-05:00').getTime() / 1000,
+                hasParadata: true
+            },
+            {
+                description: 'interview startedAt is missing',
+                startDate: '2025-01-01T00:00:00-05:00' as ISODateTimeStringWithTimezoneOffset,
+                startedAt: undefined,
+                hasParadata: true
+            },
+            {
+                description: 'interview has no paradata',
+                startDate: '2025-01-01T00:00:00-05:00' as ISODateTimeStringWithTimezoneOffset,
+                startedAt: undefined,
+                hasParadata: false
+            },
+            {
+                description: 'survey start date is invalid (should be treated as not configured)',
+                startDate: 'invalid-date-string' as ISODateTimeStringWithTimezoneOffset,
+                startedAt: new Date('2024-01-01T00:00:00-05:00').getTime() / 1000,
+                hasParadata: true
+            },
+            {
+                description: 'survey start date is malformed ISO string',
+                startDate: '2025-00-00T25:99:99-05:00' as ISODateTimeStringWithTimezoneOffset,
+                startedAt: new Date('2024-12-31T23:59:59-05:00').getTime() / 1000,
+                hasParadata: true
+            },
+            {
+                description: 'interview startedAt is NaN (should be treated as missing)',
+                startDate: '2025-01-01T00:00:00-05:00' as ISODateTimeStringWithTimezoneOffset,
+                startedAt: NaN,
+                hasParadata: true
+            },
+            {
+                description: 'interview startedAt is Infinity (should be treated as missing)',
+                startDate: '2025-01-01T00:00:00-05:00' as ISODateTimeStringWithTimezoneOffset,
+                startedAt: Infinity,
+                hasParadata: true
+            },
+            {
+                description: 'interview startedAt is -Infinity (should be treated as missing)',
+                startDate: '2025-01-01T00:00:00-05:00' as ISODateTimeStringWithTimezoneOffset,
+                startedAt: -Infinity,
+                hasParadata: true
+            }
+        ])('$description', async ({ startDate, startedAt, hasParadata }) => {
+            await jest.isolateModulesAsync(async () => {
+                // Import modules inside isolateModules to get fresh instances
+                const { default: projectConfig } = await import('evolution-common/lib/config/project.config');
+                const { interviewAuditChecks } = await import('../../InterviewAuditChecks');
+
+                // Set config for this test
+                projectConfig.startDateTimeWithTimezoneOffset = startDate;
+
+                const interview = createMockInterview();
+                interview.paradata = hasParadata ? new InterviewParadata({ startedAt }) : undefined;
+                const context: InterviewAuditCheckContext = { interview };
+
+                const result = interviewAuditChecks.I_I_StartedAtBeforeSurveyStartDate(context);
+
+                expect(result).toBeUndefined();
+            });
+        });
+    });
+
+    describe('should fail when interview startedAt is before survey start date', () => {
+        it.each([
+            {
+                description: 'in same timezone',
+                startDate: '2025-01-01T00:00:00-05:00' as ISODateTimeStringWithTimezoneOffset,
+                startedAt: new Date('2024-12-31T23:59:59-05:00').getTime() / 1000
+            },
+            {
+                description: 'across different timezones (UTC)',
+                startDate: '2025-01-01T00:00:00-05:00' as ISODateTimeStringWithTimezoneOffset,
+                startedAt: new Date('2025-01-01T04:59:59+00:00').getTime() / 1000 // 1 second before start date
+            },
+            {
+                description: 'across different timezones (PST)',
+                startDate: '2025-01-01T00:00:00-05:00' as ISODateTimeStringWithTimezoneOffset,
+                startedAt: new Date('2024-12-31T20:59:59-08:00').getTime() / 1000 // Same as 2024-12-31T23:59:59-05:00
+            },
+            {
+                description: 'across different timezones (JST)',
+                startDate: '2025-01-01T00:00:00-05:00' as ISODateTimeStringWithTimezoneOffset,
+                startedAt: new Date('2025-01-01T13:59:59+09:00').getTime() / 1000 // Same as 2024-12-31T23:59:59-05:00
+            },
+            {
+                description: 'with positive timezone offset',
+                startDate: '2025-01-01T00:00:00+02:00' as ISODateTimeStringWithTimezoneOffset,
+                startedAt: new Date('2024-12-31T23:59:59+02:00').getTime() / 1000
+            }
+        ])('$description', async ({ startDate, startedAt }) => {
+            await jest.isolateModulesAsync(async () => {
+                // Import modules inside isolateModules to get fresh instances
+                const { default: projectConfig } = await import('evolution-common/lib/config/project.config');
+                const { interviewAuditChecks } = await import('../../InterviewAuditChecks');
+
+                // Set config for this test
+                projectConfig.startDateTimeWithTimezoneOffset = startDate;
+
+                const interview = createMockInterview(undefined, validUuid);
+                interview.paradata = new InterviewParadata({ startedAt });
+                const context: InterviewAuditCheckContext = { interview };
+
+                const result = interviewAuditChecks.I_I_StartedAtBeforeSurveyStartDate(context);
+
+                expect(result).toEqual({
+                    objectType: 'interview',
+                    objectUuid: validUuid,
+                    errorCode: 'I_I_StartedAtBeforeSurveyStartDate',
+                    version: 1,
+                    level: 'error',
+                    message: 'Interview start time is before survey start date',
+                    ignore: false
+                });
+            });
+        });
+    });
+
+    describe('should pass with edge cases across timezones', () => {
+        it.each([
+            {
+                description: 'UTC to EST - same instant',
+                startDate: '2025-01-01T00:00:00-05:00' as ISODateTimeStringWithTimezoneOffset,
+                startedAt: new Date('2025-01-01T05:00:00+00:00').getTime() / 1000 // Same as start date
+            },
+            {
+                description: 'PST to EST - same instant',
+                startDate: '2025-01-01T00:00:00-05:00' as ISODateTimeStringWithTimezoneOffset,
+                startedAt: new Date('2024-12-31T21:00:00-08:00').getTime() / 1000 // Same as start date
+            },
+            {
+                description: 'JST to EST - after start date',
+                startDate: '2025-01-01T00:00:00-05:00' as ISODateTimeStringWithTimezoneOffset,
+                startedAt: new Date('2025-01-01T15:00:00+09:00').getTime() / 1000 // 01:00:00-05:00 (after)
+            },
+            {
+                description: 'positive timezone offset - after start date',
+                startDate: '2025-01-01T00:00:00+02:00' as ISODateTimeStringWithTimezoneOffset,
+                startedAt: new Date('2025-01-01T12:00:00+02:00').getTime() / 1000
+            }
+        ])('$description', async ({ startDate, startedAt }) => {
+            await jest.isolateModulesAsync(async () => {
+                // Import modules inside isolateModules to get fresh instances
+                const { default: projectConfig } = await import('evolution-common/lib/config/project.config');
+                const { interviewAuditChecks } = await import('../../InterviewAuditChecks');
+
+                // Set config for this test
+                projectConfig.startDateTimeWithTimezoneOffset = startDate;
+
+                const interview = createMockInterview();
+                interview.paradata = new InterviewParadata({ startedAt });
+                const context: InterviewAuditCheckContext = { interview };
+
+                const result = interviewAuditChecks.I_I_StartedAtBeforeSurveyStartDate(context);
+
+                expect(result).toBeUndefined();
+            });
+        });
+    });
+});

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/interview/I_M_StartedAt.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/interview/I_M_StartedAt.test.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { v4 as uuidV4 } from 'uuid';
+import { interviewAuditChecks } from '../../InterviewAuditChecks';
+import type { InterviewAuditCheckContext } from '../../../AuditCheckContexts';
+import { InterviewParadata } from 'evolution-common/lib/services/baseObjects/interview/InterviewParadata';
+import { createMockInterview } from './testHelper';
+
+describe('I_M_StartedAt audit check', () => {
+    const validUuid = uuidV4();
+
+    describe('should pass when startedAt is present', () => {
+        it.each([
+            {
+                description: 'interview has valid startedAt timestamp',
+                startedAt: 1625097600
+            },
+            {
+                description: 'interview has startedAt timestamp of 0',
+                startedAt: 0
+            }
+        ])('$description', ({ startedAt }) => {
+            const interview = createMockInterview();
+            interview.paradata = new InterviewParadata({ startedAt });
+            const context: InterviewAuditCheckContext = { interview };
+
+            const result = interviewAuditChecks.I_M_StartedAt(context);
+
+            expect(result).toBeUndefined();
+        });
+    });
+
+    describe('should fail when startedAt is missing', () => {
+        it.each([
+            {
+                description: 'interview missing startedAt',
+                hasParadata: true,
+                startedAt: undefined
+            },
+            {
+                description: 'interview has no paradata',
+                hasParadata: false,
+                startedAt: undefined
+            },
+            {
+                description: 'interview has null startedAt',
+                hasParadata: true,
+                startedAt: null
+            },
+            {
+                description: 'interview has null startedAt with no paradata',
+                hasParadata: false,
+                startedAt: null
+            },
+            {
+                description: 'interview has negative startedAt timestamp',
+                hasParadata: true,
+                startedAt: -1234567890
+            },
+            {
+                description: 'interview has negative startedAt timestamp with no paradata',
+                hasParadata: false,
+                startedAt: -1234567890
+            },
+            {
+                description: 'interview has NaN startedAt',
+                hasParadata: true,
+                startedAt: NaN
+            },
+            {
+                description: 'interview has NaN startedAt with no paradata',
+                hasParadata: false,
+                startedAt: NaN
+            },
+            {
+                description: 'interview has Infinity startedAt',
+                hasParadata: true,
+                startedAt: Infinity
+            },
+            {
+                description: 'interview has Infinity startedAt with no paradata',
+                hasParadata: false,
+                startedAt: Infinity
+            },
+            {
+                description: 'interview has -Infinity startedAt',
+                hasParadata: true,
+                startedAt: -Infinity
+            },
+            {
+                description: 'interview has -Infinity startedAt with no paradata',
+                hasParadata: false,
+                startedAt: -Infinity
+            }
+        ])('$description', ({ hasParadata, startedAt }) => {
+            const interview = createMockInterview(undefined, validUuid);
+            interview.paradata = hasParadata
+                ? new InterviewParadata({ startedAt: startedAt as number | undefined })
+                : undefined;
+            const context: InterviewAuditCheckContext = { interview };
+
+            const result = interviewAuditChecks.I_M_StartedAt(context);
+
+            expect(result).toMatchObject({
+                objectType: 'interview',
+                objectUuid: validUuid,
+                errorCode: 'I_M_StartedAt',
+                version: 1,
+                level: 'error',
+                message: 'Interview start time is missing',
+                ignore: false
+            });
+        });
+    });
+});
+

--- a/packages/evolution-common/src/services/baseObjects/attributeTypes/GenericAttributes.ts
+++ b/packages/evolution-common/src/services/baseObjects/attributeTypes/GenericAttributes.ts
@@ -23,6 +23,6 @@ export type YesNoDontKnowPreferNotToAnswer = (typeof yesNoDontKnowPreferNotToAns
 export type TimePeriod = string; // TODO: normalize time periods (when time is too precise, like for long distance journeys)
 
 export type StartEndTimestampable = {
-    startTimestamp?: number;
-    endTimestamp?: number; // could be calculated from the next start timestamp
+    startTimestamp?: number; // unix epoch timestamp in seconds (not milliseconds)
+    endTimestamp?: number; // unix epoch timestamp in seconds (not milliseconds); could be calculated from the next start timestamp
 };

--- a/packages/evolution-common/src/services/baseObjects/interview/InterviewParadata.ts
+++ b/packages/evolution-common/src/services/baseObjects/interview/InterviewParadata.ts
@@ -33,9 +33,9 @@ const interviewParadataAttributes = [
 const interviewParadataAttributesWithComposedAttributes = [...interviewParadataAttributes];
 
 export type InterviewParadataAttributes = {
-    startedAt?: number; // unix epoch timestamp;
-    updatedAt?: number; // unix epoch timestamp;
-    completedAt?: number; // unix epoch timestamp; updated at the end of the interview. Needs auditing before assuming the interview is really completed.
+    startedAt?: number; // unix epoch timestamp in seconds (not milliseconds)
+    updatedAt?: number; // unix epoch timestamp in seconds (not milliseconds)
+    completedAt?: number; // unix epoch timestamp in seconds (not milliseconds); updated at the end of the interview. Needs auditing before assuming the interview is really completed.
 
     source?: string; // source for the interview (web, phone, social, etc.)
     // In a household survey, we need to ask trips for each persons in random order to reduce biases

--- a/packages/evolution-common/src/utils/DateTimeUtils.ts
+++ b/packages/evolution-common/src/utils/DateTimeUtils.ts
@@ -60,3 +60,34 @@ export const dateToIsoWithTimezone = (
         timeZone
     }).format(date);
 };
+
+/**
+ * Converts seconds timestamp to milliseconds timestamp, validating it's finite
+ * @param seconds - Timestamp in seconds
+ * @returns Timestamp in milliseconds if valid, undefined otherwise
+ */
+export const secondsToMillisecondsTimestamp = (seconds: number | undefined): number | undefined => {
+    if (seconds === undefined) {
+        return undefined;
+    }
+    if (!Number.isFinite(seconds)) {
+        return undefined;
+    }
+    const milliseconds = seconds * 1000;
+    return Number.isFinite(milliseconds) ? milliseconds : undefined;
+};
+
+/**
+ * Parses a date string to a timestamp in milliseconds, validating the result.
+ * Accepts any date string format parseable by the Date constructor (ISO 8601 with/without
+ * timezone offset, date-only strings, etc.). Invalid or unparseable strings return undefined.
+ * @param isoDateString - Date string to parse (preferably ISO 8601 format)
+ * @returns Timestamp in milliseconds if valid, undefined otherwise
+ */
+export const parseISODateToTimestamp = (isoDateString: string | undefined): number | undefined => {
+    if (!isoDateString) {
+        return undefined;
+    }
+    const parsedTimestamp = new Date(isoDateString).getTime();
+    return Number.isFinite(parsedTimestamp) ? parsedTimestamp : undefined;
+};


### PR DESCRIPTION
Add three new audit checks to validate interview timestamps:
- I_M_StartedAt: Validates that interview has a start timestamp
- I_I_StartedAtBeforeSurveyStartDate: Flags interviews started before survey period
- I_I_StartedAtAfterSurveyEndDate: Flags interviews started after survey period

The new checks respect survey configuration boundaries and handle edge cases (undefined timestamps, missing paradata, unconfigured survey dates).

Refactored timestamp handling to use explicit !== undefined checks instead of truthy checks, ensuring proper handling of edge cases like startedAt: 0. Added inline comments documenting the seconds-to-milliseconds conversion.

Updated InterviewParadata type documentation to explicitly specify that startedAt, updatedAt, and completedAt are stored as Unix epoch timestamps in seconds (not milliseconds) for clarity across the codebase.

Changes:
- Add InterviewAuditChecks: I_M_StartedAt, I_I_StartedAtBeforeSurveyStartDate, I_I_StartedAtAfterSurveyEndDate
- Add comprehensive test suites for all three audit checks (17 tests total)
- Add English and French translations for audit error messages
- Update InterviewParadata type definitions with clarified timestamp units
- Improve timestamp conversion logic for better readability and correctness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added interview start-time audit validations (missing, before survey start, after survey end) and corresponding English/French messages.
  * Added utility functions to parse/convert timestamps (seconds ⇄ milliseconds).

* **Documentation**
  * Clarified that timestamp fields are unix epoch seconds (not milliseconds) in inline comments.

* **Tests**
  * Added comprehensive unit tests covering pass/fail cases, cross-timezone scenarios, and edge cases for the new checks and utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->