### PR TITLE
audit checks: add I_I_InvalidAccessCode for Interview

### DIFF
--- a/locales/en/audits.json
+++ b/locales/en/audits.json
@@ -3,6 +3,7 @@
     "I_M_StartedAt": "Interview start time is missing",
     "I_I_StartedAtBeforeSurveyStartDate": "Interview start time is before survey start date",
     "I_I_StartedAtAfterSurveyEndDate": "Interview start time is after survey end date",
+    "I_I_InvalidAccessCodeFormat": "Interview access code format is invalid",
 
     "HH_I_Size": "Household size is out of range (should be between 1 and 20)",
     "HH_M_Size": "Household size is missing",

--- a/locales/fr/audits.json
+++ b/locales/fr/audits.json
@@ -3,6 +3,7 @@
     "I_M_StartedAt": "La date de début de l'entrevue est manquante",
     "I_I_StartedAtBeforeSurveyStartDate": "Le début de l'entrevue est avant la date de début de l'enquête",
     "I_I_StartedAtAfterSurveyEndDate": "Le début de l'entrevue est après la date de fin de l'enquête",
+    "I_I_InvalidAccessCodeFormat": "Le format du code d'accès de l'entrevue est invalide",
 
     "HH_I_Size": "La taille du ménage est en dehors de la plage autorisée (devrait être entre 1 et 20)",
     "HH_M_Size": "La taille du ménage est manquante",

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/interview/I_I_InvalidAccessCode.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/interview/I_I_InvalidAccessCode.test.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { v4 as uuidV4 } from 'uuid';
+import type { InterviewAuditCheckContext } from '../../../AuditCheckContexts';
+import { createMockInterview } from './testHelper';
+import { interviewAuditChecks } from '../../InterviewAuditChecks';
+import { registerAccessCodeValidationFunction } from '../../../../../accessCode';
+
+// Register a simple validation function for testing
+// Valid codes are 8 digits, optionally with a hyphen in the middle (e.g., "1234-5678" or "12345678")
+registerAccessCodeValidationFunction((accessCode: string) => {
+    return /^\d{4}-?\d{4}$/.test(accessCode);
+});
+
+describe('I_I_InvalidAccessCodeFormat audit check', () => {
+    const validUuid = uuidV4();
+
+    describe('should pass in valid scenarios', () => {
+        it.each([
+            {
+                description: 'interview has valid access code with hyphen',
+                accessCode: '1234-5678'
+            },
+            {
+                description: 'interview has valid access code without hyphen',
+                accessCode: '12345678'
+            },
+            {
+                description: 'interview has no access code (undefined)',
+                accessCode: undefined
+            },
+            {
+                description: 'interview has null access code',
+                accessCode: null
+            },
+            {
+                description: 'interview has empty string access code',
+                accessCode: ''
+            }
+        ])('$description', ({ accessCode }) => {
+            const interview = createMockInterview({ accessCode: accessCode as string | undefined });
+            const context: InterviewAuditCheckContext = { interview };
+
+            const result = interviewAuditChecks.I_I_InvalidAccessCodeFormat(context);
+
+            expect(result).toBeUndefined();
+        });
+    });
+
+    describe('should fail when access code is invalid', () => {
+        it.each([
+            {
+                description: 'access code with letters',
+                accessCode: 'invalid-code'
+            },
+            {
+                description: 'access code too short',
+                accessCode: '123'
+            },
+            {
+                description: 'access code with special characters',
+                accessCode: '!@#$%^&*()'
+            },
+            {
+                description: 'access code too long',
+                accessCode: '1234567890123456789012345678901234567890'
+            },
+            {
+                description: 'access code with 7 digits only',
+                accessCode: '1234567'
+            },
+            {
+                description: 'access code with multiple hyphens',
+                accessCode: '12-34-56-78'
+            }
+        ])('$description', ({ accessCode }) => {
+            const interview = createMockInterview({ accessCode }, validUuid);
+            const context: InterviewAuditCheckContext = { interview };
+
+            const result = interviewAuditChecks.I_I_InvalidAccessCodeFormat(context);
+
+            expect(result).toEqual({
+                objectType: 'interview',
+                objectUuid: validUuid,
+                errorCode: 'I_I_InvalidAccessCodeFormat',
+                version: 1,
+                level: 'error',
+                message: 'Interview access code format is invalid',
+                ignore: false
+            });
+        });
+    });
+});
+


### PR DESCRIPTION
This audit check validates the access code of an interview. It is only validated if the access code is present. Some surveys may not implement access codes at all. The validateAccessCode function is defined in the survey project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added interview access code format validation with user-facing error messages in English and French.

* **Tests**
  * Added comprehensive tests covering valid and invalid access code scenarios, ensuring consistent error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->