### PR TITLE
feat(audits): configuration infrastructure for audit checks

### DIFF
--- a/locales/en/audits.json
+++ b/locales/en/audits.json
@@ -3,7 +3,8 @@
     "I_M_StartedAt": "Interview start time is missing",
     "I_I_StartedAtBeforeSurveyStartDate": "Interview start time is before survey start date",
     "I_I_StartedAtAfterSurveyEndDate": "Interview start time is after survey end date",
-    "I_I_InvalidAccessCodeFormat": "Interview access code format is invalid",
+    "I_M_AccessCode": "Access code is missing",
+    "I_I_InvalidAccessCodeFormat": "Access code format is invalid",
 
     "HH_I_Size": "Household size is out of range (should be between 1 and 20)",
     "HH_M_Size": "Household size is missing",

--- a/locales/fr/audits.json
+++ b/locales/fr/audits.json
@@ -3,7 +3,8 @@
     "I_M_StartedAt": "La date de début de l'entrevue est manquante",
     "I_I_StartedAtBeforeSurveyStartDate": "Le début de l'entrevue est avant la date de début de l'enquête",
     "I_I_StartedAtAfterSurveyEndDate": "Le début de l'entrevue est après la date de fin de l'enquête",
-    "I_I_InvalidAccessCodeFormat": "Le format du code d'accès de l'entrevue est invalide",
+    "I_M_AccessCode": "Le code d'accès est manquant",
+    "I_I_InvalidAccessCodeFormat": "Le format du code d'accès est invalide",
 
     "HH_I_Size": "La taille du ménage est en dehors de la plage autorisée (devrait être entre 1 et 20)",
     "HH_M_Size": "La taille du ménage est manquante",

--- a/packages/evolution-backend/src/services/audits/AuditUtils.ts
+++ b/packages/evolution-backend/src/services/audits/AuditUtils.ts
@@ -4,7 +4,9 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
+import projectConfig from 'evolution-common/lib/config/project.config';
 import { AuditForObject, Audits } from 'evolution-common/lib/services/audits/types';
+import { SurveyObjectNames } from 'evolution-common/lib/services/baseObjects/types';
 import slugify from 'slugify';
 
 /**
@@ -62,3 +64,12 @@ export const mergeWithExisting = (existingAudits: Audits, newAudits: Audits, ove
     }
     return newAudits;
 };
+
+/**
+ * Check if a field is required based on configuration
+ * @param {SurveyObjectNames} objectType - The type of survey object
+ * @param {string} field - The field to check
+ * @returns {boolean} true if the field is required, false otherwise
+ */
+export const fieldIsRequired = (objectType: SurveyObjectNames, field: string) =>
+    (projectConfig.requiredFieldsBySurveyObject?.[objectType] ?? []).includes(field);

--- a/packages/evolution-backend/src/services/audits/__tests__/AuditUtils.test.ts
+++ b/packages/evolution-backend/src/services/audits/__tests__/AuditUtils.test.ts
@@ -9,6 +9,7 @@ import slugify from 'slugify';
 
 import { mergeWithExisting, convertParamsErrorsToAudits } from '../AuditUtils';
 import type { Audits } from 'evolution-common/lib/services/audits/types';
+import type { SurveyObjectNames } from 'evolution-common/lib/services/baseObjects/types';
 
 const arbitraryUuid = uuidV4();
 
@@ -89,5 +90,137 @@ describe('mergeWithExisting', () => {
         expect(mergedAudits['outdated-error']).toBeUndefined();
         expect(mergedAudits['version-changed-error'].version).toBe(2);
         expect(mergedAudits['version-changed-error'].ignore).toBe(false);
+    });
+});
+
+// Note: These tests use jest.isolateModulesAsync to ensure projectConfig mutations don't leak between tests
+// running in parallel across different test files. We use await import() inside isolateModulesAsync to get
+// fresh module instances per test, ensuring each test has an isolated projectConfig state.
+describe('fieldIsRequired', () => {
+    it.each<{ objectType: SurveyObjectNames; field: string; isRequired: boolean }>([
+        // Test all SurveyObjectNames with required fields
+        { objectType: 'interview', field: 'accessCode', isRequired: true },
+        { objectType: 'household', field: 'size', isRequired: true },
+        { objectType: 'home', field: 'address', isRequired: true },
+        { objectType: 'organization', field: 'name', isRequired: true },
+        { objectType: 'vehicle', field: 'type', isRequired: true },
+        { objectType: 'person', field: 'age', isRequired: true },
+        { objectType: 'journey', field: 'startDate', isRequired: true },
+        { objectType: 'tripChain', field: 'origin', isRequired: true },
+        { objectType: 'visitedPlace', field: 'activity', isRequired: true },
+        { objectType: 'trip', field: 'origin', isRequired: true },
+        { objectType: 'segment', field: 'mode', isRequired: true },
+        { objectType: 'junction', field: 'location', isRequired: true },
+        { objectType: 'workPlace', field: 'name', isRequired: true },
+        { objectType: 'schoolPlace', field: 'name', isRequired: true },
+        // Test all SurveyObjectNames with non-required fields
+        { objectType: 'interview', field: 'accessCode', isRequired: false },
+        { objectType: 'household', field: 'size', isRequired: false },
+        { objectType: 'home', field: 'address', isRequired: false },
+        { objectType: 'organization', field: 'name', isRequired: false },
+        { objectType: 'vehicle', field: 'type', isRequired: false },
+        { objectType: 'person', field: 'age', isRequired: false },
+        { objectType: 'journey', field: 'startDate', isRequired: false },
+        { objectType: 'tripChain', field: 'origin', isRequired: false },
+        { objectType: 'visitedPlace', field: 'activity', isRequired: false },
+        { objectType: 'trip', field: 'origin', isRequired: false },
+        { objectType: 'segment', field: 'mode', isRequired: false },
+        { objectType: 'junction', field: 'location', isRequired: false },
+        { objectType: 'workPlace', field: 'name', isRequired: false },
+        { objectType: 'schoolPlace', field: 'name', isRequired: false }
+    ])('$objectType field "$field" should be $isRequired', async ({ objectType, field, isRequired }) => {
+        await jest.isolateModulesAsync(async () => {
+            // Import modules inside isolateModules to get fresh instances
+            const { default: projectConfig } = await import('evolution-common/lib/config/project.config');
+            const { fieldIsRequired } = await import('../AuditUtils');
+
+            // Set config for this test
+            projectConfig.requiredFieldsBySurveyObject = {
+                ...projectConfig.requiredFieldsBySurveyObject,
+                [objectType]: isRequired ? [field] : []
+            };
+
+            const result = fieldIsRequired(objectType, field);
+
+            expect(result).toBe(isRequired);
+        });
+    });
+
+    describe('should return false when top-level config is undefined', () => {
+        it('handles missing requiredFieldsBySurveyObject safely', async () => {
+            await jest.isolateModulesAsync(async () => {
+                const { default: projectConfig } = await import('evolution-common/lib/config/project.config');
+                const { fieldIsRequired } = await import('../AuditUtils');
+
+                // Simulate entirely missing config section
+                (projectConfig as any).requiredFieldsBySurveyObject = undefined;
+
+                expect(fieldIsRequired('interview', 'accessCode')).toBe(false);
+            });
+        });
+    });
+
+    describe('should handle multiple required fields', () => {
+        it('should return true for all required fields and false for non-required', async () => {
+            await jest.isolateModulesAsync(async () => {
+                // Import modules inside isolateModules to get fresh instances
+                const { default: projectConfig } = await import('evolution-common/lib/config/project.config');
+                const { fieldIsRequired } = await import('../AuditUtils');
+
+                // Set config with multiple required fields
+                projectConfig.requiredFieldsBySurveyObject = {
+                    ...projectConfig.requiredFieldsBySurveyObject,
+                    interview: ['accessCode', 'assignedDate', 'contactEmail']
+                };
+
+                expect(fieldIsRequired('interview', 'accessCode')).toBe(true);
+                expect(fieldIsRequired('interview', 'assignedDate')).toBe(true);
+                expect(fieldIsRequired('interview', 'contactEmail')).toBe(true);
+                expect(fieldIsRequired('interview', 'contactPhoneNumber')).toBe(false);
+                expect(fieldIsRequired('interview', 'nonExistentField')).toBe(false);
+            });
+        });
+    });
+
+    describe('should return false when object type key is absent', () => {
+        it('handles missing config key safely', async () => {
+            await jest.isolateModulesAsync(async () => {
+                const { default: projectConfig } = await import('evolution-common/lib/config/project.config');
+                const { fieldIsRequired } = await import('../AuditUtils');
+
+                // Remove key entirely for this test
+                projectConfig.requiredFieldsBySurveyObject = {
+                    ...projectConfig.requiredFieldsBySurveyObject,
+                };
+                delete (projectConfig.requiredFieldsBySurveyObject as any).organization;
+
+                expect(fieldIsRequired('organization', 'name')).toBe(false);
+            });
+        });
+    });
+
+    describe('should handle different object types independently', () => {
+        it('should check required fields per object type', async () => {
+            await jest.isolateModulesAsync(async () => {
+                // Import modules inside isolateModules to get fresh instances
+                const { default: projectConfig } = await import('evolution-common/lib/config/project.config');
+                const { fieldIsRequired } = await import('../AuditUtils');
+
+                // Set different required fields for different object types
+                projectConfig.requiredFieldsBySurveyObject = {
+                    ...projectConfig.requiredFieldsBySurveyObject,
+                    interview: ['accessCode'],
+                    household: ['size'],
+                    home: ['address']
+                };
+
+                expect(fieldIsRequired('interview', 'accessCode')).toBe(true);
+                expect(fieldIsRequired('interview', 'size')).toBe(false);
+                expect(fieldIsRequired('household', 'size')).toBe(true);
+                expect(fieldIsRequired('household', 'accessCode')).toBe(false);
+                expect(fieldIsRequired('home', 'address')).toBe(true);
+                expect(fieldIsRequired('home', 'accessCode')).toBe(false);
+            });
+        });
     });
 });

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/InterviewAuditChecks.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/InterviewAuditChecks.ts
@@ -11,6 +11,7 @@ import type { InterviewAuditCheckContext, InterviewAuditCheckFunction } from '..
 import projectConfig from 'evolution-common/lib/config/project.config';
 import { secondsToMillisecondsTimestamp, parseISODateToTimestamp } from 'evolution-common/lib/utils/DateTimeUtils';
 import { validateAccessCode } from '../../../accessCode';
+import { fieldIsRequired } from '../../AuditUtils';
 
 export const interviewAuditChecks: { [errorCode: string]: InterviewAuditCheckFunction } = {
     /**
@@ -129,6 +130,28 @@ export const interviewAuditChecks: { [errorCode: string]: InterviewAuditCheckFun
     },
 
     /**
+     * Check if interview access code is missing (if required)
+     * @param context - InterviewAuditCheckContext
+     * @returns {AuditForObject | undefined}
+     */
+    I_M_AccessCode: (context: InterviewAuditCheckContext): AuditForObject | undefined => {
+        const { interview } = context;
+        const accessCode = interview.accessCode;
+        if (fieldIsRequired('interview', 'accessCode') && _isBlank(accessCode)) {
+            return {
+                objectType: 'interview',
+                objectUuid: interview.uuid!,
+                errorCode: 'I_M_AccessCode',
+                version: 1,
+                level: 'error',
+                message: 'Access code is missing',
+                ignore: false
+            };
+        }
+        return undefined;
+    },
+
+    /**
      * Check if interview access code format is invalid
      * Only validates the format if access code is present.
      * It does not verify that the access code is valid
@@ -152,7 +175,7 @@ export const interviewAuditChecks: { [errorCode: string]: InterviewAuditCheckFun
                     errorCode: 'I_I_InvalidAccessCodeFormat',
                     version: 1,
                     level: 'error',
-                    message: 'Interview access code format is invalid',
+                    message: 'Access code format is invalid',
                     ignore: false
                 };
             }

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/interview/I_I_InvalidAccessCode.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/interview/I_I_InvalidAccessCode.test.ts
@@ -12,7 +12,7 @@ import { interviewAuditChecks } from '../../InterviewAuditChecks';
 import { registerAccessCodeValidationFunction } from '../../../../../accessCode';
 
 // Register a simple validation function for testing
-// Valid codes are 8 digits, optionally with a hyphen in the middle (e.g., "1234-5678" or "12345678")
+// Valid codes for testing are 8 digits, optionally with a hyphen in the middle (e.g., "1234-5678" or "12345678")
 registerAccessCodeValidationFunction((accessCode: string) => {
     return /^\d{4}-?\d{4}$/.test(accessCode);
 });
@@ -37,6 +37,10 @@ describe('I_I_InvalidAccessCodeFormat audit check', () => {
             {
                 description: 'interview has null access code',
                 accessCode: null
+            },
+            {
+                description: 'access code is single space',
+                accessCode: ' '
             },
             {
                 description: 'interview has empty string access code',
@@ -90,7 +94,7 @@ describe('I_I_InvalidAccessCodeFormat audit check', () => {
                 errorCode: 'I_I_InvalidAccessCodeFormat',
                 version: 1,
                 level: 'error',
-                message: 'Interview access code format is invalid',
+                message: 'Access code format is invalid',
                 ignore: false
             });
         });

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/interview/I_M_AccessCode.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/interview/I_M_AccessCode.test.ts
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { v4 as uuidV4 } from 'uuid';
+import type { InterviewAuditCheckContext } from '../../../AuditCheckContexts';
+import { createMockInterview } from './testHelper';
+
+// Note: These tests use jest.isolateModulesAsync to ensure projectConfig mutations don't leak between tests
+// running in parallel across different test files. We use await import() inside isolateModulesAsync to get
+// fresh module instances per test, ensuring each test has an isolated projectConfig state.
+describe('I_M_AccessCode audit check', () => {
+    const validUuid = uuidV4();
+
+    describe('should pass when access code is present', () => {
+        it.each([
+            {
+                description: 'access code is required and present',
+                accessCode: '1234-5678',
+                isRequired: true
+            },
+            {
+                description: 'access code is not required and present',
+                accessCode: '1234-5678',
+                isRequired: false
+            },
+            {
+                description: 'access code is not required and missing',
+                accessCode: undefined,
+                isRequired: false
+            },
+            {
+                description: 'access code is not required and null',
+                accessCode: null,
+                isRequired: false
+            },
+            {
+                description: 'access code is not required and empty string',
+                accessCode: '',
+                isRequired: false
+            }
+        ])('$description', async ({ accessCode, isRequired }) => {
+            await jest.isolateModulesAsync(async () => {
+                // Import modules inside isolateModules to get fresh instances
+                const { default: projectConfig } = await import('evolution-common/lib/config/project.config');
+                const { interviewAuditChecks } = await import('../../InterviewAuditChecks');
+
+                // Set config for this test
+                projectConfig.requiredFieldsBySurveyObject = {
+                    ...projectConfig.requiredFieldsBySurveyObject,
+                    interview: isRequired ? ['accessCode'] : []
+                };
+
+                const interview = createMockInterview({ accessCode: accessCode as string | undefined });
+                const context: InterviewAuditCheckContext = { interview };
+
+                const result = interviewAuditChecks.I_M_AccessCode(context);
+
+                expect(result).toBeUndefined();
+            });
+        });
+    });
+
+    describe('should fail when access code is required and missing', () => {
+        it.each([
+            {
+                description: 'access code is undefined',
+                accessCode: undefined
+            },
+            {
+                description: 'access code is null',
+                accessCode: null
+            },
+            {
+                description: 'access code is empty string',
+                accessCode: ''
+            },
+            {
+                description: 'access code is whitespace only',
+                accessCode: '   '
+            },
+            {
+                description: 'access code is tab character',
+                accessCode: '\t'
+            },
+            {
+                description: 'access code is newline character',
+                accessCode: '\n'
+            }
+        ])('$description', async ({ accessCode }) => {
+            await jest.isolateModulesAsync(async () => {
+                // Import modules inside isolateModules to get fresh instances
+                const { default: projectConfig } = await import('evolution-common/lib/config/project.config');
+                const { interviewAuditChecks } = await import('../../InterviewAuditChecks');
+
+                // Set config to require access code
+                projectConfig.requiredFieldsBySurveyObject = {
+                    ...projectConfig.requiredFieldsBySurveyObject,
+                    interview: ['accessCode']
+                };
+
+                const interview = createMockInterview({ accessCode: accessCode as string | undefined }, validUuid);
+                const context: InterviewAuditCheckContext = { interview };
+
+                const result = interviewAuditChecks.I_M_AccessCode(context);
+
+                expect(result).toEqual({
+                    objectType: 'interview',
+                    objectUuid: validUuid,
+                    errorCode: 'I_M_AccessCode',
+                    version: 1,
+                    level: 'error',
+                    message: 'Access code is missing',
+                    ignore: false
+                });
+            });
+        });
+    });
+});
+

--- a/packages/evolution-common/src/config/project.config.ts
+++ b/packages/evolution-common/src/config/project.config.ts
@@ -9,6 +9,7 @@ import projectConfig, {
     setProjectConfiguration
 } from 'chaire-lib-common/lib/config/shared/project.config';
 import { ISODateTimeStringWithTimezoneOffset } from '../utils/DateTimeUtils';
+import { AuditChecksGroup, SurveyBase, AuditRequiredFieldsBySurveyObject } from '../services/audits/types';
 
 /**
  * Specific configuration for the Evolution project
@@ -158,6 +159,21 @@ export type EvolutionProjectConfiguration = {
      * */
     postalCodeRegion: 'canada' | 'quebec' | 'other';
 
+    /**
+     * See AuditChecksGroup type for details.
+     */
+    auditChecksGroup: AuditChecksGroup;
+
+    /**
+     * See SurveyBase type for details.
+     */
+    surveyBase: SurveyBase;
+
+    /**
+     * See AuditRequiredFieldsBySurveyObject type for details.
+     */
+    requiredFieldsBySurveyObject: AuditRequiredFieldsBySurveyObject;
+
     // TODO Add more project configuration types
 };
 
@@ -217,7 +233,25 @@ const defaultConfig = {
         '#4146B5',
         '#9F41B5',
         '#B5417B'
-    ]
+    ],
+    requiredFieldsBySurveyObject: {
+        interview: [],
+        household: [],
+        home: [],
+        organization: [],
+        vehicle: [],
+        person: [],
+        journey: [],
+        tripChain: [],
+        visitedPlace: [],
+        trip: [],
+        segment: [],
+        junction: [],
+        workPlace: [],
+        schoolPlace: []
+    },
+    auditChecksGroup: 'custom', // custom by default so older surveys works.
+    surveyBase: 'householdBased'
 };
 
 // Validate and set the configuration

--- a/packages/evolution-common/src/services/audits/types.ts
+++ b/packages/evolution-common/src/services/audits/types.ts
@@ -5,7 +5,7 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 
-import { SurveyObjects } from '../baseObjects/types';
+import { ParentSurveyObjects, SurveyObjectNames } from '../baseObjects/types';
 
 export type Audit = {
     /**
@@ -48,7 +48,7 @@ export type Audits = { [errorCode: string]: Audit }; // audits by errorCode (key
  *
  * This is the base type to store survey objects with their audits.
  */
-export type SurveyObjectsWithAudits = SurveyObjects & {
+export type SurveyObjectsWithAudits = ParentSurveyObjects & {
     audits: AuditForObject[]; // all audits for the interview and its survey objects
     auditsByObject?: AuditsByObject; // audits by each object type
 };
@@ -84,4 +84,40 @@ export type AuditsByObject = {
     segments: {
         [key: string]: AuditForObject[]; // key: uuid
     };
+};
+
+/**
+ * The group of audit checks to use.
+ * This is used to determine which audit checks to run.
+ *
+ * Travel survey: a typical Origin-Destination/travel survey
+ * Long distance survey: a survey for long-distance travel, usually with multi-days journeys
+ * Usual places survey: a survey asking for places where people go on a regular basis
+ * Minimum survey: a survey with the minimum required fields
+ * Custom survey: a survey with custom audit checks (will not run audit checks from evolution)
+ *   For custom surveys, the audit checks must be configured in the survey project.
+ *
+ * New groups may be added in the future.
+ */
+export type AuditChecksGroup = 'travelSurvey' | 'longDistanceSurvey' | 'usualPlacesSurvey' | 'minimum' | 'custom';
+
+/**
+ * The scope/base of the survey.
+ * This is used to determine which survey objects to audit.
+ * Household survey: a survey in which all household members are surveyed
+ * Person survey: a survey that only surveys a single person
+ * Note: all surveys should ask for the household members
+ * characteristics even in person-based surveys (for comparison and weighting purposes).
+ * New bases may be added in the future, like Vehicle, Organization, etc.
+ */
+export type SurveyBase = 'householdBased' | 'personBased';
+
+/**
+ * The fields that are required for each survey object.
+ * A required field will make an audit check return an error if it is missing
+ * Some fields may return an audit check error only if the conditional(s) for their presence is met.
+ * See audit checks directory for details: evolution-backend/src/services/audits/auditChecks
+ */
+export type AuditRequiredFieldsBySurveyObject = {
+    [key in SurveyObjectNames]: string[];
 };

--- a/packages/evolution-common/src/services/baseObjects/types.ts
+++ b/packages/evolution-common/src/services/baseObjects/types.ts
@@ -17,11 +17,32 @@ import { Home } from './Home';
  * Composed objects are inside their parent object
  * (like persons inside a household, visited places inside a journey, etc.).
  */
-export type SurveyObjects = {
+export type ParentSurveyObjects = {
     interview: Optional<Interview>; // undefined if not valid (has errors)
     household: Optional<Household>; // undefined if not valid (has errors) or if no household is surveyed
     home: Optional<Home>; // undefined if not valid (has errors) or if no home is surveyed
 };
+
+/**
+ * Names of survey objects
+ *
+ * This is the list of names of survey objects.
+ */
+export type SurveyObjectNames =
+    | 'interview'
+    | 'household'
+    | 'home'
+    | 'organization'
+    | 'vehicle'
+    | 'person'
+    | 'journey'
+    | 'tripChain'
+    | 'visitedPlace'
+    | 'trip'
+    | 'segment'
+    | 'junction'
+    | 'workPlace'
+    | 'schoolPlace';
 
 /**
  * Errors by survey object type
@@ -54,6 +75,6 @@ export type ErrorsBySurveyObject = {
  * We store the errors by survey object type to be able to convert them
  * to audits later. Any object with at least one error will be undefined.
  */
-export type SurveyObjectsWithErrors = SurveyObjects & {
+export type SurveyObjectsWithErrors = ParentSurveyObjects & {
     errorsByObject: ErrorsBySurveyObject;
 };


### PR DESCRIPTION
Infrastructure additions:
- Add auditChecksGroup configuration (travelSurvey, longDistanceSurvey, usualPlacesSurvey, minimum, custom)
- Add surveyBase configuration (householdBased, personBased)
- Add requiredFieldsBySurveyObject configuration for flexible field requirements per survey object

Key changes:
- Add I_M_AccessCode audit check that only validates when access code is configured as required
- Update error messages to be more concise ("Access code is missing" vs "Interview access code is missing")
- Add comprehensive test coverage for I_M_AccessCode (11 tests)
- Update I_I_InvalidAccessCodeFormat tests to match new error messages

Localization:
- Add English translations for new audit error codes
- Add French translations for new audit error codes
- Update existing access code format error messages in both languages

closes #1305

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audit validation now flags missing interview access codes when required.

* **Bug Fixes**
  * Clarified access code error message to "Access code format is invalid".

* **Chores**
  * Project configuration extended to declare required fields per survey object, survey base, and audit group.
  * Added/updated English and French locale entries for access-code messages.

* **Tests**
  * Added tests for access-code validation and for the required-field utility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->