### PR TITLE
Ignore _surveyObjectsRegistry in custom attributes

### DIFF
--- a/packages/evolution-common/src/utils/ConstructorUtils.ts
+++ b/packages/evolution-common/src/utils/ConstructorUtils.ts
@@ -32,7 +32,7 @@ export class ConstructorUtils {
             if (attributeNames.includes(attribute)) {
                 // If the key exists in the attributes object, assign the value to the initialized attributes
                 initializedAttributes[attribute] = params[attribute];
-            } else if (!attributeWithComposedAttributes.includes(attribute)) {
+            } else if (!attributeWithComposedAttributes.includes(attribute) && attribute !== '_surveyObjectsRegistry') {
                 // ignore composed attributes, dealt with later in the constructor
                 // If the key doesn't exist in the attributes object, assign the value to the initialized custom attributes
                 initializedCustomAttributes[attribute] = params[attribute];

--- a/packages/evolution-common/src/utils/__tests__/ConstructorUtils.test.ts
+++ b/packages/evolution-common/src/utils/__tests__/ConstructorUtils.test.ts
@@ -28,9 +28,42 @@ describe('ConstructorUtils', () => {
             expect(attributes).toEqual({ attr1: 'value1', attr2: 'value2' });
             expect(customAttributes).toEqual({ customAttr1: 'customValue1', customAttr2: 'customValue2' });
         });
+
+        test('should not include _surveyObjectsRegistry in customAttributes', () => {
+            const params = {
+                attr1: 'value1',
+                attr2: 'value2',
+                customAttr1: 'customValue1',
+                _surveyObjectsRegistry: surveyObjectsRegistry,
+            };
+            const attributeNames = ['attr1', 'attr2'];
+            const { attributes, customAttributes } = ConstructorUtils.initializeAttributes(params, attributeNames);
+            expect(attributes).toEqual({ attr1: 'value1', attr2: 'value2' });
+            expect(customAttributes).toEqual({ customAttr1: 'customValue1' });
+            expect(customAttributes).not.toHaveProperty('_surveyObjectsRegistry');
+        });
+
+        test('should not include _surveyObjectsRegistry in customAttributes when multiple custom attributes present', () => {
+            const params = {
+                attr1: 'value1',
+                customAttr1: 'customValue1',
+                customAttr2: 'customValue2',
+                _surveyObjectsRegistry: surveyObjectsRegistry,
+                customAttr3: 'customValue3',
+            };
+            const attributeNames = ['attr1'];
+            const { attributes, customAttributes } = ConstructorUtils.initializeAttributes(params, attributeNames);
+            expect(attributes).toEqual({ attr1: 'value1' });
+            expect(customAttributes).toEqual({
+                customAttr1: 'customValue1',
+                customAttr2: 'customValue2',
+                customAttr3: 'customValue3'
+            });
+            expect(customAttributes).not.toHaveProperty('_surveyObjectsRegistry');
+        });
     });
 
-    describe('initializeAttributes', () => {
+    describe('initializeAttributes with composed attributes', () => {
         test('should initialize attributes and custom composed attributes correctly', () => {
             const params = {
                 attr1: 'value1',
@@ -45,6 +78,25 @@ describe('ConstructorUtils', () => {
             const { attributes, customAttributes } = ConstructorUtils.initializeAttributes(params, attributeNames, attributeWithComposedAttributes);
             expect(attributes).toEqual({ attr1: 'value1', attr2: 'value2' });
             expect(customAttributes).toEqual({ customAttr1: 'customValue1', customAttr2: 'customValue2' });
+        });
+
+        test('should not include _surveyObjectsRegistry or composed attributes in customAttributes', () => {
+            const params = {
+                attr1: 'value1',
+                attr2: 'value2',
+                customAttr1: 'customValue1',
+                _surveyObjectsRegistry: surveyObjectsRegistry,
+                composed1: 'foo',
+                composed2: 'bar'
+            };
+            const attributeNames = ['attr1', 'attr2'];
+            const attributeWithComposedAttributes = [...attributeNames, 'composed1', 'composed2'];
+            const { attributes, customAttributes } = ConstructorUtils.initializeAttributes(params, attributeNames, attributeWithComposedAttributes);
+            expect(attributes).toEqual({ attr1: 'value1', attr2: 'value2' });
+            expect(customAttributes).toEqual({ customAttr1: 'customValue1' });
+            expect(customAttributes).not.toHaveProperty('_surveyObjectsRegistry');
+            expect(customAttributes).not.toHaveProperty('composed1');
+            expect(customAttributes).not.toHaveProperty('composed2');
         });
     });
 


### PR DESCRIPTION
Right now, the surveyObject Registry is also saved in the custom attributes when unserializing objects. This is not needed.
We should ignore it in the custom attributes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed attribute initialization to properly exclude system-level attributes from custom attribute processing, ensuring correct attribute assignment during object construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->