### PR TITLE
Add access code to interview list columns

### DIFF
--- a/packages/evolution-backend/src/config/__tests__/projectConfig.test.ts
+++ b/packages/evolution-backend/src/config/__tests__/projectConfig.test.ts
@@ -5,8 +5,8 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 
+import { InterviewResponse } from 'evolution-common/lib/services/questionnaire/types';
 import { InterviewListAttributes, InterviewStatusAttributesBase } from 'evolution-common/lib/services/questionnaire/types';
-import projectConfig, { defaultConfig, setProjectConfig } from '../projectConfig';
 
 const interview: InterviewListAttributes = {
     id: 1,
@@ -14,7 +14,7 @@ const interview: InterviewListAttributes = {
     participant_id: 4,
     is_valid: true,
     is_completed: true,
-    response: { accessCode: 'notsure', foo: 'bar', household: { size: 0 } } as any,
+    response: { accessCode: 'notsure', foo: 'bar', household: { size: 0 } } as unknown as InterviewResponse,
     corrected_response: {},
     username: 'test',
     facebook: false,
@@ -35,132 +35,244 @@ const nullResponseInterview = {
     google: false
 };
 
+// Note: These tests use jest.isolateModulesAsync to ensure projectConfig mutations don't leak between tests
+// running in parallel across different test files. We use await import() inside isolateModulesAsync to get
+// fresh module instances per test, ensuring each test has an isolated projectConfig state.
 describe('Validation List Filter', () => {
-    test('test default validation filter', () => {
-        const interviewStatus = projectConfig.validationListFilter(interview);
-        expect(interviewStatus).toEqual({
-            id: interview.id,
-            uuid: interview.uuid,
-            is_valid: interview.is_valid,
-            is_validated: undefined,
-            is_completed: interview.is_completed,
-            username: interview.username,
-            facebook: interview.facebook,
-            google: interview.google,
-            response: { household: { size: 0 } },
-            audits: interview.audits
+    describe('when hasAccessCode is false', () => {
+        test('should not include accessCode in response', async () => {
+            await jest.isolateModulesAsync(async () => {
+                const commonProjectConfig = (await import('evolution-common/lib/config/project.config')).default;
+                const { default: projectConfig } = await import('../projectConfig');
+
+                commonProjectConfig.hasAccessCode = false;
+
+                const interviewStatus = projectConfig.validationListFilter(interview);
+                expect(interviewStatus).toEqual(expect.objectContaining({
+                    id: interview.id,
+                    uuid: interview.uuid,
+                    is_valid: interview.is_valid,
+                    is_validated: undefined,
+                    is_completed: interview.is_completed,
+                    username: interview.username,
+                    facebook: interview.facebook,
+                    google: interview.google,
+                    response: { household: { size: 0 }, _isCompleted: undefined, _validationComment: undefined },
+                    audits: interview.audits
+                }));
+                expect((interviewStatus.response as InterviewResponse).accessCode).toBeUndefined();
+            });
+        });
+
+        test('should not include accessCode with null values for response', async () => {
+            await jest.isolateModulesAsync(async () => {
+                const commonProjectConfig = (await import('evolution-common/lib/config/project.config')).default;
+                const { default: projectConfig } = await import('../projectConfig');
+
+                commonProjectConfig.hasAccessCode = false;
+
+                const interviewStatus = projectConfig.validationListFilter(nullResponseInterview as unknown as InterviewListAttributes);
+                expect(interviewStatus).toEqual(expect.objectContaining({
+                    id: interview.id,
+                    uuid: interview.uuid,
+                    is_valid: interview.is_valid,
+                    is_validated: undefined,
+                    is_completed: interview.is_completed,
+                    username: interview.username,
+                    facebook: interview.facebook,
+                    google: interview.google,
+                    response: { household: { size: undefined }, _isCompleted: undefined, _validationComment: undefined }
+                }));
+                expect((interviewStatus.response as InterviewResponse).accessCode).toBeUndefined();
+            });
         });
     });
 
-    test('test default validation filter with null values for response and corrected response', () => {
-        const interviewStatus = projectConfig.validationListFilter(nullResponseInterview as any);
-        expect(interviewStatus).toEqual({
-            id: interview.id,
-            uuid: interview.uuid,
-            is_valid: interview.is_valid,
-            is_validated: undefined,
-            is_completed: interview.is_completed,
-            username: interview.username,
-            facebook: interview.facebook,
-            google: interview.google,
-            response: { household: { size: undefined }, _isCompleted: undefined, _validationComment: undefined }
+    describe('when hasAccessCode is true', () => {
+        test('should include accessCode in response', async () => {
+            await jest.isolateModulesAsync(async () => {
+                const commonProjectConfig = (await import('evolution-common/lib/config/project.config')).default;
+                const { default: projectConfig } = await import('../projectConfig');
+
+                commonProjectConfig.hasAccessCode = true;
+
+                const interviewStatus = projectConfig.validationListFilter(interview);
+                expect(interviewStatus).toEqual(expect.objectContaining({
+                    id: interview.id,
+                    uuid: interview.uuid,
+                    is_valid: interview.is_valid,
+                    is_validated: undefined,
+                    is_completed: interview.is_completed,
+                    username: interview.username,
+                    facebook: interview.facebook,
+                    google: interview.google,
+                    response: { accessCode: 'notsure', household: { size: 0 }, _isCompleted: undefined, _validationComment: undefined },
+                    audits: interview.audits
+                }));
+            });
+        });
+
+        test('should include accessCode with null values for response', async () => {
+            await jest.isolateModulesAsync(async () => {
+                const commonProjectConfig = (await import('evolution-common/lib/config/project.config')).default;
+                const { default: projectConfig } = await import('../projectConfig');
+
+                commonProjectConfig.hasAccessCode = true;
+
+                const interviewStatus = projectConfig.validationListFilter(nullResponseInterview as unknown as InterviewListAttributes);
+                expect(interviewStatus).toEqual(expect.objectContaining({
+                    id: interview.id,
+                    uuid: interview.uuid,
+                    is_valid: interview.is_valid,
+                    is_validated: undefined,
+                    is_completed: interview.is_completed,
+                    username: interview.username,
+                    facebook: interview.facebook,
+                    google: interview.google,
+                    response: { accessCode: undefined, household: { size: undefined }, _isCompleted: undefined, _validationComment: undefined }
+                }));
+            });
         });
     });
 
-    test('Add project specific filter', () => {
-        setProjectConfig({ validationListFilter: (interview: InterviewListAttributes) => {
-            const status = defaultConfig.validationListFilter(interview) as InterviewStatusAttributesBase;
-            (status.response as any).accessCode = (interview.response as any).accessCode;
-            return status;
-        } });
+    test('Add project specific filter', async () => {
+        await jest.isolateModulesAsync(async () => {
+            const commonProjectConfig = (await import('evolution-common/lib/config/project.config')).default;
+            const { default: projectConfig, defaultConfig, setProjectConfig } = await import('../projectConfig');
 
-        const interviewStatus = projectConfig.validationListFilter(interview);
-        expect(interviewStatus).toEqual({
-            id: interview.id,
-            uuid: interview.uuid,
-            is_valid: interview.is_valid,
-            is_validated: undefined,
-            is_completed: interview.is_completed,
-            username: interview.username,
-            facebook: interview.facebook,
-            google: interview.google,
-            response: { accessCode: (interview.response as any).accessCode, household: { size: 0 } },
-            audits: interview.audits
+            commonProjectConfig.hasAccessCode = true;
+
+            setProjectConfig({ validationListFilter: (interview: InterviewListAttributes) => {
+                const status = defaultConfig.validationListFilter(interview) as InterviewStatusAttributesBase;
+                // Add custom field to response
+                (status.response as unknown as { foo: string }).foo = (interview.response as unknown as { foo: string }).foo;
+                return status;
+            } });
+
+            const interviewStatus = projectConfig.validationListFilter(interview);
+            expect(interviewStatus).toEqual(expect.objectContaining({
+                id: interview.id,
+                uuid: interview.uuid,
+                is_valid: interview.is_valid,
+                is_validated: undefined,
+                is_completed: interview.is_completed,
+                username: interview.username,
+                facebook: interview.facebook,
+                google: interview.google,
+                response: { accessCode: 'notsure', foo: 'bar', household: { size: 0 }, _isCompleted: undefined, _validationComment: undefined },
+                audits: interview.audits
+            }));
         });
     });
 });
 
 describe('Transition API configuration', () => {
+    test('Default value should not be set', async () => {
+        await jest.isolateModulesAsync(async () => {
+            // Undefine all environment variables
+            delete process.env.TRANSITION_API_URL;
+            delete process.env.TRANSITION_API_USERNAME;
+            delete process.env.TRANSITION_API_PASSWORD;
 
-    beforeEach(() => {
-        // Undefine all environment variables and transitionApi config
-        delete process.env.TRANSITION_API_URL;
-        delete process.env.TRANSITION_API_USERNAME;
-        delete process.env.TRANSITION_API_PASSWORD;
-        projectConfig.transitionApi = undefined;
-    });
+            const { default: projectConfig, setProjectConfig } = await import('../projectConfig');
 
-    test('Default value should not be set', () => {
-        setProjectConfig({
-            // Nothing to set
-        });
-        expect(projectConfig.transitionApi).toBeUndefined();
-    });
-
-    test('Should use environment variables if set', () => {
-        process.env.TRANSITION_API_URL = 'https://transition.from.env';
-        process.env.TRANSITION_API_USERNAME = 'username.env';
-        process.env.TRANSITION_API_PASSWORD = 'password.env';
-        setProjectConfig({
-            // Nothing to set
-        });
-        expect(projectConfig.transitionApi).toEqual({
-            url: 'https://transition.from.env',
-            username: 'username.env',
-            password: 'password.env'
+            setProjectConfig({
+                // Nothing to set
+            });
+            expect(projectConfig.transitionApi).toBeUndefined();
         });
     });
 
-    test('Missing password, should not be set', () => {
-        process.env.TRANSITION_API_URL = 'https://transition.from.env';
-        process.env.TRANSITION_API_USERNAME = 'username.env';
-        setProjectConfig({
-            // Nothing to set
+    test('Should use environment variables if set', async () => {
+        await jest.isolateModulesAsync(async () => {
+            process.env.TRANSITION_API_URL = 'https://transition.from.env';
+            process.env.TRANSITION_API_USERNAME = 'username.env';
+            process.env.TRANSITION_API_PASSWORD = 'password.env';
+
+            const { default: projectConfig, setProjectConfig } = await import('../projectConfig');
+
+            setProjectConfig({
+                // Nothing to set
+            });
+            expect(projectConfig.transitionApi).toEqual({
+                url: 'https://transition.from.env',
+                username: 'username.env',
+                password: 'password.env'
+            });
+
+            // Cleanup
+            delete process.env.TRANSITION_API_URL;
+            delete process.env.TRANSITION_API_USERNAME;
+            delete process.env.TRANSITION_API_PASSWORD;
         });
-        expect(projectConfig.transitionApi).toBeUndefined();
     });
 
-    test('Should use the values specified in the config if set', () => {
-        setProjectConfig({
-            transitionApi: {
+    test('Missing password, should not be set', async () => {
+        await jest.isolateModulesAsync(async () => {
+            process.env.TRANSITION_API_URL = 'https://transition.from.env';
+            process.env.TRANSITION_API_USERNAME = 'username.env';
+
+            const { default: projectConfig, setProjectConfig } = await import('../projectConfig');
+
+            setProjectConfig({
+                // Nothing to set
+            });
+            expect(projectConfig.transitionApi).toBeUndefined();
+
+            // Cleanup
+            delete process.env.TRANSITION_API_URL;
+            delete process.env.TRANSITION_API_USERNAME;
+        });
+    });
+
+    test('Should use the values specified in the config if set', async () => {
+        await jest.isolateModulesAsync(async () => {
+            delete process.env.TRANSITION_API_URL;
+            delete process.env.TRANSITION_API_USERNAME;
+            delete process.env.TRANSITION_API_PASSWORD;
+
+            const { default: projectConfig, setProjectConfig } = await import('../projectConfig');
+
+            setProjectConfig({
+                transitionApi: {
+                    url: 'http://transition',
+                    username: 'user',
+                    password: 'password'
+                }
+            });
+            expect(projectConfig.transitionApi).toEqual({
                 url: 'http://transition',
                 username: 'user',
                 password: 'password'
-            }
-        });
-        expect(projectConfig.transitionApi).toEqual({
-            url: 'http://transition',
-            username: 'user',
-            password: 'password'
+            });
         });
     });
 
-    test('Should use values in config if both environment and config set', () => {
-        process.env.TRANSITION_API_URL = 'https://transition.from.env';
-        process.env.TRANSITION_API_USERNAME = 'username.env';
-        process.env.TRANSITION_API_PASSWORD = 'password.env';
-        setProjectConfig({
-            transitionApi: {
+    test('Should use values in config if both environment and config set', async () => {
+        await jest.isolateModulesAsync(async () => {
+            process.env.TRANSITION_API_URL = 'https://transition.from.env';
+            process.env.TRANSITION_API_USERNAME = 'username.env';
+            process.env.TRANSITION_API_PASSWORD = 'password.env';
+
+            const { default: projectConfig, setProjectConfig } = await import('../projectConfig');
+
+            setProjectConfig({
+                transitionApi: {
+                    url: 'http://transition',
+                    username: 'user',
+                    password: 'password'
+                }
+            });
+            expect(projectConfig.transitionApi).toEqual({
                 url: 'http://transition',
                 username: 'user',
                 password: 'password'
-            }
-        });
-        expect(projectConfig.transitionApi).toEqual({
-            url: 'http://transition',
-            username: 'user',
-            password: 'password'
+            });
+
+            // Cleanup
+            delete process.env.TRANSITION_API_URL;
+            delete process.env.TRANSITION_API_USERNAME;
+            delete process.env.TRANSITION_API_PASSWORD;
         });
     });
 });
-

--- a/packages/evolution-backend/src/config/projectConfig.ts
+++ b/packages/evolution-backend/src/config/projectConfig.ts
@@ -13,6 +13,7 @@ import {
     InterviewListAttributes,
     InterviewStatusAttributesBase
 } from 'evolution-common/lib/services/questionnaire/types';
+import commonProjectConfig from 'evolution-common/lib/config/project.config';
 
 interface ProjectServerConfig {
     /**
@@ -76,6 +77,19 @@ export const defaultConfig: ProjectServerConfig = {
             corrected_response,
             audits
         } = interview;
+
+        // Build response object conditionally based on hasAccessCode config
+        const responseData: any = {
+            _isCompleted: response?._isCompleted,
+            household: { size: response?.household?.size },
+            _validationComment: corrected_response?._validationComment
+        };
+
+        // Only include accessCode if hasAccessCode is configured
+        if (commonProjectConfig.hasAccessCode) {
+            responseData.accessCode = response?.accessCode ?? undefined;
+        }
+
         return {
             id,
             uuid,
@@ -87,11 +101,7 @@ export const defaultConfig: ProjectServerConfig = {
             username,
             facebook,
             google,
-            response: {
-                _isCompleted: response?._isCompleted,
-                household: { size: response?.household?.size },
-                _validationComment: corrected_response?._validationComment
-            },
+            response: responseData,
             audits
         };
     },

--- a/packages/evolution-common/src/config/project.config.ts
+++ b/packages/evolution-common/src/config/project.config.ts
@@ -126,6 +126,12 @@ export type EvolutionProjectConfiguration = {
     };
 
     /**
+     * Whether the survey has an access code. If true, the access code will be
+     * added to the admin interview columns. Defaults to false.
+     */
+    hasAccessCode: boolean;
+
+    /**
      * Color palette for person visualization in maps and charts
      */
     personColorsPalette: string[];
@@ -204,6 +210,7 @@ const defaultConfig = {
     languageNames: { en: 'English', fr: 'Français' },
     title: { en: 'Survey', fr: 'Enquête' },
     postalCodeRegion: 'other',
+    hasAccessCode: false,
     personColorsPalette: [
         // FIXME See this issue https://github.com/chairemobilite/evolution/issues/1246
         '#FFAE70',

--- a/packages/evolution-frontend/src/components/admin/validations/InterviewListComponent.tsx
+++ b/packages/evolution-frontend/src/components/admin/validations/InterviewListComponent.tsx
@@ -22,6 +22,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { handleHttpOtherResponseCode } from '../../../services/errorManagement/errorHandling';
 import { Dispatch } from 'redux';
 import { InterviewStatusAttributesBase } from 'evolution-common/lib/services/questionnaire/types';
+import config from 'evolution-common/lib/config/project.config';
 
 interface InterviewListComponentProps {
     onInterviewSummaryChanged: (uuid: string, prevUuid?: string, nextUuid?: string) => void;
@@ -136,14 +137,17 @@ const InterviewListComponent: React.FunctionComponent<InterviewListComponentProp
                 Cell: ({ value }: CellArgs) => `#${value}`,
                 enableSortBy: true
             },
-            {
-                // TODO, this column is specific to projects, it should come as props from the project
-                id: 'response.accessCode',
-                label: t('admin:interviewByCodeFilter:title'),
-                accessor: 'response.accessCode',
-                Filter: InterviewByCodeFilter,
-                enableSortBy: true
-            },
+            ...(config.hasAccessCode
+                ? [
+                    {
+                        id: 'response.accessCode',
+                        label: t('admin:interviewByCodeFilter:title'),
+                        accessor: 'response.accessCode',
+                        Filter: InterviewByCodeFilter,
+                        enableSortBy: true
+                    }
+                ]
+                : []),
             {
                 id: 'created_at',
                 accessor: 'created_at',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional accessCode included in interview response data when enabled via project configuration.
  * Admin list view dynamically shows or hides the "Access Code" column based on project settings.

* **Tests**
  * Expanded test coverage for accessCode on/off, null-like responses, config permutations, and project-specific response customizations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->