### PR TITLE
feat(evolution-common): add preData attribute to survey objects

### DIFF
--- a/packages/evolution-common/src/services/baseObjects/Address.ts
+++ b/packages/evolution-common/src/services/baseObjects/Address.ts
@@ -291,7 +291,7 @@ export class Address extends Uuidable implements IValidatable {
 
         // Validate params object:
         errors.push(...ParamsValidatorUtils.isRequired('params', dirtyParams, displayName));
-        errors.push(...ParamsValidatorUtils.isObject('params', dirtyParams, displayName));
+        errors.push(...ParamsValidatorUtils.isRecord('params', dirtyParams, displayName));
 
         // Validate _uuid
         errors.push(...Uuidable.validateParams(dirtyParams));

--- a/packages/evolution-common/src/services/baseObjects/Household.ts
+++ b/packages/evolution-common/src/services/baseObjects/Household.ts
@@ -8,6 +8,7 @@
 import _omit from 'lodash/omit';
 
 import { Optional } from '../../types/Optional.type';
+import { PreData } from '../../types/shared';
 import { IValidatable, ValidatebleAttributes } from './IValidatable';
 import { WeightableAttributes, Weight, validateWeights } from './Weight';
 import { Uuidable, UuidableAttributes } from './Uuidable';
@@ -40,7 +41,8 @@ export const householdAttributes = [
     'homeOwnership',
     'contactPhoneNumber',
     'contactEmail',
-    'atLeastOnePersonWithDisability'
+    'atLeastOnePersonWithDisability',
+    'preData'
 ];
 
 export const householdAttributesWithComposedAttributes = [...householdAttributes, '_members', '_vehicles'];
@@ -61,6 +63,7 @@ export type HouseholdAttributes = {
     contactPhoneNumber?: Optional<string>;
     contactEmail?: Optional<string>;
     atLeastOnePersonWithDisability?: Optional<string>;
+    preData?: Optional<PreData>;
 } & UuidableAttributes &
     WeightableAttributes &
     ValidatebleAttributes;
@@ -95,7 +98,7 @@ export class Household extends Uuidable implements IValidatable {
     private _homeUuid?: Optional<string>; // allow reverse lookup
     private _interviewUuid?: Optional<string>; // allow reverse lookup
 
-    static _confidentialAttributes = ['contactPhoneNumber', 'contactEmail'];
+    static _confidentialAttributes = ['contactPhoneNumber', 'contactEmail', 'preData'];
 
     constructor(params: ExtendedHouseholdAttributes, surveyObjectsRegistry: SurveyObjectsRegistry) {
         super(params._uuid);
@@ -273,6 +276,14 @@ export class Household extends Uuidable implements IValidatable {
         this._attributes.atLeastOnePersonWithDisability = value;
     }
 
+    get preData(): Optional<PreData> {
+        return this._attributes.preData;
+    }
+
+    set preData(value: Optional<PreData>) {
+        this._attributes.preData = value;
+    }
+
     get members(): Optional<Person[]> {
         return this._members;
     }
@@ -357,7 +368,7 @@ export class Household extends Uuidable implements IValidatable {
         const errors: Error[] = [];
 
         errors.push(...ParamsValidatorUtils.isRequired('params', dirtyParams, displayName));
-        errors.push(...ParamsValidatorUtils.isObject('params', dirtyParams, displayName));
+        errors.push(...ParamsValidatorUtils.isRecord('params', dirtyParams, displayName));
 
         errors.push(...Uuidable.validateParams(dirtyParams));
 
@@ -422,6 +433,8 @@ export class Household extends Uuidable implements IValidatable {
                 displayName
             )
         );
+
+        errors.push(...ParamsValidatorUtils.isRecord('preData', dirtyParams.preData, displayName, false));
 
         const membersAttributes =
             dirtyParams._members !== undefined ? (dirtyParams._members as { [key: string]: unknown }[]) : [];

--- a/packages/evolution-common/src/services/baseObjects/Journey.ts
+++ b/packages/evolution-common/src/services/baseObjects/Journey.ts
@@ -8,6 +8,7 @@
 import _omit from 'lodash/omit';
 
 import { Optional } from '../../types/Optional.type';
+import { PreData } from '../../types/shared';
 import { IValidatable, ValidatebleAttributes } from './IValidatable';
 import { WeightableAttributes, Weight, validateWeights } from './Weight';
 import { Uuidable, UuidableAttributes } from './Uuidable';
@@ -40,7 +41,8 @@ export const journeyAttributes = [
     'noWorkTripReasonSpecify',
     'didTrips',
     'previousWeekRemoteWorkDays',
-    'previousWeekTravelToWorkDays'
+    'previousWeekTravelToWorkDays',
+    'preData'
 ];
 
 export const journeyAttributesWithComposedAttributes = [
@@ -71,6 +73,7 @@ export type JourneyAttributes = {
     previousWeekRemoteWorkDays?: Optional<PAttr.WeekdaySchedule>;
     /** Travel to work days for the complete week before the assigned date (Sunday to Saturday, excluding assigned date) */
     previousWeekTravelToWorkDays?: Optional<PAttr.WeekdaySchedule>;
+    preData?: Optional<PreData>;
 } & StartEndDateAndTimesAttributes &
     UuidableAttributes &
     WeightableAttributes &
@@ -107,7 +110,7 @@ export class Journey extends Uuidable implements IValidatable {
 
     private _personUuid?: Optional<string>; // allow reverse lookup: must be filled by Person.
 
-    static _confidentialAttributes = [];
+    static _confidentialAttributes = ['preData'];
 
     constructor(params: ExtendedJourneyAttributes, surveyObjectsRegistry: SurveyObjectsRegistry) {
         super(params._uuid);
@@ -313,6 +316,14 @@ export class Journey extends Uuidable implements IValidatable {
 
     set previousWeekTravelToWorkDays(value: Optional<PAttr.WeekdaySchedule>) {
         this._attributes.previousWeekTravelToWorkDays = value;
+    }
+
+    get preData(): Optional<PreData> {
+        return this._attributes.preData;
+    }
+
+    set preData(value: Optional<PreData>) {
+        this._attributes.preData = value;
     }
 
     get visitedPlaces(): Optional<VisitedPlace[]> {
@@ -578,7 +589,7 @@ export class Journey extends Uuidable implements IValidatable {
         const errors: Error[] = [];
 
         errors.push(...ParamsValidatorUtils.isRequired('params', dirtyParams, displayName));
-        errors.push(...ParamsValidatorUtils.isObject('params', dirtyParams, displayName));
+        errors.push(...ParamsValidatorUtils.isRecord('params', dirtyParams, displayName));
 
         errors.push(...Uuidable.validateParams(dirtyParams, displayName));
         errors.push(...StartEndable.validateParams(dirtyParams, displayName));
@@ -616,19 +627,21 @@ export class Journey extends Uuidable implements IValidatable {
 
         // Validate work schedule attributes
         errors.push(
-            ...ParamsValidatorUtils.isObject(
+            ...ParamsValidatorUtils.isRecord(
                 'previousWeekRemoteWorkDays',
                 dirtyParams.previousWeekRemoteWorkDays,
                 displayName
             )
         );
         errors.push(
-            ...ParamsValidatorUtils.isObject(
+            ...ParamsValidatorUtils.isRecord(
                 'previousWeekTravelToWorkDays',
                 dirtyParams.previousWeekTravelToWorkDays,
                 displayName
             )
         );
+
+        errors.push(...ParamsValidatorUtils.isRecord('preData', dirtyParams.preData, displayName, false));
 
         const visitedPlacesAttributes =
             dirtyParams._visitedPlaces !== undefined

--- a/packages/evolution-common/src/services/baseObjects/Junction.ts
+++ b/packages/evolution-common/src/services/baseObjects/Junction.ts
@@ -8,6 +8,7 @@
 import _omit from 'lodash/omit';
 
 import { Optional } from '../../types/Optional.type';
+import { PreData } from '../../types/shared';
 import { IValidatable, ValidatebleAttributes } from './IValidatable';
 import { Uuidable, UuidableAttributes } from './Uuidable';
 import { WeightableAttributes, Weight, validateWeights } from './Weight';
@@ -29,7 +30,8 @@ export const junctionAttributes = [
     '_uuid',
     'parkingType',
     'parkingFeeType',
-    'transitPlaceType'
+    'transitPlaceType',
+    'preData'
 ];
 
 export const junctionAttributesWithComposedAttributes = [...junctionAttributes, 'place'];
@@ -38,6 +40,7 @@ export type JunctionAttributes = {
     parkingType?: Optional<PlAttr.ParkingType>;
     parkingFeeType?: Optional<PlAttr.ParkingFeeType>;
     transitPlaceType?: Optional<PlAttr.TransitPlaceType>; // for transit junctions
+    preData?: Optional<PreData>;
 } & StartEndDateAndTimesAttributes &
     UuidableAttributes &
     WeightableAttributes &
@@ -69,7 +72,7 @@ export class Junction extends Uuidable implements IValidatable {
 
     private _tripUuid?: Optional<string>; // allow reverse lookup
 
-    static _confidentialAttributes = [];
+    static _confidentialAttributes = ['preData'];
 
     constructor(params: ExtendedJunctionAttributes, surveyObjectsRegistry: SurveyObjectsRegistry) {
         super(params._uuid);
@@ -201,6 +204,14 @@ export class Junction extends Uuidable implements IValidatable {
         this._attributes.transitPlaceType = value;
     }
 
+    get preData(): Optional<PreData> {
+        return this._attributes.preData;
+    }
+
+    set preData(value: Optional<PreData>) {
+        this._attributes.preData = value;
+    }
+
     get tripUuid(): Optional<string> {
         return this._tripUuid;
     }
@@ -261,7 +272,7 @@ export class Junction extends Uuidable implements IValidatable {
 
         // Validate params object:
         errors.push(...ParamsValidatorUtils.isRequired('params', dirtyParams, displayName));
-        errors.push(...ParamsValidatorUtils.isObject('params', dirtyParams, displayName));
+        errors.push(...ParamsValidatorUtils.isRecord('params', dirtyParams, displayName));
 
         // Validate _uuid:
         errors.push(...Uuidable.validateParams(dirtyParams));
@@ -279,6 +290,8 @@ export class Junction extends Uuidable implements IValidatable {
         errors.push(...ParamsValidatorUtils.isString('parkingType', dirtyParams.parkingType, displayName));
         errors.push(...ParamsValidatorUtils.isString('parkingFeeType', dirtyParams.parkingFeeType, displayName));
         errors.push(...ParamsValidatorUtils.isString('transitPlaceType', dirtyParams.transitPlaceType, displayName));
+
+        errors.push(...ParamsValidatorUtils.isRecord('preData', dirtyParams.preData, displayName, false));
 
         // Validate composed place:
         const placeAttributes = dirtyParams._place as { [key: string]: unknown };

--- a/packages/evolution-common/src/services/baseObjects/Organization.ts
+++ b/packages/evolution-common/src/services/baseObjects/Organization.ts
@@ -8,6 +8,7 @@
 import _omit from 'lodash/omit';
 
 import { Optional } from '../../types/Optional.type';
+import { PreData } from '../../types/shared';
 import { IValidatable, ValidatebleAttributes } from './IValidatable';
 import { WeightableAttributes, Weight, validateWeights } from './Weight';
 import { Uuidable, UuidableAttributes } from './Uuidable';
@@ -33,7 +34,8 @@ export const organizationAttributes = [
     'contactLastName',
     'contactPhoneNumber',
     'contactEmail',
-    'revenueLevel'
+    'revenueLevel',
+    'preData'
 ];
 
 export const organizationAttributesWithComposedAttributes = [...organizationAttributes, '_vehicles', '_places'];
@@ -48,6 +50,7 @@ export type OrganizationAttributes = {
     contactPhoneNumber?: Optional<string>;
     contactEmail?: Optional<string>;
     revenueLevel?: Optional<OAttr.RevenueLevel>;
+    preData?: Optional<PreData>;
 } & UuidableAttributes &
     WeightableAttributes &
     ValidatebleAttributes;
@@ -87,7 +90,7 @@ export class Organization extends Uuidable implements IValidatable {
 
     private _interviewUuid?: Optional<string>; // allow reverse lookup
 
-    static _confidentialAttributes = ['contactPhoneNumber', 'contactEmail'];
+    static _confidentialAttributes = ['contactPhoneNumber', 'contactEmail', 'preData'];
 
     constructor(params: ExtendedOrganizationAttributes, surveyObjectsRegistry: SurveyObjectsRegistry) {
         super(params._uuid);
@@ -216,6 +219,14 @@ export class Organization extends Uuidable implements IValidatable {
         this._attributes.revenueLevel = value;
     }
 
+    get preData(): Optional<PreData> {
+        return this._attributes.preData;
+    }
+
+    set preData(value: Optional<PreData>) {
+        this._attributes.preData = value;
+    }
+
     get vehicles(): Optional<Vehicle[]> {
         return this._vehicles;
     }
@@ -285,7 +296,7 @@ export class Organization extends Uuidable implements IValidatable {
         const errors: Error[] = [];
 
         errors.push(...ParamsValidatorUtils.isRequired('params', dirtyParams, displayName));
-        errors.push(...ParamsValidatorUtils.isObject('params', dirtyParams, displayName));
+        errors.push(...ParamsValidatorUtils.isRecord('params', dirtyParams, displayName));
 
         errors.push(...Uuidable.validateParams(dirtyParams));
 
@@ -314,6 +325,8 @@ export class Organization extends Uuidable implements IValidatable {
         errors.push(...ParamsValidatorUtils.isString('contactEmail', dirtyParams.contactEmail, displayName));
 
         errors.push(...ParamsValidatorUtils.isString('revenueLevel', dirtyParams.revenueLevel, displayName));
+
+        errors.push(...ParamsValidatorUtils.isRecord('preData', dirtyParams.preData, displayName, false));
 
         const vehiclesAttributes =
             dirtyParams._vehicles !== undefined ? (dirtyParams._vehicles as { [key: string]: unknown }[]) : [];

--- a/packages/evolution-common/src/services/baseObjects/Person.ts
+++ b/packages/evolution-common/src/services/baseObjects/Person.ts
@@ -8,6 +8,7 @@
 import _omit from 'lodash/omit';
 
 import { Optional } from '../../types/Optional.type';
+import { PreData } from '../../types/shared';
 import { IValidatable, ValidatebleAttributes } from './IValidatable';
 import { WeightableAttributes, Weight, validateWeights } from './Weight';
 import { Uuidable, UuidableAttributes } from './Uuidable';
@@ -65,7 +66,8 @@ export const personAttributes = [
     'isProxy',
     'nickname',
     'contactPhoneNumber',
-    'contactEmail'
+    'contactEmail',
+    'preData'
 ];
 
 export const personAttributesWithComposedAttributes = [
@@ -84,7 +86,8 @@ export const nonStringAttributes = [
     'age',
     'transitPasses',
     'whoWillAnswerForThisPerson',
-    'isProxy'
+    'isProxy',
+    'preData'
 ];
 
 export const stringAttributes = personAttributes.filter((attr) => !nonStringAttributes.includes(attr));
@@ -134,6 +137,7 @@ export type PersonAttributes = {
     nickname?: Optional<string>;
     contactPhoneNumber?: Optional<string>;
     contactEmail?: Optional<string>;
+    preData?: Optional<PreData>;
 } & UuidableAttributes &
     WeightableAttributes &
     ValidatebleAttributes;
@@ -176,7 +180,8 @@ export class Person extends Uuidable implements IValidatable {
         // these attributes should be hidden when exporting
         'contactPhoneNumber',
         'contactEmail',
-        'nickname'
+        'nickname',
+        'preData'
     ];
 
     constructor(params: ExtendedPersonAttributes, surveyObjectsRegistry: SurveyObjectsRegistry) {
@@ -489,6 +494,14 @@ export class Person extends Uuidable implements IValidatable {
 
     set contactEmail(value: Optional<string>) {
         this._attributes.contactEmail = value;
+    }
+
+    get preData(): Optional<PreData> {
+        return this._attributes.preData;
+    }
+
+    set preData(value: Optional<PreData>) {
+        this._attributes.preData = value;
     }
 
     get workPlaceType(): Optional<PAttr.WorkPlaceType> {
@@ -872,7 +885,7 @@ export class Person extends Uuidable implements IValidatable {
 
         // Validate params object:
         errors.push(...ParamsValidatorUtils.isRequired('params', dirtyParams, displayName));
-        errors.push(...ParamsValidatorUtils.isObject('params', dirtyParams, displayName));
+        errors.push(...ParamsValidatorUtils.isRecord('params', dirtyParams, displayName));
 
         // Validate _uuid:
         errors.push(...Uuidable.validateParams(dirtyParams));
@@ -903,6 +916,8 @@ export class Person extends Uuidable implements IValidatable {
             )
         );
         errors.push(...ParamsValidatorUtils.isBoolean('isProxy', dirtyParams.isProxy, displayName));
+
+        errors.push(...ParamsValidatorUtils.isRecord('preData', dirtyParams.preData, displayName, false));
 
         const workPlacesAttributes =
             dirtyParams._workPlaces !== undefined ? (dirtyParams._workPlaces as { [key: string]: unknown }[]) : [];

--- a/packages/evolution-common/src/services/baseObjects/README.md
+++ b/packages/evolution-common/src/services/baseObjects/README.md
@@ -79,6 +79,151 @@ A type representing an individual audit entry.
 5. **Weighting**: (If applicable) Weighting is applied to relevant objects (e.g., Household, Person) to adjust for population representation.
 6. **Export**: Processed and audited data is prepared for export and analysis. There are three types of exported data: original unmodified response data, audited interview data and admin/analysis data (including audited data, paradata and confidential attributes).
 
+## Prefilled Data System
+
+Evolution supports prefilling survey objects with data from external sources before conducting interviews. This allows surveyors to import existing data about respondents and reduce the burden of data entry or detect changes, for instance household who moved. Home address is the usual example of  prefilled data.
+
+### Overview
+
+Prefilled data is stored in the `sv_interviews_prefill` database table and linked to interviews via a reference field (typically an access code or unique identifier). When an interview is created, the system can automatically populate survey objects with this prefilled data in the preData attribute of the survey opject.
+
+### Key Attributes
+
+#### `preData`
+
+- **Purpose**: Stores custom prefilled data from external sources
+- **Type**: `Record<string, unknown>` (flexible object structure)
+- **Format**: Survey-specific; each project defines its own structure
+- **Available on**: All survey objects
+- **Use case**: Store any imported data that doesn't directly map to standard object attributes but may be useful for validation, display, or later processing
+
+#### `preGeography`
+
+- **Purpose**: Stores the original geographic location from the imported data
+- **Type**: `GeoJSON.Feature<GeoJSON.Point>`
+- **Available on**: Place and other location-based objects (Home, usual work and school places)
+- **Use case**: Preserve the original imported location separate from the potentially corrected/validated `geography` attribute, allowing comparison between imported and final declared locations
+
+### Data Flow
+
+1. **Import**: External data is imported and stored in the `sv_interviews_prefill` table using the `importPreFilledResponses` task
+2. **Mapping**: The import task maps CSV columns to survey object paths (e.g., `home.address`, `home.postalCode`)
+3. **Geography Conversion**: If coordinates are provided, they are converted to GeoJSON points and stored in both `preGeography` (original) and `geography` (editable)
+4. **Zone Calculation**: Intersecting geographic zones are pre-calculated and stored with the prefilled data
+5. **Interview Creation**: When an interview starts, the system retrieves prefilled data using `getByReferenceValue()` based on the reference field (e.g., access code)
+6. **Population**: Survey objects are created with both standard attributes and prefilled data in the `preData` attribute
+7. **Validation**: Users can validate or modify prefilled data during the interview
+8. **Preservation**: Original prefilled data remains in `preData` and `preGeography` for auditing and comparison
+
+### Database Structure
+
+The `sv_interviews_prefill` table contains:
+- `reference_field` (string, unique, indexed): The key used to lookup prefilled data (e.g., access code)
+- `responses` (JSON): The prefilled response data in the format:
+
+  ```typescript
+  {
+      [path: string]: {
+          value: unknown;
+          actionIfPresent?: 'force' | 'doNothing'
+      }
+  }
+  ```
+
+### Import Task
+
+The `importPreFilledResponses` task (`evolution-backend/src/tasks/importPreFilledResponses.task.ts`) provides a template for importing prefilled data from CSV files.
+
+**Important**: This task is designed as an **example template** that can be customized for each survey project. If your CSV has different column names or structure, you must create a custom import task in your survey project.
+
+#### Running the Task
+
+```bash
+yarn task:importPreFilledResponses -- --file /absolute/path/to/file.csv --type [optional-type]
+```
+
+#### CSV Format (Example)
+
+The default task expects specific column names. **You must customize the task in the survey project directory if your CSV uses different column names**:
+- `AccessCode`: Reference field to link data to interviews (required)
+- `PostalCode`: Postal/ZIP code
+- `Address`: Street address
+- `AptNumber`: Apartment/unit number
+- `City`: City name
+- `Province`: Province/state
+- `AddrLat`: Latitude coordinate
+- `AddrLon`: Longitude coordinate
+- `PhoneNumber`: Phone number
+- Additional columns are preserved in `preData`
+
+#### Import Process
+
+1. **Parse CSV**: Reads the CSV file and extracts data row by row
+2. **Store Original Data**: All non-blank fields are stored in `home.preData` for audit purposes
+3. **Map to Survey Fields**: CSV columns are mapped to specific survey object paths:
+   - `Address` → `home.address`
+   - `City` → `home.city`
+   - `PostalCode` → `home.postalCode`
+   - `AptNumber` → `home.apartmentNumber`
+   - `Province` → `home.region`
+   - `PhoneNumber` → `home.homePhoneNumber`
+4. **Convert Geography**: If coordinates are provided:
+   - Creates GeoJSON Point feature from `AddrLat` and `AddrLon`
+   - Saves to both `home.preGeography` (original, immutable) and `home.geography` (editable by user)
+   - Sets `lastAction` property to `'preGeocoded'`
+5. **Calculate Zones**: For geocoded locations, automatically calculates intersecting geographic zones and stores them with the prefilled data (requires zones to be imported first using chaire-lib importZones.task.ts, documented in Transition)
+
+#### Creating a Custom Import Task
+
+**Each survey project must create its own import task** tailored to their specific CSV format. To create a custom import task:
+
+1. **Copy the Template**: Use `importPreFilledResponses.task.ts` as a starting point
+2. **Create in Survey Project**: Place your custom task in `survey/src/tasks/` (e.g., `survey/src/tasks/importMyCustomData.task.ts`)
+3. **Customize Column Mapping**: Update the column names to match your CSV:
+
+   ```typescript
+   const { MyAccessCodeColumn, MyAddressColumn, MyLatColumn, MyLonColumn } = data;
+   ```
+
+4. **Map to Survey Fields**: Adjust the field mappings to match your survey structure:
+
+   ```typescript
+   prefilledResponses['home.address'] = { value: MyAddressColumn };
+   prefilledResponses['person.name'] = { value: MyNameColumn };
+   ```
+
+5. **Add Custom Logic**: Implement any data transformation, validation, or additional processing needed
+6. **Register Task**: Add your task to the survey's `package.json` scripts
+
+**Common customizations include**:
+- Different CSV column names or structure
+- Multiple target survey objects (Home, Person, Organization, etc.)
+- Custom data transformation (e.g., date parsing, unit conversion)
+- Additional validation or data cleaning
+- Different reference field (e.g., email, phone number instead of access code)
+- Custom geography conversion logic
+
+### Configuration Requirements
+
+To use prefilled data with geography conversion, surveys must provide:
+
+1. **Import Task Configuration**: Customize the `importPreFilledResponses` task to map CSV columns to survey object attributes
+2. **Geography Conversion**: The task handles coordinate conversion; surveys may need to provide address geocoding if coordinates are not available
+3. **Reference Field**: The field used to link prefilled data to interviews (typically `accessCode`, configured in survey setup)
+4. **Zone Datasets**: Load geographic zone data (e.g., census tracts, neighborhoods) for automatic zone assignment
+
+### Implementation Notes
+
+- Prefilled data is imported and stored **before** survey fielding begins
+- Data is retrieved per interview using the reference field value
+- The `actionIfPresent` flag controls whether to overwrite existing data ('force') or preserve user-entered data ('doNothing')
+- Original imported data is preserved in `preData`/`preGeography` attributes even if the user modifies the main attributes during the interview
+- This separation allows for:
+  - Quality control and validation
+  - Comparison between imported and final data
+  - Audit trails for data modifications
+  - Potential re-geocoding or correction workflows
+
 ## Future Developments
 
 - Development of the enhancement process for interview data.

--- a/packages/evolution-common/src/services/baseObjects/Routing.ts
+++ b/packages/evolution-common/src/services/baseObjects/Routing.ts
@@ -204,7 +204,7 @@ export class Routing {
 
         // Validate params object:
         errors.push(...ParamsValidatorUtils.isRequired('params', dirtyParams, displayName));
-        errors.push(...ParamsValidatorUtils.isObject('params', dirtyParams, displayName));
+        errors.push(...ParamsValidatorUtils.isRecord('params', dirtyParams, displayName));
 
         // Validate _uuid:
         errors.push(...Uuidable.validateParams(dirtyParams));
@@ -240,7 +240,7 @@ export class Routing {
 
         // Validate params object:
         // TODO: verify all attributes from the route object
-        /*errors.push(...ParamsValidatorUtils.isObject(
+        /*errors.push(...ParamsValidatorUtils.isRecord(
             'route',
             dirtyParams.route,
             displayName

--- a/packages/evolution-common/src/services/baseObjects/Segment.ts
+++ b/packages/evolution-common/src/services/baseObjects/Segment.ts
@@ -8,6 +8,7 @@
 import _omit from 'lodash/omit';
 
 import { Optional } from '../../types/Optional.type';
+import { PreData } from '../../types/shared';
 import { IValidatable, ValidatebleAttributes } from './IValidatable';
 import { Uuidable, UuidableAttributes } from './Uuidable';
 import { WeightableAttributes, Weight, validateWeights } from './Weight';
@@ -40,7 +41,8 @@ export const segmentAttributes = [
     'vehicleOccupancy',
     'paidForParking',
     'onDemandType',
-    'busLines'
+    'busLines',
+    'preData'
 ];
 
 export const segmentAttributesWithComposedAttributes = [
@@ -87,6 +89,7 @@ export type SegmentAttributes = {
     paidForParking?: Optional<boolean>;
     onDemandType?: Optional<string>;
     busLines?: Optional<string[]>; // for now, the bus lines are the line slugified shortname. TODO: discuss if we want to change that.
+    preData?: Optional<PreData>;
 } & StartEndDateAndTimesAttributes &
     UuidableAttributes &
     WeightableAttributes &
@@ -134,7 +137,7 @@ export class Segment extends Uuidable implements IValidatable {
 
     private _tripUuid?: Optional<string>;
 
-    static _confidentialAttributes = [];
+    static _confidentialAttributes = ['preData'];
 
     constructor(params: ExtendedSegmentAttributes, surveyObjectsRegistry: SurveyObjectsRegistry) {
         super(params._uuid);
@@ -384,6 +387,14 @@ export class Segment extends Uuidable implements IValidatable {
         this._attributes.busLines = value;
     }
 
+    get preData(): Optional<PreData> {
+        return this._attributes.preData;
+    }
+
+    set preData(value: Optional<PreData>) {
+        this._attributes.preData = value;
+    }
+
     get origin(): Optional<Junction> {
         return this._origin;
     }
@@ -538,7 +549,7 @@ export class Segment extends Uuidable implements IValidatable {
         const errors: Error[] = [];
 
         errors.push(...ParamsValidatorUtils.isRequired('params', dirtyParams, displayName));
-        errors.push(...ParamsValidatorUtils.isObject('params', dirtyParams, displayName));
+        errors.push(...ParamsValidatorUtils.isRecord('params', dirtyParams, displayName));
 
         errors.push(...Uuidable.validateParams(dirtyParams, displayName));
         errors.push(...StartEndable.validateParams(dirtyParams, displayName));
@@ -568,6 +579,8 @@ export class Segment extends Uuidable implements IValidatable {
         errors.push(...ParamsValidatorUtils.isString('onDemandType', dirtyParams.onDemandType, displayName));
 
         errors.push(...ParamsValidatorUtils.isArrayOfStrings('busLines', dirtyParams.busLines, displayName));
+
+        errors.push(...ParamsValidatorUtils.isRecord('preData', dirtyParams.preData, displayName, false));
 
         const transitDeclaredRoutingAttributes = dirtyParams._transitDeclaredRouting;
         if (transitDeclaredRoutingAttributes !== undefined) {

--- a/packages/evolution-common/src/services/baseObjects/TripChain.ts
+++ b/packages/evolution-common/src/services/baseObjects/TripChain.ts
@@ -8,6 +8,7 @@
 import _omit from 'lodash/omit';
 
 import { Optional } from '../../types/Optional.type';
+import { PreData } from '../../types/shared';
 import { IValidatable, ValidatebleAttributes } from './IValidatable';
 import { WeightableAttributes, Weight, validateWeights } from './Weight';
 import { Uuidable, UuidableAttributes } from './Uuidable';
@@ -35,7 +36,8 @@ export const tripChainAttributes = [
     'isMultiLoop',
     'isConstrained',
     'mainActivity',
-    'mainActivityCategory'
+    'mainActivityCategory',
+    'preData'
 ];
 
 export const tripChainAttributesWithComposedAttributes = [...tripChainAttributes, 'trips', 'visitedPlaces'];
@@ -46,6 +48,7 @@ export type TripChainAttributes = {
     isConstrained?: Optional<boolean>;
     mainActivity?: Optional<VPAttr.Activity>;
     mainActivityCategory?: Optional<VPAttr.ActivityCategory>;
+    preData?: Optional<PreData>;
 } & StartEndDateAndTimesAttributes &
     UuidableAttributes &
     WeightableAttributes &
@@ -86,7 +89,7 @@ export class TripChain extends Uuidable implements IValidatable {
 
     private _journeyUuid?: Optional<string>;
 
-    static _confidentialAttributes = [];
+    static _confidentialAttributes = ['preData'];
 
     constructor(params: ExtendedTripChainAttributes, surveyObjectsRegistry: SurveyObjectsRegistry) {
         super(params._uuid);
@@ -231,6 +234,14 @@ export class TripChain extends Uuidable implements IValidatable {
         this._attributes.mainActivityCategory = value;
     }
 
+    get preData(): Optional<PreData> {
+        return this._attributes.preData;
+    }
+
+    set preData(value: Optional<PreData>) {
+        this._attributes.preData = value;
+    }
+
     get trips(): Optional<Trip[]> {
         return this._trips;
     }
@@ -308,7 +319,7 @@ export class TripChain extends Uuidable implements IValidatable {
         const errors: Error[] = [];
 
         errors.push(...ParamsValidatorUtils.isRequired('params', dirtyParams, displayName));
-        errors.push(...ParamsValidatorUtils.isObject('params', dirtyParams, displayName));
+        errors.push(...ParamsValidatorUtils.isRecord('params', dirtyParams, displayName));
 
         errors.push(...Uuidable.validateParams(dirtyParams, displayName));
         errors.push(...StartEndable.validateParams(dirtyParams, displayName));
@@ -328,6 +339,8 @@ export class TripChain extends Uuidable implements IValidatable {
         errors.push(
             ...ParamsValidatorUtils.isString('mainActivityCategory', dirtyParams.mainActivityCategory, displayName)
         );
+
+        errors.push(...ParamsValidatorUtils.isRecord('preData', dirtyParams.preData, displayName, false));
 
         const tripsAttributes =
             dirtyParams._trips !== undefined ? (dirtyParams._trips as { [key: string]: unknown }[]) : [];

--- a/packages/evolution-common/src/services/baseObjects/Vehicle.ts
+++ b/packages/evolution-common/src/services/baseObjects/Vehicle.ts
@@ -8,6 +8,7 @@
 import _omit from 'lodash/omit';
 
 import { Optional } from '../../types/Optional.type';
+import { PreData } from '../../types/shared';
 import { IValidatable, ValidatebleAttributes } from './IValidatable';
 import { WeightableAttributes, Weight, validateWeights } from './Weight';
 import { Uuidable, UuidableAttributes } from './Uuidable';
@@ -35,7 +36,8 @@ export const vehicleAttributes = [
     'isHydrogen',
     'acquiredYear',
     'licensePlateNumber',
-    'internalId'
+    'internalId',
+    'preData'
 ];
 
 export type VehicleAttributes = {
@@ -52,6 +54,7 @@ export type VehicleAttributes = {
     acquiredYear?: Optional<number>; // date of acquisition by the owner or the organization
     licensePlateNumber?: Optional<string>;
     internalId?: Optional<string>; // This is an internal number used by an organization or a company to identify the vehicle
+    preData?: Optional<PreData>;
 } & UuidableAttributes &
     WeightableAttributes &
     ValidatebleAttributes;
@@ -73,7 +76,7 @@ export class Vehicle extends Uuidable implements IValidatable {
     private _attributes: VehicleAttributes;
     private _customAttributes: { [key: string]: unknown };
 
-    static _confidentialAttributes = ['licensePlateNumber', 'internalId'];
+    static _confidentialAttributes = ['licensePlateNumber', 'internalId', 'preData'];
 
     private _organizationUuid?: Optional<string>; // allow reverse lookup: must be filled by Organization.
     private _ownerUuid?: Optional<string>; // allow reverse lookup: must be filled by Person.
@@ -227,6 +230,14 @@ export class Vehicle extends Uuidable implements IValidatable {
         this._attributes.internalId = value;
     }
 
+    get preData(): Optional<PreData> {
+        return this._attributes.preData;
+    }
+
+    set preData(value: Optional<PreData>) {
+        this._attributes.preData = value;
+    }
+
     get ownerUuid(): Optional<string> {
         return this._ownerUuid;
     }
@@ -295,7 +306,7 @@ export class Vehicle extends Uuidable implements IValidatable {
         const errors: Error[] = [];
 
         errors.push(...ParamsValidatorUtils.isRequired('params', dirtyParams, displayName));
-        errors.push(...ParamsValidatorUtils.isObject('params', dirtyParams, displayName));
+        errors.push(...ParamsValidatorUtils.isRecord('params', dirtyParams, displayName));
 
         errors.push(...Uuidable.validateParams(dirtyParams));
 
@@ -334,6 +345,8 @@ export class Vehicle extends Uuidable implements IValidatable {
         );
 
         errors.push(...ParamsValidatorUtils.isString('internalId', dirtyParams.internalId, displayName));
+
+        errors.push(...ParamsValidatorUtils.isRecord('preData', dirtyParams.preData, displayName, false));
 
         errors.push(...ParamsValidatorUtils.isUuid('_ownerUuid', dirtyParams._ownerUuid, displayName));
         errors.push(...ParamsValidatorUtils.isUuid('_organizationUuid', dirtyParams._organizationUuid, displayName));

--- a/packages/evolution-common/src/services/baseObjects/VisitedPlace.ts
+++ b/packages/evolution-common/src/services/baseObjects/VisitedPlace.ts
@@ -8,6 +8,7 @@
 import _omit from 'lodash/omit';
 
 import { Optional } from '../../types/Optional.type';
+import { PreData } from '../../types/shared';
 import { IValidatable, ValidatebleAttributes } from './IValidatable';
 import { Uuidable, UuidableAttributes } from './Uuidable';
 import { WeightableAttributes, Weight, validateWeights } from './Weight';
@@ -33,7 +34,8 @@ export const visitedPlaceAttributes = [
     '_sequence',
     'activity',
     'activityCategory',
-    'shortcut'
+    'shortcut',
+    'preData'
 ];
 
 export const visitedPlaceAttributesWithComposedAttributes = [...visitedPlaceAttributes, '_place'];
@@ -52,6 +54,7 @@ export type VisitedPlaceAttributes = {
     activityCategory?: Optional<VPAttr.ActivityCategory>;
     /** UUID of another visited place that this place references as a shortcut */
     shortcut?: Optional<VisitedPlaceUuid>;
+    preData?: Optional<PreData>;
 } & StartEndDateAndTimesAttributes &
     UuidableAttributes &
     WeightableAttributes &
@@ -83,7 +86,7 @@ export class VisitedPlace extends Uuidable implements IValidatable {
     private _place?: Optional<Place>;
     private _journeyUuid?: Optional<string>;
 
-    static _confidentialAttributes = [];
+    static _confidentialAttributes = ['preData'];
 
     constructor(params: ExtendedVisitedPlaceAttributes, surveyObjectsRegistry: SurveyObjectsRegistry) {
         super(params._uuid);
@@ -239,6 +242,14 @@ export class VisitedPlace extends Uuidable implements IValidatable {
         this._attributes.shortcut = value;
     }
 
+    get preData(): Optional<PreData> {
+        return this._attributes.preData;
+    }
+
+    set preData(value: Optional<PreData>) {
+        this._attributes.preData = value;
+    }
+
     get journeyUuid(): Optional<string> {
         return this._journeyUuid;
     }
@@ -301,7 +312,7 @@ export class VisitedPlace extends Uuidable implements IValidatable {
 
         // Validate params object:
         errors.push(...ParamsValidatorUtils.isRequired('params', dirtyParams, displayName));
-        errors.push(...ParamsValidatorUtils.isObject('params', dirtyParams, displayName));
+        errors.push(...ParamsValidatorUtils.isRecord('params', dirtyParams, displayName));
 
         // Validate _uuid:
         errors.push(...Uuidable.validateParams(dirtyParams));
@@ -321,6 +332,8 @@ export class VisitedPlace extends Uuidable implements IValidatable {
         errors.push(...ParamsValidatorUtils.isString('activity', dirtyParams.activity, displayName));
         errors.push(...ParamsValidatorUtils.isString('activityCategory', dirtyParams.activityCategory, displayName));
         errors.push(...ParamsValidatorUtils.isUuid('shortcut', dirtyParams.shortcut, displayName));
+
+        errors.push(...ParamsValidatorUtils.isRecord('preData', dirtyParams.preData, displayName, false));
 
         // forbid self-reference when both UUIDs are present
         if (

--- a/packages/evolution-common/src/services/baseObjects/__tests__/Home.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/Home.test.ts
@@ -295,6 +295,35 @@ describe('Home', () => {
             home._isValid = false;
             expect(home._isValid).toBe(false);
         });
+
+        it('should get and set preData', () => {
+            const validHomeAttributes = createValidHomeAttributes();
+            const home = new Home(validHomeAttributes, registry);
+            const preData = { importedHomeData: 'value', residents: 4 };
+            // This seems useless, but it is actually testing the getters and setters
+            home.preData = preData;
+            expect(home.preData).toEqual(preData);
+            home.preData = undefined;
+            expect(home.preData).toBeUndefined();
+        });
+
+        it('should get and set preGeography', () => {
+            const validHomeAttributes = createValidHomeAttributes();
+            const home = new Home(validHomeAttributes, registry);
+            const preGeography = {
+                type: 'Feature' as const,
+                geometry: {
+                    type: 'Point' as const,
+                    coordinates: [-73.5, 45.5],
+                },
+                properties: {},
+            };
+            // This seems useless, but it is actually testing the getters and setters
+            home.preGeography = preGeography;
+            expect(home.preGeography).toEqual(preGeography);
+            home.preGeography = undefined;
+            expect(home.preGeography).toBeUndefined();
+        });
     });
 
     describe('custom attributes', () => {
@@ -344,6 +373,34 @@ describe('Home', () => {
             delete paramsWithoutWeights._weights;
             const home = new Home(paramsWithoutWeights, registry);
             expect(home._weights).toBeUndefined();
+        });
+    });
+
+    describe('preData and preGeography serialization', () => {
+        test('should preserve preData through (un)serialize', () => {
+            const validHomeAttributes = createValidHomeAttributes();
+            const attrs = { ...validHomeAttributes, preData: { importedHomeData: 'value', residents: 4 } };
+            const h1 = new Home(attrs, registry);
+            const h2 = Home.unserialize(attrs, registry);
+            expect(h1.preData).toEqual({ importedHomeData: 'value', residents: 4 });
+            expect(h2.preData).toEqual({ importedHomeData: 'value', residents: 4 });
+        });
+
+        test('should preserve preGeography through (un)serialize', () => {
+            const validHomeAttributes = createValidHomeAttributes();
+            const preGeography = {
+                type: 'Feature' as const,
+                geometry: {
+                    type: 'Point' as const,
+                    coordinates: [-73.5, 45.5],
+                },
+                properties: {},
+            };
+            const attrs = { ...validHomeAttributes, preGeography };
+            const h1 = new Home(attrs, registry);
+            const h2 = Home.unserialize(attrs, registry);
+            expect(h1.preGeography).toEqual(preGeography);
+            expect(h2.preGeography).toEqual(preGeography);
         });
     });
 });

--- a/packages/evolution-common/src/services/baseObjects/__tests__/Household.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/Household.test.ts
@@ -161,6 +161,10 @@ describe('Household', () => {
         ['contactPhoneNumber', 123],
         ['contactEmail', 123],
         ['atLeastOnePersonWithDisability', 123],
+        ['preData', 'invalid'],
+        ['preData', []],
+        ['preData', new Date() as any],
+        ['preData', true as any]
     ])('should return an error for invalid %s', (param, value) => {
         const invalidAttributes = { ...validAttributes, [param]: value };
         const errors = Household.validateParams(invalidAttributes);
@@ -224,6 +228,7 @@ describe('Household', () => {
             ['contactPhoneNumber', '9876543210'],
             ['contactEmail', 'updated@example.com'],
             ['atLeastOnePersonWithDisability', 'no'],
+            ['preData', { importedHouseholdData: 'value', residents: 3 }],
         ])('should set and get %s', (attribute, value) => {
             const household = new Household(validAttributes, registry);
             household[attribute] = value;
@@ -250,6 +255,16 @@ describe('Household', () => {
             const household = new Household(validAttributes, registry);
             household[attribute] = value;
             expect(household[attribute]).toEqual(value);
+        });
+    });
+
+    describe('preData serialization', () => {
+        test('should preserve preData through (un)serialize', () => {
+            const attrs = { ...validAttributes, preData: { importedHouseholdData: 'value', residents: 3 } };
+            const h1 = new Household(attrs, registry);
+            const h2 = Household.unserialize(attrs, registry);
+            expect(h1.preData).toEqual({ importedHouseholdData: 'value', residents: 3 });
+            expect(h2.preData).toEqual({ importedHouseholdData: 'value', residents: 3 });
         });
     });
 

--- a/packages/evolution-common/src/services/baseObjects/__tests__/Journey.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/Journey.test.ts
@@ -182,6 +182,10 @@ describe('Journey', () => {
             ['didTrips', 123],
             ['previousWeekRemoteWorkDays', 'invalid'],
             ['previousWeekTravelToWorkDays', 'invalid'],
+            ['preData', 'invalid'],
+            ['preData', []],
+            ['preData', new Date() as any],
+            ['preData', true as any]
         ])('should return an error for invalid %s', (param, value) => {
             const invalidAttributes = { ...validAttributes, [param]: value };
             const errors = Journey.validateParams(invalidAttributes);
@@ -212,6 +216,7 @@ describe('Journey', () => {
             ['didTrips', 'no'],
             ['previousWeekRemoteWorkDays', { friday: true, saturday: true, sunday: true }],
             ['previousWeekTravelToWorkDays', { thursday: true, friday: true }],
+            ['preData', { importedJourneyData: 'value', tripCount: 5 }],
         ])('should set and get %s', (attribute, value) => {
             const journey = new Journey(validAttributes, registry);
             journey[attribute] = value;
@@ -240,6 +245,16 @@ describe('Journey', () => {
             const journey = new Journey(validAttributes, registry);
             journey[attribute] = value;
             expect(journey[attribute]).toEqual(value);
+        });
+    });
+
+    describe('preData serialization', () => {
+        test('should preserve preData through (un)serialize', () => {
+            const attrs = { ...validAttributes, preData: { importedJourneyData: 'value', tripCount: 5 } };
+            const j1 = new Journey(attrs, registry);
+            const j2 = Journey.unserialize(attrs, registry);
+            expect(j1.preData).toEqual({ importedJourneyData: 'value', tripCount: 5 });
+            expect(j2.preData).toEqual({ importedJourneyData: 'value', tripCount: 5 });
         });
     });
 

--- a/packages/evolution-common/src/services/baseObjects/__tests__/Junction.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/Junction.test.ts
@@ -173,6 +173,10 @@ describe('Junction', () => {
             ['parkingType', 123],
             ['parkingFeeType', 123],
             ['transitPlaceType', 123],
+            ['preData', 'invalid'],
+            ['preData', []],
+            ['preData', new Date() as any],
+            ['preData', true as any],
         ])('should return an error for invalid %s', (param, value) => {
             const invalidAttributes = { ...validJunctionAttributesWithPlace, [param]: value };
             const errors = Junction.validateParams(invalidAttributes);
@@ -197,6 +201,7 @@ describe('Junction', () => {
             ['parkingType', 'interiorAssignedOrGuaranteed'],
             ['parkingFeeType', 'paidByEmployer'],
             ['transitPlaceType', 'busStation'],
+            ['preData', { importedJunctionData: 'value', waitTime: 5 }],
         ])('should set and get %s', (attribute, value) => {
             const junction = new Junction(validJunctionAttributesWithPlace, registry);
             junction[attribute] = value;
@@ -225,6 +230,16 @@ describe('Junction', () => {
             const junction = new Junction(validJunctionAttributesWithPlace, registry);
             junction[attribute] = value;
             expect(junction[attribute]).toEqual(value);
+        });
+    });
+
+    describe('preData serialization', () => {
+        test('should preserve preData through (un)serialize', () => {
+            const attrs = { ...validJunctionAttributesWithPlace, preData: { importedJunctionData: 'value', waitTime: 5 } };
+            const j1 = new Junction(attrs, registry);
+            const j2 = Junction.unserialize(attrs, registry);
+            expect(j1.preData).toEqual({ importedJunctionData: 'value', waitTime: 5 });
+            expect(j2.preData).toEqual({ importedJunctionData: 'value', waitTime: 5 });
         });
     });
 });

--- a/packages/evolution-common/src/services/baseObjects/__tests__/Organization.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/Organization.test.ts
@@ -163,6 +163,10 @@ describe('Organization', () => {
             ['contactPhoneNumber', 123],
             ['contactEmail', 123],
             ['revenueLevel', 123],
+            ['preData', 'invalid'],
+            ['preData', []],
+            ['preData', new Date() as any],
+            ['preData', true as any]
         ])('should return an error for invalid %s', (param, value) => {
             const invalidAttributes = { ...validAttributes, [param]: value };
             const errors = Organization.validateParams(invalidAttributes);
@@ -187,6 +191,7 @@ describe('Organization', () => {
             ['contactPhoneNumber', '9876543210'],
             ['contactEmail', 'jane.smith@example.com'],
             ['revenueLevel', 'Medium'],
+            ['preData', { importedOrgData: 'value', industry: 'tech' }],
         ])('should set and get %s', (attribute, value) => {
             const organization = new Organization(validAttributes, registry);
             organization[attribute] = value;
@@ -213,6 +218,16 @@ describe('Organization', () => {
             const organization = new Organization(validAttributes, registry);
             organization[attribute] = value;
             expect(organization[attribute]).toEqual(value);
+        });
+    });
+
+    describe('preData serialization', () => {
+        test('should preserve preData through (un)serialize', () => {
+            const attrs = { ...validAttributes, preData: { importedOrgData: 'value', industry: 'tech' } };
+            const o1 = new Organization(attrs, registry);
+            const o2 = Organization.unserialize(attrs, registry);
+            expect(o1.preData).toEqual({ importedOrgData: 'value', industry: 'tech' });
+            expect(o2.preData).toEqual({ importedOrgData: 'value', industry: 'tech' });
         });
     });
 

--- a/packages/evolution-common/src/services/baseObjects/__tests__/Person.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/Person.test.ts
@@ -233,6 +233,15 @@ describe('Person', () => {
             expect(errors).toHaveLength(1);
         });
 
+        test('should return an error for invalid preData', () => {
+            const invalidAttributes = { ...validAttributes, preData: 'invalid' };
+            const result = Person.create(invalidAttributes, registry);
+            expect(hasErrors(result)).toBe(true);
+            const errors = unwrap(result) as Error[];
+            expect(errors.length).toBeGreaterThan(0);
+            expect(errors[0].toString()).toContain('preData');
+        });
+
         test.each(stringAttributes)('should return an error for invalid %s', (param) => {
             const invalidAttributes = { ...validAttributes, [param]: 123 };
             const result = Person.create(invalidAttributes, registry);
@@ -882,6 +891,7 @@ describe('Person', () => {
             ['nickname', 'Johnny'],
             ['contactPhoneNumber', '9876543210'],
             ['contactEmail', 'johnny@example.com'],
+            ['preData', { importedPersonData: 'value', age: 35 }],
         ])('should set and get %s', (attribute, value) => {
             const person = new Person(validAttributes, registry);
             person[attribute] = value;
@@ -912,6 +922,16 @@ describe('Person', () => {
             const value = valueFactory();
             person[attribute] = value;
             expect(person[attribute]).toEqual(value);
+        });
+    });
+
+    describe('preData serialization', () => {
+        test('should preserve preData through (un)serialize', () => {
+            const attrs = { ...validAttributes, preData: { importedPersonData: 'value', age: 35 } };
+            const p1 = new Person(attrs, registry);
+            const p2 = Person.unserialize(attrs, registry);
+            expect(p1.preData).toEqual({ importedPersonData: 'value', age: 35 });
+            expect(p2.preData).toEqual({ importedPersonData: 'value', age: 35 });
         });
     });
 

--- a/packages/evolution-common/src/services/baseObjects/__tests__/SchoolPlace.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/SchoolPlace.test.ts
@@ -168,6 +168,15 @@ describe('SchoolPlace', () => {
         test.each([
             ['parkingType', 'streetside'],
             ['parkingFeeType', 'paidByStudent'],
+            ['preData', { importedSchoolPlaceData: 'value', studentCount: 250 }],
+            ['preGeography', {
+                type: 'Feature',
+                geometry: {
+                    type: 'Point',
+                    coordinates: [-73.7, 45.7],
+                },
+                properties: {},
+            }],
         ])('should set and get %s', (attribute, value) => {
             const schoolPlace = new SchoolPlace(validSchoolPlaceAttributes, registry);
             schoolPlace[attribute] = value;
@@ -195,6 +204,32 @@ describe('SchoolPlace', () => {
             const schoolPlace = new SchoolPlace(validSchoolPlaceAttributes, registry);
             schoolPlace[attribute] = value;
             expect(schoolPlace[attribute]).toEqual(value);
+        });
+    });
+
+    describe('preData and preGeography serialization', () => {
+        test('should preserve preData through (un)serialize', () => {
+            const attrs = { ...validSchoolPlaceAttributes, preData: { importedSchoolPlaceData: 'value', studentCount: 250 } };
+            const sp1 = new SchoolPlace(attrs, registry);
+            const sp2 = SchoolPlace.unserialize(attrs, registry);
+            expect(sp1.preData).toEqual({ importedSchoolPlaceData: 'value', studentCount: 250 });
+            expect(sp2.preData).toEqual({ importedSchoolPlaceData: 'value', studentCount: 250 });
+        });
+
+        test('should preserve preGeography through (un)serialize', () => {
+            const preGeography = {
+                type: 'Feature' as const,
+                geometry: {
+                    type: 'Point' as const,
+                    coordinates: [-73.7, 45.7],
+                },
+                properties: {},
+            };
+            const attrs = { ...validSchoolPlaceAttributes, preGeography };
+            const sp1 = new SchoolPlace(attrs, registry);
+            const sp2 = SchoolPlace.unserialize(attrs, registry);
+            expect(sp1.preGeography).toEqual(preGeography);
+            expect(sp2.preGeography).toEqual(preGeography);
         });
     });
 });

--- a/packages/evolution-common/src/services/baseObjects/__tests__/Segment.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/Segment.test.ts
@@ -158,6 +158,10 @@ describe('Segment', () => {
             ['onDemandType', 123],
             ['busLines', 'invalid'],
             ['busLines', [undefined, 'Line']],
+            ['preData', 'invalid'],
+            ['preData', []],
+            ['preData', new Date() as any],
+            ['preData', true as any]
         ])('should return an error for invalid %s', (param, value) => {
             const invalidAttributes = { ...validAttributes, [param]: value };
             const errors = Segment.validateParams(invalidAttributes);
@@ -187,6 +191,7 @@ describe('Segment', () => {
             ['paidForParking', false],
             ['onDemandType', 'pickupAtOrigin'],
             ['busLines', ['Line 3', 'Line 4']],
+            ['preData', { importedSegmentData: 'value', mode: 'bus' }],
         ])('should set and get %s', (attribute, value) => {
             const segment = new Segment(validAttributes, registry);
             segment[attribute] = value;
@@ -250,6 +255,16 @@ describe('Segment', () => {
         });
     });
 
+    describe('preData serialization', () => {
+        test('should preserve preData through (un)serialize', () => {
+            const attrs = { ...validAttributes, preData: { importedSegmentData: 'value', mode: 'bus' } };
+            const s1 = new Segment(attrs, registry);
+            const s2 = Segment.unserialize(attrs, registry);
+            expect(s1.preData).toEqual({ importedSegmentData: 'value', mode: 'bus' });
+            expect(s2.preData).toEqual({ importedSegmentData: 'value', mode: 'bus' });
+        });
+    });
+
     describe('Invalid Routing Attributes', () => {
 
         it('should report errors for invalid transitDeclaredRouting', () => {
@@ -269,7 +284,7 @@ describe('Segment', () => {
             }, registry);
             expect(hasErrors(segment)).toBe(true);
             expect(unwrap(segment)).toHaveLength(1);
-            expect(unwrap(segment)[0].toString()).toEqual('Error: TransitRouting validateParams: params should be an object');
+            expect(unwrap(segment)[0].toString()).toEqual('Error: TransitRouting validateParams: params should be a plain object (Record)');
         });
 
         it('should report errors for invalid walkingDeclaredRouting', () => {
@@ -289,7 +304,7 @@ describe('Segment', () => {
             }, registry);
             expect(hasErrors(segment)).toBe(true);
             expect(unwrap(segment)).toHaveLength(1);
-            expect(unwrap(segment)[0].toString()).toEqual('Error: WalkingRouting validateParams: params should be an object');
+            expect(unwrap(segment)[0].toString()).toEqual('Error: WalkingRouting validateParams: params should be a plain object (Record)');
         });
 
         it('should report errors for invalid cyclingDeclaredRouting', () => {
@@ -309,7 +324,7 @@ describe('Segment', () => {
             }, registry);
             expect(hasErrors(segment)).toBe(true);
             expect(unwrap(segment)).toHaveLength(1);
-            expect(unwrap(segment)[0].toString()).toEqual('Error: CyclingRouting validateParams: params should be an object');
+            expect(unwrap(segment)[0].toString()).toEqual('Error: CyclingRouting validateParams: params should be a plain object (Record)');
         });
 
         it('should report errors for invalid drivingDeclaredRouting', () => {
@@ -329,7 +344,7 @@ describe('Segment', () => {
             }, registry);
             expect(hasErrors(segment)).toBe(true);
             expect(unwrap(segment)).toHaveLength(1);
-            expect(unwrap(segment)[0].toString()).toEqual('Error: DrivingRouting validateParams: params should be an object');
+            expect(unwrap(segment)[0].toString()).toEqual('Error: DrivingRouting validateParams: params should be a plain object (Record)');
         });
 
 
@@ -351,7 +366,7 @@ describe('Segment', () => {
             }, registry);
             expect(hasErrors(segment)).toBe(true);
             expect(unwrap(segment)).toHaveLength(1);
-            expect(unwrap(segment)[0].toString()).toEqual('Error: TransitRouting validateParams: params should be an object');
+            expect(unwrap(segment)[0].toString()).toEqual('Error: TransitRouting validateParams: params should be a plain object (Record)');
         });
 
         it('should report errors for invalid walkingCalculatedRoutings', () => {
@@ -371,7 +386,7 @@ describe('Segment', () => {
             }, registry);
             expect(hasErrors(segment)).toBe(true);
             expect(unwrap(segment)).toHaveLength(1);
-            expect(unwrap(segment)[0].toString()).toEqual('Error: WalkingRouting validateParams: params should be an object');
+            expect(unwrap(segment)[0].toString()).toEqual('Error: WalkingRouting validateParams: params should be a plain object (Record)');
         });
 
         it('should report errors for invalid cyclingCalculatedRoutings', () => {
@@ -391,7 +406,7 @@ describe('Segment', () => {
             }, registry);
             expect(hasErrors(segment)).toBe(true);
             expect(unwrap(segment)).toHaveLength(1);
-            expect(unwrap(segment)[0].toString()).toEqual('Error: CyclingRouting validateParams: params should be an object');
+            expect(unwrap(segment)[0].toString()).toEqual('Error: CyclingRouting validateParams: params should be a plain object (Record)');
         });
 
         it('should report errors for invalid drivingCalculatedRoutings', () => {
@@ -411,7 +426,7 @@ describe('Segment', () => {
             }, registry);
             expect(hasErrors(segment)).toBe(true);
             expect(unwrap(segment)).toHaveLength(1);
-            expect(unwrap(segment)[0].toString()).toEqual('Error: DrivingRouting validateParams: params should be an object');
+            expect(unwrap(segment)[0].toString()).toEqual('Error: DrivingRouting validateParams: params should be a plain object (Record)');
         });
 
     });

--- a/packages/evolution-common/src/services/baseObjects/__tests__/Trip.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/Trip.test.ts
@@ -230,6 +230,10 @@ describe('Trip', () => {
             ['endTime', 'invalid'],
             ['startTimePeriod', 123],
             ['endTimePeriod', 123],
+            ['preData', 'invalid'],
+            ['preData', []],
+            ['preData', new Date() as any],
+            ['preData', true as any]
         ])('should return an error for invalid %s', (param, value) => {
             const invalidAttributes = { ...validAttributes, [param]: value };
             const errors = Trip.validateParams(invalidAttributes);
@@ -255,6 +259,7 @@ describe('Trip', () => {
             ['tripChainUuid', uuidV4()],
             ['_isValid', false],
             ['_weights', [{ weight: 2.0, method: new WeightMethod(weightMethodAttributes) }]],
+            ['preData', { importedTripData: 'value', distance: 12.5 }],
         ])('should set and get %s', (attribute, value) => {
             const trip = new Trip(validAttributes, registry);
             trip[attribute] = value;
@@ -284,6 +289,16 @@ describe('Trip', () => {
             const value = valueFactory();
             trip[attribute] = value;
             expect(trip[attribute]).toEqual(value);
+        });
+    });
+
+    describe('preData serialization', () => {
+        test('should preserve preData through (un)serialize', () => {
+            const attrs = { ...validAttributes, preData: { importedTripData: 'value', distance: 12.5 } };
+            const t1 = new Trip(attrs, registry);
+            const t2 = Trip.unserialize(attrs, registry);
+            expect(t1.preData).toEqual({ importedTripData: 'value', distance: 12.5 });
+            expect(t2.preData).toEqual({ importedTripData: 'value', distance: 12.5 });
         });
     });
 

--- a/packages/evolution-common/src/services/baseObjects/__tests__/TripChain.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/TripChain.test.ts
@@ -192,6 +192,10 @@ describe('TripChain', () => {
             ['isConstrained', 'invalid'],
             ['mainActivity', 123],
             ['mainActivityCategory', 123],
+            ['preData', 'invalid'],
+            ['preData', []],
+            ['preData', new Date() as any],
+            ['preData', true as any]
         ])('should return an error for invalid %s', (param, value) => {
             const invalidAttributes = { ...validAttributes, [param]: value };
             const errors = TripChain.validateParams(invalidAttributes);
@@ -218,6 +222,7 @@ describe('TripChain', () => {
             ['isConstrained', false],
             ['mainActivity', 'school'],
             ['mainActivityCategory', 'education'],
+            ['preData', { importedTripChainData: 'value', purpose: 'work' }],
         ])('should set and get %s', (attribute, value) => {
             const tripChain = new TripChain(validAttributes, registry);
             tripChain[attribute] = value;
@@ -245,6 +250,16 @@ describe('TripChain', () => {
             const tripChain = new TripChain(validAttributes, registry);
             tripChain[attribute] = value;
             expect(tripChain[attribute]).toEqual(value);
+        });
+    });
+
+    describe('preData serialization', () => {
+        test('should preserve preData through (un)serialize', () => {
+            const attrs = { ...validAttributes, preData: { importedTripChainData: 'value', purpose: 'work' } };
+            const tc1 = new TripChain(attrs, registry);
+            const tc2 = TripChain.unserialize(attrs, registry);
+            expect(tc1.preData).toEqual({ importedTripChainData: 'value', purpose: 'work' });
+            expect(tc2.preData).toEqual({ importedTripChainData: 'value', purpose: 'work' });
         });
     });
 

--- a/packages/evolution-common/src/services/baseObjects/__tests__/Vehicle.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/Vehicle.test.ts
@@ -117,6 +117,10 @@ describe('Vehicle', () => {
         ['acquiredYear', 'invalid'],
         ['licensePlateNumber', 123],
         ['internalId', 123],
+        ['preData', 'invalid'],
+        ['preData', []],
+        ['preData', new Date() as any],
+        ['preData', true as any]
     ])('should return an error for invalid %s', (param, value) => {
         const invalidAttributes = { ...validAttributes, [param]: value };
         const errors = Vehicle.validateParams(invalidAttributes);
@@ -160,6 +164,7 @@ describe('Vehicle', () => {
             ['acquiredYear', 2022],
             ['licensePlateNumber', 'XYZ789'],
             ['internalId', 'V002'],
+            ['preData', { importedVehicleData: 'value', vin: 'ABC123XYZ' }],
         ])('should set and get %s', (attribute, value) => {
             const vehicle = new Vehicle(validAttributes, registry);
             vehicle[attribute] = value;
@@ -184,6 +189,16 @@ describe('Vehicle', () => {
             const vehicle = new Vehicle(validAttributes, registry);
             vehicle[attribute] = value;
             expect(vehicle[attribute]).toEqual(value);
+        });
+    });
+
+    describe('preData serialization', () => {
+        test('should preserve preData through (un)serialize', () => {
+            const attrs = { ...validAttributes, preData: { importedVehicleData: 'value', vin: 'ABC123XYZ' } };
+            const v1 = new Vehicle(attrs, registry);
+            const v2 = Vehicle.unserialize(attrs, registry);
+            expect(v1.preData).toEqual({ importedVehicleData: 'value', vin: 'ABC123XYZ' });
+            expect(v2.preData).toEqual({ importedVehicleData: 'value', vin: 'ABC123XYZ' });
         });
     });
 

--- a/packages/evolution-common/src/services/baseObjects/__tests__/VisitedPlace.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/VisitedPlace.test.ts
@@ -189,6 +189,10 @@ describe('VisitedPlace', () => {
             ['activityCategory', 123],
             ['shortcut', 'invalid-uuid'],
             ['_sequence', 'invalid'],
+            ['preData', 'invalid'],
+            ['preData', []],
+            ['preData', new Date() as any],
+            ['preData', true as any]
         ])('should return an error for invalid %s', (param, value) => {
             const invalidAttributes = { ...validVisitedPlaceAttributesWithPlace, [param]: value };
             const errors = VisitedPlace.validateParams(invalidAttributes);
@@ -214,6 +218,7 @@ describe('VisitedPlace', () => {
             ['activityCategory', 'leisure'],
             ['shortcut', uuidV4()],
             ['_sequence', 2],
+            ['preData', { importedVisitedPlaceData: 'value', duration: 30 }],
         ])('should set and get %s', (attribute, value) => {
             const visitedPlace = new VisitedPlace(validVisitedPlaceAttributesWithPlace, registry);
             visitedPlace[attribute] = value;
@@ -243,6 +248,16 @@ describe('VisitedPlace', () => {
             const visitedPlace = new VisitedPlace(validVisitedPlaceAttributesWithPlace, registry);
             visitedPlace[attribute] = value;
             expect(visitedPlace[attribute]).toEqual(value);
+        });
+    });
+
+    describe('preData serialization', () => {
+        test('should preserve preData through (un)serialize', () => {
+            const attrs = { ...validVisitedPlaceAttributesWithPlace, preData: { importedVisitedPlaceData: 'value', duration: 30 } };
+            const vp1 = new VisitedPlace(attrs, registry);
+            const vp2 = VisitedPlace.unserialize(attrs, registry);
+            expect(vp1.preData).toEqual({ importedVisitedPlaceData: 'value', duration: 30 });
+            expect(vp2.preData).toEqual({ importedVisitedPlaceData: 'value', duration: 30 });
         });
     });
 });

--- a/packages/evolution-common/src/services/baseObjects/__tests__/WorkPlace.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/WorkPlace.test.ts
@@ -169,6 +169,15 @@ describe('WorkPlace', () => {
         test.each([
             ['parkingType', 'exteriorAssignedOrGuaranteed'],
             ['parkingFeeType', 'free'],
+            ['preData', { importedWorkPlaceData: 'value', employeeCount: 50 }],
+            ['preGeography', {
+                type: 'Feature',
+                geometry: {
+                    type: 'Point',
+                    coordinates: [-73.6, 45.6],
+                },
+                properties: {},
+            }],
         ])('should set and get %s', (attribute, value) => {
             const workPlace = new WorkPlace(validWorkPlaceAttributes, registry);
             workPlace[attribute] = value;
@@ -196,6 +205,32 @@ describe('WorkPlace', () => {
             const workPlace = new WorkPlace(validWorkPlaceAttributes, registry);
             workPlace[attribute] = value;
             expect(workPlace[attribute]).toEqual(value);
+        });
+    });
+
+    describe('preData and preGeography serialization', () => {
+        test('should preserve preData through (un)serialize', () => {
+            const attrs = { ...validWorkPlaceAttributes, preData: { importedWorkPlaceData: 'value', employeeCount: 50 } };
+            const wp1 = new WorkPlace(attrs, registry);
+            const wp2 = WorkPlace.unserialize(attrs, registry);
+            expect(wp1.preData).toEqual({ importedWorkPlaceData: 'value', employeeCount: 50 });
+            expect(wp2.preData).toEqual({ importedWorkPlaceData: 'value', employeeCount: 50 });
+        });
+
+        test('should preserve preGeography through (un)serialize', () => {
+            const preGeography = {
+                type: 'Feature' as const,
+                geometry: {
+                    type: 'Point' as const,
+                    coordinates: [-73.6, 45.6],
+                },
+                properties: {},
+            };
+            const attrs = { ...validWorkPlaceAttributes, preGeography };
+            const wp1 = new WorkPlace(attrs, registry);
+            const wp2 = WorkPlace.unserialize(attrs, registry);
+            expect(wp1.preGeography).toEqual(preGeography);
+            expect(wp2.preGeography).toEqual(preGeography);
         });
     });
 

--- a/packages/evolution-common/src/services/baseObjects/interview/Interview.ts
+++ b/packages/evolution-common/src/services/baseObjects/interview/Interview.ts
@@ -8,6 +8,7 @@
 import _omit from 'lodash/omit';
 
 import { Optional } from '../../../types/Optional.type';
+import { PreData } from '../../../types/shared';
 import { Uuidable, UuidableAttributes } from '../Uuidable';
 import { YesNoDontKnow } from '../attributeTypes/GenericAttributes';
 import { ConstructorUtils } from '../../../utils/ConstructorUtils';
@@ -53,7 +54,8 @@ const interviewAttributesNames = [
     'interestRange',
     'difficultyRange',
     'burdenRange',
-    'consideredAbandoning'
+    'consideredAbandoning',
+    'preData'
 ];
 
 const interviewAttributesWithComposedAttributes = [...interviewAttributesNames, '_paradata'];
@@ -91,6 +93,7 @@ export type InterviewAttributes = {
     difficultyRange?: number; // respondent appreciation of the interview difficulty (range from very easy to very difficult)
     burdenRange?: number; // respondent appreciation of the interview burden (range from very light to very heavy)
     consideredAbandoning?: YesNoDontKnow; // yes/no/dontKnow if the respondent considered abandoning the interview
+    preData?: PreData;
 } & UuidableAttributes;
 
 export type InterviewWithComposedObjects = InterviewAttributes & {
@@ -188,7 +191,8 @@ export class Interview extends Uuidable {
         'interestRange', // only for analysis/admin exports
         'difficultyRange', // only for analysis/admin exports
         'burdenRange', // only for analysis/admin exports
-        'consideredAbandoning' // only for analysis/admin exports
+        'consideredAbandoning', // only for analysis/admin exports
+        'preData' // only for admin exports
     ];
 
     // Use InterviewUnserializer create function to generate/validate Interview object from json data with nested composed objects
@@ -431,6 +435,14 @@ export class Interview extends Uuidable {
 
     set consideredAbandoning(value: Optional<string>) {
         this._attributes.consideredAbandoning = value;
+    }
+
+    get preData(): Optional<PreData> {
+        return this._attributes.preData;
+    }
+
+    set preData(value: Optional<PreData>) {
+        this._attributes.preData = value;
     }
 
     get paradata(): Optional<InterviewParadata> {

--- a/packages/evolution-common/src/services/baseObjects/interview/InterviewParadata.ts
+++ b/packages/evolution-common/src/services/baseObjects/interview/InterviewParadata.ts
@@ -219,7 +219,7 @@ export class InterviewParadata {
         const errors: Error[] = [];
 
         errors.push(...ParamsValidatorUtils.isRequired('params', dirtyParams, displayName));
-        errors.push(...ParamsValidatorUtils.isObject('params', dirtyParams, displayName));
+        errors.push(...ParamsValidatorUtils.isRecord('params', dirtyParams, displayName));
 
         // TODO: also check if start/end timestamps are inside the survey period:
         errors.push(...ParamsValidatorUtils.isPositiveInteger('startedAt', dirtyParams.startedAt, displayName));
@@ -351,7 +351,7 @@ export class InterviewParadata {
             }
         }
 
-        errors.push(...ParamsValidatorUtils.isObject('sections', dirtyParams.sections, displayName));
+        errors.push(...ParamsValidatorUtils.isRecord('sections', dirtyParams.sections, displayName));
         // TODO: validate the section metadata object when we will have implemented the format
         return errors;
     };

--- a/packages/evolution-common/src/services/baseObjects/interview/InterviewUnserializer.ts
+++ b/packages/evolution-common/src/services/baseObjects/interview/InterviewUnserializer.ts
@@ -25,7 +25,7 @@ export const validateParams = function (
     errors.push(...ParamsValidatorUtils.isPositiveNumber('id', interviewAttributes.id, displayName));
 
     errors.push(...ParamsValidatorUtils.isRequired('params', dirtyParams, displayName));
-    errors.push(...ParamsValidatorUtils.isObject('params', dirtyParams, displayName));
+    errors.push(...ParamsValidatorUtils.isRecord('params', dirtyParams, displayName));
 
     errors.push(...Uuidable.validateParams(dirtyParams));
 

--- a/packages/evolution-common/src/services/baseObjects/interview/__tests__/Interview.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/interview/__tests__/Interview.test.ts
@@ -223,8 +223,67 @@ describe('Interview', () => {
             expect(interview.paradata).toBe(paradata);
         });
 
+        it('should get and set preData', () => {
+            const interview = new Interview(validParams, createRawInterviewAttributes(), registry);
+            const preData = { importedInterviewData: 'value', respondentId: 'R123' };
+            interview.preData = preData;
+            expect(interview.preData).toEqual(preData);
+            interview.preData = undefined;
+            expect(interview.preData).toBeUndefined();
+        });
+
+        it('should handle preData in constructor', () => {
+            const paramsWithPreData = {
+                ...validParams,
+                preData: { importedField: 'importedValue', surveyId: 'S456' }
+            };
+            const interview = new Interview(paramsWithPreData, createRawInterviewAttributes(), registry);
+            expect(interview.preData).toEqual({ importedField: 'importedValue', surveyId: 'S456' });
+        });
+
+        // TODO: These tests are skipped until setter validation is implemented
+        // The preData setter should validate using ParamsValidatorUtils.isRecord()
+        it.skip('should reject invalid types for preData', () => {
+            const interview = new Interview(validParams, createRawInterviewAttributes(), registry);
+            expect(() => {
+                interview.preData = [] as any;
+            }).toThrow(/validation|TypeError|Invalid preData|should be a plain object \(Record\)/);
+        });
+
+        it.skip('should reject non-object types for preData', () => {
+            const interview = new Interview(validParams, createRawInterviewAttributes(), registry);
+            expect(() => {
+                interview.preData = 'string value' as any;
+            }).toThrow(/validation|TypeError|Invalid preData|should be a plain object \(Record\)/);
+            expect(() => {
+                interview.preData = 123 as any;
+            }).toThrow(/validation|TypeError|Invalid preData|should be a plain object \(Record\)/);
+            expect(() => {
+                interview.preData = true as any;
+            }).toThrow(/validation|TypeError|Invalid preData|should be a plain object \(Record\)/);
+        });
+
         // Add similar tests for household, person, and organization
         // once their implementations are complete
+    });
+
+    describe('preData serialization', () => {
+        test('should preserve preData through create and unserialize', () => {
+            const paramsWithPreData = {
+                ...validParams,
+                preData: { importedInterviewData: 'value', respondentId: 'R123' }
+            };
+            const result1 = create(paramsWithPreData, createRawInterviewAttributes(), registry);
+            expect(isOk(result1)).toBe(true);
+            if (isOk(result1)) {
+                const interview1 = result1.result;
+                expect(interview1.preData).toEqual({ importedInterviewData: 'value', respondentId: 'R123' });
+
+                // Also test direct constructor
+                const interview2 = new Interview(paramsWithPreData, createRawInterviewAttributes(), registry);
+                expect(interview2.preData).toEqual({ importedInterviewData: 'value', respondentId: 'R123' });
+            }
+        });
     });
 
     describe('confidential attributes', () => {

--- a/packages/evolution-common/src/types/shared.ts
+++ b/packages/evolution-common/src/types/shared.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+/**
+ * Type for prefilled data imported from external sources.
+ * This flexible JSON object format stores survey-specific imported data.
+ * TODO: we may type this in the future and delegate the survey project to provide
+ * mappings between imported csv data and preData objects.
+ */
+export type PreData = Record<string, unknown>;

--- a/packages/evolution-common/src/utils/ParamsValidatorUtils.ts
+++ b/packages/evolution-common/src/utils/ParamsValidatorUtils.ts
@@ -21,12 +21,28 @@ import {
 declare type Class<T = unknown> = new (...args: unknown[]) => T;
 
 export class ParamsValidatorUtils {
-    static isObject(attribute: string, value: unknown, displayName: string): Error[] {
-        if (value !== undefined && value !== null && typeof value !== 'object') {
-            return [new Error(`${displayName} validateParams: ${attribute} should be an object`)];
-        } else {
+    // isRecord checks if the value is a plain object (Record type) - excludes arrays, primitives, and class instances
+    static isRecord(attribute: string, value: unknown, displayName: string, allowNullParameter = true): Error[] {
+        // undefined is always allowed
+        if (value === undefined) {
             return [];
         }
+
+        // null is conditionally allowed based on allowNullParameter
+        if (value === null) {
+            if (allowNullParameter) {
+                return [];
+            } else {
+                return [new Error(`${displayName} validateParams: ${attribute} should not be null`)];
+            }
+        }
+
+        // Check if it's a plain object (Record type)
+        if (typeof value !== 'object' || Array.isArray(value) || value.constructor !== Object) {
+            return [new Error(`${displayName} validateParams: ${attribute} should be a plain object (Record)`)];
+        }
+
+        return [];
     }
 
     static isRequired(attribute: string, value: unknown, displayName: string): Error[] {

--- a/packages/evolution-common/src/utils/__tests__/ParamsValidatorUtils.test.ts
+++ b/packages/evolution-common/src/utils/__tests__/ParamsValidatorUtils.test.ts
@@ -12,31 +12,73 @@ class TestClass { }
 
 describe('ParamsValidatorUtils', () => {
 
-    describe('isObject', () => {
-        test('should return no errors for a valid object', () => {
-            const errors = ParamsValidatorUtils.isObject('attr', {}, 'TestClass');
+    describe('isRecord', () => {
+        test('should return no errors for a valid plain object', () => {
+            const errors = ParamsValidatorUtils.isRecord('attr', {}, 'TestClass');
             expect(errors).toEqual([]);
         });
 
         test('should return no errors for an undefined value', () => {
-            const errors = ParamsValidatorUtils.isObject('attr', undefined, 'TestClass');
+            const errors = ParamsValidatorUtils.isRecord('attr', undefined, 'TestClass');
             expect(errors).toEqual([]);
         });
 
-        test('should return no errors for an null value', () => {
-            const errors = ParamsValidatorUtils.isObject('attr', null, 'TestClass');
+        test('should return no errors for a null value when allowNullParameter is true (default)', () => {
+            const errors = ParamsValidatorUtils.isRecord('attr', null, 'TestClass');
             expect(errors).toEqual([]);
         });
 
-        test('should return no errors for an non-empty object', () => {
-            const errors = ParamsValidatorUtils.isObject('attr', { foo: 'bar' }, 'TestClass');
+        test('should return no errors for a null value when allowNullParameter is explicitly true', () => {
+            const errors = ParamsValidatorUtils.isRecord('attr', null, 'TestClass', true);
             expect(errors).toEqual([]);
         });
 
-        test('should return an error for a non-object value', () => {
-            const errors = ParamsValidatorUtils.isObject('attr', 'invalid', 'TestClass');
+        test('should return an error for a null value when allowNullParameter is false', () => {
+            const errors = ParamsValidatorUtils.isRecord('attr', null, 'TestClass', false);
             expect(errors).toHaveLength(1);
-            expect(errors[0].message).toContain('should be an object');
+            expect(errors[0].message).toContain('should not be null');
+        });
+
+        test('should return no errors for a non-empty plain object', () => {
+            const errors = ParamsValidatorUtils.isRecord('attr', { foo: 'bar' }, 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return an error for a string value', () => {
+            const errors = ParamsValidatorUtils.isRecord('attr', 'invalid', 'TestClass');
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be a plain object (Record)');
+        });
+
+        test('should return an error for a number value', () => {
+            const errors = ParamsValidatorUtils.isRecord('attr', 123, 'TestClass');
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be a plain object (Record)');
+        });
+
+        test('should return an error for a boolean value', () => {
+            const errors = ParamsValidatorUtils.isRecord('attr', true, 'TestClass');
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be a plain object (Record)');
+        });
+
+        test('should return an error for an array value', () => {
+            const errors = ParamsValidatorUtils.isRecord('attr', ['foo', 'bar'], 'TestClass');
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be a plain object (Record)');
+        });
+
+        test('should return an error for an empty array value', () => {
+            const errors = ParamsValidatorUtils.isRecord('attr', [], 'TestClass');
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be a plain object (Record)');
+        });
+
+        test('should return an error for a class instance', () => {
+            const instance = new TestClass();
+            const errors = ParamsValidatorUtils.isRecord('attr', instance, 'TestClass');
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be a plain object (Record)');
         });
     });
 


### PR DESCRIPTION
Add preData attribute to support importing external data into survey objects before conducting interviews. This enables surveys to prefill responses from external data sources, reducing respondent burden.

Changes:
- Add preData attribute to 11 survey objects (Household, Journey, Junction, Organization, Person, Segment, Trip, TripChain, Vehicle, VisitedPlace, Interview)
- Add preData and preGeography attributes to Place (inherited by Home, WorkPlace, SchoolPlace, and other Place subclasses)
- Implement getters, setters, and validation for preData fields

Tests:
- Add comprehensive tests for preData field validation in all affected objects
- Add tests for preData getters and setters in parametric test suites
- Add tests for preGeography in Place and Home objects
- Verify invalid preData values are properly rejected during validation

Documentation:
- Add "Prefilled Data System" section to README.md with:
  - Overview of preData and preGeography attributes
  - Data flow and database structure explanation
  - Configuration requirements and mapping details
  - Custom import task implementation guide
  - Example CSV format and usage instructions

The preData attribute stores custom prefilled data in a flexible JSON object format (Record<string, unknown>), while preDataGeography specifically stores original geographic data as GeoJSON Point Features for Place objects.

Related: importPreFilledResponses.task.ts provides a template for creating custom import tasks tailored to specific survey CSV formats.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Many core objects now support a new preData attribute; Place objects also support preGeography.

* **Documentation**
  * Added a comprehensive guide for the prefilled-data system, import format, and configuration.

* **Tests**
  * Expanded coverage verifying preData and preGeography validation and (un)serialization across objects.

* **Bug Fixes / Validation**
  * Stronger validation: params and preData must be plain records; related error messages clarified.

* **Privacy**
  * preData marked confidential for relevant object types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->