### PR TITLE
Add audit checks for home

### DIFF
--- a/locales/en/audits.json
+++ b/locales/en/audits.json
@@ -8,6 +8,8 @@
 
     "HH_I_Size": "Household size is out of range (should be between 1 and 20)",
     "HH_M_Size": "Household size is missing",
+    "HM_I_preGeographyAndHomeGeographyTooFarApartError": "Pre-filled and declared home geographies are far apart",
+    "HM_I_preGeographyAndHomeGeographyTooFarApartWarning": "Pre-filled and declared home geographies are a bit far apart",
 
     "HM_M_Geography": "Home geography is missing",
     "HM_I_Geography": "Home geography is invalid",

--- a/locales/fr/audits.json
+++ b/locales/fr/audits.json
@@ -8,6 +8,8 @@
 
     "HH_I_Size": "La taille du ménage est en dehors de la plage autorisée (devrait être entre 1 et 20)",
     "HH_M_Size": "La taille du ménage est manquante",
+    "HM_I_preGeographyAndHomeGeographyTooFarApartError": "Les géographies pré-remplie et déclarée du domicile sont éloignées",
+    "HM_I_preGeographyAndHomeGeographyTooFarApartWarning": "Les géographies pré-remplie et déclarée du domicile sont un peu éloignées",
 
     "HM_M_Geography": "La géographie du domicile est manquante",
     "HM_I_Geography": "La géographie du domicile est invalide",

--- a/packages/evolution-backend/package.json
+++ b/packages/evolution-backend/package.json
@@ -26,6 +26,7 @@
     },
     "dependencies": {
         "@casl/ability": "^6.7.3",
+        "@turf/distance": "^7.1.0",
         "chaire-lib-backend": "^0.2.2",
         "chaire-lib-common": "^0.2.2",
         "connect-session-knex": "^4.0.2",

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/HomeAuditChecks.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/HomeAuditChecks.ts
@@ -6,9 +6,21 @@
  */
 
 import { isFeature, isPoint } from 'geojson-validation';
+import { distance as turfDistance } from '@turf/distance';
 
 import type { AuditForObject } from 'evolution-common/lib/services/audits/types';
 import type { HomeAuditCheckContext, HomeAuditCheckFunction } from '../AuditCheckContexts';
+
+// Distances are arbitrary. This should only detect distances that could cause
+// change in travel behaviour.
+// TODO: More research is needed to find better thresholds.
+export const MAX_DISTANCE_PRE_AND_GEOGRAPHY_ERROR = 200;
+export const MIN_DISTANCE_PRE_AND_GEOGRAPHY_WARNING = 50;
+
+const isNotBlankAndValidPoint = (feature: unknown): boolean => {
+    // isFeature and isPoint will return false for undefined or null values so no need to check
+    return isFeature(feature) && isPoint((feature as GeoJSON.Feature).geometry);
+};
 
 export const homeAuditChecks: { [errorCode: string]: HomeAuditCheckFunction } = {
     /**
@@ -44,7 +56,7 @@ export const homeAuditChecks: { [errorCode: string]: HomeAuditCheckFunction } = 
         const { home } = context;
         const geography = home.geography;
 
-        if (geography && (!isFeature(geography) || !isPoint(geography.geometry))) {
+        if (geography && !isNotBlankAndValidPoint(geography)) {
             return {
                 objectType: 'home',
                 objectUuid: home._uuid!,
@@ -57,5 +69,68 @@ export const homeAuditChecks: { [errorCode: string]: HomeAuditCheckFunction } = 
         }
 
         return undefined; // No audit needed
+    },
+
+    /**
+     * Check if home has a preGeography and home geography are more than MAX_DISTANCE_PRE_AND_GEOGRAPHY_ERROR meters apart
+     * @param context - HomeAuditCheckContext
+     * @returns AuditForObject
+     */
+    HM_I_preGeographyAndHomeGeographyTooFarApartError: (context: HomeAuditCheckContext): AuditForObject | undefined => {
+        const home = context.home;
+        const preGeography = home.preGeography;
+        const geography = home.geography;
+        if (isNotBlankAndValidPoint(preGeography) && isNotBlankAndValidPoint(geography)) {
+            const distance = turfDistance(
+                preGeography as GeoJSON.Feature<GeoJSON.Point>,
+                geography as GeoJSON.Feature<GeoJSON.Point>,
+                { units: 'meters' }
+            );
+            if (distance >= MAX_DISTANCE_PRE_AND_GEOGRAPHY_ERROR) {
+                return {
+                    objectType: 'home',
+                    objectUuid: home._uuid!,
+                    errorCode: 'HM_I_preGeographyAndHomeGeographyTooFarApartError',
+                    version: 1,
+                    level: 'error',
+                    message: 'Pre-filled and declared home geography are far apart',
+                    ignore: false
+                };
+            }
+        }
+        return undefined;
+    },
+
+    /**
+     * Check if home has a preGeography and home geography are more than MIN_DISTANCE_PRE_AND_GEOGRAPHY_WARNING meters apart but less than MAX_DISTANCE_PRE_AND_GEOGRAPHY_ERROR meters apart
+     * See HM_I_preGeographyAndHomeGeographyTooFarApartError for more than MAX_DISTANCE_PRE_AND_GEOGRAPHY_ERROR meters apart
+     * @param context - HomeAuditCheckContext
+     * @returns AuditForObject
+     */
+    HM_I_preGeographyAndHomeGeographyTooFarApartWarning: (
+        context: HomeAuditCheckContext
+    ): AuditForObject | undefined => {
+        const home = context.home;
+        const preGeography = home.preGeography;
+        const geography = home.geography;
+        if (isNotBlankAndValidPoint(preGeography) && isNotBlankAndValidPoint(geography)) {
+            const distance = turfDistance(
+                preGeography as GeoJSON.Feature<GeoJSON.Point>,
+                geography as GeoJSON.Feature<GeoJSON.Point>,
+                { units: 'meters' }
+            );
+            if (distance >= MIN_DISTANCE_PRE_AND_GEOGRAPHY_WARNING && distance < MAX_DISTANCE_PRE_AND_GEOGRAPHY_ERROR) {
+                return {
+                    objectType: 'home',
+                    objectUuid: home._uuid!,
+                    errorCode: 'HM_I_preGeographyAndHomeGeographyTooFarApartWarning',
+                    version: 1,
+                    level: 'warning',
+                    message: 'Pre-filled and declared home geography are a bit far apart',
+                    ignore: false
+                };
+            }
+        }
+        return undefined;
     }
 };

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/home/HM_I_preGeographyAndHomeGeographyTooFarApartError.integration.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/home/HM_I_preGeographyAndHomeGeographyTooFarApartError.integration.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { v4 as uuidV4 } from 'uuid';
+import { homeAuditChecks } from '../../HomeAuditChecks';
+import { createContextWithHome } from './testHelper';
+
+describe('HM_I_preGeographyAndHomeGeographyTooFarApartError audit check - Integration tests with real turfDistance', () => {
+    const validUuid = uuidV4();
+
+    it('should error when coordinates are far apart (Montreal to Quebec City, ~250km)', () => {
+        const context = createContextWithHome(
+            {
+                preGeography: {
+                    type: 'Feature' as const,
+                    properties: {},
+                    geometry: { type: 'Point' as const, coordinates: [-73.5673, 45.5017] } // Montreal
+                },
+                geography: {
+                    type: 'Feature' as const,
+                    properties: {},
+                    geometry: { type: 'Point' as const, coordinates: [-71.2080, 46.8139] } // Quebec City
+                }
+            },
+            validUuid
+        );
+
+        const result = homeAuditChecks.HM_I_preGeographyAndHomeGeographyTooFarApartError(context);
+
+        expect(result).toBeDefined();
+        expect(result?.errorCode).toBe('HM_I_preGeographyAndHomeGeographyTooFarApartError');
+        expect(result?.level).toBe('error');
+        expect(result?.objectType).toBe('home');
+        expect(result?.objectUuid).toBe(validUuid);
+    });
+
+    it('should pass when coordinates are close together (~7.8 meters)', () => {
+        const context = createContextWithHome(
+            {
+                preGeography: {
+                    type: 'Feature' as const,
+                    properties: {},
+                    geometry: { type: 'Point' as const, coordinates: [-73.5673, 45.5017] }
+                },
+                geography: {
+                    type: 'Feature' as const,
+                    properties: {},
+                    geometry: { type: 'Point' as const, coordinates: [-73.5672, 45.5017] }
+                }
+            },
+            validUuid
+        );
+
+        const result = homeAuditChecks.HM_I_preGeographyAndHomeGeographyTooFarApartError(context);
+
+        expect(result).toBeUndefined();
+    });
+});
+

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/home/HM_I_preGeographyAndHomeGeographyTooFarApartError.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/home/HM_I_preGeographyAndHomeGeographyTooFarApartError.test.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { v4 as uuidV4 } from 'uuid';
+import { homeAuditChecks, MAX_DISTANCE_PRE_AND_GEOGRAPHY_ERROR } from '../../HomeAuditChecks';
+import { createContextWithHome } from './testHelper';
+
+jest.mock('@turf/distance', () => ({
+    distance: jest.fn()
+}));
+
+import { distance as turfDistance } from '@turf/distance';
+
+describe('HM_I_preGeographyAndHomeGeographyTooFarApartError audit check', () => {
+    const validUuid = uuidV4();
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('should pass when geographies are missing or undefined', () => {
+        it.each([
+            {
+                name: 'preGeography is missing',
+                preGeography: undefined,
+                geography: {
+                    type: 'Feature' as const,
+                    properties: {},
+                    geometry: { type: 'Point' as const, coordinates: [-73.5, 45.5] }
+                }
+            },
+            {
+                name: 'geography is missing',
+                preGeography: {
+                    type: 'Feature' as const,
+                    properties: {},
+                    geometry: { type: 'Point' as const, coordinates: [-73.5, 45.5] }
+                },
+                geography: undefined
+            },
+            {
+                name: 'both geographies are missing',
+                preGeography: undefined,
+                geography: undefined
+            }
+        ])('$name', ({ preGeography, geography }) => {
+            const context = createContextWithHome(
+                {
+                    preGeography,
+                    geography
+                },
+                validUuid
+            );
+
+            const result = homeAuditChecks.HM_I_preGeographyAndHomeGeographyTooFarApartError(context);
+
+            expect(result).toBeUndefined();
+        });
+    });
+
+    describe('should pass when distance is < threshold', () => {
+        it.each([
+            {
+                name: `distance < ${MAX_DISTANCE_PRE_AND_GEOGRAPHY_ERROR} meters (exactly ${MAX_DISTANCE_PRE_AND_GEOGRAPHY_ERROR - 1} meters)`,
+                distance: MAX_DISTANCE_PRE_AND_GEOGRAPHY_ERROR - 1
+            }
+        ])('$name', ({ distance }) => {
+            (turfDistance as jest.Mock).mockReturnValue(distance);
+
+            const context = createContextWithHome(
+                {
+                    preGeography: {
+                        type: 'Feature' as const,
+                        properties: {},
+                        geometry: { type: 'Point' as const, coordinates: [-73.5, 45.5] }
+                    },
+                    geography: {
+                        type: 'Feature' as const,
+                        properties: {},
+                        geometry: { type: 'Point' as const, coordinates: [-73.5, 45.5] }
+                    }
+                },
+                validUuid
+            );
+
+            const result = homeAuditChecks.HM_I_preGeographyAndHomeGeographyTooFarApartError(context);
+
+            expect(result).toBeUndefined();
+        });
+    });
+
+    describe(`should error when distance is >= ${MAX_DISTANCE_PRE_AND_GEOGRAPHY_ERROR} meters`, () => {
+        it.each([
+            {
+                name: `distance exactly ${MAX_DISTANCE_PRE_AND_GEOGRAPHY_ERROR} meters`,
+                distance: MAX_DISTANCE_PRE_AND_GEOGRAPHY_ERROR // Mocked: 200 meters
+            },
+            {
+                name: `distance > ${MAX_DISTANCE_PRE_AND_GEOGRAPHY_ERROR} meters (exactly ${MAX_DISTANCE_PRE_AND_GEOGRAPHY_ERROR + 1} meters)`,
+                distance: MAX_DISTANCE_PRE_AND_GEOGRAPHY_ERROR + 1 // Mocked: 201 meters
+            }
+        ])('$name', ({ distance }) => {
+            (turfDistance as jest.Mock).mockReturnValue(distance);
+
+            const context = createContextWithHome(
+                {
+                    preGeography: {
+                        type: 'Feature' as const,
+                        properties: {},
+                        geometry: { type: 'Point' as const, coordinates: [-73.5, 45.5] }
+                    },
+                    geography: {
+                        type: 'Feature' as const,
+                        properties: {},
+                        geometry: { type: 'Point' as const, coordinates: [-73.5, 45.5] }
+                    }
+                },
+                validUuid
+            );
+
+            const result = homeAuditChecks.HM_I_preGeographyAndHomeGeographyTooFarApartError(context);
+
+            expect(result).toMatchObject({
+                objectType: 'home',
+                objectUuid: validUuid,
+                errorCode: 'HM_I_preGeographyAndHomeGeographyTooFarApartError',
+                version: 1,
+                level: 'error',
+                message: 'Pre-filled and declared home geography are far apart',
+                ignore: false
+            });
+        });
+    });
+});

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/home/HM_I_preGeographyAndHomeGeographyTooFarApartWarning.integration.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/home/HM_I_preGeographyAndHomeGeographyTooFarApartWarning.integration.test.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { v4 as uuidV4 } from 'uuid';
+import { homeAuditChecks } from '../../HomeAuditChecks';
+import { createContextWithHome } from './testHelper';
+
+describe('HM_I_preGeographyAndHomeGeographyTooFarApartWarning audit check - Integration tests with real turfDistance', () => {
+    const validUuid = uuidV4();
+
+    it('should warn when coordinates are moderately far apart (~93.5 meters)', () => {
+        const context = createContextWithHome(
+            {
+                preGeography: {
+                    type: 'Feature' as const,
+                    properties: {},
+                    geometry: { type: 'Point' as const, coordinates: [-73.5673, 45.5017] }
+                },
+                geography: {
+                    type: 'Feature' as const,
+                    properties: {},
+                    geometry: { type: 'Point' as const, coordinates: [-73.5661, 45.5017] }
+                }
+            },
+            validUuid
+        );
+
+        const result = homeAuditChecks.HM_I_preGeographyAndHomeGeographyTooFarApartWarning(context);
+
+        expect(result).toBeDefined();
+        expect(result?.errorCode).toBe('HM_I_preGeographyAndHomeGeographyTooFarApartWarning');
+        expect(result?.level).toBe('warning');
+        expect(result?.objectType).toBe('home');
+        expect(result?.objectUuid).toBe(validUuid);
+    });
+
+    it('should pass when coordinates are very close together (~7.8 meters)', () => {
+        const context = createContextWithHome(
+            {
+                preGeography: {
+                    type: 'Feature' as const,
+                    properties: {},
+                    geometry: { type: 'Point' as const, coordinates: [-73.5673, 45.5017] }
+                },
+                geography: {
+                    type: 'Feature' as const,
+                    properties: {},
+                    geometry: { type: 'Point' as const, coordinates: [-73.5672, 45.5017] }
+                }
+            },
+            validUuid
+        );
+
+        const result = homeAuditChecks.HM_I_preGeographyAndHomeGeographyTooFarApartWarning(context);
+
+        expect(result).toBeUndefined();
+    });
+
+    it('should pass when coordinates are far apart (~250km) - handled by error check', () => {
+        const context = createContextWithHome(
+            {
+                preGeography: {
+                    type: 'Feature' as const,
+                    properties: {},
+                    geometry: { type: 'Point' as const, coordinates: [-73.5673, 45.5017] } // Montreal
+                },
+                geography: {
+                    type: 'Feature' as const,
+                    properties: {},
+                    geometry: { type: 'Point' as const, coordinates: [-71.2080, 46.8139] } // Quebec City
+                }
+            },
+            validUuid
+        );
+
+        const result = homeAuditChecks.HM_I_preGeographyAndHomeGeographyTooFarApartWarning(context);
+
+        expect(result).toBeUndefined();
+    });
+});
+

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/home/HM_I_preGeographyAndHomeGeographyTooFarApartWarning.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/home/HM_I_preGeographyAndHomeGeographyTooFarApartWarning.test.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { v4 as uuidV4 } from 'uuid';
+import { homeAuditChecks, MAX_DISTANCE_PRE_AND_GEOGRAPHY_ERROR, MIN_DISTANCE_PRE_AND_GEOGRAPHY_WARNING } from '../../HomeAuditChecks';
+import { createContextWithHome } from './testHelper';
+
+jest.mock('@turf/distance', () => ({
+    distance: jest.fn()
+}));
+
+import { distance as turfDistance } from '@turf/distance';
+
+describe('HM_I_preGeographyAndHomeGeographyTooFarApartWarning audit check', () => {
+    const validUuid = uuidV4();
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('should pass when geographies are missing or undefined', () => {
+        it.each([
+            {
+                name: 'preGeography is missing',
+                preGeography: undefined,
+                geography: {
+                    type: 'Feature' as const,
+                    properties: {},
+                    geometry: { type: 'Point' as const, coordinates: [-73.5, 45.5] }
+                }
+            },
+            {
+                name: 'geography is missing',
+                preGeography: {
+                    type: 'Feature' as const,
+                    properties: {},
+                    geometry: { type: 'Point' as const, coordinates: [-73.5, 45.5] }
+                },
+                geography: undefined
+            },
+            {
+                name: 'both geographies are missing',
+                preGeography: undefined,
+                geography: undefined
+            }
+        ])('$name', ({ preGeography, geography }) => {
+            const context = createContextWithHome(
+                {
+                    preGeography,
+                    geography
+                },
+                validUuid
+            );
+
+            const result = homeAuditChecks.HM_I_preGeographyAndHomeGeographyTooFarApartWarning(context);
+
+            expect(result).toBeUndefined();
+        });
+    });
+
+    describe(`should pass when distance is < ${MIN_DISTANCE_PRE_AND_GEOGRAPHY_WARNING} meters or >= ${MAX_DISTANCE_PRE_AND_GEOGRAPHY_ERROR} meters`, () => {
+        it.each([
+            {
+                name: `distance < ${MIN_DISTANCE_PRE_AND_GEOGRAPHY_WARNING} meters (exactly ${MIN_DISTANCE_PRE_AND_GEOGRAPHY_WARNING - 1} meters)`,
+                distance: MIN_DISTANCE_PRE_AND_GEOGRAPHY_WARNING - 1
+            },
+            {
+                name: `distance >= ${MAX_DISTANCE_PRE_AND_GEOGRAPHY_ERROR} meters (exactly ${MAX_DISTANCE_PRE_AND_GEOGRAPHY_ERROR} meters)`,
+                distance: MAX_DISTANCE_PRE_AND_GEOGRAPHY_ERROR
+            }
+        ])('$name', ({ distance }) => {
+            (turfDistance as jest.Mock).mockReturnValue(distance);
+
+            const context = createContextWithHome(
+                {
+                    preGeography: {
+                        type: 'Feature' as const,
+                        properties: {},
+                        geometry: { type: 'Point' as const, coordinates: [-73.5, 45.5] }
+                    },
+                    geography: {
+                        type: 'Feature' as const,
+                        properties: {},
+                        geometry: { type: 'Point' as const, coordinates: [-73.5, 45.5] }
+                    }
+                },
+                validUuid
+            );
+
+            const result = homeAuditChecks.HM_I_preGeographyAndHomeGeographyTooFarApartWarning(context);
+
+            expect(result).toBeUndefined();
+        });
+    });
+
+    describe(`should warn when distance is >= ${MIN_DISTANCE_PRE_AND_GEOGRAPHY_WARNING} and < ${MAX_DISTANCE_PRE_AND_GEOGRAPHY_ERROR} meters`, () => {
+        it.each([
+            {
+                name: `distance exactly ${MIN_DISTANCE_PRE_AND_GEOGRAPHY_WARNING} meters`,
+                distance: MIN_DISTANCE_PRE_AND_GEOGRAPHY_WARNING
+            },
+            {
+                name: `distance exactly ${MAX_DISTANCE_PRE_AND_GEOGRAPHY_ERROR - 1} meters`,
+                distance: MAX_DISTANCE_PRE_AND_GEOGRAPHY_ERROR - 1
+            }
+        ])('$name', ({ distance }) => {
+            (turfDistance as jest.Mock).mockReturnValue(distance);
+
+            const context = createContextWithHome(
+                {
+                    preGeography: {
+                        type: 'Feature' as const,
+                        properties: {},
+                        geometry: { type: 'Point' as const, coordinates: [-73.5, 45.5] }
+                    },
+                    geography: {
+                        type: 'Feature' as const,
+                        properties: {},
+                        geometry: { type: 'Point' as const, coordinates: [-73.5, 45.5] }
+                    }
+                },
+                validUuid
+            );
+
+            const result = homeAuditChecks.HM_I_preGeographyAndHomeGeographyTooFarApartWarning(context);
+
+            expect(result).toMatchObject({
+                objectType: 'home',
+                objectUuid: validUuid,
+                errorCode: 'HM_I_preGeographyAndHomeGeographyTooFarApartWarning',
+                level: 'warning',
+                message: 'Pre-filled and declared home geography are a bit far apart',
+                ignore: false
+            });
+        });
+    });
+});


### PR DESCRIPTION
- HM_I_preGeographyAndHomeGeographyTooFarApartError (200 meters for now)
- HM_I_preGeographyAndHomeGeographyTooFarApartWarning (50 meters for now)

Distances are arbitrary. This should only detect distances that could occur change in travel behaviour. More research is needed to find better thresholds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation that flags when pre-filled and declared home locations are unusually far apart, with error and warning levels.
  * Added English and French translations for the new validation messages.

* **Tests**
  * Added unit and integration tests covering the new geographic validation checks and their threshold behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->