### PR TITLE
Add async support for audit checks for API calls

### DIFF
--- a/packages/evolution-backend/src/services/audits/AuditService.ts
+++ b/packages/evolution-backend/src/services/audits/AuditService.ts
@@ -71,7 +71,7 @@ export class AuditService {
 
         // Step 3: Run object audits
         console.log('Step 3: Running object audits...');
-        const objectAudits = SurveyObjectAuditor.auditSurveyObjects(surveyObjectsWithAudits);
+        const objectAudits = await SurveyObjectAuditor.auditSurveyObjects(surveyObjectsWithAudits);
         surveyObjectsWithAudits.audits.push(...objectAudits);
         surveyObjectsWithAudits.auditsByObject = auditsArrayToAuditsByObject(surveyObjectsWithAudits.audits);
 

--- a/packages/evolution-backend/src/services/audits/SurveyObjectAuditor.ts
+++ b/packages/evolution-backend/src/services/audits/SurveyObjectAuditor.ts
@@ -15,9 +15,9 @@ export class SurveyObjectAuditor {
     /**
      * Run audits on all survey objects
      * @param surveyObjectsWithAudits - Survey objects with audits
-     * @returns Array of audit objects
+     * @returns Promise resolving to array of audit objects
      */
-    static auditSurveyObjects(surveyObjectsWithAudits: SurveyObjectsWithAudits): AuditForObject[] {
+    static async auditSurveyObjects(surveyObjectsWithAudits: SurveyObjectsWithAudits): Promise<AuditForObject[]> {
         const allAudits: AuditForObject[] = [];
 
         // Run interview audit checks
@@ -25,7 +25,11 @@ export class SurveyObjectAuditor {
             const interviewContext: auditChecks.InterviewAuditCheckContext = {
                 interview: surveyObjectsWithAudits.interview
             };
-            allAudits.push(...auditChecks.runInterviewAuditChecks(interviewContext, auditChecks.interviewAuditChecks));
+            const interviewAudits = await auditChecks.runInterviewAuditChecks(
+                interviewContext,
+                auditChecks.interviewAuditChecks
+            );
+            allAudits.push(...interviewAudits);
         } else {
             console.warn('Interview not found or invalid, skipping survey objects audit checks');
             return allAudits;
@@ -37,7 +41,11 @@ export class SurveyObjectAuditor {
                 household: surveyObjectsWithAudits.household,
                 interview: surveyObjectsWithAudits.interview
             };
-            allAudits.push(...auditChecks.runHouseholdAuditChecks(householdContext, auditChecks.householdAuditChecks));
+            const householdAudits = await auditChecks.runHouseholdAuditChecks(
+                householdContext,
+                auditChecks.householdAuditChecks
+            );
+            allAudits.push(...householdAudits);
         }
 
         // Audit home
@@ -47,7 +55,8 @@ export class SurveyObjectAuditor {
                 household: surveyObjectsWithAudits.household,
                 interview: surveyObjectsWithAudits.interview
             };
-            allAudits.push(...auditChecks.runHomeAuditChecks(homeContext, auditChecks.homeAuditChecks));
+            const homeAudits = await auditChecks.runHomeAuditChecks(homeContext, auditChecks.homeAuditChecks);
+            allAudits.push(...homeAudits);
         }
 
         // Audit persons and their nested objects
@@ -59,7 +68,11 @@ export class SurveyObjectAuditor {
                     home: surveyObjectsWithAudits.home,
                     interview: surveyObjectsWithAudits.interview
                 };
-                allAudits.push(...auditChecks.runPersonAuditChecks(personContext, auditChecks.personAuditChecks));
+                const personAudits = await auditChecks.runPersonAuditChecks(
+                    personContext,
+                    auditChecks.personAuditChecks
+                );
+                allAudits.push(...personAudits);
 
                 // Audit journeys for this person
                 if (person.journeys) {
@@ -71,9 +84,11 @@ export class SurveyObjectAuditor {
                             home: surveyObjectsWithAudits.home,
                             interview: surveyObjectsWithAudits.interview
                         };
-                        allAudits.push(
-                            ...auditChecks.runJourneyAuditChecks(journeyContext, auditChecks.journeyAuditChecks)
+                        const journeyAudits = await auditChecks.runJourneyAuditChecks(
+                            journeyContext,
+                            auditChecks.journeyAuditChecks
                         );
+                        allAudits.push(...journeyAudits);
 
                         // Run visited place audit checks for this journey
                         if (journey.visitedPlaces) {
@@ -86,12 +101,11 @@ export class SurveyObjectAuditor {
                                     home: surveyObjectsWithAudits.home,
                                     interview: surveyObjectsWithAudits.interview
                                 };
-                                allAudits.push(
-                                    ...auditChecks.runVisitedPlaceAuditChecks(
-                                        visitedPlaceContext,
-                                        auditChecks.visitedPlaceAuditChecks
-                                    )
+                                const visitedPlaceAudits = await auditChecks.runVisitedPlaceAuditChecks(
+                                    visitedPlaceContext,
+                                    auditChecks.visitedPlaceAuditChecks
                                 );
+                                allAudits.push(...visitedPlaceAudits);
                             }
                         }
 
@@ -106,9 +120,11 @@ export class SurveyObjectAuditor {
                                     home: surveyObjectsWithAudits.home,
                                     interview: surveyObjectsWithAudits.interview
                                 };
-                                allAudits.push(
-                                    ...auditChecks.runTripAuditChecks(tripContext, auditChecks.tripAuditChecks)
+                                const tripAudits = await auditChecks.runTripAuditChecks(
+                                    tripContext,
+                                    auditChecks.tripAuditChecks
                                 );
+                                allAudits.push(...tripAudits);
 
                                 // Run segment audit checks for this trip
                                 if (trip.segments) {
@@ -122,12 +138,11 @@ export class SurveyObjectAuditor {
                                             home: surveyObjectsWithAudits.home,
                                             interview: surveyObjectsWithAudits.interview
                                         };
-                                        allAudits.push(
-                                            ...auditChecks.runSegmentAuditChecks(
-                                                segmentContext,
-                                                auditChecks.segmentAuditChecks
-                                            )
+                                        const segmentAudits = await auditChecks.runSegmentAuditChecks(
+                                            segmentContext,
+                                            auditChecks.segmentAuditChecks
                                         );
+                                        allAudits.push(...segmentAudits);
                                     }
                                 }
                             }

--- a/packages/evolution-backend/src/services/audits/__tests__/SurveyObjectAuditor.test.ts
+++ b/packages/evolution-backend/src/services/audits/__tests__/SurveyObjectAuditor.test.ts
@@ -23,7 +23,7 @@ import {
 
 // Mock the audit functions
 jest.mock('../auditChecks', () => ({
-    runInterviewAuditChecks: jest.fn().mockReturnValue([
+    runInterviewAuditChecks: jest.fn().mockResolvedValue([
         {
             objectType: 'interview',
             objectUuid: 'interview-uuid',
@@ -34,7 +34,7 @@ jest.mock('../auditChecks', () => ({
             ignore: false
         }
     ]),
-    runHouseholdAuditChecks: jest.fn().mockReturnValue([
+    runHouseholdAuditChecks: jest.fn().mockResolvedValue([
         {
             objectType: 'household',
             objectUuid: 'household-uuid',
@@ -45,7 +45,7 @@ jest.mock('../auditChecks', () => ({
             ignore: false
         }
     ]),
-    runHomeAuditChecks: jest.fn().mockReturnValue([
+    runHomeAuditChecks: jest.fn().mockResolvedValue([
         {
             objectType: 'home',
             objectUuid: 'home-uuid',
@@ -56,9 +56,9 @@ jest.mock('../auditChecks', () => ({
             ignore: false
         }
     ]),
-    runPersonAuditChecks: jest.fn().mockReturnValue([]),
-    runJourneyAuditChecks: jest.fn().mockReturnValue([]),
-    runVisitedPlaceAuditChecks: jest.fn().mockReturnValue([
+    runPersonAuditChecks: jest.fn().mockResolvedValue([]),
+    runJourneyAuditChecks: jest.fn().mockResolvedValue([]),
+    runVisitedPlaceAuditChecks: jest.fn().mockResolvedValue([
         {
             objectType: 'visitedPlace',
             objectUuid: 'visitedplace-uuid',
@@ -69,8 +69,8 @@ jest.mock('../auditChecks', () => ({
             ignore: false
         }
     ]),
-    runTripAuditChecks: jest.fn().mockReturnValue([]),
-    runSegmentAuditChecks: jest.fn().mockReturnValue([]),
+    runTripAuditChecks: jest.fn().mockResolvedValue([]),
+    runSegmentAuditChecks: jest.fn().mockResolvedValue([]),
     interviewAuditChecks: {},
     householdAuditChecks: {},
     homeAuditChecks: {},
@@ -134,10 +134,10 @@ describe('SurveyObjectAuditor', () => {
     });
 
     describe('auditSurveyObjects', () => {
-        it('should audit interview when present', () => {
+        it('should audit interview when present', async () => {
             const surveyObjects = createMockSurveyObjects();
 
-            const audits = SurveyObjectAuditor.auditSurveyObjects(surveyObjects);
+            const audits = await SurveyObjectAuditor.auditSurveyObjects(surveyObjects);
 
             expect(runInterviewAuditChecks).toHaveBeenCalledWith({
                 interview: surveyObjects.interview
@@ -154,10 +154,10 @@ describe('SurveyObjectAuditor', () => {
             });
         });
 
-        it('should audit household when present', () => {
+        it('should audit household when present', async () => {
             const surveyObjects = createMockSurveyObjects();
 
-            const audits = SurveyObjectAuditor.auditSurveyObjects(surveyObjects);
+            const audits = await SurveyObjectAuditor.auditSurveyObjects(surveyObjects);
 
             expect(runHouseholdAuditChecks).toHaveBeenCalledWith({
                 household: surveyObjects.household,
@@ -175,10 +175,10 @@ describe('SurveyObjectAuditor', () => {
             });
         });
 
-        it('should audit home when present', () => {
+        it('should audit home when present', async () => {
             const surveyObjects = createMockSurveyObjects();
 
-            const audits = SurveyObjectAuditor.auditSurveyObjects(surveyObjects);
+            const audits = await SurveyObjectAuditor.auditSurveyObjects(surveyObjects);
 
             expect(runHomeAuditChecks).toHaveBeenCalledWith({
                 home: surveyObjects.home,
@@ -197,10 +197,10 @@ describe('SurveyObjectAuditor', () => {
             });
         });
 
-        it('should audit visited places with full hierarchy context', () => {
+        it('should audit visited places with full hierarchy context', async () => {
             const surveyObjects = createMockSurveyObjects();
 
-            const audits = SurveyObjectAuditor.auditSurveyObjects(surveyObjects);
+            const audits = await SurveyObjectAuditor.auditSurveyObjects(surveyObjects);
 
             expect(runVisitedPlaceAuditChecks).toHaveBeenCalledWith({
                 visitedPlace: surveyObjects.household?.members?.[0]?.journeys?.[0]?.visitedPlaces?.[0],
@@ -222,7 +222,7 @@ describe('SurveyObjectAuditor', () => {
             });
         });
 
-        it('should handle missing survey objects gracefully', () => {
+        it('should handle missing survey objects gracefully', async () => {
             const surveyObjects: SurveyObjectsWithAudits = {
                 audits: [],
                 interview: undefined,
@@ -240,7 +240,7 @@ describe('SurveyObjectAuditor', () => {
                 }
             };
 
-            const audits = SurveyObjectAuditor.auditSurveyObjects(surveyObjects);
+            const audits = await SurveyObjectAuditor.auditSurveyObjects(surveyObjects);
 
             expect(runInterviewAuditChecks).not.toHaveBeenCalled();
             expect(runHouseholdAuditChecks).not.toHaveBeenCalled();
@@ -249,13 +249,13 @@ describe('SurveyObjectAuditor', () => {
             expect(audits).toHaveLength(0);
         });
 
-        it('should handle household without members', () => {
+        it('should handle household without members', async () => {
             const surveyObjects = createMockSurveyObjects();
             if (surveyObjects.household?.members) {
                 surveyObjects.household.members = [];
             }
 
-            const audits = SurveyObjectAuditor.auditSurveyObjects(surveyObjects);
+            const audits = await SurveyObjectAuditor.auditSurveyObjects(surveyObjects);
 
             expect(runInterviewAuditChecks).toHaveBeenCalled();
             expect(runHouseholdAuditChecks).toHaveBeenCalled();
@@ -266,13 +266,13 @@ describe('SurveyObjectAuditor', () => {
             expect(audits.length).toBeGreaterThanOrEqual(3);
         });
 
-        it('should handle person without journeys', () => {
+        it('should handle person without journeys', async () => {
             const surveyObjects = createMockSurveyObjects();
             if (surveyObjects.household?.members?.[0]) {
                 surveyObjects.household.members[0].journeys = [];
             }
 
-            const audits = SurveyObjectAuditor.auditSurveyObjects(surveyObjects);
+            const audits = await SurveyObjectAuditor.auditSurveyObjects(surveyObjects);
 
             expect(runVisitedPlaceAuditChecks).not.toHaveBeenCalled();
 
@@ -280,13 +280,13 @@ describe('SurveyObjectAuditor', () => {
             expect(audits.length).toBeGreaterThanOrEqual(3);
         });
 
-        it('should handle journey without visited places', () => {
+        it('should handle journey without visited places', async () => {
             const surveyObjects = createMockSurveyObjects();
             if (surveyObjects.household?.members?.[0]?.journeys?.[0]) {
                 surveyObjects.household.members[0].journeys[0].visitedPlaces = [];
             }
 
-            const audits = SurveyObjectAuditor.auditSurveyObjects(surveyObjects);
+            const audits = await SurveyObjectAuditor.auditSurveyObjects(surveyObjects);
 
             expect(runVisitedPlaceAuditChecks).not.toHaveBeenCalled();
 
@@ -294,10 +294,10 @@ describe('SurveyObjectAuditor', () => {
             expect(audits.length).toBeGreaterThanOrEqual(3);
         });
 
-        it('should combine all audits from different objects', () => {
+        it('should combine all audits from different objects', async () => {
             const surveyObjects = createMockSurveyObjects();
 
-            const audits = SurveyObjectAuditor.auditSurveyObjects(surveyObjects);
+            const audits = await SurveyObjectAuditor.auditSurveyObjects(surveyObjects);
 
             // Should have audits from interview, household, home, and visited place
             expect(audits.length).toBeGreaterThanOrEqual(4);

--- a/packages/evolution-backend/src/services/audits/auditChecks/AuditCheckContexts.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/AuditCheckContexts.ts
@@ -100,12 +100,29 @@ export type SegmentAuditCheckContext = {
 
 /**
  * Generic audit check function signatures
+ * Audit checks can be synchronous or asynchronous (e.g., for API calls)
  */
-export type InterviewAuditCheckFunction = (context: InterviewAuditCheckContext) => AuditForObject | undefined;
-export type HouseholdAuditCheckFunction = (context: HouseholdAuditCheckContext) => AuditForObject | undefined;
-export type HomeAuditCheckFunction = (context: HomeAuditCheckContext) => AuditForObject | undefined;
-export type PersonAuditCheckFunction = (context: PersonAuditCheckContext) => AuditForObject | undefined;
-export type JourneyAuditCheckFunction = (context: JourneyAuditCheckContext) => AuditForObject | undefined;
-export type VisitedPlaceAuditCheckFunction = (context: VisitedPlaceAuditCheckContext) => AuditForObject | undefined;
-export type TripAuditCheckFunction = (context: TripAuditCheckContext) => AuditForObject | undefined;
-export type SegmentAuditCheckFunction = (context: SegmentAuditCheckContext) => AuditForObject | undefined;
+export type InterviewAuditCheckFunction = (
+    context: InterviewAuditCheckContext
+) => AuditForObject | undefined | Promise<AuditForObject | undefined>;
+export type HouseholdAuditCheckFunction = (
+    context: HouseholdAuditCheckContext
+) => AuditForObject | undefined | Promise<AuditForObject | undefined>;
+export type HomeAuditCheckFunction = (
+    context: HomeAuditCheckContext
+) => AuditForObject | undefined | Promise<AuditForObject | undefined>;
+export type PersonAuditCheckFunction = (
+    context: PersonAuditCheckContext
+) => AuditForObject | undefined | Promise<AuditForObject | undefined>;
+export type JourneyAuditCheckFunction = (
+    context: JourneyAuditCheckContext
+) => AuditForObject | undefined | Promise<AuditForObject | undefined>;
+export type VisitedPlaceAuditCheckFunction = (
+    context: VisitedPlaceAuditCheckContext
+) => AuditForObject | undefined | Promise<AuditForObject | undefined>;
+export type TripAuditCheckFunction = (
+    context: TripAuditCheckContext
+) => AuditForObject | undefined | Promise<AuditForObject | undefined>;
+export type SegmentAuditCheckFunction = (
+    context: SegmentAuditCheckContext
+) => AuditForObject | undefined | Promise<AuditForObject | undefined>;

--- a/packages/evolution-backend/src/services/audits/auditChecks/AuditCheckRunners.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/AuditCheckRunners.ts
@@ -11,14 +11,14 @@ import * as auditChecks from './AuditCheckContexts';
 /**
  * Run all interview audit checks
  */
-export const runInterviewAuditChecks = (
+export const runInterviewAuditChecks = async (
     context: auditChecks.InterviewAuditCheckContext,
     auditChecks: { [errorCode: string]: auditChecks.InterviewAuditCheckFunction }
-): AuditForObject[] => {
+): Promise<AuditForObject[]> => {
     const audits: AuditForObject[] = [];
 
     for (const errorCode in auditChecks) {
-        const auditResult = auditChecks[errorCode](context);
+        const auditResult = await auditChecks[errorCode](context);
         if (auditResult && context.interview._uuid) {
             audits.push(auditResult);
         }
@@ -30,14 +30,14 @@ export const runInterviewAuditChecks = (
 /**
  * Run all household audit checks
  */
-export const runHouseholdAuditChecks = (
+export const runHouseholdAuditChecks = async (
     context: auditChecks.HouseholdAuditCheckContext,
     auditChecks: { [errorCode: string]: auditChecks.HouseholdAuditCheckFunction }
-): AuditForObject[] => {
+): Promise<AuditForObject[]> => {
     const audits: AuditForObject[] = [];
 
     for (const errorCode in auditChecks) {
-        const auditResult = auditChecks[errorCode](context);
+        const auditResult = await auditChecks[errorCode](context);
         if (auditResult && context.household._uuid) {
             audits.push(auditResult);
         }
@@ -49,14 +49,14 @@ export const runHouseholdAuditChecks = (
 /**
  * Run all home audit checks
  */
-export const runHomeAuditChecks = (
+export const runHomeAuditChecks = async (
     context: auditChecks.HomeAuditCheckContext,
     auditChecks: { [errorCode: string]: auditChecks.HomeAuditCheckFunction }
-): AuditForObject[] => {
+): Promise<AuditForObject[]> => {
     const audits: AuditForObject[] = [];
 
     for (const errorCode in auditChecks) {
-        const auditResult = auditChecks[errorCode](context);
+        const auditResult = await auditChecks[errorCode](context);
         if (auditResult && context.home._uuid) {
             audits.push(auditResult);
         }
@@ -68,14 +68,14 @@ export const runHomeAuditChecks = (
 /**
  * Run all person audit checks
  */
-export const runPersonAuditChecks = (
+export const runPersonAuditChecks = async (
     context: auditChecks.PersonAuditCheckContext,
     auditChecks: { [errorCode: string]: auditChecks.PersonAuditCheckFunction }
-): AuditForObject[] => {
+): Promise<AuditForObject[]> => {
     const audits: AuditForObject[] = [];
 
     for (const errorCode in auditChecks) {
-        const auditResult = auditChecks[errorCode](context);
+        const auditResult = await auditChecks[errorCode](context);
         if (auditResult && context.person._uuid) {
             audits.push(auditResult);
         }
@@ -87,14 +87,14 @@ export const runPersonAuditChecks = (
 /**
  * Run all journey audit checks
  */
-export const runJourneyAuditChecks = (
+export const runJourneyAuditChecks = async (
     context: auditChecks.JourneyAuditCheckContext,
     auditChecks: { [errorCode: string]: auditChecks.JourneyAuditCheckFunction }
-): AuditForObject[] => {
+): Promise<AuditForObject[]> => {
     const audits: AuditForObject[] = [];
 
     for (const errorCode in auditChecks) {
-        const auditResult = auditChecks[errorCode](context);
+        const auditResult = await auditChecks[errorCode](context);
         if (auditResult && context.journey._uuid) {
             audits.push(auditResult);
         }
@@ -106,14 +106,14 @@ export const runJourneyAuditChecks = (
 /**
  * Run all visited place audit checks
  */
-export const runVisitedPlaceAuditChecks = (
+export const runVisitedPlaceAuditChecks = async (
     context: auditChecks.VisitedPlaceAuditCheckContext,
     auditChecks: { [errorCode: string]: auditChecks.VisitedPlaceAuditCheckFunction }
-): AuditForObject[] => {
+): Promise<AuditForObject[]> => {
     const audits: AuditForObject[] = [];
 
     for (const errorCode in auditChecks) {
-        const auditResult = auditChecks[errorCode](context);
+        const auditResult = await auditChecks[errorCode](context);
         if (auditResult && context.visitedPlace._uuid) {
             audits.push(auditResult);
         }
@@ -125,14 +125,14 @@ export const runVisitedPlaceAuditChecks = (
 /**
  * Run all trip audit checks
  */
-export const runTripAuditChecks = (
+export const runTripAuditChecks = async (
     context: auditChecks.TripAuditCheckContext,
     auditChecks: { [errorCode: string]: auditChecks.TripAuditCheckFunction }
-): AuditForObject[] => {
+): Promise<AuditForObject[]> => {
     const audits: AuditForObject[] = [];
 
     for (const errorCode in auditChecks) {
-        const auditResult = auditChecks[errorCode](context);
+        const auditResult = await auditChecks[errorCode](context);
         if (auditResult && context.trip._uuid) {
             audits.push(auditResult);
         }
@@ -144,14 +144,14 @@ export const runTripAuditChecks = (
 /**
  * Run all segment audit checks
  */
-export const runSegmentAuditChecks = (
+export const runSegmentAuditChecks = async (
     context: auditChecks.SegmentAuditCheckContext,
     auditChecks: { [errorCode: string]: auditChecks.SegmentAuditCheckFunction }
-): AuditForObject[] => {
+): Promise<AuditForObject[]> => {
     const audits: AuditForObject[] = [];
 
     for (const errorCode in auditChecks) {
-        const auditResult = auditChecks[errorCode](context);
+        const auditResult = await auditChecks[errorCode](context);
         if (auditResult && context.segment._uuid) {
             audits.push(auditResult);
         }

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/HomeAuditChecks.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/HomeAuditChecks.test.ts
@@ -14,7 +14,7 @@ import { createContextWithHome } from './home/testHelper';
 describe('runHomeAuditChecks - Integration', () => {
     const validUuid = uuidV4();
 
-    it('should run all audit checks and return empty array when all checks pass', () => {
+    it('should run all audit checks and return empty array when all checks pass', async () => {
         const context = createContextWithHome();
 
         // Mock audit checks that all pass (return undefined)
@@ -24,12 +24,12 @@ describe('runHomeAuditChecks - Integration', () => {
             TEST_CHECK_3: () => undefined
         };
 
-        const audits = runHomeAuditChecks(context, mockAuditChecks);
+        const audits = await runHomeAuditChecks(context, mockAuditChecks);
 
         expect(audits).toHaveLength(0);
     });
 
-    it('should aggregate results from multiple failing checks', () => {
+    it('should aggregate results from multiple failing checks', async () => {
         const context = createContextWithHome(undefined, validUuid);
 
         // Mock audit checks where some fail (return audit objects)
@@ -55,7 +55,7 @@ describe('runHomeAuditChecks - Integration', () => {
             })
         };
 
-        const audits = runHomeAuditChecks(context, mockAuditChecks);
+        const audits = await runHomeAuditChecks(context, mockAuditChecks);
 
         expect(audits).toHaveLength(2);
         expect(audits.some((a) => a.errorCode === 'TEST_FAIL_1')).toBe(true);
@@ -63,12 +63,12 @@ describe('runHomeAuditChecks - Integration', () => {
         expect(audits.some((a) => a.errorCode === 'TEST_PASS')).toBe(false);
     });
 
-    it('should handle empty audit checks object', () => {
+    it('should handle empty audit checks object', async () => {
         const context = createContextWithHome();
 
         const mockAuditChecks: { [errorCode: string]: HomeAuditCheckFunction } = {};
 
-        const audits = runHomeAuditChecks(context, mockAuditChecks);
+        const audits = await runHomeAuditChecks(context, mockAuditChecks);
 
         expect(audits).toHaveLength(0);
     });

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/HouseholdAuditChecks.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/HouseholdAuditChecks.test.ts
@@ -14,7 +14,7 @@ import { createContextWithHousehold } from './household/testHelper';
 describe('runHouseholdAuditChecks - Integration', () => {
     const validUuid = uuidV4();
 
-    it('should run all audit checks and return empty array when all checks pass', () => {
+    it('should run all audit checks and return empty array when all checks pass', async () => {
         const context = createContextWithHousehold();
 
         // Mock audit checks that all pass (return undefined)
@@ -24,12 +24,12 @@ describe('runHouseholdAuditChecks - Integration', () => {
             TEST_CHECK_3: () => undefined
         };
 
-        const audits = runHouseholdAuditChecks(context, mockAuditChecks);
+        const audits = await runHouseholdAuditChecks(context, mockAuditChecks);
 
         expect(audits).toHaveLength(0);
     });
 
-    it('should aggregate results from multiple failing checks', () => {
+    it('should aggregate results from multiple failing checks', async () => {
         const context = createContextWithHousehold(undefined, validUuid);
 
         // Mock audit checks where some fail (return audit objects)
@@ -55,7 +55,7 @@ describe('runHouseholdAuditChecks - Integration', () => {
             })
         };
 
-        const audits = runHouseholdAuditChecks(context, mockAuditChecks);
+        const audits = await runHouseholdAuditChecks(context, mockAuditChecks);
 
         expect(audits).toHaveLength(2);
         expect(audits.some((a) => a.errorCode === 'TEST_FAIL_1')).toBe(true);
@@ -64,12 +64,12 @@ describe('runHouseholdAuditChecks - Integration', () => {
 
     });
 
-    it('should handle empty audit checks object', () => {
+    it('should handle empty audit checks object', async () => {
         const context = createContextWithHousehold();
 
         const mockAuditChecks: { [errorCode: string]: HouseholdAuditCheckFunction } = {};
 
-        const audits = runHouseholdAuditChecks(context, mockAuditChecks);
+        const audits = await runHouseholdAuditChecks(context, mockAuditChecks);
 
         expect(audits).toHaveLength(0);
     });

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/InterviewAuditChecks.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/InterviewAuditChecks.test.ts
@@ -14,7 +14,7 @@ import { createContextWithInterview } from './interview/testHelper';
 describe('runInterviewAuditChecks - Integration', () => {
     const validUuid = uuidV4();
 
-    it('should run all audit checks and return empty array when all checks pass', () => {
+    it('should run all audit checks and return empty array when all checks pass', async () => {
         const context = createContextWithInterview();
 
         // Mock audit checks that all pass (return undefined)
@@ -24,12 +24,12 @@ describe('runInterviewAuditChecks - Integration', () => {
             TEST_CHECK_3: () => undefined
         };
 
-        const audits = runInterviewAuditChecks(context, mockAuditChecks);
+        const audits = await runInterviewAuditChecks(context, mockAuditChecks);
 
         expect(audits).toHaveLength(0);
     });
 
-    it('should aggregate results from multiple failing checks', () => {
+    it('should aggregate results from multiple failing checks', async () => {
         const context = createContextWithInterview(undefined, validUuid);
 
         // Mock audit checks where some fail (return audit objects)
@@ -55,7 +55,7 @@ describe('runInterviewAuditChecks - Integration', () => {
             })
         };
 
-        const audits = runInterviewAuditChecks(context, mockAuditChecks);
+        const audits = await runInterviewAuditChecks(context, mockAuditChecks);
 
         expect(audits).toHaveLength(2);
         expect(audits.some((a) => a.errorCode === 'TEST_FAIL_1')).toBe(true);
@@ -63,12 +63,12 @@ describe('runInterviewAuditChecks - Integration', () => {
         expect(audits.some((a) => a.errorCode === 'TEST_PASS')).toBe(false);
     });
 
-    it('should handle empty audit checks object', () => {
+    it('should handle empty audit checks object', async () => {
         const context = createContextWithInterview();
 
         const mockAuditChecks: { [errorCode: string]: InterviewAuditCheckFunction } = {};
 
-        const audits = runInterviewAuditChecks(context, mockAuditChecks);
+        const audits = await runInterviewAuditChecks(context, mockAuditChecks);
 
         expect(audits).toHaveLength(0);
     });

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/JourneyAuditChecks.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/JourneyAuditChecks.test.ts
@@ -14,7 +14,7 @@ import { createContextWithJourney } from './journey/testHelper';
 describe('runJourneyAuditChecks - Integration', () => {
     const validUuid = uuidV4();
 
-    it('should run all audit checks and return empty array when all checks pass', () => {
+    it('should run all audit checks and return empty array when all checks pass', async () => {
         const context = createContextWithJourney();
 
         // Mock audit checks that all pass (return undefined)
@@ -24,12 +24,12 @@ describe('runJourneyAuditChecks - Integration', () => {
             TEST_CHECK_3: () => undefined
         };
 
-        const audits = runJourneyAuditChecks(context, mockAuditChecks);
+        const audits = await runJourneyAuditChecks(context, mockAuditChecks);
 
         expect(audits).toHaveLength(0);
     });
 
-    it('should aggregate results from multiple failing checks', () => {
+    it('should aggregate results from multiple failing checks', async () => {
         const context = createContextWithJourney(undefined, validUuid);
 
         // Mock audit checks where some fail (return audit objects)
@@ -55,7 +55,7 @@ describe('runJourneyAuditChecks - Integration', () => {
             })
         };
 
-        const audits = runJourneyAuditChecks(context, mockAuditChecks);
+        const audits = await runJourneyAuditChecks(context, mockAuditChecks);
 
         expect(audits).toHaveLength(2);
         expect(audits.some((a) => a.errorCode === 'TEST_FAIL_1')).toBe(true);
@@ -63,12 +63,12 @@ describe('runJourneyAuditChecks - Integration', () => {
         expect(audits.some((a) => a.errorCode === 'TEST_PASS')).toBe(false);
     });
 
-    it('should handle empty audit checks object', () => {
+    it('should handle empty audit checks object', async () => {
         const context = createContextWithJourney();
 
         const mockAuditChecks: { [errorCode: string]: JourneyAuditCheckFunction } = {};
 
-        const audits = runJourneyAuditChecks(context, mockAuditChecks);
+        const audits = await runJourneyAuditChecks(context, mockAuditChecks);
 
         expect(audits).toHaveLength(0);
     });

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/PersonAuditChecks.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/PersonAuditChecks.test.ts
@@ -14,7 +14,7 @@ import { createContextWithPerson } from './person/testHelper';
 describe('runPersonAuditChecks - Integration', () => {
     const validUuid = uuidV4();
 
-    it('should run all audit checks and return empty array when all checks pass', () => {
+    it('should run all audit checks and return empty array when all checks pass', async () => {
         const context = createContextWithPerson();
 
         // Mock audit checks that all pass (return undefined)
@@ -24,12 +24,12 @@ describe('runPersonAuditChecks - Integration', () => {
             TEST_CHECK_3: () => undefined
         };
 
-        const audits = runPersonAuditChecks(context, mockAuditChecks);
+        const audits = await runPersonAuditChecks(context, mockAuditChecks);
 
         expect(audits).toHaveLength(0);
     });
 
-    it('should aggregate results from multiple failing checks', () => {
+    it('should aggregate results from multiple failing checks', async () => {
         const context = createContextWithPerson(undefined, validUuid);
 
         // Mock audit checks where some fail (return audit objects)
@@ -55,7 +55,7 @@ describe('runPersonAuditChecks - Integration', () => {
             })
         };
 
-        const audits = runPersonAuditChecks(context, mockAuditChecks);
+        const audits = await runPersonAuditChecks(context, mockAuditChecks);
 
         expect(audits).toHaveLength(2);
         expect(audits.some((a) => a.errorCode === 'TEST_FAIL_1')).toBe(true);
@@ -63,12 +63,12 @@ describe('runPersonAuditChecks - Integration', () => {
         expect(audits.some((a) => a.errorCode === 'TEST_PASS')).toBe(false);
     });
 
-    it('should handle empty audit checks object', () => {
+    it('should handle empty audit checks object', async () => {
         const context = createContextWithPerson();
 
         const mockAuditChecks: { [errorCode: string]: PersonAuditCheckFunction } = {};
 
-        const audits = runPersonAuditChecks(context, mockAuditChecks);
+        const audits = await runPersonAuditChecks(context, mockAuditChecks);
 
         expect(audits).toHaveLength(0);
     });

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/SegmentAuditChecks.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/SegmentAuditChecks.test.ts
@@ -14,7 +14,7 @@ import { createContextWithSegment } from './segment/testHelper';
 describe('runSegmentAuditChecks - Integration', () => {
     const validUuid = uuidV4();
 
-    it('should run all audit checks and return empty array when all checks pass', () => {
+    it('should run all audit checks and return empty array when all checks pass', async () => {
         const context = createContextWithSegment();
 
         // Mock audit checks that all pass (return undefined)
@@ -24,12 +24,12 @@ describe('runSegmentAuditChecks - Integration', () => {
             TEST_CHECK_3: () => undefined
         };
 
-        const audits = runSegmentAuditChecks(context, mockAuditChecks);
+        const audits = await runSegmentAuditChecks(context, mockAuditChecks);
 
         expect(audits).toHaveLength(0);
     });
 
-    it('should aggregate results from multiple failing checks', () => {
+    it('should aggregate results from multiple failing checks', async () => {
         const context = createContextWithSegment(undefined, validUuid);
 
         // Mock audit checks where some fail (return audit objects)
@@ -55,7 +55,7 @@ describe('runSegmentAuditChecks - Integration', () => {
             })
         };
 
-        const audits = runSegmentAuditChecks(context, mockAuditChecks);
+        const audits = await runSegmentAuditChecks(context, mockAuditChecks);
 
         expect(audits).toHaveLength(2);
         expect(audits.some((a) => a.errorCode === 'TEST_FAIL_1')).toBe(true);
@@ -63,12 +63,12 @@ describe('runSegmentAuditChecks - Integration', () => {
         expect(audits.some((a) => a.errorCode === 'TEST_PASS')).toBe(false);
     });
 
-    it('should handle empty audit checks object', () => {
+    it('should handle empty audit checks object', async () => {
         const context = createContextWithSegment();
 
         const mockAuditChecks: { [errorCode: string]: SegmentAuditCheckFunction } = {};
 
-        const audits = runSegmentAuditChecks(context, mockAuditChecks);
+        const audits = await runSegmentAuditChecks(context, mockAuditChecks);
 
         expect(audits).toHaveLength(0);
     });

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/TripAuditChecks.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/TripAuditChecks.test.ts
@@ -15,7 +15,7 @@ describe('runTripAuditChecks - Integration', () => {
     const validUuid = uuidV4();
 
 
-    it('should run all audit checks and return empty array when all checks pass', () => {
+    it('should run all audit checks and return empty array when all checks pass', async () => {
         const context = createContextWithTrip();
 
         // Mock audit checks that all pass (return undefined)
@@ -25,12 +25,12 @@ describe('runTripAuditChecks - Integration', () => {
             TEST_CHECK_3: () => undefined
         };
 
-        const audits = runTripAuditChecks(context, mockAuditChecks);
+        const audits = await runTripAuditChecks(context, mockAuditChecks);
 
         expect(audits).toHaveLength(0);
     });
 
-    it('should aggregate results from multiple failing checks', () => {
+    it('should aggregate results from multiple failing checks', async () => {
         const context = createContextWithTrip(undefined, validUuid);
 
         // Mock audit checks where some fail (return audit objects)
@@ -56,7 +56,7 @@ describe('runTripAuditChecks - Integration', () => {
             })
         };
 
-        const audits = runTripAuditChecks(context, mockAuditChecks);
+        const audits = await runTripAuditChecks(context, mockAuditChecks);
 
         expect(audits).toHaveLength(2);
         expect(audits.some((a) => a.errorCode === 'TEST_FAIL_1')).toBe(true);
@@ -64,13 +64,130 @@ describe('runTripAuditChecks - Integration', () => {
         expect(audits.some((a) => a.errorCode === 'TEST_PASS')).toBe(false);
     });
 
-    it('should handle empty audit checks object', () => {
+    it('should handle empty audit checks object', async () => {
         const context = createContextWithTrip();
 
         const mockAuditChecks: { [errorCode: string]: TripAuditCheckFunction } = {};
 
-        const audits = runTripAuditChecks(context, mockAuditChecks);
+        const audits = await runTripAuditChecks(context, mockAuditChecks);
 
         expect(audits).toHaveLength(0);
+    });
+
+    it('should handle async check functions that return Promise<AuditForObject>', async () => {
+        const context = createContextWithTrip(undefined, validUuid);
+
+        // Mock audit checks with async functions
+        const mockAuditChecks: { [errorCode: string]: TripAuditCheckFunction } = {
+            ASYNC_CHECK_1: async (): Promise<AuditForObject> => {
+                return Promise.resolve({
+                    objectType: 'trip',
+                    objectUuid: validUuid,
+                    errorCode: 'ASYNC_CHECK_1',
+                    version: 1,
+                    level: 'error',
+                    message: 'Async failure 1',
+                    ignore: false
+                });
+            },
+            ASYNC_CHECK_2: async (): Promise<AuditForObject | undefined> => {
+                return Promise.resolve({
+                    objectType: 'trip',
+                    objectUuid: validUuid,
+                    errorCode: 'ASYNC_CHECK_2',
+                    version: 1,
+                    level: 'warning',
+                    message: 'Async failure 2',
+                    ignore: false
+                });
+            },
+            ASYNC_PASS: async () => Promise.resolve(undefined)
+        };
+
+        const audits = await runTripAuditChecks(context, mockAuditChecks);
+
+        expect(audits).toHaveLength(2);
+        expect(audits.some((a) => a.errorCode === 'ASYNC_CHECK_1')).toBe(true);
+        expect(audits.some((a) => a.errorCode === 'ASYNC_CHECK_2')).toBe(true);
+        expect(audits.some((a) => a.errorCode === 'ASYNC_PASS')).toBe(false);
+    });
+
+    it('should reject when a check throws synchronously', async () => {
+        const context = createContextWithTrip(undefined, validUuid);
+
+        const mockAuditChecks: { [errorCode: string]: TripAuditCheckFunction } = {
+            PASSING_CHECK: (): AuditForObject => ({
+                objectType: 'trip',
+                objectUuid: validUuid,
+                errorCode: 'PASSING_CHECK',
+                version: 1,
+                level: 'error',
+                message: 'This should succeed',
+                ignore: false
+            }),
+            THROWING_CHECK: () => {
+                throw new Error('Synchronous error');
+            }
+        };
+
+        // Current implementation does not handle errors, so it will reject
+        await expect(runTripAuditChecks(context, mockAuditChecks)).rejects.toThrow('Synchronous error');
+    });
+
+    it('should reject when a check returns rejected Promise', async () => {
+        const context = createContextWithTrip(undefined, validUuid);
+
+        const mockAuditChecks: { [errorCode: string]: TripAuditCheckFunction } = {
+            PASSING_CHECK: (): AuditForObject => ({
+                objectType: 'trip',
+                objectUuid: validUuid,
+                errorCode: 'PASSING_CHECK',
+                version: 1,
+                level: 'error',
+                message: 'This should succeed',
+                ignore: false
+            }),
+            REJECTING_CHECK: async () => {
+                return Promise.reject(new Error('Async rejection'));
+            }
+        };
+
+        // Current implementation does not handle rejections, so it will reject
+        await expect(runTripAuditChecks(context, mockAuditChecks)).rejects.toThrow('Async rejection');
+    });
+
+    it('should handle mixed sync/async checks and reject on first error', async () => {
+        const context = createContextWithTrip(undefined, validUuid);
+
+        const mockAuditChecks: { [errorCode: string]: TripAuditCheckFunction } = {
+            SYNC_PASS: () => undefined,
+            SYNC_FAIL: (): AuditForObject => ({
+                objectType: 'trip',
+                objectUuid: validUuid,
+                errorCode: 'SYNC_FAIL',
+                version: 1,
+                level: 'error',
+                message: 'Sync failure',
+                ignore: false
+            }),
+            ASYNC_PASS: async () => Promise.resolve(undefined),
+            ASYNC_FAIL: async (): Promise<AuditForObject> => {
+                return Promise.resolve({
+                    objectType: 'trip',
+                    objectUuid: validUuid,
+                    errorCode: 'ASYNC_FAIL',
+                    version: 1,
+                    level: 'warning',
+                    message: 'Async failure',
+                    ignore: false
+                });
+            },
+            THROWING_CHECK: () => {
+                throw new Error('This check throws');
+            }
+        };
+
+        // Current implementation rejects on the throwing check
+        await expect(runTripAuditChecks(context, mockAuditChecks)).rejects.toThrow('This check throws');
     });
 });

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/home/HM_I_preGeographyAndHomeGeographyTooFarApartError.integration.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/home/HM_I_preGeographyAndHomeGeographyTooFarApartError.integration.test.ts
@@ -32,10 +32,12 @@ describe('HM_I_preGeographyAndHomeGeographyTooFarApartError audit check - Integr
         const result = homeAuditChecks.HM_I_preGeographyAndHomeGeographyTooFarApartError(context);
 
         expect(result).toBeDefined();
-        expect(result?.errorCode).toBe('HM_I_preGeographyAndHomeGeographyTooFarApartError');
-        expect(result?.level).toBe('error');
-        expect(result?.objectType).toBe('home');
-        expect(result?.objectUuid).toBe(validUuid);
+        expect(result).toMatchObject({
+            errorCode: 'HM_I_preGeographyAndHomeGeographyTooFarApartError',
+            level: 'error',
+            objectType: 'home',
+            objectUuid: validUuid
+        });
     });
 
     it('should pass when coordinates are close together (~7.8 meters)', () => {

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/home/HM_I_preGeographyAndHomeGeographyTooFarApartWarning.integration.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/home/HM_I_preGeographyAndHomeGeographyTooFarApartWarning.integration.test.ts
@@ -32,10 +32,12 @@ describe('HM_I_preGeographyAndHomeGeographyTooFarApartWarning audit check - Inte
         const result = homeAuditChecks.HM_I_preGeographyAndHomeGeographyTooFarApartWarning(context);
 
         expect(result).toBeDefined();
-        expect(result?.errorCode).toBe('HM_I_preGeographyAndHomeGeographyTooFarApartWarning');
-        expect(result?.level).toBe('warning');
-        expect(result?.objectType).toBe('home');
-        expect(result?.objectUuid).toBe(validUuid);
+        expect(result).toMatchObject({
+            errorCode: 'HM_I_preGeographyAndHomeGeographyTooFarApartWarning',
+            level: 'warning',
+            objectType: 'home',
+            objectUuid: validUuid
+        });
     });
 
     it('should pass when coordinates are very close together (~7.8 meters)', () => {


### PR DESCRIPTION
Audit check functions can now be async to support fetching data from external APIs for validation. This enables audit checks that need to query external services (e.g., address validation APIs, geocoding services, is point in water, etc.) to verify survey data.

Changes:
- Updated audit check function type signatures to support Promise returns
- Made all audit check runners async and await results
- Updated SurveyObjectAuditor to be async and await all runners
- Updated AuditService to await SurveyObjectAuditor
- Updated all test files to handle async audit checks

Backward compatible: existing synchronous audit checks continue to work without modification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Audit processing converted to fully asynchronous so object-level checks complete before audits are aggregated and reported; no public interfaces changed.
* **Tests**
  * Updated unit and integration tests to async/await; added coverage for async checks, mixed sync/async behavior, and error/rejection propagation; consolidated some assertions for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->