### PR TITLE
feat: Add extended audit checks system

### DIFF
--- a/packages/evolution-backend/src/services/audits/AuditService.ts
+++ b/packages/evolution-backend/src/services/audits/AuditService.ts
@@ -26,10 +26,18 @@ export class AuditService {
      * This function must be called before reviewing and after any change
      * in the corrected response during review process.
      * It must also be called if corrected response is reset from original response.
-     * @param interview - Interview attributes to audit
+     * The runExtendedAuditChecks parameter is used to control Whether to run extended audit checks.
+     * Some audit checks are special and would fetch data from external services or perform
+     * long or complex calculations. we do not want to run these checks on each audit
+     * call, especially during review, when any change to the data will refresh the audit checks.
+     * @param interviewAttributes - Interview attributes to audit
+     * @param runExtendedAuditChecks - whether to run extended audit checks
      * @returns Promise<SurveyObjectsWithAudits> - Complete audit results
      */
-    static async auditInterview(interviewAttributes: InterviewAttributes): Promise<SurveyObjectsWithAudits> {
+    static async auditInterview(
+        interviewAttributes: InterviewAttributes,
+        runExtendedAuditChecks: boolean = false
+    ): Promise<SurveyObjectsWithAudits> {
         console.log(`Starting audit workflow for interview ${interviewAttributes.uuid}`);
 
         // If the interview has no response or corrected response, return an empty survey objects with audits
@@ -71,7 +79,10 @@ export class AuditService {
 
         // Step 3: Run object audits
         console.log('Step 3: Running object audits...');
-        const objectAudits = await SurveyObjectAuditor.auditSurveyObjects(surveyObjectsWithAudits);
+        const objectAudits = await SurveyObjectAuditor.auditSurveyObjects(
+            surveyObjectsWithAudits,
+            runExtendedAuditChecks
+        );
         surveyObjectsWithAudits.audits.push(...objectAudits);
         surveyObjectsWithAudits.auditsByObject = auditsArrayToAuditsByObject(surveyObjectsWithAudits.audits);
 

--- a/packages/evolution-backend/src/services/audits/SurveyObjectAuditor.ts
+++ b/packages/evolution-backend/src/services/audits/SurveyObjectAuditor.ts
@@ -15,9 +15,16 @@ export class SurveyObjectAuditor {
     /**
      * Run audits on all survey objects
      * @param surveyObjectsWithAudits - Survey objects with audits
+     * @param runExtendedAuditChecks - Whether to run extended audit checks
+     * Some audit checks are special and would fetch data from external services or perform
+     * long or complex calculations. we do not want to run these checks on each audit
+     * call, especially during review, when any change to the data will refresh the audit checks.
      * @returns Promise resolving to array of audit objects
      */
-    static async auditSurveyObjects(surveyObjectsWithAudits: SurveyObjectsWithAudits): Promise<AuditForObject[]> {
+    static async auditSurveyObjects(
+        surveyObjectsWithAudits: SurveyObjectsWithAudits,
+        runExtendedAuditChecks: boolean = false
+    ): Promise<AuditForObject[]> {
         const allAudits: AuditForObject[] = [];
 
         // Run interview audit checks
@@ -27,7 +34,9 @@ export class SurveyObjectAuditor {
             };
             const interviewAudits = await auditChecks.runInterviewAuditChecks(
                 interviewContext,
-                auditChecks.interviewAuditChecks
+                runExtendedAuditChecks
+                    ? Object.assign({}, auditChecks.interviewAuditChecks, auditChecks.interviewExtendedAuditChecks)
+                    : auditChecks.interviewAuditChecks
             );
             allAudits.push(...interviewAudits);
         } else {
@@ -43,7 +52,9 @@ export class SurveyObjectAuditor {
             };
             const householdAudits = await auditChecks.runHouseholdAuditChecks(
                 householdContext,
-                auditChecks.householdAuditChecks
+                runExtendedAuditChecks
+                    ? Object.assign({}, auditChecks.householdAuditChecks, auditChecks.householdExtendedAuditChecks)
+                    : auditChecks.householdAuditChecks
             );
             allAudits.push(...householdAudits);
         }
@@ -55,7 +66,12 @@ export class SurveyObjectAuditor {
                 household: surveyObjectsWithAudits.household,
                 interview: surveyObjectsWithAudits.interview
             };
-            const homeAudits = await auditChecks.runHomeAuditChecks(homeContext, auditChecks.homeAuditChecks);
+            const homeAudits = await auditChecks.runHomeAuditChecks(
+                homeContext,
+                runExtendedAuditChecks
+                    ? Object.assign({}, auditChecks.homeAuditChecks, auditChecks.homeExtendedAuditChecks)
+                    : auditChecks.homeAuditChecks
+            );
             allAudits.push(...homeAudits);
         }
 
@@ -70,7 +86,9 @@ export class SurveyObjectAuditor {
                 };
                 const personAudits = await auditChecks.runPersonAuditChecks(
                     personContext,
-                    auditChecks.personAuditChecks
+                    runExtendedAuditChecks
+                        ? Object.assign({}, auditChecks.personAuditChecks, auditChecks.personExtendedAuditChecks)
+                        : auditChecks.personAuditChecks
                 );
                 allAudits.push(...personAudits);
 
@@ -86,7 +104,13 @@ export class SurveyObjectAuditor {
                         };
                         const journeyAudits = await auditChecks.runJourneyAuditChecks(
                             journeyContext,
-                            auditChecks.journeyAuditChecks
+                            runExtendedAuditChecks
+                                ? Object.assign(
+                                    {},
+                                    auditChecks.journeyAuditChecks,
+                                    auditChecks.journeyExtendedAuditChecks
+                                )
+                                : auditChecks.journeyAuditChecks
                         );
                         allAudits.push(...journeyAudits);
 
@@ -103,7 +127,13 @@ export class SurveyObjectAuditor {
                                 };
                                 const visitedPlaceAudits = await auditChecks.runVisitedPlaceAuditChecks(
                                     visitedPlaceContext,
-                                    auditChecks.visitedPlaceAuditChecks
+                                    runExtendedAuditChecks
+                                        ? Object.assign(
+                                            {},
+                                            auditChecks.visitedPlaceAuditChecks,
+                                            auditChecks.visitedPlaceExtendedAuditChecks
+                                        )
+                                        : auditChecks.visitedPlaceAuditChecks
                                 );
                                 allAudits.push(...visitedPlaceAudits);
                             }
@@ -122,7 +152,13 @@ export class SurveyObjectAuditor {
                                 };
                                 const tripAudits = await auditChecks.runTripAuditChecks(
                                     tripContext,
-                                    auditChecks.tripAuditChecks
+                                    runExtendedAuditChecks
+                                        ? Object.assign(
+                                            {},
+                                            auditChecks.tripAuditChecks,
+                                            auditChecks.tripExtendedAuditChecks
+                                        )
+                                        : auditChecks.tripAuditChecks
                                 );
                                 allAudits.push(...tripAudits);
 
@@ -140,7 +176,13 @@ export class SurveyObjectAuditor {
                                         };
                                         const segmentAudits = await auditChecks.runSegmentAuditChecks(
                                             segmentContext,
-                                            auditChecks.segmentAuditChecks
+                                            runExtendedAuditChecks
+                                                ? Object.assign(
+                                                    {},
+                                                    auditChecks.segmentAuditChecks,
+                                                    auditChecks.segmentExtendedAuditChecks
+                                                )
+                                                : auditChecks.segmentAuditChecks
                                         );
                                         allAudits.push(...segmentAudits);
                                     }

--- a/packages/evolution-backend/src/services/audits/SurveyObjectsAndAuditsFactory.ts
+++ b/packages/evolution-backend/src/services/audits/SurveyObjectsAndAuditsFactory.ts
@@ -27,10 +27,15 @@ export class SurveyObjectsAndAuditsFactory {
     /**
      * Create survey objects and audits for an interview then save audits to db
      * @param {InterviewAttributes} interview - The interview to create survey objects and audits for
+     * @param {boolean} runExtendedAuditChecks - Whether to run extended audit checks
+     * Some audit checks are special and would fetch data from external services or perform
+     * long or complex calculations. we do not want to run these checks on each audit
+     * call, especially during review, when any change to the data will refresh the audit checks.
      * @returns {Promise<SurveyObjectsWithAudits>} A promise that resolves with the survey objects and audits
      */
     static createSurveyObjectsAndSaveAuditsToDb = async (
-        interview: InterviewAttributes
+        interview: InterviewAttributes,
+        runExtendedAuditChecks: boolean = false
     ): Promise<SurveyObjectsWithAudits> => {
         /**
          * corrected_response is required to create survey objects and audits.
@@ -42,7 +47,7 @@ export class SurveyObjectsAndAuditsFactory {
         }
 
         // Create survey objects, check errors and get audits:
-        const surveyObjectsWithAudits = await AuditService.auditInterview(interview);
+        const surveyObjectsWithAudits = await AuditService.auditInterview(interview, runExtendedAuditChecks);
 
         // Save audits to database and return updated structure
         const newAudits = await auditsDbQueries.setAuditsForInterview(interview.id, surveyObjectsWithAudits.audits);

--- a/packages/evolution-backend/src/services/audits/__tests__/AuditService.test.ts
+++ b/packages/evolution-backend/src/services/audits/__tests__/AuditService.test.ts
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { v4 as uuidV4 } from 'uuid';
+import { AuditService } from '../AuditService';
+import { SurveyObjectAuditor } from '../SurveyObjectAuditor';
+import { SurveyObjectsFactory } from '../../surveyObjects/SurveyObjectsFactory';
+import { InterviewAttributes } from 'evolution-common/lib/services/questionnaire/types';
+
+// Mock the dependencies
+jest.mock('../SurveyObjectAuditor');
+jest.mock('../../surveyObjects/SurveyObjectsFactory');
+
+describe('AuditService', () => {
+    const mockInterviewUuid = uuidV4();
+    const mockHouseholdUuid = uuidV4();
+    const mockHomeUuid = uuidV4();
+
+    const createMockInterview = (): InterviewAttributes => ({
+        id: 123,
+        uuid: mockInterviewUuid,
+        participant_id: 456,
+        is_valid: false,
+        is_completed: false,
+        response: {
+            _uuid: mockInterviewUuid,
+            household: {
+                _uuid: mockHouseholdUuid,
+                size: 2
+            }
+        },
+        corrected_response: {
+            _uuid: mockInterviewUuid,
+            household: {
+                _uuid: mockHouseholdUuid,
+                size: 2
+            }
+        },
+        validations: {},
+        logs: []
+    } as InterviewAttributes);
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        // Setup default mock implementations
+        (SurveyObjectsFactory.prototype.createAllObjectsWithErrors as jest.Mock) = jest
+            .fn()
+            .mockResolvedValue({
+                interview: { _uuid: mockInterviewUuid },
+                household: { _uuid: mockHouseholdUuid },
+                home: { _uuid: mockHomeUuid },
+                errorsByObject: {
+                    interviewUuid: mockInterviewUuid,
+                    householdUuid: mockHouseholdUuid,
+                    homeUuid: mockHomeUuid,
+                    interview: [],
+                    household: [],
+                    home: [],
+                    personsByUuid: {},
+                    journeysByUuid: {},
+                    visitedPlacesByUuid: {},
+                    tripsByUuid: {},
+                    segmentsByUuid: {}
+                }
+            });
+
+        (SurveyObjectAuditor.auditSurveyObjects as jest.Mock) = jest.fn().mockResolvedValue([
+            {
+                objectType: 'interview',
+                objectUuid: mockInterviewUuid,
+                errorCode: 'TEST_AUDIT',
+                version: 1,
+                level: 'warning',
+                message: 'Test audit',
+                ignore: false
+            }
+        ]);
+    });
+
+    describe('auditInterview', () => {
+        it('should return empty survey objects when interview has no response', async () => {
+            const interview = createMockInterview();
+            interview.response = undefined as any;
+
+            const result = await AuditService.auditInterview(interview);
+
+            expect(result).toEqual({
+                audits: [],
+                interview: undefined,
+                household: undefined,
+                home: undefined
+            });
+            expect(SurveyObjectsFactory.prototype.createAllObjectsWithErrors).not.toHaveBeenCalled();
+            expect(SurveyObjectAuditor.auditSurveyObjects).not.toHaveBeenCalled();
+        });
+
+        it('should return empty survey objects when interview has no corrected response', async () => {
+            const interview = createMockInterview();
+            interview.corrected_response = undefined as any;
+
+            const result = await AuditService.auditInterview(interview);
+
+            expect(result).toEqual({
+                audits: [],
+                interview: undefined,
+                household: undefined,
+                home: undefined
+            });
+            expect(SurveyObjectsFactory.prototype.createAllObjectsWithErrors).not.toHaveBeenCalled();
+            expect(SurveyObjectAuditor.auditSurveyObjects).not.toHaveBeenCalled();
+        });
+
+        it('should pass runExtendedAuditChecks=false by default to SurveyObjectAuditor', async () => {
+            const interview = createMockInterview();
+
+            await AuditService.auditInterview(interview);
+
+            expect(SurveyObjectAuditor.auditSurveyObjects).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    interview: expect.any(Object),
+                    household: expect.any(Object),
+                    home: expect.any(Object)
+                }),
+                false
+            );
+        });
+
+        it('should pass runExtendedAuditChecks=true to SurveyObjectAuditor when flag is true', async () => {
+            const interview = createMockInterview();
+
+            await AuditService.auditInterview(interview, true);
+
+            expect(SurveyObjectAuditor.auditSurveyObjects).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    interview: expect.any(Object),
+                    household: expect.any(Object),
+                    home: expect.any(Object)
+                }),
+                true
+            );
+        });
+
+        it('should pass runExtendedAuditChecks=false to SurveyObjectAuditor when flag is false', async () => {
+            const interview = createMockInterview();
+
+            await AuditService.auditInterview(interview, false);
+
+            expect(SurveyObjectAuditor.auditSurveyObjects).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    interview: expect.any(Object),
+                    household: expect.any(Object),
+                    home: expect.any(Object)
+                }),
+                false
+            );
+        });
+
+        it('should create survey objects and run audits', async () => {
+            const interview = createMockInterview();
+
+            const result = await AuditService.auditInterview(interview);
+
+            expect(SurveyObjectsFactory.prototype.createAllObjectsWithErrors).toHaveBeenCalledWith(interview);
+            expect(SurveyObjectAuditor.auditSurveyObjects).toHaveBeenCalled();
+            expect(result.audits).toHaveLength(1);
+            expect(result.audits[0].errorCode).toBe('TEST_AUDIT');
+        });
+
+        it('should aggregate audits from parameter errors and object audits', async () => {
+            const interview = createMockInterview();
+
+            // Mock parameter errors
+            (SurveyObjectsFactory.prototype.createAllObjectsWithErrors as jest.Mock).mockResolvedValue({
+                interview: { _uuid: mockInterviewUuid },
+                household: { _uuid: mockHouseholdUuid },
+                home: { _uuid: mockHomeUuid },
+                errorsByObject: {
+                    interviewUuid: mockInterviewUuid,
+                    householdUuid: mockHouseholdUuid,
+                    homeUuid: mockHomeUuid,
+                    interview: [
+                        {
+                            path: 'test.path',
+                            message: 'Parameter error'
+                        }
+                    ],
+                    household: [],
+                    home: [],
+                    personsByUuid: {},
+                    journeysByUuid: {},
+                    visitedPlacesByUuid: {},
+                    tripsByUuid: {},
+                    segmentsByUuid: {}
+                }
+            });
+
+            const result = await AuditService.auditInterview(interview, false);
+
+            // Should have both parameter error audit and object audit
+            expect(result.audits.length).toBeGreaterThanOrEqual(2);
+            expect(result.audits.some((a) => a.errorCode === 'TEST_AUDIT')).toBe(true);
+            expect(result.audits.some((a) => a.objectType === 'interview' && a.errorCode !== 'TEST_AUDIT')).toBe(true);
+        });
+    });
+});
+

--- a/packages/evolution-backend/src/services/audits/__tests__/Audits.test.ts
+++ b/packages/evolution-backend/src/services/audits/__tests__/Audits.test.ts
@@ -140,7 +140,7 @@ describe('createSurveyObjectsAndSaveAuditsToDb', () => {
 
         // Should call AuditService
         expect(mockAuditInterview).toHaveBeenCalledTimes(1);
-        expect(mockAuditInterview).toHaveBeenCalledWith(interviewAttributes);
+        expect(mockAuditInterview).toHaveBeenCalledWith(interviewAttributes, false);
 
         // Should return the audits from AuditService
         expect(objectsAndAudits.audits).toEqual(mockAuditsFromService);

--- a/packages/evolution-backend/src/services/audits/__tests__/SurveyObjectAuditor.test.ts
+++ b/packages/evolution-backend/src/services/audits/__tests__/SurveyObjectAuditor.test.ts
@@ -20,66 +20,81 @@ import {
     runHomeAuditChecks,
     runVisitedPlaceAuditChecks
 } from '../auditChecks';
+import { Interview } from 'evolution-common/lib/services/baseObjects/interview/Interview';
 
 // Mock the audit functions
-jest.mock('../auditChecks', () => ({
-    runInterviewAuditChecks: jest.fn().mockResolvedValue([
-        {
-            objectType: 'interview',
-            objectUuid: 'interview-uuid',
-            errorCode: 'I_L_InterviewAudited',
-            level: 'info',
-            message: 'Interview audited',
-            version: 1,
-            ignore: false
-        }
-    ]),
-    runHouseholdAuditChecks: jest.fn().mockResolvedValue([
-        {
-            objectType: 'household',
-            objectUuid: 'household-uuid',
-            errorCode: 'HH_I_Size',
-            level: 'error',
-            message: 'Invalid household size',
-            version: 1,
-            ignore: false
-        }
-    ]),
-    runHomeAuditChecks: jest.fn().mockResolvedValue([
-        {
-            objectType: 'home',
-            objectUuid: 'home-uuid',
-            errorCode: 'HM_I_Address',
-            level: 'warning',
-            message: 'Invalid home address',
-            version: 1,
-            ignore: false
-        }
-    ]),
-    runPersonAuditChecks: jest.fn().mockResolvedValue([]),
-    runJourneyAuditChecks: jest.fn().mockResolvedValue([]),
-    runVisitedPlaceAuditChecks: jest.fn().mockResolvedValue([
-        {
-            objectType: 'visitedPlace',
-            objectUuid: 'visitedplace-uuid',
-            errorCode: 'VP_M_Geography',
-            level: 'warning',
-            message: 'Missing geography',
-            version: 1,
-            ignore: false
-        }
-    ]),
-    runTripAuditChecks: jest.fn().mockResolvedValue([]),
-    runSegmentAuditChecks: jest.fn().mockResolvedValue([]),
-    interviewAuditChecks: {},
-    householdAuditChecks: {},
-    homeAuditChecks: {},
-    personAuditChecks: {},
-    journeyAuditChecks: {},
-    visitedPlaceAuditChecks: {},
-    tripAuditChecks: {},
-    segmentAuditChecks: {}
-}));
+jest.mock('../auditChecks', () => {
+    // Create mock functions inside the factory to avoid hoisting issues
+    const mockNormalCheck = jest.fn();
+    const mockExtendedCheck = jest.fn();
+
+    return {
+        runInterviewAuditChecks: jest.fn().mockResolvedValue([
+            {
+                objectType: 'interview',
+                objectUuid: 'interview-uuid',
+                errorCode: 'I_L_InterviewAudited',
+                level: 'info',
+                message: 'Interview audited',
+                version: 1,
+                ignore: false
+            }
+        ]),
+        runHouseholdAuditChecks: jest.fn().mockResolvedValue([
+            {
+                objectType: 'household',
+                objectUuid: 'household-uuid',
+                errorCode: 'HH_I_Size',
+                level: 'error',
+                message: 'Invalid household size',
+                version: 1,
+                ignore: false
+            }
+        ]),
+        runHomeAuditChecks: jest.fn().mockResolvedValue([
+            {
+                objectType: 'home',
+                objectUuid: 'home-uuid',
+                errorCode: 'HM_I_Address',
+                level: 'warning',
+                message: 'Invalid home address',
+                version: 1,
+                ignore: false
+            }
+        ]),
+        runPersonAuditChecks: jest.fn().mockResolvedValue([]),
+        runJourneyAuditChecks: jest.fn().mockResolvedValue([]),
+        runVisitedPlaceAuditChecks: jest.fn().mockResolvedValue([
+            {
+                objectType: 'visitedPlace',
+                objectUuid: 'visitedplace-uuid',
+                errorCode: 'VP_M_Geography',
+                level: 'warning',
+                message: 'Missing geography',
+                version: 1,
+                ignore: false
+            }
+        ]),
+        runTripAuditChecks: jest.fn().mockResolvedValue([]),
+        runSegmentAuditChecks: jest.fn().mockResolvedValue([]),
+        interviewAuditChecks: { normalCheck: mockNormalCheck },
+        householdAuditChecks: { normalCheck: mockNormalCheck },
+        homeAuditChecks: { normalCheck: mockNormalCheck },
+        personAuditChecks: { normalCheck: mockNormalCheck },
+        journeyAuditChecks: { normalCheck: mockNormalCheck },
+        visitedPlaceAuditChecks: { normalCheck: mockNormalCheck },
+        tripAuditChecks: { normalCheck: mockNormalCheck },
+        segmentAuditChecks: { normalCheck: mockNormalCheck },
+        interviewExtendedAuditChecks: { extendedCheck: mockExtendedCheck },
+        householdExtendedAuditChecks: { extendedCheck: mockExtendedCheck },
+        homeExtendedAuditChecks: { extendedCheck: mockExtendedCheck },
+        personExtendedAuditChecks: { extendedCheck: mockExtendedCheck },
+        journeyExtendedAuditChecks: { extendedCheck: mockExtendedCheck },
+        visitedPlaceExtendedAuditChecks: { extendedCheck: mockExtendedCheck },
+        tripExtendedAuditChecks: { extendedCheck: mockExtendedCheck },
+        segmentExtendedAuditChecks: { extendedCheck: mockExtendedCheck }
+    };
+});
 
 
 describe('SurveyObjectAuditor', () => {
@@ -91,7 +106,7 @@ describe('SurveyObjectAuditor', () => {
     const tripUuid = uuidV4();
 
     const createMockSurveyObjects = (): SurveyObjectsWithAudits => {
-        const mockInterview = { _uuid: interviewUuid, _id: 123 };
+        const mockInterview = { _uuid: interviewUuid, _id: 123 } as unknown as Interview;
         const mockHome = { _uuid: 'home-uuid' } as Home;
         const mockHousehold = { _uuid: householdUuid, size: 2, members: [] } as unknown as Household;
 
@@ -122,7 +137,7 @@ describe('SurveyObjectAuditor', () => {
         mockHousehold.members = [mockPerson];
 
         return {
-            interview: mockInterview as any,
+            interview: mockInterview as unknown as Interview,
             home: mockHome,
             household: mockHousehold,
             audits: []
@@ -139,9 +154,12 @@ describe('SurveyObjectAuditor', () => {
 
             const audits = await SurveyObjectAuditor.auditSurveyObjects(surveyObjects);
 
-            expect(runInterviewAuditChecks).toHaveBeenCalledWith({
-                interview: surveyObjects.interview
-            }, expect.any(Object));
+            expect(runInterviewAuditChecks).toHaveBeenCalledWith(
+                {
+                    interview: surveyObjects.interview
+                },
+                expect.any(Object)
+            );
 
             expect(audits).toContainEqual({
                 objectType: 'interview',
@@ -159,10 +177,13 @@ describe('SurveyObjectAuditor', () => {
 
             const audits = await SurveyObjectAuditor.auditSurveyObjects(surveyObjects);
 
-            expect(runHouseholdAuditChecks).toHaveBeenCalledWith({
-                household: surveyObjects.household,
-                interview: surveyObjects.interview
-            }, expect.any(Object));
+            expect(runHouseholdAuditChecks).toHaveBeenCalledWith(
+                {
+                    household: surveyObjects.household,
+                    interview: surveyObjects.interview
+                },
+                expect.any(Object)
+            );
 
             expect(audits).toContainEqual({
                 objectType: 'household',
@@ -180,11 +201,14 @@ describe('SurveyObjectAuditor', () => {
 
             const audits = await SurveyObjectAuditor.auditSurveyObjects(surveyObjects);
 
-            expect(runHomeAuditChecks).toHaveBeenCalledWith({
-                home: surveyObjects.home,
-                household: surveyObjects.household,
-                interview: surveyObjects.interview
-            }, expect.any(Object));
+            expect(runHomeAuditChecks).toHaveBeenCalledWith(
+                {
+                    home: surveyObjects.home,
+                    household: surveyObjects.household,
+                    interview: surveyObjects.interview
+                },
+                expect.any(Object)
+            );
 
             expect(audits).toContainEqual({
                 objectType: 'home',
@@ -202,14 +226,17 @@ describe('SurveyObjectAuditor', () => {
 
             const audits = await SurveyObjectAuditor.auditSurveyObjects(surveyObjects);
 
-            expect(runVisitedPlaceAuditChecks).toHaveBeenCalledWith({
-                visitedPlace: surveyObjects.household?.members?.[0]?.journeys?.[0]?.visitedPlaces?.[0],
-                person: surveyObjects.household?.members?.[0],
-                journey: surveyObjects.household?.members?.[0]?.journeys?.[0],
-                household: surveyObjects.household,
-                home: surveyObjects.home,
-                interview: surveyObjects.interview
-            }, expect.any(Object));
+            expect(runVisitedPlaceAuditChecks).toHaveBeenCalledWith(
+                {
+                    visitedPlace: surveyObjects.household?.members?.[0]?.journeys?.[0]?.visitedPlaces?.[0],
+                    person: surveyObjects.household?.members?.[0],
+                    journey: surveyObjects.household?.members?.[0]?.journeys?.[0],
+                    household: surveyObjects.household,
+                    home: surveyObjects.home,
+                    interview: surveyObjects.interview
+                },
+                expect.any(Object)
+            );
 
             expect(audits).toContainEqual({
                 objectType: 'visitedPlace',
@@ -308,6 +335,65 @@ describe('SurveyObjectAuditor', () => {
             expect(objectTypes).toContain('household');
             expect(objectTypes).toContain('home');
             expect(objectTypes).toContain('visitedPlace');
+        });
+
+        describe('Extended Audit Checks Flag', () => {
+            it('should pass only normal checks when runExtendedAuditChecks=false by default', async () => {
+                const surveyObjects = createMockSurveyObjects();
+
+                await SurveyObjectAuditor.auditSurveyObjects(surveyObjects);
+
+                // Verify that only normal checks are passed (no extended checks)
+                const interviewChecks = (runInterviewAuditChecks as jest.Mock).mock.calls[0][1];
+                expect(interviewChecks).toHaveProperty('normalCheck');
+                expect(interviewChecks).not.toHaveProperty('extendedCheck');
+
+                const householdChecks = (runHouseholdAuditChecks as jest.Mock).mock.calls[0][1];
+                expect(householdChecks).toHaveProperty('normalCheck');
+                expect(householdChecks).not.toHaveProperty('extendedCheck');
+
+                const homeChecks = (runHomeAuditChecks as jest.Mock).mock.calls[0][1];
+                expect(homeChecks).toHaveProperty('normalCheck');
+                expect(homeChecks).not.toHaveProperty('extendedCheck');
+            });
+
+            it('should pass both normal and extended checks when runExtendedAuditChecks=true', async () => {
+                const surveyObjects = createMockSurveyObjects();
+
+                await SurveyObjectAuditor.auditSurveyObjects(surveyObjects, true);
+
+                // Verify that both normal and extended checks are passed
+                const interviewChecks = (runInterviewAuditChecks as jest.Mock).mock.calls[0][1];
+                expect(interviewChecks).toHaveProperty('normalCheck');
+                expect(interviewChecks).toHaveProperty('extendedCheck');
+
+                const householdChecks = (runHouseholdAuditChecks as jest.Mock).mock.calls[0][1];
+                expect(householdChecks).toHaveProperty('normalCheck');
+                expect(householdChecks).toHaveProperty('extendedCheck');
+
+                const homeChecks = (runHomeAuditChecks as jest.Mock).mock.calls[0][1];
+                expect(homeChecks).toHaveProperty('normalCheck');
+                expect(homeChecks).toHaveProperty('extendedCheck');
+
+                const visitedPlaceChecks = (runVisitedPlaceAuditChecks as jest.Mock).mock.calls[0][1];
+                expect(visitedPlaceChecks).toHaveProperty('normalCheck');
+                expect(visitedPlaceChecks).toHaveProperty('extendedCheck');
+            });
+
+            it('should pass only normal checks when runExtendedAuditChecks=false explicitly', async () => {
+                const surveyObjects = createMockSurveyObjects();
+
+                await SurveyObjectAuditor.auditSurveyObjects(surveyObjects, false);
+
+                // Verify that only normal checks are passed (no extended checks)
+                const interviewChecks = (runInterviewAuditChecks as jest.Mock).mock.calls[0][1];
+                expect(interviewChecks).toHaveProperty('normalCheck');
+                expect(interviewChecks).not.toHaveProperty('extendedCheck');
+
+                const householdChecks = (runHouseholdAuditChecks as jest.Mock).mock.calls[0][1];
+                expect(householdChecks).toHaveProperty('normalCheck');
+                expect(householdChecks).not.toHaveProperty('extendedCheck');
+            });
         });
     });
 });

--- a/packages/evolution-backend/src/services/audits/__tests__/SurveyObjectsAndAuditsFactory.test.ts
+++ b/packages/evolution-backend/src/services/audits/__tests__/SurveyObjectsAndAuditsFactory.test.ts
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { v4 as uuidV4 } from 'uuid';
+import { SurveyObjectsAndAuditsFactory } from '../SurveyObjectsAndAuditsFactory';
+import { AuditService } from '../AuditService';
+import auditsDbQueries from '../../../models/audits.db.queries';
+import { InterviewAttributes } from 'evolution-common/lib/services/questionnaire/types';
+
+// Mock the dependencies
+jest.mock('../AuditService');
+jest.mock('../../../models/audits.db.queries');
+
+describe('SurveyObjectsAndAuditsFactory', () => {
+    const mockInterviewUuid = uuidV4();
+    const mockHouseholdUuid = uuidV4();
+
+    const createMockInterview = (): InterviewAttributes => ({
+        id: 123,
+        uuid: mockInterviewUuid,
+        participant_id: 456,
+        is_valid: false,
+        is_completed: false,
+        response: {
+            _uuid: mockInterviewUuid,
+            household: {
+                _uuid: mockHouseholdUuid,
+                size: 2
+            }
+        },
+        corrected_response: {
+            _uuid: mockInterviewUuid,
+            household: {
+                _uuid: mockHouseholdUuid,
+                size: 2
+            }
+        },
+        validations: {},
+        logs: []
+    } as InterviewAttributes);
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        // Setup default mock implementations
+        (AuditService.auditInterview as jest.Mock).mockResolvedValue({
+            interview: { _uuid: mockInterviewUuid },
+            household: { _uuid: mockHouseholdUuid },
+            home: { _uuid: 'home-uuid' },
+            audits: [
+                {
+                    objectType: 'interview',
+                    objectUuid: mockInterviewUuid,
+                    errorCode: 'TEST_AUDIT',
+                    version: 1,
+                    level: 'warning',
+                    message: 'Test audit',
+                    ignore: false
+                }
+            ],
+            auditsByObject: {
+                interview: [],
+                household: [],
+                home: [],
+                persons: {},
+                journeys: {},
+                visitedPlaces: {},
+                trips: {},
+                segments: {}
+            }
+        });
+
+        (auditsDbQueries.setAuditsForInterview as jest.Mock).mockResolvedValue([
+            {
+                objectType: 'interview',
+                objectUuid: mockInterviewUuid,
+                errorCode: 'TEST_AUDIT',
+                version: 1,
+                level: 'warning',
+                message: 'Test audit',
+                ignore: false
+            }
+        ]);
+    });
+
+    describe('createSurveyObjectsAndSaveAuditsToDb', () => {
+        it('should throw error when corrected_response is missing', async () => {
+            const interview = createMockInterview();
+            interview.corrected_response = undefined as any;
+
+            await expect(
+                SurveyObjectsAndAuditsFactory.createSurveyObjectsAndSaveAuditsToDb(interview)
+            ).rejects.toThrow('Corrected response is required to create survey objects and audits');
+
+            expect(AuditService.auditInterview).not.toHaveBeenCalled();
+        });
+
+        it('should pass runExtendedAuditChecks=false by default to AuditService', async () => {
+            const interview = createMockInterview();
+
+            await SurveyObjectsAndAuditsFactory.createSurveyObjectsAndSaveAuditsToDb(interview);
+
+            expect(AuditService.auditInterview).toHaveBeenCalledWith(interview, false);
+        });
+
+        it('should pass runExtendedAuditChecks=true to AuditService when flag is true', async () => {
+            const interview = createMockInterview();
+
+            await SurveyObjectsAndAuditsFactory.createSurveyObjectsAndSaveAuditsToDb(interview, true);
+
+            expect(AuditService.auditInterview).toHaveBeenCalledWith(interview, true);
+        });
+
+        it('should pass runExtendedAuditChecks=false to AuditService when flag is false', async () => {
+            const interview = createMockInterview();
+
+            await SurveyObjectsAndAuditsFactory.createSurveyObjectsAndSaveAuditsToDb(interview, false);
+
+            expect(AuditService.auditInterview).toHaveBeenCalledWith(interview, false);
+        });
+
+        it('should create survey objects and save audits to database', async () => {
+            const interview = createMockInterview();
+
+            const result = await SurveyObjectsAndAuditsFactory.createSurveyObjectsAndSaveAuditsToDb(interview);
+
+            expect(AuditService.auditInterview).toHaveBeenCalledWith(interview, false);
+            expect(auditsDbQueries.setAuditsForInterview).toHaveBeenCalledWith(
+                interview.id,
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        errorCode: 'TEST_AUDIT'
+                    })
+                ])
+            );
+            expect(result.audits).toHaveLength(1);
+        });
+
+        it('should update auditsByObject after saving audits', async () => {
+            const interview = createMockInterview();
+
+            const result = await SurveyObjectsAndAuditsFactory.createSurveyObjectsAndSaveAuditsToDb(interview, true);
+
+            expect(result.auditsByObject).toBeDefined();
+            expect(result.audits).toHaveLength(1);
+        });
+    });
+});
+

--- a/packages/evolution-backend/src/services/audits/auditChecks/AuditCheckRunners.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/AuditCheckRunners.ts
@@ -23,7 +23,6 @@ export const runInterviewAuditChecks = async (
             audits.push(auditResult);
         }
     }
-
     return audits;
 };
 
@@ -42,7 +41,6 @@ export const runHouseholdAuditChecks = async (
             audits.push(auditResult);
         }
     }
-
     return audits;
 };
 
@@ -61,7 +59,6 @@ export const runHomeAuditChecks = async (
             audits.push(auditResult);
         }
     }
-
     return audits;
 };
 
@@ -80,7 +77,6 @@ export const runPersonAuditChecks = async (
             audits.push(auditResult);
         }
     }
-
     return audits;
 };
 
@@ -99,7 +95,6 @@ export const runJourneyAuditChecks = async (
             audits.push(auditResult);
         }
     }
-
     return audits;
 };
 
@@ -118,7 +113,6 @@ export const runVisitedPlaceAuditChecks = async (
             audits.push(auditResult);
         }
     }
-
     return audits;
 };
 
@@ -137,7 +131,6 @@ export const runTripAuditChecks = async (
             audits.push(auditResult);
         }
     }
-
     return audits;
 };
 
@@ -156,6 +149,5 @@ export const runSegmentAuditChecks = async (
             audits.push(auditResult);
         }
     }
-
     return audits;
 };

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/HomeExtendedAuditChecks.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/HomeExtendedAuditChecks.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import type { HomeAuditCheckFunction } from '../AuditCheckContexts';
+
+export const homeExtendedAuditChecks: { [errorCode: string]: HomeAuditCheckFunction } = {};

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/HouseholdExtendedAuditChecks.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/HouseholdExtendedAuditChecks.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import type { HouseholdAuditCheckFunction } from '../AuditCheckContexts';
+
+export const householdExtendedAuditChecks: { [errorCode: string]: HouseholdAuditCheckFunction } = {};

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/InterviewExtendedAuditChecks.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/InterviewExtendedAuditChecks.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import type { InterviewAuditCheckFunction } from '../AuditCheckContexts';
+
+export const interviewExtendedAuditChecks: { [errorCode: string]: InterviewAuditCheckFunction } = {};

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/JourneyExtendedAuditChecks.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/JourneyExtendedAuditChecks.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import type { JourneyAuditCheckFunction } from '../AuditCheckContexts';
+
+export const journeyExtendedAuditChecks: { [errorCode: string]: JourneyAuditCheckFunction } = {};

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/PersonExtendedAuditChecks.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/PersonExtendedAuditChecks.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import type { PersonAuditCheckFunction } from '../AuditCheckContexts';
+
+export const personExtendedAuditChecks: { [errorCode: string]: PersonAuditCheckFunction } = {};

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/SegmentExtendedAuditChecks.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/SegmentExtendedAuditChecks.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import type { SegmentAuditCheckFunction } from '../AuditCheckContexts';
+
+export const segmentExtendedAuditChecks: { [errorCode: string]: SegmentAuditCheckFunction } = {};

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/TripExtendedAuditChecks.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/TripExtendedAuditChecks.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import type { TripAuditCheckFunction } from '../AuditCheckContexts';
+
+export const tripExtendedAuditChecks: { [errorCode: string]: TripAuditCheckFunction } = {};

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/VisitedPlaceExtendedAuditChecks.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/VisitedPlaceExtendedAuditChecks.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import type { VisitedPlaceAuditCheckFunction } from '../AuditCheckContexts';
+
+export const visitedPlaceExtendedAuditChecks: { [errorCode: string]: VisitedPlaceAuditCheckFunction } = {};

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/VisitedPlaceAuditChecks.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/VisitedPlaceAuditChecks.test.ts
@@ -153,5 +153,4 @@ describe('runVisitedPlaceAuditChecks - Integration', () => {
 
         await expect(runVisitedPlaceAuditChecks(context, mockAuditChecks)).rejects.toThrow('Async check rejected');
     });
-
 });

--- a/packages/evolution-backend/src/services/audits/auditChecks/index.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/index.ts
@@ -11,10 +11,18 @@ export * from './AuditCheckRunners';
 
 // Export all audit check functions
 export * from './checks/InterviewAuditChecks';
+export * from './checks/InterviewExtendedAuditChecks';
 export * from './checks/HouseholdAuditChecks';
+export * from './checks/HouseholdExtendedAuditChecks';
 export * from './checks/HomeAuditChecks';
+export * from './checks/HomeExtendedAuditChecks';
 export * from './checks/PersonAuditChecks';
+export * from './checks/PersonExtendedAuditChecks';
 export * from './checks/JourneyAuditChecks';
+export * from './checks/JourneyExtendedAuditChecks';
 export * from './checks/VisitedPlaceAuditChecks';
+export * from './checks/VisitedPlaceExtendedAuditChecks';
 export * from './checks/TripAuditChecks';
+export * from './checks/TripExtendedAuditChecks';
 export * from './checks/SegmentAuditChecks';
+export * from './checks/SegmentExtendedAuditChecks';


### PR DESCRIPTION
Implement a conditional audit system that allows expensive or async audit checks to run separately from regular audits. This prevents performance issues during interview review while enabling comprehensive validation when needed.

Backend Changes:
- Add extendedAuditChecks parameter to all audit check runners (Interview, Household, Home, Person, Journey, Trip, VisitedPlace, Segment)
- Add runExtendedAuditChecks boolean flag to conditionally execute extended checks
- Create placeholder ExtendedAuditChecks files for all survey object types
- Update AuditService to pass runExtendedAuditChecks through audit pipeline
- Update SurveyObjectAuditor to route extended checks separately
- Add runExtendedAuditChecks query parameter support in survey validation API
- Optimize await logic: only await when result is actually a Promise

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional extended audit checks feature enabling more comprehensive audit validation when activated.

* **Tests**
  * Added comprehensive test coverage for extended audit checks across all audit object types.

* **Refactor**
  * Renamed and enhanced audit method signature to support optional audit check selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->