### PR TITLE
feat(admin): add refresh audits with extended checks button

### DIFF
--- a/locales/en/admin.json
+++ b/locales/en/admin.json
@@ -47,6 +47,7 @@
     "usersPageTitle": "Users",
     "errorsCount": "{{n}} errors",
     "refreshInterview": "Get latest changes from server",
+    "refreshInterviewWithExtended": "Refresh audits with extended checks",
     "resetInterview": "Reset corrected responses to original responses",
     "closeInterviewSummary": "Close",
     "editValidationInterview": "Edit survey",

--- a/locales/fr/admin.json
+++ b/locales/fr/admin.json
@@ -47,6 +47,7 @@
     "usersPageTitle": "Utilisateurs",
     "errorsCount": "{{n}} erreurs",
     "refreshInterview": "Rafraîchir les données du serveur",
+    "refreshInterviewWithExtended": "Rafraîchir les audits avec vérifications étendues",
     "resetInterview": "Réinitialiser les réponses corrigées aux réponses originales",
     "closeInterviewSummary": "Fermer",
     "editValidationInterview": "Éditer l'entrevue",

--- a/packages/evolution-frontend/src/components/admin/validations/InterviewSummary.tsx
+++ b/packages/evolution-frontend/src/components/admin/validations/InterviewSummary.tsx
@@ -34,8 +34,14 @@ const InterviewSummary = (props: InterviewSummaryProps) => {
     const interview = useSelector((state: RootState) => state.survey.interview) as UserRuntimeInterviewAttributes;
     const user = useSelector((state: RootState) => state.auth.user) as CliUser;
 
+    // extended: false runs only standard audit checks (fast, suitable for frequent refreshes during review)
     const refreshInterview = useCallback(() => {
-        dispatch(startFetchCorrectedInterviewAndAudits(interview.uuid));
+        dispatch(startFetchCorrectedInterviewAndAudits(interview.uuid, false));
+    }, [dispatch, interview.uuid]);
+
+    // extended: true runs additional audit checks that may fetch external data or perform complex calculations (slower, use sparingly)
+    const refreshInterviewWithExtended = useCallback(() => {
+        dispatch(startFetchCorrectedInterviewAndAudits(interview.uuid, true));
     }, [dispatch, interview.uuid]);
 
     const resetInterview = useCallback(() => {
@@ -78,6 +84,7 @@ const InterviewSummary = (props: InterviewSummaryProps) => {
                         prevInterviewUuid={props.prevInterviewUuid}
                         nextInterviewUuid={props.nextInterviewUuid}
                         refreshInterview={refreshInterview}
+                        refreshInterviewWithExtended={refreshInterviewWithExtended}
                         resetInterview={resetInterview}
                         user={user}
                         interview={interview}

--- a/packages/evolution-frontend/src/components/admin/validations/ValidationLinks.tsx
+++ b/packages/evolution-frontend/src/components/admin/validations/ValidationLinks.tsx
@@ -19,6 +19,7 @@ import { faHandPaper } from '@fortawesome/free-solid-svg-icons/faHandPaper';
 import { faClipboardList } from '@fortawesome/free-solid-svg-icons/faClipboardList';
 import { faChevronCircleRight } from '@fortawesome/free-solid-svg-icons/faChevronCircleRight';
 import { faChevronCircleLeft } from '@fortawesome/free-solid-svg-icons/faChevronCircleLeft';
+import { faBolt } from '@fortawesome/free-solid-svg-icons/faBolt';
 
 import ConfirmModal from 'chaire-lib-frontend/lib/components/modal/ConfirmModal';
 import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
@@ -34,6 +35,7 @@ type ValidationLinksProps = {
     nextInterviewUuid?: string;
     prevInterviewUuid?: string;
     refreshInterview: () => void;
+    refreshInterviewWithExtended: () => void;
     resetInterview: () => void;
     interviewIsComplete: boolean;
     interviewIsValidated: boolean;
@@ -50,6 +52,7 @@ const ValidationLinks: React.FunctionComponent<ValidationLinksProps> = ({
     nextInterviewUuid,
     prevInterviewUuid,
     refreshInterview,
+    refreshInterviewWithExtended,
     resetInterview,
     interviewIsComplete,
     interviewIsValidated,
@@ -240,6 +243,20 @@ const ValidationLinks: React.FunctionComponent<ValidationLinksProps> = ({
                 }}
                 title={t('admin:refreshInterview')}
             >
+                <FontAwesomeIcon icon={faSyncAlt} />
+            </a>{' '}
+            <a
+                href="#"
+                className="_together"
+                onClick={(e) => {
+                    e.preventDefault();
+                    refreshInterviewWithExtended();
+                }}
+                title={t('admin:refreshInterviewWithExtended')}
+            >
+                <span className="_small">
+                    <FontAwesomeIcon icon={faBolt} />
+                </span>
                 <FontAwesomeIcon icon={faSyncAlt} />
             </a>{' '}
             <a href="#" onClick={handleResetClick} title={t('admin:resetInterview')}>


### PR DESCRIPTION
Add button in frontend validation interface to refresh audits with extended checks enabled. Extended checks perform complex/async validations that are skipped during normal audit runs to improve performance.

- Add 'extended' query parameter to correctInterview API endpoint
- Update SurveyObjectAuditor to conditionally run extended checks
- Add refresh button with bolt+sync icons after regular refresh button
- Add EN/FR translations for extended audit refresh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended audit checks functionality added for enhanced survey validation.
  * New action button (bolt icon) introduced in the validation panel to trigger extended audit refreshes.
  * Multilingual support added: extended audit feature now available in English and French locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->