### PR TITLE
paradata: add a respondent behavior page and queries

### DIFF
--- a/locales/en/admin.json
+++ b/locales/en/admin.json
@@ -208,7 +208,21 @@
             "invalidValueType": "Invalid value type received from server.",
             "jsonConversion": "Error converting data to json.",
             "serverError": "Server error: Failed to fetch value.",
-            "fetchError": "Error fetching data."
+            "fetchError": "Error fetching data.",
+            "invalidResponse": "Invalid response from server"
+        },
+        "RespondentBehavior": {
+            "sectionTitle": "Respondent Behavior",
+            "IncompleteInterviewsLastActions": "Last action by participant",
+            "EventType": "Action",
+            "Count": "Count",
+            "NoData": "No data",
+            "DropoutAnalysis": "Drop-out analysis (incomplete interviews only)",
+            "eventTypes": {
+                "widget_interaction": "Widget interaction",
+                "section_change": "Section change",
+                "button_click": "Button click"
+            }
         }
     }
 }

--- a/locales/fr/admin.json
+++ b/locales/fr/admin.json
@@ -208,7 +208,21 @@
             "invalidValueType": "Type de valeur invalide reçu du serveur.",
             "jsonConversion": "Erreur lors de la conversion des données en JSON.",
             "serverError": "Erreur serveur : Échec de récupération de la valeur.",
-            "fetchError": "Erreur lors de la récupération des données."
+            "fetchError": "Erreur lors de la récupération des données.",
+            "invalidResponse": "Réponse invalide du serveur"
+        },
+        "RespondentBehavior": {
+            "sectionTitle": "Comportement du répondant",
+            "IncompleteInterviewsLastActions": "Dernière action des participants",
+            "EventType": "Action",
+            "Count": "Nombre",
+            "NoData": "Aucune donnée",
+            "DropoutAnalysis": "Analyse d'abandon (entrevues incomplètes seulement)",
+            "eventTypes": {
+                "widget_interaction": "Interaction avec le widget",
+                "section_change": "Changement de section",
+                "button_click": "Clic sur un bouton"
+            }
         }
     }
 }

--- a/packages/evolution-backend/src/api/admin.routes.ts
+++ b/packages/evolution-backend/src/api/admin.routes.ts
@@ -10,6 +10,8 @@ import knex from 'chaire-lib-backend/lib/config/shared/db.config';
 import router from 'chaire-lib-backend/lib/api/admin.routes';
 // Add export routes from admin/exports.routes
 import { addExportRoutes } from './admin/exports.routes';
+import { RespondentBehaviorService } from '../services/paradata/respondentBehavior';
+import * as Status from 'chaire-lib-common/lib/utils/Status';
 
 addExportRoutes();
 
@@ -32,6 +34,9 @@ router.all('/data/widgets/:widget/', (req, res, _next) => {
         break;
     case 'interviews-completion-rate':
         getInterviewsCompletionRate(res);
+        break;
+    case 'respondent-behavior-metrics':
+        getRespondentBehaviorMetrics(res);
         break;
     default:
         // TODO: new widgets will be added
@@ -132,6 +137,17 @@ const getInterviewsCompletionRate = async (res) => {
     } catch (error) {
         console.error('Error fetching interviews completion rate:', error);
         return res.status(500).json({ status: 'ERROR', message: 'Failed to fetch interviews completion rate' });
+    }
+};
+
+// Get respondent behavior metrics
+const getRespondentBehaviorMetrics = async (res) => {
+    try {
+        const metrics = await RespondentBehaviorService.getRespondentBehaviorMetrics();
+        return res.status(200).json(Status.createOk(metrics));
+    } catch (error) {
+        console.error('Error fetching respondent behavior metrics:', error);
+        return res.status(500).json(Status.createError('Failed to fetch respondent behavior metrics'));
     }
 };
 

--- a/packages/evolution-backend/src/services/paradata/__tests__/respondentBehavior.test.ts
+++ b/packages/evolution-backend/src/services/paradata/__tests__/respondentBehavior.test.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import paradataQueries from '../../../models/paradataEvents.db.queries';
+import knex from 'chaire-lib-backend/lib/config/shared/db.config';
+
+import { RespondentBehaviorService } from '../respondentBehavior';
+
+// Mock the paradata queries module used by the service
+jest.mock('../../../models/paradataEvents.db.queries', () => ({
+    createParadataWithWidgetPathTable: jest.fn(),
+    getIncompleteInterviewsLastEventCounts: jest.fn()
+}));
+const createParadataTblMock = paradataQueries.createParadataWithWidgetPathTable as jest.MockedFunction<typeof paradataQueries.createParadataWithWidgetPathTable>;
+const getIncompleteInterviewsLastEventCountsMock = paradataQueries.getIncompleteInterviewsLastEventCounts as jest.MockedFunction<typeof paradataQueries.getIncompleteInterviewsLastEventCounts>;
+
+// Mock the knex transaction function used by the service
+jest.mock('chaire-lib-backend/lib/config/shared/db.config', () => ({
+    transaction: jest.fn()
+}));
+const transactionMock = knex.transaction as jest.MockedFunction<typeof knex.transaction>;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+describe('RespondentBehaviorService', () => {
+    test('getRespondentBehaviorMetrics returns parsed counts and calls creation/query functions', async () => {
+        // Prepare mock trx and behavior
+        const mockTrx = { raw: jest.fn() } as any;
+
+        // Mock knex.transaction to call the callback with our mockTrx
+        transactionMock.mockImplementation(async (cb) => {
+            return await cb(mockTrx);
+        });
+
+        // Mock the paradata queries to return one row
+        getIncompleteInterviewsLastEventCountsMock.mockResolvedValueOnce([
+            { event_type: 'button_click', count: '7' }
+        ]);
+
+        // Call the service
+        const metrics = await RespondentBehaviorService.getRespondentBehaviorMetrics();
+
+        // Assertions: createParadataWithWidgetPathTable and getIncompleteInterviewsLastEventCounts called with trx
+        expect(paradataQueries.createParadataWithWidgetPathTable).toHaveBeenCalledTimes(1);
+        expect(paradataQueries.createParadataWithWidgetPathTable).toHaveBeenCalledWith(mockTrx);
+        expect(paradataQueries.getIncompleteInterviewsLastEventCounts).toHaveBeenCalledTimes(1);
+        expect(paradataQueries.getIncompleteInterviewsLastEventCounts).toHaveBeenCalledWith(mockTrx);
+
+        // The returned metrics should parse the count string as number
+        expect(metrics).toBeDefined();
+        expect(metrics.incompleteInterviewsLastActionCounts).toHaveLength(1);
+        expect(metrics.incompleteInterviewsLastActionCounts[0]).toEqual({ eventType: 'button_click', count: 7 });
+
+        // The transaction should have had its isolation level set
+        expect(mockTrx.raw).toHaveBeenCalledWith('SET TRANSACTION ISOLATION LEVEL READ COMMITTED');
+    });
+
+    test('getRespondentBehaviorMetrics propagates errors from queries', async () => {
+        const mockTrx = { raw: jest.fn() } as any;
+        transactionMock.mockImplementation(async (cb) => cb(mockTrx));
+
+        const error = new Error('db failure');
+        createParadataTblMock.mockRejectedValueOnce(error);
+
+        await expect(RespondentBehaviorService.getRespondentBehaviorMetrics()).rejects.toThrow('db failure');
+
+        expect(createParadataTblMock).toHaveBeenCalledWith(mockTrx);
+    });
+});

--- a/packages/evolution-backend/src/services/paradata/respondentBehavior.ts
+++ b/packages/evolution-backend/src/services/paradata/respondentBehavior.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import knex from 'chaire-lib-backend/lib/config/shared/db.config';
+import paradataEventsDbQueries from '../../models/paradataEvents.db.queries';
+import { RespondentBehaviorMetrics } from 'evolution-common/lib/services/paradata/types';
+
+export class RespondentBehaviorService {
+    /**
+     * Retrieves respondent behavior metrics by creating a temporary table within a transaction
+     * and running queries against it. The transaction is read-only and uses READ COMMITTED
+     * isolation level to avoid blocking other operations.
+     *
+     * @returns Promise<RespondentBehaviorMetrics> The computed metrics
+     */
+    static getRespondentBehaviorMetrics = async (): Promise<RespondentBehaviorMetrics> => {
+        // Use a transaction with READ COMMITTED isolation level to avoid blocking
+        // The transaction will automatically commit at the end, dropping the temporary table
+        return await knex.transaction(async (trx) => {
+            // Set transaction to READ COMMITTED to minimize locking
+            await trx.raw('SET TRANSACTION ISOLATION LEVEL READ COMMITTED');
+
+            // Create the temporary table (will be auto-dropped on commit due to ON COMMIT DROP)
+            console.time('Create temp paradata with widget path table');
+            await paradataEventsDbQueries.createParadataWithWidgetPathTable(trx);
+            console.timeEnd('Create temp paradata with widget path table');
+
+            // Get incomplete interviews last event counts
+            const lastEventCounts = await paradataEventsDbQueries.getIncompleteInterviewsLastEventCounts(trx);
+
+            // Transform the results to match the expected type
+            const incompleteInterviewsLastActionCounts = lastEventCounts.map((row) => ({
+                eventType: row.event_type,
+                count: parseInt(row.count, 10)
+            }));
+
+            // TODO: Add more respondent behavior metrics queries here as needed
+
+            return {
+                incompleteInterviewsLastActionCounts
+            };
+        });
+    };
+}

--- a/packages/evolution-common/src/services/paradata/types.ts
+++ b/packages/evolution-common/src/services/paradata/types.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+/**
+ * Represents a count of last events by widget path for incomplete interviews
+ */
+export type IncompleteInterviewsLastActionCount = {
+    eventType: string;
+    count: number;
+};
+
+/**
+ * Response structure for respondent behavior metrics
+ */
+export type RespondentBehaviorMetrics = {
+    incompleteInterviewsLastActionCounts: IncompleteInterviewsLastActionCount[];
+};

--- a/packages/evolution-frontend/src/components/admin/monitoring/DropoutAnalysis.tsx
+++ b/packages/evolution-frontend/src/components/admin/monitoring/DropoutAnalysis.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { RespondentBehaviorMetrics } from 'evolution-common/lib/services/paradata/types';
+
+type Props = {
+    data: RespondentBehaviorMetrics;
+};
+
+const IncompleteInterviewsLastAction: React.FC<Props> = ({ data }) => {
+    const { t } = useTranslation();
+    const incompleteInterviewsLastEventCounts = data.incompleteInterviewsLastActionCounts || [];
+
+    return (
+        <section className="monitoring-chart-container admin-widget-container">
+            <h3>{t('admin:monitoring.RespondentBehavior.IncompleteInterviewsLastActions')}</h3>
+            {incompleteInterviewsLastEventCounts.length > 0 ? (
+                <div className="monitoring-table-container">
+                    <table className="monitoring-table">
+                        <thead>
+                            <tr>
+                                <th>{t('admin:monitoring.RespondentBehavior.EventType')}</th>
+                                <th>{t('admin:monitoring.RespondentBehavior.Count')}</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {incompleteInterviewsLastEventCounts.map((row, idx) => (
+                                <tr key={idx}>
+                                    <td>{t(`admin:monitoring.RespondentBehavior.eventTypes.${row.eventType}`)}</td>
+                                    <td>{row.count}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            ) : (
+                <div className="monitoring-no-data">{t('admin:monitoring.RespondentBehavior.NoData')}</div>
+            )}
+        </section>
+    );
+};
+
+export const DropoutAnalysis: React.FC<Props> = ({ data }) => {
+    const { t } = useTranslation();
+
+    return (
+        <details className="monitoring-collapsible" open>
+            <summary className="monitoring-collapsible__summary">
+                {t('admin:monitoring.RespondentBehavior.DropoutAnalysis')}
+            </summary>
+
+            <div className="monitoring-collapsible__content">
+                {/* Primary table: last action event by participants counts for incomplete interviews */}
+                <IncompleteInterviewsLastAction data={data} />
+
+                {/* Add other widgets here */}
+            </div>
+        </details>
+    );
+};
+
+export default DropoutAnalysis;

--- a/packages/evolution-frontend/src/components/admin/monitoring/RespondentBehaviorCharts.tsx
+++ b/packages/evolution-frontend/src/components/admin/monitoring/RespondentBehaviorCharts.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import Loader from 'react-spinners/HashLoader';
+import DropoutAnalysis from './DropoutAnalysis';
+import * as Status from 'chaire-lib-common/lib/utils/Status';
+import { RespondentBehaviorMetrics } from 'evolution-common/lib/services/paradata/types';
+
+// Main respondent behavior page: fetches metrics once and renders multiple collapsible sections
+export const RespondentBehaviorCharts: React.FC = () => {
+    const { t } = useTranslation();
+    const [metrics, setMetrics] = React.useState<RespondentBehaviorMetrics | undefined>(undefined);
+    const [errorKey, setErrorKey] = React.useState<string | null>(null);
+    const [loading, setLoading] = React.useState<boolean>(true);
+
+    React.useEffect(() => {
+        const abortController = new AbortController();
+        setLoading(true);
+        setErrorKey(null);
+
+        // Fetch the metrics from the API endpoint (single fetch used by all sections)
+        fetch('/api/admin/data/widgets/respondent-behavior-metrics', {
+            method: 'POST',
+            body: JSON.stringify({ refreshCache: false }),
+            credentials: 'include',
+            headers: { 'Content-Type': 'application/json' },
+            signal: abortController.signal
+        })
+            .then((response) => {
+                if (response.status === 200) {
+                    return response.json();
+                }
+                throw new Error(`HTTP ${response.status}`);
+            })
+            .then((jsonData: Status.Status<RespondentBehaviorMetrics>) => {
+                if (Status.isStatusOk(jsonData)) {
+                    setMetrics(Status.unwrap(jsonData));
+                } else {
+                    setErrorKey('admin:monitoring.errors.invalidResponse');
+                    console.error(t('admin:monitoring.errors.invalidResponse'), jsonData);
+                }
+            })
+            .catch((err) => {
+                if (err.name === 'AbortError') return;
+                setErrorKey('admin:monitoring.errors.fetchError');
+                console.error(t('admin:monitoring.errors.fetchError'), err);
+            })
+            .finally(() => {
+                if (!abortController.signal.aborted) setLoading(false);
+            });
+
+        return () => abortController.abort();
+    }, []);
+
+    return (
+        <section className="monitoring-section">
+            <h2>{t('admin:monitoring.RespondentBehavior.sectionTitle')}</h2>
+
+            {errorKey ? (
+                <div className="monitoring-error">{t(errorKey)}</div>
+            ) : loading ? (
+                <div className="monitoring-loading-container">
+                    <Loader size={'30px'} color={'#aaaaaa'} loading={true} />
+                </div>
+            ) : (
+                <div className="monitoring-charts-container">
+                    {/* Each section is a collapsible <details>. Add more sections here as needed. */}
+
+                    {/* Drop-out analysis section */}
+                    {metrics && <DropoutAnalysis data={metrics} />}
+
+                    {/* Future sections: e.g., "Response Time Analysis", "Interaction Heatmap", etc. */}
+                </div>
+            )}
+        </section>
+    );
+};

--- a/packages/evolution-frontend/src/components/admin/pages/RespondentBehaviorPage.tsx
+++ b/packages/evolution-frontend/src/components/admin/pages/RespondentBehaviorPage.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import React from 'react';
+
+import { RespondentBehaviorCharts } from '../monitoring/RespondentBehaviorCharts';
+
+const RespondentBehaviorPage: React.FC = () => {
+    // FIXME Experimental: This should be part of the monitoring page, not
+    // loaded by default, but with loadable. But we keep it "hidden" for now,
+    // until we are certain the metrics are correctly calculated and we can
+    // trust the data shown.
+    return (
+        <div className="admin">
+            <div className="survey">
+                <div className="monitoring">
+                    <RespondentBehaviorCharts />
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default RespondentBehaviorPage;

--- a/packages/evolution-frontend/src/components/admin/routers/AdminSurveyRouter.tsx
+++ b/packages/evolution-frontend/src/components/admin/routers/AdminSurveyRouter.tsx
@@ -10,6 +10,7 @@ import { Route, Routes } from 'react-router';
 import AdminMonitoringPage from '../pages/AdminMonitoringPage';
 import AdminReviewPage from '../pages/ReviewPage';
 import AdminSurveyCorrectionPage from '../pages/SurveyCorrection';
+import AdminRespondentBehaviorPage from '../pages/RespondentBehaviorPage';
 import SurveyUnavailablePage from '../../pages/SurveyUnavailablePage';
 import NotFoundPage from '../../pages/NotFoundPage';
 import UnauthorizedPage from 'chaire-lib-frontend/lib/components/pages/UnauthorizedPage';
@@ -92,6 +93,7 @@ const AdminSurveyRouter: React.FunctionComponent = () => (
             element={<PrivateRoute component={InterviewsPage} permissions={{ Interviews: ['read', 'update'] }} />}
         />
         <Route path="/admin/monitoring" element={<AdminRoute component={AdminMonitoringPage} />} />
+        <Route path="/admin/respondent-behavior" element={<AdminRoute component={AdminRespondentBehaviorPage} />} />
         <Route
             path="/admin/validation"
             element={<PrivateRoute component={AdminReviewPage} permissions={{ Interviews: ['validate'] }} />}


### PR DESCRIPTION
First commit of a series that will bring the paradata analysis to the monitoring UI charts.

* Add a backend query to retrieve respondent behavior metrics: first a temp table is created from the paradata table to more easily query even types and specific data. Then all queries are run with this table and the interview data, within a single transaction.

* Add a query to retrieve the last action performed by participants on incomplete interview, to get the drop-out action.

* Add a type for the respondent behavior metrics, shared by frontend and backend

* Add an admin route to retrieve the respondent behavior metrics

* In the frontend add a page at `/admin/respondent-behavior` that will contain the respondent behavior sections and metrics. This page is "hidden" for now, until it has been tested with some surveys and we can confirm the data presented is helpful, meaningful, complete and correct.

* Add a first section: "Dropout analysis" to analyse dropout points of incomplete interviews. A first table shows the last action performed by participants

For future metrics and queries to display, they will required:
* A type for the metric in the `evolution-common/src/services/paradata/types.ts` file.
* A backend query to retrieve this data from the database and paradata
* A frontend component to display the data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Respondent Behavior monitoring section and admin page with charts and a collapsible dropout analysis showing incomplete-interview last-action counts; supports translations and loading/error states.
  * New API endpoint to fetch respondent behavior metrics and new types for returned metrics.

* **Bug Fixes**
  * Added an "Invalid response from server" error message for improved error reporting.

* **Tests**
  * Added tests covering respondent behavior metrics and related data queries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->