### PR TITLE
infoMap: Add support for MultiPolygon data

### DIFF
--- a/packages/evolution-common/src/services/questionnaire/types/WidgetConfig.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/WidgetConfig.ts
@@ -440,7 +440,7 @@ export type InfoMapWidgetConfig = {
     geojsons: ParsingFunction<{
         points?: GeoJSON.FeatureCollection<GeoJSON.Point, SurveyMapObjectProperty>;
         linestrings?: GeoJSON.FeatureCollection<GeoJSON.LineString, SurveyMapObjectProperty>;
-        polygons?: GeoJSON.FeatureCollection<GeoJSON.Polygon, SurveyMapObjectPolygonProperty>;
+        polygons?: GeoJSON.FeatureCollection<GeoJSON.Polygon | GeoJSON.MultiPolygon, SurveyMapObjectPolygonProperty>;
     }>;
     defaultCenter?: { lat: number; lon: number } | ParsingFunction<{ lat: number; lon: number }>;
     maxZoom?: number;


### PR DESCRIPTION
The infoMap's polygon geojson property now supports both Polygon and MultiPolygon features. The type and widgets are updated accordingly.

Also fix the display of polygons with holes by adding all the rings to the paths, not just the outer one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Map widget now supports complex polygon geometries (holes and MultiPolygons), rendering all rings and constituent polygons so multi-part and hole-containing shapes display correctly on survey maps.
  * Visual styling and defaults are preserved while rendering now handles multiple rings/polygons for improved geographic detail.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->