### PR TITLE
calculations: add accessibility map calculation function

### DIFF
--- a/packages/evolution-backend/src/services/routing/__tests__/RouteCalculation.test.ts
+++ b/packages/evolution-backend/src/services/routing/__tests__/RouteCalculation.test.ts
@@ -5,17 +5,19 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 
-import { calculateTimeDistanceByMode, getTransitSummary } from '../';
+import { calculateTimeDistanceByMode, getTransitSummary, getTransitAccessibilityMap } from '../';
 import each from 'jest-each';
-import { getTimeAndDistanceFromTransitionApi, summaryFromTransitionApi } from '../RouteCalculationFromTransition';
+import { getTimeAndDistanceFromTransitionApi, summaryFromTransitionApi, transitAccessibilityMapFromTransitionApi } from '../RouteCalculationFromTransition';
 import projectConfig from '../../../config/projectConfig';
 
 jest.mock('../RouteCalculationFromTransition', () => ({
     getTimeAndDistanceFromTransitionApi: jest.fn(),
-    summaryFromTransitionApi: jest.fn()
+    summaryFromTransitionApi: jest.fn(),
+    transitAccessibilityMapFromTransitionApi: jest.fn()
 }));
 const mockedRouteFromTransition = getTimeAndDistanceFromTransitionApi as jest.MockedFunction<typeof getTimeAndDistanceFromTransitionApi>;
 const mockedSummaryFromTransition = summaryFromTransitionApi as jest.MockedFunction<typeof summaryFromTransitionApi>;
+const mockedAccessibilityMapFromTransition = transitAccessibilityMapFromTransitionApi as jest.MockedFunction<typeof transitAccessibilityMapFromTransitionApi>;
 
 beforeEach(() => {
     jest.clearAllMocks();
@@ -163,6 +165,92 @@ describe('getTransitSummary: with Transition', () => {
 
 });
 
+describe('getTransitAccessibilityMap: invalid parameters', () => {
+
+    const validParameters = {
+        point: { type: 'Point' as const, coordinates: [0, 0] },
+        departureSecondsSinceMidnight: 10000,
+        maxTotalTravelTimeMinutes: 30,
+        numberOfPolygons: 3,
+        transitScenario: 'scenarioId'
+    };
+
+    each([
+        ['Invalid point', 'point', { type: 'LineString' as const, coordinates: [[0, 0], [1, 1]] }, 'Invalid point'],
+        ['Negative trip time', 'departureSecondsSinceMidnight', -1, 'Invalid departure time'],
+        ['Trip time too large', 'departureSecondsSinceMidnight', 29 * 3600, 'Invalid departure time'],
+        ['No scenario', 'transitScenario', undefined, 'Transit accessibility map requires a scenario'],
+        ['No max travel time', 'maxTotalTravelTimeMinutes', undefined, 'Invalid max total travel time'],
+        ['Zero max travel time', 'maxTotalTravelTimeMinutes', 0, 'Invalid max total travel time'],
+        ['Negative max travel time', 'maxTotalTravelTimeMinutes', -10, 'Invalid max total travel time'],
+        ['Zero number of polygons', 'numberOfPolygons', 0, 'Invalid number of polygons'],
+        ['Negative number of polygons', 'numberOfPolygons', -5, 'Invalid number of polygons'],
+    ]).test('Invalid parameters: %s', async (_, testedParam, value, expected) => {
+        const parameters = { ...validParameters, [testedParam]: value };
+        await expect(getTransitAccessibilityMap(parameters)).rejects.toThrow(expected);
+    });
+
+});
+
+describe('getTransitAccessibilityMap: with Transition', () => {
+    beforeEach(() => {
+        projectConfig.transitionApi = {
+            url: 'http://transition',
+            username: 'user',
+            password: 'password'
+        };
+    });
+
+    test('Throw an error', async () => {
+        const validParameters = {
+            point: { type: 'Point' as const, coordinates: [0, 0] },
+            departureSecondsSinceMidnight: 10000,
+            maxTotalTravelTimeMinutes: 30,
+            numberOfPolygons: 3,
+            transitScenario: 'scenarioId'
+        };
+        mockedAccessibilityMapFromTransition.mockRejectedValueOnce(new Error('Transition URL not set in project config'));
+        await expect(getTransitAccessibilityMap(validParameters)).rejects.toThrow('Transition URL not set in project config');
+        expect(mockedAccessibilityMapFromTransition).toHaveBeenCalledTimes(1);
+        expect(mockedAccessibilityMapFromTransition).toHaveBeenCalledWith(validParameters);
+    });
+
+    test('Return calculation results', async () => {
+        const validParameters = {
+            point: { type: 'Point' as const, coordinates: [0, 0] },
+            departureSecondsSinceMidnight: 10000,
+            maxTotalTravelTimeMinutes: 30,
+            numberOfPolygons: 3,
+            transitScenario: 'scenarioId'
+        };
+        const accessibilityResult = {
+            status: 'success' as const,
+            polygons: {
+                type: 'FeatureCollection' as const,
+                features: [
+                    {
+                        type: 'Feature' as const,
+                        geometry: {
+                            type: 'MultiPolygon' as const,
+                            coordinates: [[[[-73.5, 45.5], [-73.4, 45.5], [-73.4, 45.4], [-73.5, 45.4], [-73.5, 45.5]]]]
+                        },
+                        properties: {
+                            durationSeconds: 600,
+                            areaSqM: 1000000
+                        }
+                    }
+                ]
+            },
+            source: 'transitionApi'
+        };
+        mockedAccessibilityMapFromTransition.mockResolvedValueOnce(accessibilityResult);
+        const result = await getTransitAccessibilityMap(validParameters);
+        expect(mockedAccessibilityMapFromTransition).toHaveBeenCalledTimes(1);
+        expect(mockedAccessibilityMapFromTransition).toHaveBeenCalledWith(validParameters);
+        expect(result).toEqual(accessibilityResult);
+    });
+});
+
 describe('No method specified', () => {
     beforeEach(() => {
         projectConfig.transitionApi = undefined;
@@ -189,5 +277,17 @@ describe('No method specified', () => {
         };
         await expect(getTransitSummary(validParameters)).rejects.toThrow('No summary method available');
         expect(mockedSummaryFromTransition).not.toHaveBeenCalled();
+    });
+
+    test('getTransitAccessibilityMap', async () => {
+        const validParameters = {
+            point: { type: 'Point' as const, coordinates: [0, 0] },
+            departureSecondsSinceMidnight: 10000,
+            maxTotalTravelTimeMinutes: 30,
+            numberOfPolygons: 3,
+            transitScenario: 'scenarioId'
+        };
+        await expect(getTransitAccessibilityMap(validParameters)).rejects.toThrow('No accessibility map method available');
+        expect(mockedAccessibilityMapFromTransition).not.toHaveBeenCalled();
     });
 });

--- a/packages/evolution-backend/src/services/routing/types.ts
+++ b/packages/evolution-backend/src/services/routing/types.ts
@@ -71,3 +71,37 @@ export type SummaryResult = {
           lines: SummarySuccessResult['result']['lines'];
       }
 );
+
+export type AccessibilityMapCalculationParameter = {
+    /**
+     * The point from which to calculate the accessibility map
+     */
+    point: GeoJSON.Point | GeoJSON.Feature<GeoJSON.Point>;
+    /**
+     * The time of the trip, in seconds since midnight
+     */
+    departureSecondsSinceMidnight: number;
+    /** The scenario to use for calculations */
+    transitScenario: string;
+    /** The number of polygons to generate */
+    numberOfPolygons?: number;
+    /** The maximum total travel time in minutes */
+    maxTotalTravelTimeMinutes: number;
+    /** whether to calculate points of interest */
+    calculatePois?: boolean;
+};
+
+export type AccessibilityMapResult = {
+    // The source of the accessibility map calculation. Can be used to identify
+    // the method called for this calculation
+    source: string;
+} & (
+    | {
+          status: 'error';
+          error: string;
+      }
+    | {
+          status: 'success';
+          polygons: GeoJSON.FeatureCollection<GeoJSON.MultiPolygon>;
+      }
+);


### PR DESCRIPTION
And implement it using the Transition API.

Add types for the query parameters and results. This returns the geojson polygons, so it makes the query to fetch the geojson polygons as well. Not all parameters are implemented for now. It supports the `numberOfPolygons` and `calculatePois` parameters, as well as the total travel time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added transit accessibility map calculation capability. Users can now generate accessibility maps showing areas reachable from a specified location within a given travel time, based on departure time and transit scenario. The feature includes optional Points of Interest identification and returns polygon-based accessibility boundaries for visualization and analysis.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->