### PR TITLE
survey: serve a survey ended landing page

### DIFF
--- a/docs/SURVEY_END_DATE.md
+++ b/docs/SURVEY_END_DATE.md
@@ -1,0 +1,97 @@
+# Survey End Date Feature
+
+This feature allows the server to automatically display a "Thank You" page when the survey end date has passed, preventing new responses after the configured end date.
+
+## Configuration
+
+To enable this feature, set the `endDateTimeWithTimezoneOffset` in your project configuration file:
+
+```typescript
+// In your config.js or similar configuration file
+export default {
+    // ... other config
+    endDateTimeWithTimezoneOffset: '2025-12-31T23:59:59-05:00'  // ISO 8601 format with timezone
+}
+```
+
+The date format must be ISO 8601 with timezone offset: `YYYY-MM-DDTHH:MM:SS±HH:MM`
+
+## How it Works
+
+1. **Server Check**: When a request comes for the participant app, the server checks if the current time is after the configured `endDateTimeWithTimezoneOffset`.
+
+2. **App Routing**: 
+   - If the survey is still active, the normal survey app is served
+   - If the survey has ended, a special "Survey Ended" app is served with a thank you message
+
+3. **Localization**: The thank you message supports multiple languages through the localization files.
+
+## Components
+
+### Backend
+
+- **surveyStatus.ts**: Contains the `isSurveyEnded()` function that checks if the current time is past the end date
+
+### Frontend
+
+- **SurveyEndedPage.tsx**: React component that displays the thank you message
+- **app-survey-ended.tsx**: Application entry point for the survey ended bundle
+
+### Build Configuration
+
+- **webpack.config.js**: Updated with multiple entry points to build both survey and survey-ended apps
+
+### Localization
+
+Add translations in your locale files under `surveyEnded.thankYouMessage`:
+
+**English** (`locales/en/survey.json`):
+```json
+{
+    "surveyEnded": {
+        "thankYouMessage": "<h2 class=\"_dark-green _strong center\">Thank you for your interest!</h2><p class=\"center\">This survey has ended and is no longer accepting new responses.</p><p class=\"center\">We greatly appreciate your interest in participating.</p>"
+    }
+}
+```
+
+**French** (`locales/fr/survey.json`):
+```json
+{
+    "surveyEnded": {
+        "thankYouMessage": "<h2 class=\"_dark-green _strong center\">Merci de votre intérêt!</h2><p class=\"center\">Cette enquête est terminée et n'accepte plus de nouvelles réponses.</p><p class=\"center\">Nous apprécions grandement votre intérêt à participer.</p>"
+    }
+}
+```
+
+## Building
+
+The webpack configuration now uses multiple entry points, so building the main survey app automatically builds both the regular survey and the survey-ended app:
+
+```bash
+# Development build with watch mode (builds both apps)
+yarn build:dev
+
+# Production build (builds both apps)
+yarn build:prod
+```
+
+This single build command will generate both:
+- `index-survey-{projectName}.html` and `survey-{projectName}-bundle.js` for the main survey
+- `index-survey-ended-{projectName}.html` and `survey-ended-{projectName}-bundle.js` for the ended survey
+
+## Testing
+
+To test this feature:
+
+1. Set `endDateTimeWithTimezoneOffset` to a date in the past
+2. Build both apps (main and survey-ended)
+3. Start the server
+4. Visit the home page - you should see the thank you message instead of the survey
+
+## Notes
+
+- The date check happens on every request, so there's no need to restart the server when the end date is reached
+- The date check affects only the application servicing, to fetch the application bundle, not every request, so a participant filling an interview when the survey end date is reached will still be able to complete. But he will not be able to continue after refreshing the page with F5.
+- The feature gracefully handles invalid dates by defaulting to keeping the survey active
+- If no end date is configured, the survey remains active indefinitely
+- The survey ended page includes the same banner and logo as the home page for consistent branding

--- a/example/demo_survey/locales/en/survey.json
+++ b/example/demo_survey/locales/en/survey.json
@@ -5,6 +5,9 @@
         "start": "Start",
         "AgreementText": "I consent to the usage of my data for research purposes"
     },
+    "surveyEnded": {
+        "thankYouMessage": "<h2 class=\"_dark-green _strong center\">Thank you for your interest!</h2><p class=\"center\">This survey has ended and is no longer accepting new responses.</p><p class=\"center\">We greatly appreciate your interest in participating.</p>"
+    },
     "footer": "<p class=\"center\" style=\"font-size: 85%; margin-bottom: 2rem; padding-top: 2rem;\">Powered by <a href=\"https://github.com/chairemobilite/evolution\" target=\"_blank\">Evolution</a></p>",
     "postregistration": {
         "introduction": "Thank you for your participation!",

--- a/example/demo_survey/locales/fr/survey.json
+++ b/example/demo_survey/locales/fr/survey.json
@@ -5,6 +5,9 @@
         "start": "Débuter",
         "AgreementText": "Je consens à l'usage des mes données à des fins de recherche"
     },
+    "surveyEnded": {
+        "thankYouMessage": "<h2 class=\"_dark-green _strong center\">Merci de votre intérêt!</h2><p class=\"center\">Cette enquête est terminée et n'accepte plus de nouvelles réponses.</p><p class=\"center\">Nous apprécions grandement votre intérêt à participer.</p>"
+    },
     "footer": "<p class=\"center\" style=\"font-size: 85%; margin-bottom: 2rem; padding-top: 2rem;\">Propulsé par <a href=\"https://github.com/chairemobilite/evolution\" target=\"_blank\">Evolution</a></p>",
     "postregistration": {
         "introduction": "Merci pour votre participation!",

--- a/packages/evolution-backend/src/apps/participant/__tests__/serverApp.test.ts
+++ b/packages/evolution-backend/src/apps/participant/__tests__/serverApp.test.ts
@@ -1,0 +1,328 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import express from 'express';
+import request from 'supertest';
+import { setupServerApp } from '../serverApp';
+import * as surveyStatus from '../../../services/surveyStatus/surveyStatus';
+import { fileManager } from 'chaire-lib-backend/lib/utils/filesystem/fileManager';
+
+// Mock the dependencies
+jest.mock('chaire-lib-backend/lib/config/server.config', () => ({
+    __esModule: true,
+    default: {
+        projectShortname: 'test-project'
+    }
+}));
+
+jest.mock('chaire-lib-backend/lib/config/shared/db.config', () => ({
+    __esModule: true,
+    default: {}
+}));
+
+jest.mock('../../../services/auth/participantAuthModel', () => ({
+    participantAuthModel: {}
+}));
+
+jest.mock('../../../services/auth/auth.config', () => ({
+    __esModule: true,
+    default: jest.fn().mockReturnValue({
+        initialize: jest.fn().mockReturnValue((req, res, next) => next()),
+        session: jest.fn().mockReturnValue((req, res, next) => next())
+    })
+}));
+
+jest.mock('chaire-lib-backend/lib/utils/filesystem/directoryManager', () => ({
+    directoryManager: {
+        createDirectoryIfNotExistsAbsolute: jest.fn(),
+        createDirectoryIfNotExists: jest.fn()
+    }
+}));
+
+jest.mock('chaire-lib-backend/lib/utils/filesystem/fileManager', () => ({
+    fileManager: {
+        fileExistsAbsolute: jest.fn().mockReturnValue(true)
+    }
+}));
+const mockFileExistsAbsolute = fileManager.fileExistsAbsolute as jest.MockedFunction<typeof fileManager.fileExistsAbsolute>;
+
+jest.mock('../../../api/auth.routes', () => ({
+    __esModule: true,
+    default: jest.fn()
+}));
+
+jest.mock('../../participant/routes', () => ({
+    __esModule: true,
+    default: jest.fn()
+}));
+
+jest.mock('chaire-lib-backend/lib/api/trRouting.routes', () => ({
+    __esModule: true,
+    default: jest.fn()
+}));
+
+jest.mock('connect-session-knex', () => {
+    const MockStore = jest.fn().mockImplementation(() => ({
+        on: jest.fn()
+    }));
+    return jest.fn().mockReturnValue(MockStore);
+});
+
+jest.mock('serve-favicon', () => {
+    return jest.fn().mockReturnValue((req, res, next) => next());
+});
+
+// Mock the survey status module
+jest.mock('../../../services/surveyStatus/surveyStatus');
+
+describe('serverApp index path routing', () => {
+    let app: express.Express;
+    let sendFileMock: jest.Mock;
+
+    beforeEach(() => {
+        // Reset mocks before each test
+        jest.clearAllMocks();
+
+        // Set up the test environment
+        process.env.NODE_ENV = 'test';
+        process.env.EXPRESS_SESSION_SECRET_KEY = 'test-secret-key';
+
+        // Create a new express app for each test
+        app = express();
+
+        // Create mock for sendFile
+        sendFileMock = jest.fn();
+
+        // Intercept all routes to mock sendFile BEFORE they are registered
+        // This middleware must be added before setupServerApp is called
+        app.use((req, res, next) => {
+            const originalSendFile = res.sendFile.bind(res);
+            res.sendFile = jest.fn((path: string, options?: any, callback?: any) => {
+                sendFileMock(path);
+                // Send mock response based on the file path
+                if (path.includes('notFound404')) {
+                    return res.status(404).send('404 Not Found');
+                } else if (path.includes('index-survey-ended')) {
+                    return res.status(200).send('Survey Ended Page');
+                } else if (path.includes('index-survey')) {
+                    return res.status(200).send('Survey Page');
+                } else if (path.includes('incompatible')) {
+                    return res.status(200).send('Incompatible Page');
+                } else {
+                    return res.status(200).send('File Content');
+                }
+            }) as any;
+            next();
+        });
+
+        // Setup the server app AFTER adding the sendFile mock middleware
+        setupServerApp(app);
+    });
+
+    afterEach(() => {
+        // Clean up
+        delete process.env.EXPRESS_SESSION_SECRET_KEY;
+    });
+
+    describe('* handler when survey is not ended', () => {
+        beforeEach(() => {
+            // Mock isSurveyEnded to return false
+            jest.spyOn(surveyStatus, 'isSurveyEnded').mockReturnValue(false);
+        });
+
+        test('should return the regular index page for root path', async () => {
+            const response = await request(app).get('/');
+
+            expect(response.status).toBe(200);
+            expect(response.text).toBe('Survey Page');
+            expect(surveyStatus.isSurveyEnded).toHaveBeenCalled();
+            expect(sendFileMock).toHaveBeenCalledWith(
+                expect.stringContaining('index-survey-test-project_test.html')
+            );
+        });
+
+        test('should return the regular index page for unmatched routes', async () => {
+            const response = await request(app).get('/some/random/path');
+
+            expect(response.status).toBe(200);
+            expect(response.text).toBe('Survey Page');
+            expect(surveyStatus.isSurveyEnded).toHaveBeenCalled();
+            expect(sendFileMock).toHaveBeenCalledWith(
+                expect.stringContaining('index-survey-test-project_test.html')
+            );
+        });
+
+        test('should return 404 for file extensions that do not exist', async () => {
+            const response = await request(app).get('/nonexistent.php');
+
+            expect(response.status).toBe(404);
+            expect(sendFileMock).toHaveBeenCalledWith(
+                expect.stringContaining('notFound404.html')
+            );
+        });
+    });
+
+    describe('* handler when survey has ended', () => {
+        beforeEach(() => {
+            // Mock isSurveyEnded to return true
+            jest.spyOn(surveyStatus, 'isSurveyEnded').mockReturnValue(true);
+        });
+
+        test('should return the survey ended index page for root path', async () => {
+            const response = await request(app).get('/');
+
+            expect(response.status).toBe(200);
+            expect(response.text).toBe('Survey Ended Page');
+            expect(surveyStatus.isSurveyEnded).toHaveBeenCalled();
+            expect(sendFileMock).toHaveBeenCalledWith(
+                expect.stringContaining('index-survey-ended-test-project_test.html')
+            );
+        });
+
+        test('should return the survey ended index page for unmatched routes', async () => {
+            const response = await request(app).get('/some/random/path');
+
+            expect(response.status).toBe(200);
+            expect(response.text).toBe('Survey Ended Page');
+            expect(surveyStatus.isSurveyEnded).toHaveBeenCalled();
+            expect(sendFileMock).toHaveBeenCalledWith(
+                expect.stringContaining('index-survey-ended-test-project_test.html')
+            );
+        });
+
+        test('should return 404 for file extensions that do not exist', async () => {
+            const response = await request(app).get('/nonexistent.php');
+
+            expect(response.status).toBe(404);
+            expect(sendFileMock).toHaveBeenCalledWith(
+                expect.stringContaining('notFound404.html')
+            );
+        });
+
+        test('should serve regular index if survey ended page does not exist', async () => {
+            mockFileExistsAbsolute.mockReturnValueOnce(false);
+            // Create a new express app this test to override the previous setup and simulate missing survey ended page
+            app = express();
+
+            // Create mock for sendFile
+            sendFileMock = jest.fn();
+
+            // Intercept all routes to mock sendFile BEFORE they are registered
+            // This middleware must be added before setupServerApp is called
+            app.use((req, res, next) => {
+                const originalSendFile = res.sendFile.bind(res);
+                res.sendFile = jest.fn((path: string, options?: any, callback?: any) => {
+                    sendFileMock(path);
+                    // Send mock response based on the file path
+                    if (path.includes('notFound404')) {
+                        return res.status(404).send('404 Not Found');
+                    } else if (path.includes('index-survey-ended')) {
+                        return res.status(200).send('Survey Ended Page');
+                    } else if (path.includes('index-survey')) {
+                        return res.status(200).send('Survey Page');
+                    } else if (path.includes('incompatible')) {
+                        return res.status(200).send('Incompatible Page');
+                    } else {
+                        return res.status(200).send('File Content');
+                    }
+                }) as any;
+                next();
+            });
+
+            setupServerApp(app);
+
+            const response = await request(app).get('/');
+
+            expect(response.status).toBe(200);
+            expect(response.text).toBe('Survey Page');
+            expect(surveyStatus.isSurveyEnded).toHaveBeenCalled();
+            expect(sendFileMock).toHaveBeenCalledWith(
+                expect.stringContaining('index-survey-test-project_test.html')
+            );
+            expect(mockFileExistsAbsolute).toHaveBeenCalledWith(
+                expect.stringContaining('index-survey-ended-test-project_test.html')
+            );
+        });
+    });
+
+    describe('* handler with file extension handling', () => {
+        beforeEach(() => {
+            jest.spyOn(surveyStatus, 'isSurveyEnded').mockReturnValue(false);
+        });
+
+        test('should return 404 for .png files that do not exist', async () => {
+            const response = await request(app).get('/missing-image.png');
+            expect(response.status).toBe(404);
+        });
+
+        test('should return 404 for .json files that do not exist', async () => {
+            const response = await request(app).get('/missing-data.json');
+            expect(response.status).toBe(404);
+        });
+
+        test('should not treat query parameters as file extensions', async () => {
+            const response = await request(app).get('/path?file=test.js');
+            // Should return the index page, not 404
+            expect(response.status).toBe(200);
+            expect(surveyStatus.isSurveyEnded).toHaveBeenCalled();
+        });
+    });
+
+    describe('special routes', () => {
+        beforeEach(() => {
+            jest.spyOn(surveyStatus, 'isSurveyEnded').mockReturnValue(false);
+        });
+
+        test('should return status for /ping endpoint', async () => {
+            const response = await request(app).get('/ping');
+
+            expect(response.status).toBe(200);
+            expect(response.body).toEqual({ status: 'online' });
+        });
+
+        test('should return incompatible page for /incompatible endpoint', async () => {
+            const response = await request(app).get('/incompatible');
+
+            expect(response.status).toBe(200);
+            // Note: The actual file content would be checked in integration tests
+        });
+    });
+
+    describe('custom server setup function', () => {
+        test('should call the custom setup function if provided', () => {
+            const mockSetupFct = jest.fn();
+            const testApp = express();
+
+            setupServerApp(testApp, mockSetupFct);
+
+            expect(mockSetupFct).toHaveBeenCalled();
+        });
+
+        test('should handle errors from custom setup function gracefully', () => {
+            const mockSetupFct = jest.fn().mockImplementation(() => {
+                throw new Error('Setup error');
+            });
+            const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+            const testApp = express();
+
+            expect(() => setupServerApp(testApp, mockSetupFct)).not.toThrow();
+            expect(consoleSpy).toHaveBeenCalledWith(
+                'Error running project specific server setup function: ',
+                expect.any(Error)
+            );
+
+            consoleSpy.mockRestore();
+        });
+
+        test('should work without a custom setup function', () => {
+            const testApp = express();
+
+            expect(() => setupServerApp(testApp)).not.toThrow();
+        });
+    });
+
+    test.todo('add tests for missing or existing js/css files handled by other handlers than *');
+});

--- a/packages/evolution-backend/src/services/surveyStatus/__tests__/surveyStatus.test.ts
+++ b/packages/evolution-backend/src/services/surveyStatus/__tests__/surveyStatus.test.ts
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import moment from 'moment';
+import { isSurveyEnded } from '../surveyStatus';
+import projectConfig from 'evolution-common/lib/config/project.config';
+
+// Mock the project config
+jest.mock('evolution-common/lib/config/project.config', () => ({
+    __esModule: true,
+    default: {
+        endDateTimeWithTimezoneOffset: undefined
+    }
+}));
+
+describe('isSurveyEnded', () => {
+    // Store original console methods
+    const originalConsoleLog = console.log;
+    const originalConsoleError = console.error;
+
+    beforeEach(() => {
+        // Mock console to avoid cluttering test output
+        console.log = jest.fn();
+        console.error = jest.fn();
+        // Reset the config before each test
+        (projectConfig as any).endDateTimeWithTimezoneOffset = undefined;
+    });
+
+    afterEach(() => {
+        // Restore console
+        console.log = originalConsoleLog;
+        console.error = originalConsoleError;
+        jest.clearAllMocks();
+    });
+
+    describe('when no end date is configured', () => {
+        test('should return false', () => {
+            expect(isSurveyEnded()).toBe(false);
+        });
+
+        test('should not log any errors', () => {
+            isSurveyEnded();
+            expect(console.error).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('when end date is in the past', () => {
+        test('should return true for a date one day ago', () => {
+            const yesterday = moment().subtract(1, 'day').format('YYYY-MM-DDTHH:mm:ssZ');
+            (projectConfig as any).endDateTimeWithTimezoneOffset = yesterday;
+            
+            expect(isSurveyEnded()).toBe(true);
+        });
+
+        test('should return true for a date one hour ago', () => {
+            const oneHourAgo = moment().subtract(1, 'hour').format('YYYY-MM-DDTHH:mm:ssZ');
+            (projectConfig as any).endDateTimeWithTimezoneOffset = oneHourAgo;
+            
+            expect(isSurveyEnded()).toBe(true);
+        });
+
+        test('should return true for a date one minute ago', () => {
+            const oneMinuteAgo = moment().subtract(1, 'minute').format('YYYY-MM-DDTHH:mm:ssZ');
+            (projectConfig as any).endDateTimeWithTimezoneOffset = oneMinuteAgo;
+            
+            expect(isSurveyEnded()).toBe(true);
+        });
+
+        test('should return true for a specific past date with timezone', () => {
+            (projectConfig as any).endDateTimeWithTimezoneOffset = '2024-12-31T23:59:59-05:00';
+            
+            expect(isSurveyEnded()).toBe(true);
+        });
+    });
+
+    describe('when end date is in the future', () => {
+        test('should return false for a date one day from now', () => {
+            const tomorrow = moment().add(1, 'day').format('YYYY-MM-DDTHH:mm:ssZ');
+            (projectConfig as any).endDateTimeWithTimezoneOffset = tomorrow;
+            
+            expect(isSurveyEnded()).toBe(false);
+        });
+
+        test('should return false for a date one hour from now', () => {
+            const oneHourLater = moment().add(1, 'hour').format('YYYY-MM-DDTHH:mm:ssZ');
+            (projectConfig as any).endDateTimeWithTimezoneOffset = oneHourLater;
+            
+            expect(isSurveyEnded()).toBe(false);
+        });
+
+        test('should return false for a date one minute from now', () => {
+            const oneMinuteLater = moment().add(1, 'minute').format('YYYY-MM-DDTHH:mm:ssZ');
+            (projectConfig as any).endDateTimeWithTimezoneOffset = oneMinuteLater;
+            
+            expect(isSurveyEnded()).toBe(false);
+        });
+    });
+
+    describe('with different timezone offsets', () => {
+        test('should correctly handle positive timezone offset', () => {
+            const pastDateWithPositiveOffset = moment().subtract(1, 'day').format('YYYY-MM-DDTHH:mm:ss+09:00');
+            (projectConfig as any).endDateTimeWithTimezoneOffset = pastDateWithPositiveOffset;
+            
+            expect(isSurveyEnded()).toBe(true);
+        });
+
+        test('should correctly handle negative timezone offset', () => {
+            const pastDateWithNegativeOffset = moment().subtract(1, 'day').format('YYYY-MM-DDTHH:mm:ss-08:00');
+            (projectConfig as any).endDateTimeWithTimezoneOffset = pastDateWithNegativeOffset;
+            
+            expect(isSurveyEnded()).toBe(true);
+        });
+
+        test('should correctly handle UTC timezone', () => {
+            const pastDateUTC = moment().subtract(1, 'day').utc().format('YYYY-MM-DDTHH:mm:ss+00:00');
+            (projectConfig as any).endDateTimeWithTimezoneOffset = pastDateUTC;
+            
+            expect(isSurveyEnded()).toBe(true);
+        });
+
+        test('should correctly compare times across different timezones', () => {
+            // Set end date to yesterday at 5 PM EST (UTC-5)
+            (projectConfig as any).endDateTimeWithTimezoneOffset = '2024-12-15T17:00:00-05:00';
+            
+            // This should be true as the date is in the past regardless of current timezone
+            expect(isSurveyEnded()).toBe(true);
+        });
+
+        test('should return true when end time is 1 hour earlier but in timezone 2 hours ahead (where HH:mm:ss is 1 hour ahead in our time zone, survey is ended)', () => {
+            // End time is 1 hour ago in local time, but represented in a timezone that's 2 hours ahead
+            // This means the actual moment is still 1 hour in the past
+            const oneHourAgo = moment().subtract(1, 'hour');
+            const currentOffset = moment().utcOffset();
+            const endTimeInFutureTimezone = oneHourAgo.clone().utcOffset(currentOffset + 120).format('YYYY-MM-DDTHH:mm:ssZZ');
+            (projectConfig as any).endDateTimeWithTimezoneOffset = endTimeInFutureTimezone;
+            
+            expect(isSurveyEnded()).toBe(true);
+        });
+
+        test('should return false when end time is 1 hour later but in timezone 2 hours behind (survey is not finished)', () => {
+            // End time is 1 hour in the future in local time, but represented in a timezone that's 2 hours in the future
+            // This means the actual moment is 1 hour in the past
+            const oneHourLater = moment().add(1, 'hour');
+            const currentOffset = moment().utcOffset();
+            const endTimeInPastTimezone = oneHourLater.clone().utcOffset(currentOffset - 120).format('YYYY-MM-DDTHH:mm:ssZZ');
+            (projectConfig as any).endDateTimeWithTimezoneOffset = endTimeInPastTimezone;
+            
+            expect(isSurveyEnded()).toBe(false);
+        });
+    });
+
+    describe('with invalid date formats', () => {
+        test('should return false for invalid date string', () => {
+            (projectConfig as any).endDateTimeWithTimezoneOffset = 'not-a-valid-date';
+            
+            expect(isSurveyEnded()).toBe(false);
+        });
+
+        test('should log an error for invalid date string', () => {
+            (projectConfig as any).endDateTimeWithTimezoneOffset = 'invalid-date';
+            
+            expect(isSurveyEnded()).toBe(false);
+            
+            expect(console.error).toHaveBeenCalledWith(
+                'Invalid endDateTimeWithTimezoneOffset configured: invalid-date'
+            );
+        });
+
+        test('should return true for date without timezone', () => {
+            (projectConfig as any).endDateTimeWithTimezoneOffset = '2024-12-31T23:59:59';
+            
+            // Moment will still parse this, but it's not in the correct format
+            // The function should still work but we're testing that it handles it
+            const result = isSurveyEnded();
+            expect(result).toBe(true);
+        });
+
+        test('should return false for empty string', () => {
+            (projectConfig as any).endDateTimeWithTimezoneOffset = '';
+            
+            // Empty string should be falsy and return false early
+            expect(isSurveyEnded()).toBe(false);
+        });
+    });
+
+});

--- a/packages/evolution-backend/src/services/surveyStatus/surveyStatus.ts
+++ b/packages/evolution-backend/src/services/surveyStatus/surveyStatus.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import projectConfig from 'evolution-common/lib/config/project.config';
+import { parseISODateToTimestamp } from 'evolution-common/lib/utils/DateTimeUtils';
+
+/**
+ * Check if the survey has ended based on the configured end date/time
+ * @returns true if the current time is after the survey end date, false otherwise
+ */
+export const isSurveyEnded = (): boolean => {
+    const endDateTime = projectConfig.endDateTimeWithTimezoneOffset;
+    if (!endDateTime) {
+        // No end date configured, survey is still active
+        return false;
+    }
+
+    try {
+        // Parse the configured end date/time
+        const surveyEndTimestamp = parseISODateToTimestamp(projectConfig.endDateTimeWithTimezoneOffset);
+        if (surveyEndTimestamp === undefined) {
+            console.error(`Invalid endDateTimeWithTimezoneOffset configured: ${endDateTime}`);
+            return false;
+        }
+
+        // Get current epoch timestamp
+        const nowTimestamp = Date.now();
+        return nowTimestamp > surveyEndTimestamp;
+    } catch (error) {
+        console.error('Error checking survey end date:', error);
+        return false;
+    }
+};

--- a/packages/evolution-frontend/src/apps/participant/app-survey-ended.tsx
+++ b/packages/evolution-frontend/src/apps/participant/app-survey-ended.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { I18nextProvider } from 'react-i18next';
+
+import config from 'evolution-common/lib/config/project.config';
+import i18n from '../../config/i18n.config';
+import SurveyEndedPage from '../../components/pages/SurveyEndedPage';
+import '../../styles/survey/styles-participant-survey.scss';
+
+const runSurveyEndedApp = () => {
+    document.title = config.title[i18n.language];
+
+    const Jsx: React.FC = () => {
+        return (
+            <I18nextProvider i18n={i18n}>
+                <SurveyEndedPage />
+            </I18nextProvider>
+        );
+    };
+
+    const container = document.getElementById('app');
+    if (container) {
+        const root = createRoot(container);
+        root.render(<Jsx />);
+    }
+};
+
+runSurveyEndedApp();

--- a/packages/evolution-frontend/src/components/pages/SurveyEndedPage.tsx
+++ b/packages/evolution-frontend/src/components/pages/SurveyEndedPage.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import moment from 'moment';
+
+import config from 'evolution-common/lib/config/project.config';
+
+const SurveyEndedPage: React.FunctionComponent = () => {
+    const { t, i18n } = useTranslation();
+
+    return (
+        <div className="survey">
+            <div style={{ width: '100%', margin: '0 auto', maxWidth: '60em' }}>
+                {config.introBanner && config.bannerPaths && (
+                    <div className="main-logo center">
+                        <img src={config.bannerPaths[i18n.language]} style={{ width: '100%' }} alt="Banner" />
+                    </div>
+                )}
+                <div style={{ width: '100%', margin: '0 auto', maxWidth: '30em', padding: '0 1rem' }}>
+                    <form className="apptr__form" id="survey_form">
+                        {config.logoPaths && (
+                            <div className="main-logo center">
+                                <img src={config.logoPaths[i18n.language]} style={{ width: '100%' }} alt="Logo" />
+                            </div>
+                        )}
+                        <div
+                            dangerouslySetInnerHTML={{
+                                __html: t('survey:surveyEnded.thankYouMessage')
+                            }}
+                        />
+                        <div className="center">
+                            {config.languages.map((language) => {
+                                return i18n.language !== language ? (
+                                    <button
+                                        type="button"
+                                        className="menu-button em"
+                                        key={`header__nav-language-${language}`}
+                                        onClick={() => {
+                                            i18n.changeLanguage(language);
+                                            moment.locale(language);
+                                        }}
+                                    >
+                                        {config.languageNames[language]}
+                                    </button>
+                                ) : null;
+                            })}
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default SurveyEndedPage;


### PR DESCRIPTION
"after" part of #361

* Add a `isSurveyEnded` function that uses the `endDateTimeWithTimezoneOffset` configuration option to know if the survey period has ended
* Add a `SurveyEndedPage` component to display a message at the end of the survey period. Text can be modified by the `survey:surveyEnded.thankYouMessage` translation string.
* Add a new webpack entry point to create an app that contains only this component for survey ended pages.
* Let the express server validate if the survey is active or ended and return the appropriate entry file.
* Add unit tests for the backend functions
* Add documentation on implementing this feature in a survey.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Localized survey completion page shown after a configured end date/time, with a translatable thank-you message (supports HTML) and language switching.
  * App now serves a dedicated "survey ended" experience when a survey has expired.

* **Tests**
  * Added tests for end-date detection across timezones and server routing between active vs ended surveys.

* **Documentation**
  * New doc describing end-date configuration, behavior, localization, and build/run notes.

* **Chores**
  * Build updated to produce separate entry points/outputs for active and ended survey pages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->