### PR TITLE
survey: send server update when section submitted and invalid

### DIFF
--- a/packages/evolution-common/src/services/questionnaire/types/Data.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/Data.ts
@@ -408,6 +408,10 @@ export type StartRemoveGroupedObjects = (
  * update in the interview.  The key is the path to update and the value is the
  * new value. A dot-separated path will be exploded to the corresponding nested
  * object path.
+ * @param {UserAction} [options.userAction] The user action that triggered the
+ * update. Successful navigation will cause a `sectionChange` action to be
+ * logged, but in case navigation is not successful, this will be the logged
+ * action instead. Leave empty if the update was not triggered by a user action.
  * @param {GotoFunction} [options.gotoFunction] A function used to redirect the
  * page to a specific URL
  * @param {(interview: UserRuntimeInterviewAttributes) => void} [callback] An
@@ -419,6 +423,7 @@ export type StartNavigate = (
     options?: {
         requestedSection?: NavigationSection;
         valuesByPath?: { [path: string]: unknown };
+        userAction?: UserAction;
         gotoFunction?: GotoFunction;
     },
     callback?: (interview: UserRuntimeInterviewAttributes, targetSection: NavigationSection) => void

--- a/packages/evolution-frontend/src/actions/Survey.ts
+++ b/packages/evolution-frontend/src/actions/Survey.ts
@@ -291,7 +291,7 @@ const updateInterviewCallback = async (
         }
 
         // No changes to send to the server, just update the state and quit
-        if (isEqual(updatedValuesByPath, { _all: true }) && _isBlank(unsetPaths)) {
+        if (isEqual(updatedValuesByPath, { _all: true }) && _isBlank(unsetPaths) && _isBlank(userAction)) {
             // '_all' means the "save" button was clicked and the form was submitted, so the form may not follow the normal form change workflow
             dispatch(updateInterviewState(_cloneDeep(updatedInterview), {}, true));
             if (typeof callback === 'function') {
@@ -528,7 +528,7 @@ const navigate = (targetSection: NavigationSection): SurveyAction => ({
 export const startNavigateWithUpdateCallback =
     (
         fctUpdateInterview: typeof startUpdateInterview,
-        { requestedSection, valuesByPath = {}, gotoFunction }: Parameters<StartNavigate>[0] = {},
+        { requestedSection, valuesByPath = {}, gotoFunction, userAction }: Parameters<StartNavigate>[0] = {},
         callback?: Parameters<StartNavigate>[1]
     ) =>
         async (
@@ -567,9 +567,15 @@ export const startNavigateWithUpdateCallback =
                 };
                 const [shouldNavigate, prevSectionInterview, validationValuesByPath] = validateCurrentSection();
 
-                // If the current section is not valid, do not navigate and update interview
+                // If the current section is not valid, do not navigate, simply update interview to log invalid widgets
                 if (!shouldNavigate) {
-                    dispatch(updateInterviewState(prevSectionInterview, {}, true));
+                    await dispatch(
+                        fctUpdateInterview({
+                            sectionShortname: navigation?.currentSection?.sectionShortname || '',
+                            userAction,
+                            valuesByPath: { _all: true }
+                        })
+                    );
                     return;
                 }
 

--- a/packages/evolution-frontend/src/actions/SurveyAdmin.ts
+++ b/packages/evolution-frontend/src/actions/SurveyAdmin.ts
@@ -148,8 +148,8 @@ const updateSurveyCorrectedInterview = async (
             }
         }
 
-        if (isEqual(updatedValuesByPath, { _all: true }) && _isBlank(unsetPaths)) {
-            dispatch(updateInterviewState(_cloneDeep(updatedInterview)));
+        if (isEqual(updatedValuesByPath, { _all: true }) && _isBlank(unsetPaths) && _isBlank(userAction)) {
+            dispatch(updateInterviewState(_cloneDeep(updatedInterview), {}, true));
             if (typeof callback === 'function') {
                 callback(updatedInterview);
             }
@@ -177,7 +177,7 @@ const updateSurveyCorrectedInterview = async (
             if (body.status === 'success' && body.interviewId === updatedInterview.uuid) {
                 //surveyHelper.devLog('Interview saved to db');
                 //setTimeout(function() {
-                dispatch(updateInterviewState(_cloneDeep(updatedInterview)));
+                dispatch(updateInterviewState(_cloneDeep(updatedInterview), {}, updatedValuesByPath['_all'] === true));
                 if (typeof callback === 'function') {
                     callback(updatedInterview);
                 }

--- a/packages/evolution-frontend/src/components/survey/Button.tsx
+++ b/packages/evolution-frontend/src/components/survey/Button.tsx
@@ -12,6 +12,7 @@ import { withSurveyContext, WithSurveyContextProps } from '../hoc/WithSurveyCont
 import ConfirmModal from 'chaire-lib-frontend/lib/components/modal/ConfirmModal';
 import {
     ButtonWidgetConfig,
+    StartNavigate,
     StartUpdateInterview,
     UserRuntimeInterviewAttributes
 } from 'evolution-common/lib/services/questionnaire/types';
@@ -64,7 +65,22 @@ const Button: React.FC<ButtonProps & WithSurveyContextProps & WithTranslation> =
             }
             return props.startUpdateInterview(data, callback);
         },
-        [props.startUpdateInterview]
+        [props.startUpdateInterview, props.path]
+    );
+
+    const startNavigateForButtonClick: StartNavigate = React.useCallback(
+        (options, callback) => {
+            const definedOptions = options || {};
+            // Set the button click user action to the startNavigate call
+            if (definedOptions.userAction === undefined) {
+                definedOptions.userAction = {
+                    type: 'buttonClick',
+                    buttonId: props.path
+                };
+            }
+            return props.startNavigate(definedOptions, callback);
+        },
+        [props.startNavigate, props.path]
     );
 
     const onMouseDown = () => {
@@ -91,7 +107,7 @@ const Button: React.FC<ButtonProps & WithSurveyContextProps & WithTranslation> =
                 startUpdateInterview: startUpdateInterviewForButtonClick,
                 startAddGroupedObjects: props.startAddGroupedObjects,
                 startRemoveGroupedObjects: props.startRemoveGroupedObjects,
-                startNavigate: props.startNavigate
+                startNavigate: startNavigateForButtonClick
             },
             props.interview,
             props.path,

--- a/packages/evolution-frontend/src/components/survey/__tests__/Button.test.tsx
+++ b/packages/evolution-frontend/src/components/survey/__tests__/Button.test.tsx
@@ -187,7 +187,8 @@ describe('Button widget: behavioral tests', () => {
         expect(commonWidgetConfig.action).toHaveBeenCalledWith({
             startUpdateInterview: expect.any(Function),
             startAddGroupedObjects: startAddGroupedObjectsMock,
-            startRemoveGroupedObjects: startRemoveGroupedObjectsMock
+            startRemoveGroupedObjects: startRemoveGroupedObjectsMock,
+            startNavigate: expect.any(Function)
         }, interviewAttributes, 'home.region', 'test', {}, undefined);
     });
 
@@ -224,7 +225,8 @@ describe('Button widget: behavioral tests', () => {
         expect(actionFunction).toHaveBeenCalledWith({
             startUpdateInterview: expect.any(Function),
             startAddGroupedObjects: startAddGroupedObjectsMock,
-            startRemoveGroupedObjects: startRemoveGroupedObjectsMock
+            startRemoveGroupedObjects: startRemoveGroupedObjectsMock,
+            startNavigate: expect.any(Function)
         }, interviewAttributes, 'home.region', 'test', {}, undefined);
         expect(startUpdateInterviewMock).toHaveBeenCalledTimes(1);
         expect(startUpdateInterviewMock).toHaveBeenCalledWith({
@@ -280,7 +282,8 @@ describe('Button widget: behavioral tests', () => {
         expect(commonWidgetConfig.action).toHaveBeenCalledWith({
             startUpdateInterview: expect.any(Function),
             startAddGroupedObjects: startAddGroupedObjectsMock,
-            startRemoveGroupedObjects: startRemoveGroupedObjectsMock
+            startRemoveGroupedObjects: startRemoveGroupedObjectsMock,
+            startNavigate: expect.any(Function)
         }, interviewAttributes, 'home.region', 'test', {}, undefined);
     });
 
@@ -371,7 +374,8 @@ describe('Button widget: behavioral tests', () => {
         expect(commonWidgetConfig.action).toHaveBeenCalledWith({
             startUpdateInterview: expect.any(Function),
             startAddGroupedObjects: startAddGroupedObjectsMock,
-            startRemoveGroupedObjects: startRemoveGroupedObjectsMock
+            startRemoveGroupedObjects: startRemoveGroupedObjectsMock,
+            startNavigate: expect.any(Function)
         }, interviewAttributes, 'home.region', 'test', {}, undefined);
     });
 });


### PR DESCRIPTION
fixes #1342

When a call to navigate is invalid and should not trigger validation (when there are invalid widgets on the page for example), there should still be an update query sent to the backend to log the user action that triggered the invalid navigation request.

The `StartNavigate` options argument receives and option `userAction` field to describe the action that triggered the navigation, in case of un-successful validation, this userAction will be used instead of a `sectionChange` action.

Button widgets now pass a `buttonClick` user action on navigation.

Update tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User actions are now propagated with navigation events, ensuring button clicks and other interactions are consistently recorded.
  * No-change navigations that include a user action will trigger the appropriate server update and state refresh.

* **Tests**
  * Added and adjusted tests to cover user-action propagation, server request flows, and navigation callbacks.

* **Bug Fixes**
  * Fixed inconsistent handling of navigation callbacks so UI actions reliably update state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->