### PR TITLE
paradata: properly handle `undefined` eventData when logging

### DIFF
--- a/packages/evolution-backend/src/models/paradataEvents.db.queries.ts
+++ b/packages/evolution-backend/src/models/paradataEvents.db.queries.ts
@@ -42,7 +42,7 @@ const log = async ({
             interview_id: interviewId,
             user_id: userId,
             event_type: eventType,
-            event_data: JSON.stringify(eventData).replaceAll('\\u0000', ''),
+            event_data: eventData === undefined ? null : JSON.stringify(eventData).replaceAll('\\u0000', ''),
             for_correction: forCorrection ?? false
         };
         await knex(tableName).insert(dbObject);


### PR DESCRIPTION
If the `eventData` is `undefined`, the `JSON.stringify` will return `undefined` and throw an error, so we make sure to keep it `undefined` if it is the case.

Add tests to cover this use case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of missing event data in paradata event logging, ensuring undefined entries are correctly stored as null values in the database instead of causing errors.

* **Tests**
  * Added test coverage for undefined event data scenarios to ensure proper behavior in edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->