### PR TITLE
Bug: Fix bug with incorrect node version with tasks.json

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,6 +5,7 @@
             "label": "Update Main",
             "dependsOrder": "sequence",
             "dependsOn": [
+                "NVM Use 24",
                 "Git Checkout Main",
                 "Git Pull Origin Main",
                 "Yarn Reset Submodules",
@@ -44,6 +45,11 @@
                 "isDefault": true
             },
             "command": "yarn build:admin:dev && yarn start:admin --port 8082"
+        },
+        {
+            "label": "NVM Use 24",
+            "type": "shell",
+            "command": ". $HOME/.nvm/nvm.sh && nvm use 24"
         },
         {
             "label": "Compile Dev",


### PR DESCRIPTION
# Pull request

## Description
Bug: Fix bug with incorrect node version with tasks.json

## Justification
Visual Studio Code terminal doesn't take the good Node version when doing tasks, but we need Node 24 for installing packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling configuration to ensure proper Node.js version compatibility during build processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->