### PR TITLE
fix(ui): move zoom controls to top-left for better visibility

### DIFF
--- a/packages/evolution-frontend/src/components/inputs/maps/google/InputMapGoogle.tsx
+++ b/packages/evolution-frontend/src/components/inputs/maps/google/InputMapGoogle.tsx
@@ -221,8 +221,7 @@ const InputMapGoogle: React.FunctionComponent<InputGoogleMapPointProps & WithTra
                 cameraControl: false,
                 zoomControlOptions: {
                     position: google.maps.ControlPosition.LEFT_TOP,
-                    style: google.maps.ZoomControlStyle.SMALL
-                }
+                     }
             }}
             onLoad={onLoad}
             onUnmount={onUnmount}


### PR DESCRIPTION
This PR moves the Google Maps zoom controls from RIGHT_BOTTOM to LEFT_TOP. This was requested by the maintainers in the localisation repository to ensure the controls are visible in smaller map containers. 
Reference: chairemobilite/localisation#54

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Relocated the map zoom control to the top-left, improving visibility and accessibility and reducing overlap with other UI elements.
  * This is strictly a UI positioning change; map behavior, interactions, and data flow remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->