### PR TITLE
segmentSection: decouple questionnaire mode type from model

### DIFF
--- a/locales/en/segments.yml
+++ b/locales/en/segments.yml
@@ -14,7 +14,9 @@ modePre:
     WalkOrMobilityHelp: <strong>Walking</strong> or <strong>wheeling</strong> (eg. wheelchair)
     Bicycle: <strong>Bicycle</strong> or <strong>e-bike</strong>
     Transit: <strong>Public transit</strong>
+    Paratransit: <strong>Paratransit</strong>
     Taxi: <strong>Taxi</strong> or equivalent (eg. Uber, Lyft)
+    Ferry: <strong>Ferry</strong>
     Other: <strong>Other</strong>
     DontKnow: <strong>I don't know</strong>
     PreferNotToAnswer: <strong>Prefer not to answer</strong>
@@ -26,11 +28,16 @@ mode:
     BicycleBikesharingElectric: <strong>Electric bike sharing</strong>
     BicyclePassenger: <strong>Passenger on bike</strong>
     KickScooterElectric: <strong>Electric Kick Scooter</strong>
+    CarDriver: <strong>Driver</strong> (car/moto/scooter/truck)
     CarDriverPersonal: <strong>Driver</strong> with personal vehicle (car/moto/scooter/truck)
     CarDriverRental: <strong>Driver</strong> with rental vehicle (car/moto/scooter/truck)
+    CarDriverCarsharing: <strong>Carsharing</strong>
     CarDriverCarsharingStationBased: <strong>Carsharing</strong> station based
     CarDriverCarsharingFreeFloating: <strong>Carsharing</strong> free floating
     CarDriverCarsharingUnspecified: <strong>Carsharing</strong>
+    PrivateBoat: <strong>Private boat</strong>
+    Snowmobile: <strong>Snowmobile</strong>
+    AllTerrainVehicle: <strong>All-terrain vehicle</strong> (quad/ATV)
     CarPassenger: <strong>Passenger</strong> (car/motorcycle/moped/truck)
     TransitBus: <strong>Bus</strong>
     TransitBRT: <strong>Bus rapid service</strong>

--- a/locales/fr/segments.yml
+++ b/locales/fr/segments.yml
@@ -14,7 +14,9 @@ modePre:
     WalkOrMobilityHelp: <strong>Marche</strong> ou <strong>aide à la mobilité</strong>
     Bicycle: <strong>Vélo</strong> ou <strong>vélo électrique</strong>
     Transit: <strong>Transport collectif</strong>
+    Paratransit: <strong>Transport adapté</strong>
     Taxi: <strong>Taxi</strong> ou équivalent (ex. Uber, Lyft)
+    Ferry: <strong>Traversier</strong>
     Other: <strong>Autre</strong>
     DontKnow: <strong>Je ne sais pas</strong>
     PreferNotToAnswer: <strong>Préfère ne pas répondre</strong>
@@ -26,12 +28,17 @@ mode:
     BicycleBikesharingElectric: <strong>Vélo partage électrique</strong>
     BicyclePassenger: <strong>Vélo passager</strong>
     KickScooterElectric: <strong>Trottinette électrique</strong>
+    CarDriver: <strong>Auto conducteur</strong> (voiture/moto/scooter/camion)
     CarDriverPersonal: <strong>Auto conducteur</strong> avec voiture personnelle
     CarDriverRental: <strong>Auto conducteur</strong> avec voiture de location
+    CarDriverCarsharing: <strong>Autopartage</strong>
     CarDriverCarsharingStationBased: <strong>Autopartage</strong> basé station
     CarDriverCarsharingFreeFloating: <strong>Autopartage</strong> en libre service
     CarDriverCarsharingUnspecified: <strong>Autopartage</strong>
     CarPassenger: <strong>Passager</strong> (voiture/moto/scooter/camion)
+    PrivateBoat: <strong>Bateau privé</strong>
+    Snowmobile: <strong>Motoneige</strong>
+    AllTerrainVehicle: <strong>Véhicule tout-terrain</strong> (quad/VTT)
     TransitBus: <strong>Bus</strong>
     TransitBRT: <strong>Service rapide par bus</strong>
     TransitSchoolBus: <strong>Bus</strong> (<strong>Lignes scolaires</strong> opérée par une agence de transport collectif)

--- a/packages/evolution-common/src/services/odSurvey/types.ts
+++ b/packages/evolution-common/src/services/odSurvey/types.ts
@@ -5,9 +5,7 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 // This file contains types and constants that are used in the
-// Origin-Destination survey context, ie with journey, trips and segments
-
-import { Mode } from '../baseObjects/attributeTypes/SegmentAttributes';
+// Origin-Destination questionnaire context, ie with journey, trips and segments
 
 /**
  * Activities that do not involve a destination
@@ -20,13 +18,76 @@ export const loopActivities = ['workOnTheRoad', 'leisureStroll'];
  */
 export const simpleModes = ['carDriver', 'walk', 'bicycle', 'bicycleElectric', 'kickScooterElectric'];
 
-const modePreValues = [
+/**
+ * Modes of transportation. The elements in this array can identify are meant to
+ * differentiate between the various types of road user, the infrastructure
+ * used, the potential payment types and what kind of organisation offers the
+ * service, if any. These modes are for the questionnaire context and differ
+ * from those of the base objects used in the enhancement process.
+ */
+export const modeValues = [
+    // Active mode
+    'walk',
+    'bicycle',
+    'bicycleElectric',
+    'bicyclePassenger',
+    'bicycleBikesharing',
+    'bicycleBikesharingElectric',
+    'kickScooterElectric',
+    // Modes for disabilities
+    'wheelchair',
+    'mobilityScooter', // Electric wheelchair, mobility scooter, etc.
+    'paratransit',
+    // Private motorized modes
+    'carDriver', // complementary type: CarType
+    'carDriverCarsharing',
+    'carPassenger',
+    'motorcycle', // includes motorbike, scooter, moped, etc.
+    'snowmobile',
+    'privateBoat',
+    'allTerrainVehicle', // ATV, quad, etc.
+    // Transit modes
+    'transitBus', // includes Bus Transit System (BTS) category C
+    'transitBRT', // Bus Rapid Transit category B
+    'transitSchoolBus', // for school lines managed by transit agencies
+    'transitStreetCar', // category C
+    'transitFerry', // Ferry, without a car
+    'transitGondola', // category A
+    'transitMonorail', // category A
+    'transitRRT', // Rapid Rail Transit (metro, subway, aerial train), category A
+    'transitLRT', // Light Rail Transit, category B
+    'transitLRRT', // Light Rail Rapid Transit, category A
+    'transitHSR', // High Speed Rail, category A
+    'transitRegionalRail', // category A
+    'transitOnDemand', // On demand services (bus, minivan, taxi), usually managed by transit agencies
+    'transitTaxi', // Collective taxi
+    'intercityBus',
+    'intercityTrain',
+    'schoolBus',
+    'otherBus', // Private buses, like hired buses for events, groups, etc.
+    'taxi',
+    'ferryWithCar',
+    'plane',
+    'otherActiveMode', // Skateboard, kick scooter, rollerblade, etc.
+    'other',
+    'dontKnow',
+    'preferNotToAnswer'
+] as const;
+
+export type Mode = (typeof modeValues)[number];
+
+export const modePreValues = [
     'carDriver',
     'carPassenger',
     'walk',
     'bicycle',
     'transit',
+    // FIXME Add separate transit light and heavy categories when we add configuration and support decent default configurations, otherwise, there would be too many modesPre/modes
     'taxi',
+    'ferry',
+    // Modes that may involve disability assistance
+    'paratransit',
+    // Other modes
     'other',
     'dontKnow',
     'preferNotToAnswer'
@@ -40,12 +101,15 @@ export const modeToModePreMap: { [mode in Mode]: ModePre[] } = {
     walk: ['walk'],
     bicycle: ['bicycle'],
     bicyclePassenger: ['bicycle'],
+    bicycleElectric: ['bicycle'],
+    bicycleBikesharing: ['bicycle'],
+    bicycleBikesharingElectric: ['bicycle'],
     kickScooterElectric: ['bicycle', 'other'],
     transitBus: ['transit'],
     transitBRT: ['transit'],
     transitSchoolBus: ['transit', 'other'],
     transitStreetCar: ['transit'],
-    transitFerry: ['transit', 'other'],
+    transitFerry: ['transit', 'other', 'ferry'],
     transitGondola: ['transit', 'other'],
     transitMonorail: ['transit'],
     transitRRT: ['transit'],
@@ -60,18 +124,22 @@ export const modeToModePreMap: { [mode in Mode]: ModePre[] } = {
     otherBus: ['other'],
     carDriver: ['carDriver'],
     carPassenger: ['carPassenger'],
+    carDriverCarsharing: ['carDriver'],
+    allTerrainVehicle: ['other'],
+    snowmobile: ['other'],
+    privateBoat: ['other', 'ferry'],
     transitTaxi: ['transit', 'taxi'],
     taxi: ['taxi'],
-    paratransit: ['other', 'transit'],
+    paratransit: ['other', 'transit', 'paratransit'],
     wheelchair: ['walk', 'other'],
     mobilityScooter: ['walk', 'other'],
     plane: ['other'],
     otherActiveMode: ['other'],
     motorcycle: ['other'],
-    ferryWithCar: ['other'],
+    ferryWithCar: ['other', 'ferry'],
     other: ['other'],
     dontKnow: ['dontKnow'],
-    preferNotToAnswer: []
+    preferNotToAnswer: ['preferNotToAnswer']
 };
 
 /**

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/helpers.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/helpers.test.ts
@@ -377,3 +377,151 @@ describe('shouldShowSameAsReverseTripQuestion', () => {
     });
 
 });
+
+describe('conditionalPersonMayHaveDisability', () => {
+
+    test('Person has disability set to "yes"', () => {
+        // Prepare test data
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        interview.response._activePersonId = 'personId1';
+        setResponse(interview, 'household.persons.personId1.hasDisability', 'yes');
+
+        // Test conditional
+        const result = helpers.conditionalPersonMayHaveDisability(interview, 'household.persons.personId1');
+        expect(result).toEqual(true);
+    });
+
+    test('Person has disability set to "preferNotToAnswer"', () => {
+        // Prepare test data
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        interview.response._activePersonId = 'personId1';
+        setResponse(interview, 'household.persons.personId1.hasDisability', 'preferNotToAnswer');
+
+        // Test conditional
+        const result = helpers.conditionalPersonMayHaveDisability(interview, 'household.persons.personId1');
+        expect(result).toEqual(true);
+    });
+
+    test('Person has disability set to "dontKnow"', () => {
+        // Prepare test data
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        interview.response._activePersonId = 'personId1';
+        setResponse(interview, 'household.persons.personId1.hasDisability', 'dontKnow');
+
+        // Test conditional
+        const result = helpers.conditionalPersonMayHaveDisability(interview, 'household.persons.personId1');
+        expect(result).toEqual(true);
+    });
+
+    test('Person has disability set to "no"', () => {
+        // Prepare test data
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        interview.response._activePersonId = 'personId1';
+        setResponse(interview, 'household.persons.personId1.hasDisability', 'no');
+
+        // Test conditional
+        const result = helpers.conditionalPersonMayHaveDisability(interview, 'household.persons.personId1');
+        expect(result).toEqual(false);
+    });
+
+    test('Person has disability not set (undefined)', () => {
+        // Prepare test data
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        interview.response._activePersonId = 'personId1';
+        // hasDisability is undefined by default in test data
+
+        // Test conditional
+        const result = helpers.conditionalPersonMayHaveDisability(interview, 'household.persons.personId1');
+        // FIXME When undefined, should it return true or false? There's a FIXME in OD helpers to decide this
+        expect(result).toEqual(false);
+    });
+
+    test('No persons in household', () => {
+        // Prepare test data
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        setResponse(interview, 'household.persons', {});
+
+        // Test conditional
+        const result = helpers.conditionalPersonMayHaveDisability(interview, 'path');
+        expect(result).toEqual(true);
+    });
+});
+
+describe('conditionalHhMayHaveDisability', () => {
+
+    test('At least one person has disability set to "yes"', () => {
+        // Prepare test data
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        setResponse(interview, 'household.persons.personId1.hasDisability', 'yes');
+        setResponse(interview, 'household.persons.personId2.hasDisability', 'no');
+
+        // Test conditional
+        const result = helpers.conditionalHhMayHaveDisability(interview, 'path');
+        expect(result).toEqual(true);
+    });
+
+    test('At least one person has disability set to "preferNotToAnswer"', () => {
+        // Prepare test data
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        setResponse(interview, 'household.persons.personId1.hasDisability', 'no');
+        setResponse(interview, 'household.persons.personId2.hasDisability', 'preferNotToAnswer');
+
+        // Test conditional
+        const result = helpers.conditionalHhMayHaveDisability(interview, 'path');
+        expect(result).toEqual(true);
+    });
+
+    test('At least one person has disability set to "dontKnow"', () => {
+        // Prepare test data
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        setResponse(interview, 'household.persons.personId1.hasDisability', 'no');
+        setResponse(interview, 'household.persons.personId2.hasDisability', 'dontKnow');
+
+        // Test conditional
+        const result = helpers.conditionalHhMayHaveDisability(interview, 'path');
+        expect(result).toEqual(true);
+    });
+
+    test('All persons have disability set to "no"', () => {
+        // Prepare test data
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        setResponse(interview, 'household.persons.personId1.hasDisability', 'no');
+        setResponse(interview, 'household.persons.personId2.hasDisability', 'no');
+        setResponse(interview, 'household.persons.personId3.hasDisability', 'no');
+
+        // Test conditional
+        const result = helpers.conditionalHhMayHaveDisability(interview, 'path');
+        expect(result).toEqual(false);
+    });
+
+    test('Multiple persons with mixed disability values', () => {
+        // Prepare test data
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        setResponse(interview, 'household.persons.personId1.hasDisability', 'yes');
+        setResponse(interview, 'household.persons.personId2.hasDisability', 'preferNotToAnswer');
+        setResponse(interview, 'household.persons.personId3.hasDisability', 'no');
+
+        // Test conditional
+        const result = helpers.conditionalHhMayHaveDisability(interview, 'path');
+        expect(result).toEqual(true);
+    });
+
+    test('All persons have hasDisability undefined', () => {
+        // Prepare test data - hasDisability is undefined by default in test data
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+
+        // Test conditional
+        const result = helpers.conditionalHhMayHaveDisability(interview, 'path');
+        expect(result).toEqual(false);
+    });
+
+    test('No persons in household', () => {
+        // Prepare test data
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        setResponse(interview, 'household.persons', {});
+
+        // Test conditional
+        const result = helpers.conditionalHhMayHaveDisability(interview, 'path');
+        expect(result).toEqual(false);
+    });
+});

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetSegmentMode.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetSegmentMode.test.ts
@@ -12,12 +12,12 @@ import { getModeWidgetConfig } from '../widgetSegmentMode';
 import { interviewAttributesForTestCases } from '../../../../../tests/surveys';
 import { getResponse, setResponse, translateString } from '../../../../../utils/helpers';
 import * as surveyHelper from '../../../../odSurvey/helpers';
-import { modeValues } from '../../../../baseObjects/attributeTypes/SegmentAttributes';
-import { modePreToModeMap, modeToModePreMap } from '../../../../odSurvey/types';
+import { Mode, ModePre, modePreToModeMap, modeToModePreMap, modeValues } from '../../../../odSurvey/types';
 import { shouldShowSameAsReverseTripQuestion, getPreviousTripSingleSegment } from '../helpers';
 import { modeToIconMapping } from '../modeIconMapping';
 
 jest.mock('../helpers', () => ({
+    ...jest.requireActual('../helpers'),
     shouldShowSameAsReverseTripQuestion: jest.fn().mockReturnValue(false),
     getPreviousTripSingleSegment: jest.fn()
 }));
@@ -91,7 +91,7 @@ describe('Mode choices conditionals', () => {
 
     // Test specific conditional for modes, where person may have disability
     each(
-        ['wheelchair', 'mobilityScooter'].flatMap((mode) => Object.keys(modePreToModeMap).flatMap((modePre) => [[true, mode, modePre, modeToModePreMap[mode].includes(modePre as any)], [false, mode, modePre, modeToModePreMap[mode].includes(modePre as any)]]))
+        ['wheelchair' as Mode, 'mobilityScooter' as Mode].flatMap((mode: Mode) => Object.keys(modePreToModeMap).flatMap((modePre) => [[true, mode, modePre, modeToModePreMap[mode].includes(modePre as ModePre)], [false, mode, modePre, modeToModePreMap[mode].includes(modePre as ModePre)]]))
     ).test('Test modePre with person may have disability (%s) conditional for mode %s with modePre %s: %s', (personMayHaveDisability, choiceValue, modePreValue, expectedIfTrue) => {
         // Spy on the personMayHaveDisability function
         if (expectedIfTrue) {
@@ -114,7 +114,7 @@ describe('Mode choices conditionals', () => {
 
     // Test specific conditional for modes, where they may be disabilities in the household
     each(
-        ['paratransit'].flatMap((mode) => Object.keys(modePreToModeMap).flatMap((modePre) => [[true, mode, modePre, modeToModePreMap[mode].includes(modePre as any)], [false, mode, modePre, modeToModePreMap[mode].includes(modePre as any)]]))
+        ['paratransit' as Mode].flatMap((mode: Mode) => Object.keys(modePreToModeMap).flatMap((modePre) => [[true, mode, modePre, modeToModePreMap[mode].includes(modePre as ModePre)], [false, mode, modePre, modeToModePreMap[mode].includes(modePre as ModePre)]]))
     ).test('Test modePre with hh may have disability (%s) conditional for mode %s with modePre %s: %s', (hhMayHaveDisability, choiceValue, modePreValue, expectedIfTrue) => {
         // Spy on the householdMayHaveDisability function
         if (expectedIfTrue) {

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/modeIconMapping.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/modeIconMapping.ts
@@ -5,7 +5,7 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 
-import { Mode } from '../../../baseObjects/attributeTypes/SegmentAttributes';
+import { Mode, ModePre } from '../../../odSurvey/types';
 
 /**
  * Maps modes to their corresponding icon paths
@@ -21,6 +21,10 @@ export const modeToIconMapping: Record<Mode, string> = {
     bicycle: '/dist/icons/modes/bicycle/bicycle_with_rider.svg',
     // FIXME Confirm this icon
     bicyclePassenger: '/dist/icons/modes/bicycle/bicycle_with_rider.svg',
+    bicycleElectric: '/dist/icons/modes/bicycle/bicycle_without_rider_electric.svg',
+    // FIXME Add bicycle bike sharing icons
+    bicycleBikesharing: '/dist/icons/modes/bicycle/bicycle_bikesharing.svg',
+    bicycleBikesharingElectric: '/dist/icons/modes/bicycle/bicycle_bikesharing_electric.svg',
     kickScooterElectric: '/dist/icons/modes/kick_scooter/kick_scooter_electric.svg',
     // FIXME Confirm this icon
     otherActiveMode: '/dist/icons/modes/kick_scooter/kick_scooter.svg',
@@ -29,6 +33,11 @@ export const modeToIconMapping: Record<Mode, string> = {
     // Cars
     carDriver: '/dist/icons/modes/car/car_driver_without_passenger.svg',
     carPassenger: '/dist/icons/modes/car/car_passenger.svg',
+    carDriverCarsharing: '/dist/icons/modes/car/carsharing.svg',
+    // FIXME Confirm these icons
+    snowmobile: '/dist/icons/modes/other/snowmobile.svg',
+    privateBoat: '/dist/icons/modes/other/private_boat.svg',
+    allTerrainVehicle: '/dist/icons/modes/other/all_terrain_vehicle.svg',
 
     // Transit buses
     transitBus: '/dist/icons/modes/bus/bus_city.svg',
@@ -70,6 +79,20 @@ export const modeToIconMapping: Record<Mode, string> = {
     preferNotToAnswer: '/dist/icons/modes/other/air_balloon.svg'
 };
 
+const modePreToModeIconMapping: Record<ModePre, Mode> = {
+    walk: 'walk',
+    bicycle: 'bicycle',
+    paratransit: 'paratransit',
+    carDriver: 'carDriver',
+    carPassenger: 'carPassenger',
+    taxi: 'taxi',
+    other: 'other',
+    dontKnow: 'dontKnow',
+    preferNotToAnswer: 'preferNotToAnswer',
+    transit: 'transitBus',
+    ferry: 'transitFerry'
+};
+
 /**
  * Returns the appropriate icon path for a given mode
  * @param mode The transportation mode
@@ -77,4 +100,13 @@ export const modeToIconMapping: Record<Mode, string> = {
  */
 export const getModeIcon = (mode: Mode): string => {
     return modeToIconMapping[mode] || '/dist/icons/modes/other/air_balloon.svg';
+};
+
+/**
+ * Returns the appropriate icon path for a given mode
+ * @param modePre The transportation mode
+ * @returns The path to the icon for the mode
+ */
+export const getModePreIcon = (modePre: ModePre): string => {
+    return modeToIconMapping[modePreToModeIconMapping[modePre]] || '/dist/icons/modes/other/air_balloon.svg';
 };

--- a/packages/evolution-common/src/services/questionnaire/types/Data.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/Data.ts
@@ -15,6 +15,7 @@ import { Optional } from '../../../types/Optional.type';
 import { SegmentAttributes } from '../../baseObjects/Segment';
 import { HouseholdAttributes } from '../../baseObjects/Household';
 import { NavigationSection } from './NavigationTypes';
+import { Mode, ModePre } from '../../odSurvey/types';
 
 export type ParsingFunction<T> = (interview: UserInterviewAttributes, path: string, user?: CliUser) => T;
 
@@ -150,10 +151,11 @@ export type Trip = TripAttributes & {
     };
 };
 
-export type Segment = SegmentAttributes & {
+export type Segment = Omit<SegmentAttributes, 'mode'> & {
     _sequence: number;
     _isNew: boolean;
-    modePre?: string;
+    modePre?: ModePre;
+    mode?: Mode;
     sameModeAsReverseTrip?: boolean;
     hasNextMode?: boolean;
 };

--- a/packages/evolution-common/src/tests/surveys/testCasesInterview.ts
+++ b/packages/evolution-common/src/tests/surveys/testCasesInterview.ts
@@ -209,7 +209,7 @@ export const interviewAttributesForTestCases: UserRuntimeInterviewAttributes = {
                                             _uuid: 'segmentId2P2T2',
                                             _sequence: 2,
                                             _isNew: false,
-                                            modePre: 'bus'
+                                            modePre: 'transit'
                                         }
                                     }
                                 },


### PR DESCRIPTION
fixes #1363

The modes in `baseObjects` describe the model built by Evolution and thus a 'mode' may be divided in multiple fields, with the type of motorization, ownership, etc. In the questionnaire, though, we should limit the number of questions to ask the respondent to reduce the burden, so we ask one or two questions, mode category and optionally mode, with values that could be converted to multiple other fields.

This commit adds a `Mode` type on the questionnaire side and updates the builtin widgets to use those types. A few modes are added to the list.

Note that this is not exhaustive. Since the demo_survey uses those widgets and they are not yet configurable, every current mode is displayed. But, later commits will add segment section configuration, where it will be possible to specify the level of granularity in choices, with a few defaults that would limit and sort the choices available in different situations (for example transit-intensive urban areas vs rural areas). It will then be possible to add possible values from which to pick for a given survey.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded transport modes (Paratransit, Ferry, CarDriver variants, PrivateBoat, Snowmobile, AllTerrainVehicle) with updated mode handling and icon support
  * New conditional checks for disability-related options to tailor choices

* **Localization**
  * Added English and French labels/translations for all new transport modes

* **Tests**
  * Added and updated unit tests covering disability conditionals and mode/label behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->