### PR TITLE
Widget: Allow dynamic height configuration for InfoMap component

### DIFF
--- a/packages/evolution-common/src/services/questionnaire/types/WidgetConfig.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/WidgetConfig.ts
@@ -442,6 +442,7 @@ export type InfoMapWidgetConfig = {
         linestrings?: GeoJSON.FeatureCollection<GeoJSON.LineString, SurveyMapObjectProperty>;
         polygons?: GeoJSON.FeatureCollection<GeoJSON.Polygon | GeoJSON.MultiPolygon, SurveyMapObjectPolygonProperty>;
     }>;
+    height?: string;
     defaultCenter?: { lat: number; lon: number } | ParsingFunction<{ lat: number; lon: number }>;
     maxZoom?: number;
     defaultZoom?: number;

--- a/packages/evolution-frontend/src/components/survey/InfoMap.tsx
+++ b/packages/evolution-frontend/src/components/survey/InfoMap.tsx
@@ -292,7 +292,7 @@ const InfoMap: React.FC<InfoMapProps & WithTranslation> = (props: InfoMapProps &
                     boxSizing: 'border-box',
                     position: 'relative',
                     width: '100%',
-                    height: '400px',
+                    height: props.widgetConfig.height || '400px',
                     border: '1px solid rgba(0,0,0,0.2'
                 }}
                 center={center}


### PR DESCRIPTION
# Pull request


## Justification
We need this for localisation.

## Description
Widget: Allow dynamic height configuration for InfoMap component
Updated the InfoMap component to utilize a configurable height from the widget configuration, defaulting to '400px' if not specified. This change enhances flexibility in rendering the InfoMap based on user-defined settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Map widgets now support configurable height settings, enabling flexible customization of map container dimensions with a default fallback to maintain compatibility with existing implementations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->