### PR TITLE
admin: move the router initialization in the `Jsx` component

### DIFF
--- a/packages/evolution-frontend/src/apps/admin/index.tsx
+++ b/packages/evolution-frontend/src/apps/admin/index.tsx
@@ -37,12 +37,12 @@ setApplicationConfiguration({
 
 export default () => {
     document.title = config.title[i18n.language];
-    const router = React.useMemo(() => createBrowserRouter(getAdminSurveyRoutes()), []);
 
     const store = configureStore();
     const Jsx = () => {
         const [state, dispatch] = React.useReducer(interviewReducer, initialState);
         const [devMode, dispatchSurvey] = React.useReducer(surveyReducer, { devMode: false });
+        const router = React.useMemo(() => createBrowserRouter(getAdminSurveyRoutes()), []);
 
         return (
             <SurveyContext.Provider


### PR DESCRIPTION
fixes #1376

The statement was moved outside the `Jsx` function in a recent commit and caused error when initializing the app, as the React is not yet initialized at that moment. It is moved back in the function, called after app initialization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal component initialization logic for improved performance and code organization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->