### PR TITLE
accessibilityMap: add access/egress and walking speed parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased (0.6.0)] - YYYY-MM-DD
 
 ### Added
+- Added `maxAccessEgressTravelTimeMinutes` and `walkingSpeedKmPerHour` to accessibility map calculation parameters (#1379)
 
 ### Changed
 

--- a/packages/evolution-backend/src/services/routing/index.ts
+++ b/packages/evolution-backend/src/services/routing/index.ts
@@ -135,6 +135,14 @@ export const getTransitAccessibilityMap = async function (
         throw new Error('Invalid number of polygons');
     }
 
+    if (parameters.maxAccessEgressTravelTimeMinutes !== undefined && parameters.maxAccessEgressTravelTimeMinutes <= 0) {
+        throw new Error('Invalid max access/egress travel time');
+    }
+
+    if (parameters.walkingSpeedKmPerHour !== undefined && parameters.walkingSpeedKmPerHour <= 0) {
+        throw new Error('Invalid walking speed');
+    }
+
     // All parameters are valid, dispatch to the proper accessibility map
     // function. Only supporting transition public API for now, but we could
     // have more eventually

--- a/packages/evolution-backend/src/services/routing/types.ts
+++ b/packages/evolution-backend/src/services/routing/types.ts
@@ -89,6 +89,21 @@ export type AccessibilityMapCalculationParameter = {
     maxTotalTravelTimeMinutes: number;
     /** whether to calculate points of interest */
     calculatePois?: boolean;
+    /** The maximum access/egress travel time in minutes */
+    maxAccessEgressTravelTimeMinutes?: number;
+    /** The walking speed in kilometers per hour, to calculate access and egress travel times */
+    walkingSpeedKmPerHour?: number;
+};
+
+/**
+ * Properties for polygons in the accessibility map. Comes from the Transition
+ * API documentation
+ */
+export type AccessibilityMapPolygonProperties = {
+    durationSeconds: number;
+    areaSqM: number;
+    accessiblePlacesCountByCategory?: Record<string, number>;
+    accessiblePlacesCountByDetailedCategory?: Record<string, number>;
 };
 
 export type AccessibilityMapResult = {
@@ -102,6 +117,6 @@ export type AccessibilityMapResult = {
       }
     | {
           status: 'success';
-          polygons: GeoJSON.FeatureCollection<GeoJSON.MultiPolygon>;
+          polygons: GeoJSON.FeatureCollection<GeoJSON.MultiPolygon, AccessibilityMapPolygonProperties>;
       }
 );


### PR DESCRIPTION
Those are parameters supported by Transition and that may be required by consumers of this function. Also type the properties of the returned polygons, to include the duration, area and extra accessibility data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional parameters to customize accessibility map calculations: max access/egress travel time and walking speed.
  * Accessibility map polygons now include richer metadata (duration, area, and optional counts of accessible places).

* **Bug Fixes**
  * Improved validation for parameter values and clearer error messages for bad requests.

* **Tests**
  * Expanded parameterized tests covering multiple scenarios (with/without POIs and optional params).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->