### PR TITLE
segments: add a separate validateButtonAction for next section

### DIFF
--- a/example/demo_survey/src/survey/helper.ts
+++ b/example/demo_survey/src/survey/helper.ts
@@ -15,9 +15,11 @@ import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import i18n                     from 'evolution-frontend/lib/config/i18n.config';
 import * as surveyHelperNew     from 'evolution-common/lib/utils/helpers';
 import * as odSurveyHelper     from 'evolution-common/lib/services/odSurvey/helpers';
-import { getVisitedPlaceDescription } from 'evolution-frontend/lib/services/display/frontendHelper';
+import { getFormattedDate, getVisitedPlaceDescription, validateButtonAction, validateButtonActionWithCompleteSection } from 'evolution-frontend/lib/services/display/frontendHelper';
 import { Person, VisitedPlace } from 'evolution-common/lib/services/questionnaire/types';
 import { Mode } from 'evolution-common/lib/services/odSurvey/types';
+import { WidgetFactoryOptions } from 'evolution-common/lib/services/questionnaire/sections/types';
+import { faCheckCircle } from '@fortawesome/free-solid-svg-icons/faCheckCircle';
 
 // Configuration for the segments section
 // FIXME As sections and their widgets become more builtin, this thould be moved elsewhere. For now, it just needs to be available for both widgets.ts and sections.ts files
@@ -54,6 +56,16 @@ export const segmentSectionConfig = {
         'other',
         'dontKnow'
     ] as Mode[]
+};
+
+// FIXME Move elsewhere. It is not here to be available for widgets.ts, sections.ts and questionnaire.ts files
+export const widgetFactoryOptions: WidgetFactoryOptions = {
+    getFormattedDate: getFormattedDate,
+    buttonActions: { 
+        validateButtonActionWithCompleteSection: validateButtonActionWithCompleteSection,
+        validateButtonAction: validateButtonAction
+    },
+    iconMapper: { 'check-circle': faCheckCircle }
 };
 
 const homeSectionComplete = function(interview) {

--- a/example/demo_survey/src/survey/questionnaire.ts
+++ b/example/demo_survey/src/survey/questionnaire.ts
@@ -2,20 +2,12 @@ import { SegmentsSectionFactory } from 'evolution-common/lib/services/questionna
 import * as odSurveyHelper from 'evolution-common/lib/services/odSurvey/helpers';
 import surveySections from './sections';
 import * as widgetsConfig from './widgets';
-import helper, { segmentSectionConfig } from './helper';
+import helper, { segmentSectionConfig, widgetFactoryOptions } from './helper';
 import { getAndValidateSurveySections, SectionConfig } from 'evolution-common/lib/services/questionnaire/types';
-import { getFormattedDate, validateButtonActionWithCompleteSection } from 'evolution-frontend/lib/services/display/frontendHelper';
-import { faCheckCircle } from '@fortawesome/free-solid-svg-icons/faCheckCircle';
 
 // FIXME For now this file is here and has quite a bit of code. Eventually, the
 // questionnaire generation should be done in Evolution directly when we have
 // more builtin stuff
-
-const widgetFactoryOptions = {
-    getFormattedDate: getFormattedDate,
-    buttonActions: { validateButtonAction: validateButtonActionWithCompleteSection },
-    iconMapper: { 'check-circle': faCheckCircle }
-};
 
 const segmentSectionConfigFactory = new SegmentsSectionFactory(segmentSectionConfig, widgetFactoryOptions);
 const segmentSectionConfigFromFactory = segmentSectionConfigFactory.getSectionConfig();

--- a/example/demo_survey/src/survey/widgets.ts
+++ b/example/demo_survey/src/survey/widgets.ts
@@ -4,7 +4,6 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import { faCheckCircle } from '@fortawesome/free-solid-svg-icons/faCheckCircle';
 import { faPlay } from '@fortawesome/free-solid-svg-icons/faPlay';
 
 import { validateButtonActionWithCompleteSection } from 'evolution-frontend/lib/services/display/frontendHelper';
@@ -120,6 +119,7 @@ export const personNoSchoolTripReason: any       = travelBehaviorWidgets.personN
 export const personWhoAnsweredForThisPerson: any = travelBehaviorWidgets.personWhoAnsweredForThisPerson;
 
 import * as endWidgets from './widgets/end';
+import { widgetFactoryOptions } from './helper';
 
 export const householdResidentialPhoneType: any                 = endWidgets.householdResidentialPhoneType;
 export const householdWouldLikeToParticipateInOtherSurveys: any = endWidgets.householdWouldLikeToParticipateInOtherSurveys;
@@ -133,16 +133,9 @@ export const completedText: any                                 = endWidgets.com
 
 // multi-sections widgets:
 
-const buttonOptions = {
-  iconMapper: { "check-circle": faCheckCircle },
-  buttonActions: {
-    validateButtonAction: validateButtonActionWithCompleteSection,
-  },
-};
+export const buttonSaveNextSection = getButtonValidateAndGotoNextSection('survey:SaveAndContinue', widgetFactoryOptions);
 
-export const buttonSaveNextSection = getButtonValidateAndGotoNextSection('survey:SaveAndContinue', buttonOptions);
-
-export const buttonSaveNextSection2 = getButtonValidateAndGotoNextSection('survey:SaveAndContinue', buttonOptions);
+export const buttonSaveNextSection2 = getButtonValidateAndGotoNextSection('survey:SaveAndContinue', widgetFactoryOptions);
 
 export const buttonStartNextSection: any = {
   type: "button",
@@ -158,8 +151,8 @@ export const buttonStartNextSection: any = {
   action: validateButtonActionWithCompleteSection
 }
 
-export const buttonContinueNextSection = getButtonValidateAndGotoNextSection('survey:Continue', buttonOptions);;
+export const buttonContinueNextSection = getButtonValidateAndGotoNextSection('survey:Continue', widgetFactoryOptions);
 
-export const buttonConfirmNextSection = getButtonValidateAndGotoNextSection('survey:ConfirmAndContinue', buttonOptions);
+export const buttonConfirmNextSection = getButtonValidateAndGotoNextSection('survey:ConfirmAndContinue', widgetFactoryOptions);
 
-export const buttonCompleteInterview = getButtonValidateAndGotoNextSection('survey:CompleteInterview', buttonOptions);
+export const buttonCompleteInterview = getButtonValidateAndGotoNextSection('survey:CompleteInterview', widgetFactoryOptions);

--- a/packages/evolution-common/src/services/questionnaire/sections/common/__tests__/buttonValidateAndGotoNextSection.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/common/__tests__/buttonValidateAndGotoNextSection.test.ts
@@ -7,15 +7,10 @@
 import _cloneDeep from 'lodash/cloneDeep';
 
 import { getButtonValidateAndGotoNextSection } from '../buttonValidateAndGotoNextSection';
-import { interviewAttributesForTestCases } from '../../../../../tests/surveys';
+import { interviewAttributesForTestCases, widgetFactoryOptions } from '../../../../../tests/surveys';
 import * as utilHelpers from '../../../../../utils/helpers';
 
 // Prepare configuration options
-const mockButtonValidate = jest.fn();
-const options = {
-    buttonActions: { validateButtonAction: mockButtonValidate },
-    iconMapper: { 'check-circle': 'check-circle' as any }
-}
 const translatableKey = 'myButtonKey';
 
 beforeEach(() => {
@@ -25,7 +20,7 @@ beforeEach(() => {
 describe('getButtonValidateAndGotoNextSection', () => {
 
     test('should return the correct widget config', () => {
-        const widgetConfig = getButtonValidateAndGotoNextSection(translatableKey, options);
+        const widgetConfig = getButtonValidateAndGotoNextSection(translatableKey, widgetFactoryOptions);
         expect(widgetConfig).toEqual({
             type: 'button',
             color: 'green',
@@ -34,14 +29,14 @@ describe('getButtonValidateAndGotoNextSection', () => {
             path: 'buttonValidateGotoNextSection',
             icon: 'check-circle',
             align: 'center',
-            action: mockButtonValidate
+            action: widgetFactoryOptions.buttonActions.validateButtonActionWithCompleteSection
         });
     });
 
 });
 
 describe('getButtonValidateAndGotoNextSection labels', () => {
-    const widgetConfig = getButtonValidateAndGotoNextSection(translatableKey, options);
+    const widgetConfig = getButtonValidateAndGotoNextSection(translatableKey, widgetFactoryOptions);
 
     test('should return the right label for title', () => {
         const mockedT = jest.fn();
@@ -54,12 +49,12 @@ describe('getButtonValidateAndGotoNextSection labels', () => {
 });
 
 describe('getButtonValidateAndGotoNextSection button action', () => {
-    const widgetConfig = getButtonValidateAndGotoNextSection(translatableKey, options);
+    const widgetConfig = getButtonValidateAndGotoNextSection(translatableKey, widgetFactoryOptions);
 
     test('test button action', () => {
-        expect(mockButtonValidate).not.toHaveBeenCalled();
+        expect(widgetFactoryOptions.buttonActions.validateButtonActionWithCompleteSection).not.toHaveBeenCalled();
         const action = widgetConfig.action;
         action({ startUpdateInterview: jest.fn(), startAddGroupedObjects: jest.fn(), startRemoveGroupedObjects: jest.fn(), startNavigate: jest.fn() }, interviewAttributesForTestCases, 'path', 'segments', {});
-        expect(mockButtonValidate).toHaveBeenCalled();
+        expect(widgetFactoryOptions.buttonActions.validateButtonActionWithCompleteSection).toHaveBeenCalled();
     })
 });

--- a/packages/evolution-common/src/services/questionnaire/sections/common/__tests__/widgetPersonVisitedPlacesMap.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/common/__tests__/widgetPersonVisitedPlacesMap.test.ts
@@ -6,7 +6,7 @@
  */
 import _cloneDeep from 'lodash/cloneDeep';
 import { getPersonVisitedPlacesMapConfig } from '../widgetPersonVisitedPlacesMap';
-import { interviewAttributesForTestCases } from '../../../../../tests/surveys';
+import { interviewAttributesForTestCases, widgetFactoryOptions } from '../../../../../tests/surveys';
 import * as odHelpers from '../../../../odSurvey/helpers';
 import projectConfig from '../../../../../config/project.config';
 import { pointsToBezierCurve } from '../../../../geodata/SurveyGeographyUtils';
@@ -61,6 +61,7 @@ describe('personVisitedPlacesMapConfig', () => {
 describe('personVisitedPlacesMapConfig title', () => {
 
     const options = {
+        ...widgetFactoryOptions,
         context: jest.fn().mockImplementation((context: string) => context),
         getFormattedDate: mockGetFormattedDate
     };

--- a/packages/evolution-common/src/services/questionnaire/sections/common/__tests__/widgetsSwitchPerson.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/common/__tests__/widgetsSwitchPerson.test.ts
@@ -7,17 +7,11 @@
 import _cloneDeep from 'lodash/cloneDeep';
 
 import { SwitchPersonWidgetsFactory } from '../widgetsSwitchPerson';
-import { interviewAttributesForTestCases } from '../../../../../tests/surveys';
+import { interviewAttributesForTestCases, widgetFactoryOptions } from '../../../../../tests/surveys';
 import * as utilHelpers from '../../../../../utils/helpers';
 import { ButtonWidgetConfig, TextWidgetConfig } from '../../../../questionnaire/types';
 
 import * as odHelpers from '../../../../odSurvey/helpers';
-
-const widgetFactoryOptions = {
-    getFormattedDate: (date: string) => date,
-    buttonActions: { validateButtonAction: jest.fn() },
-    iconMapper: {}
-};
 
 jest.mock('../../../../odSurvey/helpers', () => ({
     getInterviewablePersonsArray: jest.fn().mockReturnValue([]),

--- a/packages/evolution-common/src/services/questionnaire/sections/common/buttonValidateAndGotoNextSection.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/common/buttonValidateAndGotoNextSection.ts
@@ -6,27 +6,25 @@
  */
 import { ButtonWidgetConfig } from '../../../questionnaire/types';
 import { TFunction } from 'i18next';
-import { IconProp } from '@fortawesome/fontawesome-svg-core';
-import { ButtonAction } from '../../types';
+import { WidgetFactoryOptions } from '../types';
 
 /**
- * Get the configuration for a button that will call the `validateButtonAction`
- * provided in the options when clicked.
+ * Get the configuration for a button that will call the
+ * `validateButtonActionWithCompleteSection` provided in the options when
+ * clicked.
  *
  * @param translatableLabel The text to use for this button. It should be a
  * translatable string key, automatically, its custom version in the
  * customSurvey namespace will be added to the call
- * @param options
+ * @param {WidgetFactoryOptions} options The options to use for this widget
+ * configuration. It should include the
+ * `validateButtonActionWithCompleteSection` function in its `buttonActions`
+ * property, and the `check-circle` icon in its `iconMapper` property.
  * @returns {ButtonWidgetConfig} The configuration object for the button widget.
  */
 export const getButtonValidateAndGotoNextSection = (
     translatableLabel: string,
-    // FIXME: Type this when there is a few more widgets implemented
-    options: {
-        context?: () => string;
-        buttonActions: { validateButtonAction: ButtonAction };
-        iconMapper: { [iconName: string]: IconProp };
-    }
+    options: WidgetFactoryOptions
 ): ButtonWidgetConfig => {
     return {
         type: 'button',
@@ -37,6 +35,6 @@ export const getButtonValidateAndGotoNextSection = (
         hideWhenRefreshing: true,
         icon: options.iconMapper['check-circle'],
         align: 'center',
-        action: options.buttonActions.validateButtonAction
+        action: options.buttonActions.validateButtonActionWithCompleteSection
     };
 };

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/buttonSaveTripSegments.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/buttonSaveTripSegments.test.ts
@@ -7,7 +7,7 @@
 import _cloneDeep from 'lodash/cloneDeep';
 
 import { getButtonSaveTripSegmentsConfig } from '../buttonSaveTripSegments';
-import { interviewAttributesForTestCases } from '../../../../../tests/surveys';
+import { interviewAttributesForTestCases, widgetFactoryOptions } from '../../../../../tests/surveys';
 import * as utilHelpers from '../../../../../utils/helpers';
 import * as odHelpers from '../../../../odSurvey/helpers';
 
@@ -20,12 +20,6 @@ const mockedGetPerson = odHelpers.getPerson as jest.MockedFunction<typeof odHelp
 const mockedGetActiveJourney = odHelpers.getActiveJourney as jest.MockedFunction<typeof odHelpers.getActiveJourney>;
 const mockedSelectNextIncompleteTrip = odHelpers.selectNextIncompleteTrip as jest.MockedFunction<typeof odHelpers.selectNextIncompleteTrip>;
 
-// Prepare configuration options
-const mockButtonValidate = jest.fn();
-const options = {
-    buttonActions: { validateButtonAction: mockButtonValidate },
-    iconMapper: { 'check-circle': 'check-circle' as any }
-};
 
 beforeEach(() => {
     jest.clearAllMocks();
@@ -34,7 +28,7 @@ beforeEach(() => {
 describe('getButtonSaveTripSegmentsConfig', () => {
 
     test('should return the correct widget config', () => {
-        const widgetConfig = getButtonSaveTripSegmentsConfig(options);
+        const widgetConfig = getButtonSaveTripSegmentsConfig(widgetFactoryOptions);
         expect(widgetConfig).toEqual({
             type: 'button',
             color: 'green',
@@ -43,7 +37,7 @@ describe('getButtonSaveTripSegmentsConfig', () => {
             path: 'buttonSaveTrip',
             icon: 'check-circle',
             align: 'center',
-            action: mockButtonValidate,
+            action: widgetFactoryOptions.buttonActions.validateButtonAction,
             saveCallback: expect.any(Function),
             conditional: expect.any(Function)
         });
@@ -52,7 +46,7 @@ describe('getButtonSaveTripSegmentsConfig', () => {
 });
 
 describe('getButtonSaveTripSegmentsConfig labels', () => {
-    const widgetConfig = getButtonSaveTripSegmentsConfig(options);
+    const widgetConfig = getButtonSaveTripSegmentsConfig(widgetFactoryOptions);
 
     test('should return the right label for title', () => {
         const mockedT = jest.fn();
@@ -65,7 +59,7 @@ describe('getButtonSaveTripSegmentsConfig labels', () => {
 });
 
 describe('getButtonSaveTripSegmentsConfig conditional', () => {
-    const widgetConfig = getButtonSaveTripSegmentsConfig(options);
+    const widgetConfig = getButtonSaveTripSegmentsConfig(widgetFactoryOptions);
 
     jest.spyOn(utilHelpers, 'getResponse').mockReturnValue({});
     const mockedGetResponse = utilHelpers.getResponse as jest.MockedFunction<typeof utilHelpers.getResponse>;
@@ -109,18 +103,18 @@ describe('getButtonSaveTripSegmentsConfig conditional', () => {
 });
 
 describe('getButtonSaveTripSegmentsConfig button action', () => {
-    const widgetConfig = getButtonSaveTripSegmentsConfig(options);
+    const widgetConfig = getButtonSaveTripSegmentsConfig(widgetFactoryOptions);
 
     test('test button action', () => {
-        expect(mockButtonValidate).not.toHaveBeenCalled();
+        expect(widgetFactoryOptions.buttonActions.validateButtonAction).not.toHaveBeenCalled();
         const action = widgetConfig.action;
         action({ startUpdateInterview: jest.fn(), startAddGroupedObjects: jest.fn(), startRemoveGroupedObjects: jest.fn(), startNavigate: jest.fn() }, interviewAttributesForTestCases, 'path', 'segments', {});
-        expect(mockButtonValidate).toHaveBeenCalled();
+        expect(widgetFactoryOptions.buttonActions.validateButtonAction).toHaveBeenCalled();
     });
 });
 
 describe('getButtonSaveTripSegmentsConfig save callback', () => {
-    const widgetConfig = getButtonSaveTripSegmentsConfig(options);
+    const widgetConfig = getButtonSaveTripSegmentsConfig(widgetFactoryOptions);
 
     jest.spyOn(utilHelpers, 'getResponse').mockReturnValue({});
     const mockedGetResponse = utilHelpers.getResponse as jest.MockedFunction<typeof utilHelpers.getResponse>;

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/groupPersonTrips.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/groupPersonTrips.test.ts
@@ -7,20 +7,14 @@
 import _cloneDeep from 'lodash/cloneDeep';
 
 import { PersonTripsGroupConfigFactory } from '../groupPersonTrips';
-import { interviewAttributesForTestCases, maskFunctions } from '../../../../../tests/surveys';
+import { interviewAttributesForTestCases, maskFunctions, widgetFactoryOptions } from '../../../../../tests/surveys';
 import * as utilHelpers from '../../../../../utils/helpers';
-import { WidgetFactoryOptions } from '../../types';
 import { GroupConfig, SegmentSectionConfiguration, WidgetConfig } from '../../../types';
 import { SegmentsGroupConfigFactory } from '../groupSegments';
 import { Mode } from '../../../../odSurvey/types';
 import { getTripSegmentsIntro } from '../widgetTripSegmentsIntro';
 import { getButtonSaveTripSegmentsConfig } from '../buttonSaveTripSegments';
 
-const widgetFactoryOptions: WidgetFactoryOptions = {
-    getFormattedDate: (date: string) => date,
-    buttonActions: { validateButtonAction: jest.fn() },
-    iconMapper: {}
-};
 const segmentSectionConfig = {
     type: 'segments' as const,
     enabled: true

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/groupSegments.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/groupSegments.test.ts
@@ -7,21 +7,15 @@
 import _cloneDeep from 'lodash/cloneDeep';
 
 import { SegmentsGroupConfigFactory } from '../groupSegments';
-import { interviewAttributesForTestCases, maskFunctions } from '../../../../../tests/surveys';
+import { interviewAttributesForTestCases, maskFunctions, widgetFactoryOptions } from '../../../../../tests/surveys';
 import * as utilHelpers from '../../../../../utils/helpers';
 import { GroupConfig, SegmentSectionConfiguration, WidgetConfig } from '../../../types';
 import { getModePreWidgetConfig } from '../widgetSegmentModePre';
 import { getSameAsReverseTripWidgetConfig } from '../widgetSameAsReverseTrip';
-import { WidgetFactoryOptions } from '../../types';
 import { getModeWidgetConfig } from '../widgetSegmentMode';
 import { getSegmentHasNextModeWidgetConfig } from '../widgetSegmentHasNextMode';
 import { Mode } from '../../../../odSurvey/types';
 
-const widgetFactoryOptions: WidgetFactoryOptions = {
-    getFormattedDate: (date: string) => date,
-    buttonActions: { validateButtonAction: jest.fn() },
-    iconMapper: {}
-};
 const segmentSectionConfig = {
     type: 'segments' as const,
     enabled: true

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/sectionSegment.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/sectionSegment.test.ts
@@ -8,10 +8,9 @@ import _cloneDeep from 'lodash/cloneDeep';
 import { v4 as uuidv4 } from 'uuid';
 
 import { SegmentsSectionFactory } from '../sectionSegments';
-import { interviewAttributesForTestCases, maskFunctions } from '../../../../../tests/surveys';
+import { interviewAttributesForTestCases, maskFunctions, widgetFactoryOptions } from '../../../../../tests/surveys';
 import * as utilHelpers from '../../../../../utils/helpers';
 import * as odHelpers from '../../../../odSurvey/helpers';
-import { WidgetFactoryOptions } from '../../types';
 import { SegmentSectionConfiguration, WidgetConfig } from '../../../types';
 import { Mode } from '../../../../odSurvey/types';
 import { PersonTripsGroupConfigFactory } from '../groupPersonTrips';
@@ -24,11 +23,6 @@ jest.mock('uuid', () => ({
     v4: jest.fn().mockReturnValue('newTripId')
 }));
 const mockUuidv4 = uuidv4 as jest.MockedFunction<typeof uuidv4>;
-const widgetFactoryOptions: WidgetFactoryOptions = {
-    getFormattedDate: (date: string) => date,
-    buttonActions: { validateButtonAction: jest.fn() },
-    iconMapper: {}
-};
 const segmentSectionConfig = {
     type: 'segments' as const,
     enabled: true

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetPersonTripsTitle.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetPersonTripsTitle.test.ts
@@ -6,7 +6,7 @@
  */
 import _cloneDeep from 'lodash/cloneDeep';
 import { getPersonsTripsTitleWidgetConfig } from '../widgetPersonTripsTitle';
-import { interviewAttributesForTestCases } from '../../../../../tests/surveys';
+import { interviewAttributesForTestCases, widgetFactoryOptions } from '../../../../../tests/surveys';
 import * as odHelpers from '../../../../odSurvey/helpers';
 
 jest.mock('../../../../odSurvey/helpers', () => ({
@@ -18,13 +18,8 @@ const mockedGetActivePerson = odHelpers.getActivePerson as jest.MockedFunction<t
 const mockedGetActiveJourney = odHelpers.getActiveJourney as jest.MockedFunction<typeof odHelpers.getActiveJourney>;
 const mockedGetCountOrSelfDeclared = odHelpers.getCountOrSelfDeclared as jest.MockedFunction<typeof odHelpers.getCountOrSelfDeclared>;
 
-const mockGetFormattedDate = jest.fn().mockReturnValue('formattedDate');
-const widgetFactoryOptions = {
-    context: jest.fn(),
-    getFormattedDate: mockGetFormattedDate,
-    buttonActions: { validateButtonAction: jest.fn() },
-    iconMapper: {}
-};
+const mockGetFormattedDate = widgetFactoryOptions.getFormattedDate as jest.MockedFunction<typeof widgetFactoryOptions.getFormattedDate>;
+mockGetFormattedDate.mockReturnValue('formattedDate');
 
 beforeEach(() => {
     jest.clearAllMocks();

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetSegmentMode.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetSegmentMode.test.ts
@@ -9,18 +9,13 @@ import _cloneDeep from 'lodash/cloneDeep';
 import each from 'jest-each';
 import { InputRadioType, QuestionWidgetConfig, RadioChoiceType } from '../../../../questionnaire/types';
 import { getModeWidgetConfig } from '../widgetSegmentMode';
-import { interviewAttributesForTestCases } from '../../../../../tests/surveys';
+import { interviewAttributesForTestCases, widgetFactoryOptions } from '../../../../../tests/surveys';
 import { getResponse, setResponse, translateString } from '../../../../../utils/helpers';
 import * as surveyHelper from '../../../../odSurvey/helpers';
 import { Mode, ModePre, modePreToModeMap, modeToModePreMap, modeValues } from '../../../../odSurvey/types';
 import { shouldShowSameAsReverseTripQuestion, getPreviousTripSingleSegment } from '../helpers';
 import { modeToIconMapping } from '../modeIconMapping';
 
-const widgetFactoryOptions = {
-    getFormattedDate: (date: string) => date,
-    buttonActions: { validateButtonAction: jest.fn() },
-    iconMapper: {}
-};
 const segmentSectionConfig = {
     type: 'segments' as const,
     enabled: true

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetSegmentModePre.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetSegmentModePre.test.ts
@@ -8,17 +8,12 @@ import _cloneDeep from 'lodash/cloneDeep';
 import each from 'jest-each';
 import { InputRadioType, QuestionWidgetConfig, RadioChoiceType } from '../../../../questionnaire/types';
 import { getModePreWidgetConfig } from '../widgetSegmentModePre';
-import { interviewAttributesForTestCases } from '../../../../../tests/surveys';
+import { interviewAttributesForTestCases, widgetFactoryOptions } from '../../../../../tests/surveys';
 import { getResponse, setResponse, translateString } from '../../../../../utils/helpers';
 import * as surveyHelper from '../../../../odSurvey/helpers';
 import { shouldShowSameAsReverseTripQuestion, getPreviousTripSingleSegment } from '../helpers';
 import { Mode } from '../../../../odSurvey/types';
 
-const widgetFactoryOptions = {
-    getFormattedDate: (date: string) => date,
-    buttonActions: { validateButtonAction: jest.fn() },
-    iconMapper: {}
-};
 const segmentSectionConfig = {
     type: 'segments' as const,
     enabled: true

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/buttonSaveTripSegments.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/buttonSaveTripSegments.ts
@@ -8,18 +8,10 @@ import { ButtonWidgetConfig } from '../../../questionnaire/types';
 import { getPath, getResponse } from '../../../../utils/helpers';
 import * as odHelpers from '../../../odSurvey/helpers';
 import { TFunction } from 'i18next';
-import { IconProp } from '@fortawesome/fontawesome-svg-core';
-import { ButtonAction, InterviewUpdateCallbacks, Segment, UserInterviewAttributes } from '../../types';
+import { InterviewUpdateCallbacks, Segment, UserInterviewAttributes } from '../../types';
+import { WidgetFactoryOptions } from '../types';
 
-export const getButtonSaveTripSegmentsConfig = (
-    // FIXME: Type this when there is a few more widgets implemented
-    options: {
-        context?: () => string;
-        buttonActions: { validateButtonAction: ButtonAction };
-        iconMapper: { [iconName: string]: IconProp };
-    }
-): ButtonWidgetConfig => {
-    // TODO These should be some configuration receive here to fine-tune the section's content
+export const getButtonSaveTripSegmentsConfig = (options: WidgetFactoryOptions): ButtonWidgetConfig => {
     return {
         type: 'button',
         color: 'green',

--- a/packages/evolution-common/src/services/questionnaire/sections/types.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/types.ts
@@ -63,7 +63,22 @@ export type WidgetFactoryOptions = {
      * frontend code, so they can be mapped to each button action when creating
      * the survey.
      */
-    buttonActions: { validateButtonAction: ButtonAction };
+    buttonActions: {
+        /**
+         * When the button is clicked, this action will try to navigate to the
+         * next section and submit the current one, or display the errors of the
+         * current section if any.  This is the action to use for buttons that
+         * complete a section.
+         */
+        validateButtonActionWithCompleteSection: ButtonAction;
+        /**
+         * When the button is clicked, this action will simply submit the
+         * current data and call a callback provided by the widget. This is the
+         * action to use for buttons that would not trigger section change, but
+         * have actions, for example to complete a group and go to the next.
+         */
+        validateButtonAction: ButtonAction;
+    };
     /**
      * Map an icon name to its FontAwesome icon definition.
      *

--- a/packages/evolution-common/src/tests/surveys/index.ts
+++ b/packages/evolution-common/src/tests/surveys/index.ts
@@ -5,6 +5,8 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 
+import { WidgetFactoryOptions } from '../../services/questionnaire/sections/types';
+
 export { interviewAttributesForTestCases } from './testCasesInterview';
 
 /**
@@ -25,4 +27,11 @@ export const maskFunctions = (value: unknown): unknown => {
         );
     }
     return value;
+};
+
+/** Provide the mandatory options for widget factory calls. */
+export const widgetFactoryOptions: WidgetFactoryOptions = {
+    getFormattedDate: jest.fn().mockImplementation((date: string) => date),
+    buttonActions: { validateButtonAction: jest.fn(), validateButtonActionWithCompleteSection: jest.fn() },
+    iconMapper: { 'check-circle': 'check-circle' as any }
 };


### PR DESCRIPTION
This fixes a regression with commit
f2ade4d1e3e69b13e30e851d034b751e1955efc9 where it was not possible to confirm a segment group because it tried to navigate to the next section, but it is not possible.

It adds a separate `validateButtonActionWithCompleteSection` button action to the `buttonActions` part of the `WidgetFactoryOptions`. Thus each button can choose the appropriate action to call depending on its need.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized widget factory configuration (button actions and icon mappings) for consistent use across the survey UI
  * Added a second button validation action to support both section-completing navigation and standard validation flows

* **Tests**
  * Updated test suites to use the new centralized widget factory configuration and its mocked helpers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->