### PR TITLE
segments: support adding custom widgets in segment group

### DIFF
--- a/example/demo_survey/src/survey/helper.ts
+++ b/example/demo_survey/src/survey/helper.ts
@@ -4,26 +4,21 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import moment       from 'moment-business-days';
-import isEmpty      from 'lodash/isEmpty';
 import isEqual      from 'lodash/isEqual';
 import _get         from 'lodash/get';
-import _cloneDeep from 'lodash/cloneDeep';
-import { distance as turfDistance } from '@turf/turf';
 
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
-import i18n                     from 'evolution-frontend/lib/config/i18n.config';
 import * as surveyHelperNew     from 'evolution-common/lib/utils/helpers';
 import * as odSurveyHelper     from 'evolution-common/lib/services/odSurvey/helpers';
 import { getFormattedDate, getVisitedPlaceDescription, validateButtonAction, validateButtonActionWithCompleteSection } from 'evolution-frontend/lib/services/display/frontendHelper';
-import { Person, VisitedPlace } from 'evolution-common/lib/services/questionnaire/types';
+import { SegmentSectionConfiguration, VisitedPlace } from 'evolution-common/lib/services/questionnaire/types';
 import { Mode } from 'evolution-common/lib/services/odSurvey/types';
 import { WidgetFactoryOptions } from 'evolution-common/lib/services/questionnaire/sections/types';
 import { faCheckCircle } from '@fortawesome/free-solid-svg-icons/faCheckCircle';
 
 // Configuration for the segments section
 // FIXME As sections and their widgets become more builtin, this thould be moved elsewhere. For now, it just needs to be available for both widgets.ts and sections.ts files
-export const segmentSectionConfig = {
+export const segmentSectionConfig: SegmentSectionConfiguration = {
     type: 'segments' as const,
     enabled: true,
     modesIncludeOnly: [
@@ -55,7 +50,28 @@ export const segmentSectionConfig = {
         'otherActiveMode',
         'other',
         'dontKnow'
-    ] as Mode[]
+    ] as Mode[],
+    additionalSegmentWidgetNames: [
+        //'segmentParkingType',
+        'segmentParkingPaymentType',
+        'segmentVehicleOccupancy',
+        'segmentVehicleType',
+        'segmentDriver',
+        'segmentBridgesAndTunnels',
+        'segmentHighways',
+        'segmentUsedBikesharing',
+        'segmentSubwayStationStart',
+        'segmentSubwayStationEnd',
+        'segmentSubwayTransferStations',
+        'segmentTrainStationStart',
+        'segmentTrainStationEnd',
+        'segmentHowToBus',
+        'segmentBusLines',
+        'segmentBusLinesWarning',
+        'segmentOnDemandType',
+        'tripJunctionQueryString',
+        'tripJunctionGeography'
+    ]
 };
 
 // FIXME Move elsewhere. It is not here to be available for widgets.ts, sections.ts and questionnaire.ts files

--- a/example/demo_survey/src/survey/widgets/segments.tsx
+++ b/example/demo_survey/src/survey/widgets/segments.tsx
@@ -4,8 +4,6 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import moment from 'moment-business-days';
-import { faCheckCircle } from '@fortawesome/free-solid-svg-icons/faCheckCircle';
 import _get from 'lodash/get';
 import { distance as turfDistance } from '@turf/turf';
 
@@ -13,41 +11,10 @@ import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import config from 'chaire-lib-common/lib/config/shared/project.config';
 import * as surveyHelperNew from 'evolution-common/lib/utils/helpers';
 import * as odSurveyHelper from 'evolution-common/lib/services/odSurvey/helpers';
-import helper, { segmentSectionConfig } from '../helper';
+import helper from '../helper';
 import subwayStations from '../subwayStations.json';
 import trainStations  from '../trainStations.json';
 import busRoutes  from '../busRoutes.json';
-import { GroupConfig } from 'evolution-common/lib/services/questionnaire/types';
-import { getFormattedDate, validateButtonAction } from 'evolution-frontend/lib/services/display/frontendHelper';
-
-/*
-TODO These were the original widgets for the group, as well as some from other surveys, that should eventually be configurable
-widgets: [
-    'segmentSameModeAsReverseTrip',
-    'segmentModePre',
-    'segmentMode',
-    //'segmentParkingType',
-    'segmentParkingPaymentType',
-    'segmentVehicleOccupancy',
-    'segmentVehicleType',
-    'segmentDriver',
-    'segmentBridgesAndTunnels',
-    'segmentHighways',
-    'segmentUsedBikesharing',
-    'segmentSubwayStationStart',
-    'segmentSubwayStationEnd',
-    'segmentSubwayTransferStations',
-    'segmentTrainStationStart',
-    'segmentTrainStationEnd',
-    'segmentHowToBus',
-    'segmentBusLines',
-    'segmentBusLinesWarning',
-    'segmentOnDemandType',
-    'tripJunctionQueryString',
-    'tripJunctionGeography',
-    'segmentHasNextMode'
-  ]
-    */
 
 export const segmentVehicleOccupancy = {
   type: "question",

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/groupSegments.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/groupSegments.test.ts
@@ -196,3 +196,28 @@ describe('SegmentsGroupConfigFactory segments GroupConfig widget', () => {
 
     });
 });
+
+test('SegmentsGroupConfigFactory segments GroupConfig widget with additional widget names', () => {
+    const segmentSectionConfigWithWidgets: SegmentSectionConfiguration = _cloneDeep(segmentSectionConfig);
+    segmentSectionConfigWithWidgets.additionalSegmentWidgetNames = ['customWidget1', 'customWidget2'];
+    const widgetConfig = new SegmentsGroupConfigFactory(segmentSectionConfigWithWidgets, widgetFactoryOptions).getWidgetConfigs()['segments'] as GroupConfig;
+    expect(widgetConfig).toEqual({
+        type: 'group',
+        path: 'segments',
+        title: expect.any(Function),
+        name: expect.any(Function),
+        showTitle: false,
+        showGroupedObjectDeleteButton: expect.any(Function),
+        showGroupedObjectAddButton: expect.any(Function),
+        groupedObjectAddButtonLabel: expect.any(Function),
+        addButtonLocation: 'bottom' as const,
+        widgets: [
+            'segmentSameModeAsReverseTrip',
+            'segmentModePre',
+            'segmentMode',
+            'customWidget1',
+            'customWidget2',
+            'segmentHasNextMode'
+        ]
+    });
+});

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/groupSegments.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/groupSegments.ts
@@ -24,6 +24,7 @@ export class SegmentsGroupConfigFactory implements WidgetConfigFactory {
     }
 
     private getSegmentsGroupConfig = (): GroupConfig => {
+        const additionalWidgetNames = this.sectionConfig.additionalSegmentWidgetNames || [];
         // TODO These should be some configuration receive here to fine-tune the section's content
         return {
             type: 'group',
@@ -57,8 +58,9 @@ export class SegmentsGroupConfigFactory implements WidgetConfigFactory {
                 'segmentSameModeAsReverseTrip',
                 'segmentModePre',
                 'segmentMode',
+                // Additional widgets are added here
+                ...additionalWidgetNames,
                 'segmentHasNextMode'
-                // TODO Add more configurable widgets here, either custom or depending on the segments section configuration
             ]
         };
     };

--- a/packages/evolution-common/src/services/questionnaire/types/SectionConfig.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/SectionConfig.ts
@@ -505,6 +505,13 @@ export type SegmentSectionConfiguration = {
      * the modePre and mode questions.
      */
     modesExclude?: Mode[];
+    /**
+     * Names of additional widgets to include in the segment group of the
+     * section besides the default ones (modePre, mode, etc). The widgets need
+     * to be defined by these names in the survey's widget configuration. They
+     * will be added after the mode question, before the hasNextMode question.
+     */
+    additionalSegmentWidgetNames?: string[];
 };
 
 // TODO Add more section configuration types as we support more


### PR DESCRIPTION
completes #1345

This adds the `additionalSegmentWidgetNames` configuration option to the `SegmentSectionConfiguration` type. It contains a list of widget names to add after the mode question and before the has next mode question.

These widgets need to be defined in the survey itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Survey segments can now include additional custom widgets via a new configurable list, allowing more flexible segment layouts.

* **Tests**
  * Added coverage verifying additional widgets are correctly included and ordered in segment configurations.

* **Chores**
  * Removed unused imports and cleaned up legacy commented code for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->