### PR TITLE
add sessions for Terminal Keeper (example)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,8 @@ dist
 # vscode
 .vscode/launch.json
 .vscode/restore-terminals.json
+## sessions.json is for Terminal Keeper extension
+.vscode/sessions.json
 
 # custom
 public/dist/

--- a/.vscode/sessions.json.example
+++ b/.vscode/sessions.json.example
@@ -1,0 +1,91 @@
+{
+    "$schema": "https://cdn.statically.io/gh/nguyenngoclongdev/cdn/main/schema/v11/terminal-keeper.json",
+    "theme": "tribe",
+    "active": "evolution-dev",
+    "activateOnStartup": false,
+    "keepExistingTerminals": true,
+    "sessions": {
+        "evolution-dev": [
+            {
+                "name": "git",
+                "commands": [
+                    "git status"
+                ],
+                "icon": "source-control",
+                "color": "terminal.ansiBlue"
+            },
+            {
+                "name": "compile",
+                "commands": [
+                    "yarn compile"
+                ],
+                "icon": "gear",
+                "color": "terminal.ansiYellow"
+            },
+            {
+                "name": "build",
+                "commands": [
+                    "yarn build:dev"
+                ],
+                "icon": "package",
+                "color": "terminal.ansiGreen"
+            },
+            {
+                "name": "build-admin",
+                "commands": [
+                    "yarn build:admin:dev"
+                ],
+                "icon": "package",
+                "color": "terminal.ansiRed"
+            },
+            {
+                "name": "server",
+                "commands": [
+                    "yarn start"
+                ],
+                "icon": "server",
+                "color": "terminal.ansiGreen"
+            },
+            {
+                "name": "server-admin",
+                "commands": [
+                    "yarn start:admin"
+                ],
+                "icon": "server",
+                "color": "terminal.ansiRed"
+            },
+            {
+                "name": "test-all",
+                "commands": [
+                    "yarn test"
+                ],
+                "icon": "beaker",
+                "color": "terminal.ansiYellow"
+            },
+            {
+                "name": "test-evolution-common",
+                "commands": [
+                    "yarn workspace evolution-common test"
+                ],
+                "icon": "beaker",
+                "color": "terminal.ansiYellow"
+            },
+            {
+                "name": "test-evolution-backend",
+                "commands": [
+                    "yarn workspace evolution-backend test"
+                ],
+                "icon": "beaker",
+                "color": "terminal.ansiYellow"
+            },
+            {
+                "name": "test-evolution-frontend",
+                "commands": [
+                    "yarn workspace evolution-frontend test"
+                ],
+                "icon": "beaker",
+                "color": "terminal.ansiYellow"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
This will auto prepare useful yarn commands in distinct terminal tabs to make it faster to open workspace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated .gitignore to exclude VSCode terminal session configuration files
  * Added example VSCode Terminal Keeper sessions configuration with pre-configured development profiles including git, compile, build, and test sessions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->