### PR TITLE
paradata: add platform and language details to exported data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - In the root `package.json` add a resolution of `kdbush` to 3.0.0 to avoid compilation errors with some packages depending on a more recent version. This requirement comes from Transition, who does the same (see https://github.com/chairemobilite/transition/issues/921 to track issue to upgrade/remove `kdbush`).
 
 
+## [Unreleased (0.5.1)] - YYYY-MM-DD
+
+### Added
+- Added `platform`, `os`, `browser` and `language` fields to each record of the exported paradata (#1395)
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+### Dependency updates
+
+
 ## [0.5.0] - 2026-01-30
 
 ### Added

--- a/packages/evolution-backend/package.json
+++ b/packages/evolution-backend/package.json
@@ -27,6 +27,7 @@
     "dependencies": {
         "@casl/ability": "^6.7.3",
         "@turf/turf": "^7.3.1",
+        "bowser": "^2.11.0",
         "chaire-lib-backend": "^0.2.2",
         "chaire-lib-common": "^0.2.2",
         "connect-session-knex": "^4.0.2",

--- a/packages/evolution-backend/src/models/paradataEvents.db.queries.ts
+++ b/packages/evolution-backend/src/models/paradataEvents.db.queries.ts
@@ -54,11 +54,12 @@ const log = async ({
 };
 
 /**
- * Streams the paradata for a single or all interviews.
+ * Streams the paradata for a single or all interviews. The paradata is sorted
+ * by interview and timestamp.
  *
  * @param {Object} options Options object
- * @param {number|undefined} options.interviewId The id of the interview to get the logs
- * for. Leave undefined to get all the paradata
+ * @param {number|undefined} options.interviewId The id of the interview to get
+ * the logs for. Leave undefined to get all the paradata
  * @param {boolean|undefined} options.forCorrection If true, only get paradata
  * entries for corrected interviews. If false, only get paradata entries for
  * participant responses. If undefined, get all paradata entries.


### PR DESCRIPTION
fixes #1395

It gets from the log event data the browser's data (in `response._browser` or `corrected_response._browser` in the `values_by_path` field) and the language data (from `response._language` or `corrected_response._language` or `language_change` events). This information stays valid for the user/participant/review context until the next change in the same context.

The 4 fields: `os`, `platform`, `browser` and `language` are added to each exported paradata row. If the information is not available, the fields are left blank.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interview log exports now include per-record context fields: platform, operating system, browser, and language in exported paradata.

* **Tests**
  * Expanded test coverage to validate presence and propagation of the new context fields across varied log scenarios (context switches, multiple users, language changes, legacy events).

* **Chores**
  * Added an Unreleased (0.5.1) entry to the CHANGELOG documenting the newly added export fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->