### PR TITLE
Refactor: Refresh the CSS in dev mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased (0.6.0)] - YYYY-MM-DD
 
 ### Added
+- **CSS refresh in dev mode**: Changes to `.scss` files are automatically picked up by `yarn build:dev` and apply after a page reload (fixes [#1403](https://github.com/chairemobilite/evolution/issues/1403)). Survey projects that want the same: see [#1407](https://github.com/chairemobilite/evolution/pull/1407) for the webpack modifications.
 - Added `maxAccessEgressTravelTimeMinutes` and `walkingSpeedKmPerHour` to accessibility map calculation parameters (#1379)
 
 ### Changed
@@ -21,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 ### Dependency updates
+- style-loader: 4.0.0
 - lodash: 4.17.21 => 4.17.23
 - @types/lodash: 4.17.21 => 4.17.23
 - yargs: 17.7.2 => 18.0.0

--- a/example/demo_generator/package.json
+++ b/example/demo_generator/package.json
@@ -51,6 +51,7 @@
         "cross-env": "^10.1.0",
         "eslint": "^8.57.1",
         "prettier-eslint-cli": "^8.0.1",
+        "style-loader": "^4.0.0",
         "typescript": "^5.9.3"
     }
 }

--- a/example/demo_generator/webpack.admin.config.js
+++ b/example/demo_generator/webpack.admin.config.js
@@ -9,6 +9,10 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const CompressionPlugin = require('compression-webpack-plugin');
 
+// Ensure server config is found regardless of cwd
+if (!process.env.PROJECT_CONFIG) {
+    process.env.PROJECT_CONFIG = path.join(__dirname, 'config.js');
+}
 require('chaire-lib-backend/lib/config/dotenv.config');
 
 if (!process.env.NODE_ENV) {
@@ -47,6 +51,10 @@ module.exports = (env) => {
     const isProduction = process.env.NODE_ENV === 'production';
     console.log('process.env.NODE_ENV', process.env.NODE_ENV);
 
+    // In dev, style-loader injects CSS via <style> so SCSS changes apply after reload
+    const styleLoader = isProduction ? MiniCssExtractPlugin.loader : 'style-loader';
+    const evolutionFrontendRoot = path.dirname(require.resolve('evolution-frontend/package.json'));
+
     const languages = config.languages || ['fr', 'en'];
     const momentLanguagesFilter = `/${languages.join('|')}/`;
 
@@ -82,7 +90,17 @@ module.exports = (env) => {
             publicPath: '/dist/'
         },
         watchOptions: {
-            ignored: ['node_modules/**'],
+            // In dev, watch evolution-frontend and evolution-common so CSS/TS changes trigger rebuild
+            // Exclude lib/styles from evolution-frontend since we use alias to point to src/styles
+            ignored: isProduction
+                // In production, ignore all node_modules to avoid rebuilding the whole project
+                ? new RegExp('node_modules/')
+                // Ignore all node_modules except evolution-frontend and evolution-common, 
+                // and also specifically ignore the lib/styles directory of evolution-frontend 
+                // (which we override via an alias to our src/styles).
+                : new RegExp(
+                    `(node_modules\\/(?!evolution-frontend|evolution-common)|${path.join(evolutionFrontendRoot, 'lib', 'styles').replace(/\\/g, '/').replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`
+                  ),
             aggregateTimeout: 600
         },
         module: {
@@ -103,7 +121,7 @@ module.exports = (env) => {
                 {
                     test: /\.s?css$/,
                     use: [
-                        MiniCssExtractPlugin.loader,
+                        styleLoader,
                         {
                             loader: 'css-loader',
                             options: {
@@ -213,6 +231,10 @@ module.exports = (env) => {
             mainFields: ['browser', 'main', 'module'],
             modules: ['node_modules'],
             extensions: ['.json', '.js', '.ts', '.tsx'],
+            // In dev, read SCSS from evolution-frontend source so changes apply without running copy-files
+            alias: isProduction ? {} : {
+                [path.join(evolutionFrontendRoot, 'lib', 'styles')]: path.join(evolutionFrontendRoot, 'src', 'styles')
+            },
             // These modules are not used in the frontend, don't try to resolve them as they are nodejs only and don't have a browser counterpart (but they may be used in transition-legacy which is still not cleanly separated)
             fallback: { path: false, buffer: false }
         },

--- a/example/demo_generator/webpack.config.js
+++ b/example/demo_generator/webpack.config.js
@@ -9,6 +9,10 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const CompressionPlugin = require('compression-webpack-plugin');
 
+// Ensure server config is found regardless of cwd (fixes serve:dev when run from any directory)
+if (!process.env.PROJECT_CONFIG) {
+    process.env.PROJECT_CONFIG = path.join(__dirname, 'config.js');
+}
 require('chaire-lib-backend/lib/config/dotenv.config');
 
 if (!process.env.NODE_ENV) {
@@ -30,6 +34,9 @@ module.exports = (env) => {
     const isProduction = process.env.NODE_ENV === 'production';
     console.log('process.env.NODE_ENV', process.env.NODE_ENV);
 
+    // In dev, style-loader injects CSS via <style> so SCSS changes apply after reload without a separate .css file
+    const styleLoader = isProduction ? MiniCssExtractPlugin.loader : 'style-loader';
+
     const languages = config.languages || ['fr', 'en'];
     const momentLanguagesFilter = `/${languages.join('|')}/`;
 
@@ -37,6 +44,7 @@ module.exports = (env) => {
     const customStylesFilePath = `${__dirname}/lib/styles/styles.scss`;
     const customLocalesFilePath = `${__dirname}/locales`;
     const entry = [entryFileName, customStylesFilePath];
+    const evolutionFrontendRoot = path.dirname(require.resolve('evolution-frontend/package.json'));
     const includeDirectories = [
         path.join(__dirname, 'lib', 'survey'),
 
@@ -64,7 +72,17 @@ module.exports = (env) => {
             publicPath: '/dist/'
         },
         watchOptions: {
-            ignored: ['node_modules/**'],
+            // In dev, watch evolution-frontend and evolution-common so CSS/TS changes trigger rebuild
+            // Exclude lib/styles from evolution-frontend since we use alias to point to src/styles
+            ignored: isProduction
+                // In production, ignore all node_modules to avoid rebuilding the whole project
+                ? new RegExp('node_modules/')
+                // Ignore all node_modules except evolution-frontend and evolution-common, 
+                // and also specifically ignore the lib/styles directory of evolution-frontend 
+                // (which we override via an alias to our src/styles).
+                : new RegExp(
+                    `(node_modules\\/(?!evolution-frontend|evolution-common)|${path.join(evolutionFrontendRoot, 'lib', 'styles').replace(/\\/g, '/').replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`
+                ),
             aggregateTimeout: 600
         },
         module: {
@@ -85,7 +103,7 @@ module.exports = (env) => {
                 {
                     test: /\.s?css$/,
                     use: [
-                        MiniCssExtractPlugin.loader,
+                        styleLoader, // In dev, style-loader injects CSS via <style> so SCSS changes apply after reload without a separate .css file
                         {
                             loader: 'css-loader',
                             options: {
@@ -195,6 +213,10 @@ module.exports = (env) => {
             mainFields: ['browser', 'main', 'module'],
             modules: ['node_modules'],
             extensions: ['.json', '.js', '.ts', '.tsx'],
+            // In dev, read SCSS from evolution-frontend source so changes apply without running copy-files
+            alias: isProduction ? {} : {
+                [path.join(evolutionFrontendRoot, 'lib', 'styles')]: path.join(evolutionFrontendRoot, 'src', 'styles')
+            },
             // These modules are not used in the frontend, don't try to resolve them as they are nodejs only and don't have a browser counterpart (but they may be used in transition-legacy which is still not cleanly separated)
             fallback: { path: false, buffer: false }
         },

--- a/example/demo_survey/package.json
+++ b/example/demo_survey/package.json
@@ -67,6 +67,7 @@
         "mini-css-extract-plugin": "^2.9.4",
         "sass": "^1.97.0",
         "sass-loader": "^16.0.6",
+        "style-loader": "^4.0.0",
         "source-map-loader": "^5.0.0",
         "ts-loader": "^9.5.4",
         "ts-shader-loader": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13344,6 +13344,11 @@ strnum@^2.1.0:
   resolved "https://registry.yarnpkg.com/strnum/-/strnum-2.1.2.tgz#a5e00ba66ab25f9cafa3726b567ce7a49170937a"
   integrity sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==
 
+style-loader@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-4.0.0.tgz#0ea96e468f43c69600011e0589cb05c44f3b17a5"
+  integrity sha512-1V4WqhhZZgjVAVJyt7TdDPZoPBPNHbekX4fWnCJL1yQukhCeZhJySUL+gL9y6sNdN95uEOS83Y55SqHcP7MzLA==
+
 style-to-object@^1.0.0:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/style-to-object/-/style-to-object-1.0.8.tgz#67a29bca47eaa587db18118d68f9d95955e81292"


### PR DESCRIPTION
# Pull request

- [x] I think I need to add the changes in the CHANGELOG.md file.

## Description
Refactor: Add style-loader dependency and update webpack configurations
Fix: #1403
- Add style-loader dependency and update webpack configurations
- Adjusted watch options to improve rebuild efficiency for specific directories. 
Note: it still doesn't hot reloading in dev mode, but we just need to refresh the page now to see any frontend changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched CSS loading between development (in-DOM injection) and production (extracted files) for faster dev feedback.
  * Enabled dev-time aliasing so SCSS is read from source and adjusted watch behavior to rebuild on frontend/style changes.
  * Added a dev dependency to support the new dev CSS workflow.

* **Documentation**
  * Changelog entry describing refreshed dev-mode CSS behavior and rebuild/apply workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->