### PR TITLE
Fix error in the README for surveyArea geojson

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ module.exports = {
   surveyAreaGeojsonPath: 'surveyArea.geojson'
 };
 ```
-The path is relative to the survey project directory (where the configuration file is located). If this property is missing or the file is not found, territorial validation is skipped.
+The path is relative to the survey project directory (projectDirectory param in config file). If this property is missing or the file is not found, territorial validation is skipped.
 
 ### GeoJSON Specifications
 


### PR DESCRIPTION
The text was incorrect, it is not relative to the config file location, but to the project directory path set in the config file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with clarified guidance on configuration parameter paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->