### PR TITLE
webpack: Add helper functions for webpack generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **CSS refresh in dev mode**: Changes to `.scss` files are automatically picked up by `yarn build:dev` and apply after a page reload (fixes [#1403](https://github.com/chairemobilite/evolution/issues/1403)). Survey projects that want the same: see [#1407](https://github.com/chairemobilite/evolution/pull/1407) for the webpack modifications.
 - Added `maxAccessEgressTravelTimeMinutes` and `walkingSpeedKmPerHour` to accessibility map calculation parameters (#1379)
+- Added utility functions for webpack generation in evolution-frontend: `createParticipantWebpackConfig` and `createAdminWebpackConfig`. The example projects implement this approach. Projects should consider using those for simlicity. (#1405)
 
 ### Changed
 

--- a/example/demo_generator/package.json
+++ b/example/demo_generator/package.json
@@ -51,7 +51,6 @@
         "cross-env": "^10.1.0",
         "eslint": "^8.57.1",
         "prettier-eslint-cli": "^8.0.1",
-        "style-loader": "^4.0.0",
         "typescript": "^5.9.3"
     }
 }

--- a/example/demo_generator/webpack.admin.config.js
+++ b/example/demo_generator/webpack.admin.config.js
@@ -1,13 +1,5 @@
-// TODO: We should remove everything that is not used anymore in this file
-
-const fs = require('fs');
 const path = require('path');
-const webpack = require('webpack');
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const CopyWebpackPlugin = require('copy-webpack-plugin');
-const HtmlWebpackPlugin = require('html-webpack-plugin');
-const { CleanWebpackPlugin } = require('clean-webpack-plugin');
-const CompressionPlugin = require('compression-webpack-plugin');
+const { createAdminWebpackConfig } = require('evolution-frontend/lib/utils/dev/webpackAdmin');
 
 // Ensure server config is found regardless of cwd
 if (!process.env.PROJECT_CONFIG) {
@@ -21,228 +13,36 @@ if (!process.env.NODE_ENV) {
 
 const configuration = require('chaire-lib-backend/lib/config/server.config');
 const config = configuration.default ? configuration.default : configuration;
-// For the admin app, the adminAuth should replace the auth configuration
-// FIXME This is the kind of config that should come from the server, not be inserted in the client in webpack
-if (!config.adminAuth) {
-    console.warn(
-        'Configuration error: you need to specify the adminAuth key in the config.js file. Will use default values.'
-    );
-    config.adminAuth = {
-        localLogin: {
-            registerWithPassword: true,
-            registerWithEmailOnly: true,
-            confirmEmail: false,
-            forgotPasswordPage: true
-        }
-    };
-}
-config.auth = config.adminAuth;
-delete config.adminAuth;
 
 // Public directory from which files are served
 const publicDirectory = path.join(__dirname, '..', '..', 'public');
-const bundleOutputPath = path.join(publicDirectory, 'dist', config.projectShortname, 'admin');
-
-const appIncludeName = 'survey';
 
 module.exports = (env) => {
-    console.log(`building js for project ${config.projectShortname}`);
-
-    const isProduction = process.env.NODE_ENV === 'production';
-    console.log('process.env.NODE_ENV', process.env.NODE_ENV);
-
-    // In dev, style-loader injects CSS via <style> so SCSS changes apply after reload
-    const styleLoader = isProduction ? MiniCssExtractPlugin.loader : 'style-loader';
-    const evolutionFrontendRoot = path.dirname(require.resolve('evolution-frontend/package.json'));
-
-    const languages = config.languages || ['fr', 'en'];
-    const momentLanguagesFilter = `/${languages.join('|')}/`;
-
-    const entryFileName = './lib/admin/app-admin.js';
     const customStylesFilePath = `${__dirname}/lib/styles/styles.scss`;
     const customLocalesFilePath = `${__dirname}/locales`;
-    const entry = [entryFileName, customStylesFilePath];
     const includeDirectories = [
         path.join(__dirname, 'lib', 'admin'),
         path.join(__dirname, 'lib', 'survey'),
-
         path.join(__dirname, 'locales'),
         path.join(__dirname, 'assets')
     ];
 
-    return {
-        // Controls which information to display (see https://webpack.js.org/configuration/stats/)
-        stats: {
-            errorDetails: true,
-            children: true
-        },
-        node: {
-            // global will be deprecated at next major release, see where it is being used
-            global: 'warn'
-        },
-        mode: process.env.NODE_ENV,
-        entry: entry,
-        output: {
-            path: bundleOutputPath,
-            filename: isProduction
-                ? `survey-admin-${config.projectShortname}-bundle-${process.env.NODE_ENV}.[contenthash].js`
-                : `survey-admin-${config.projectShortname}-bundle-${process.env.NODE_ENV}.dev.js`,
-            publicPath: '/dist/'
-        },
-        watchOptions: {
-            // In dev, watch evolution-frontend and evolution-common so CSS/TS changes trigger rebuild
-            // Exclude lib/styles from evolution-frontend since we use alias to point to src/styles
-            ignored: isProduction
-                // In production, ignore all node_modules to avoid rebuilding the whole project
-                ? new RegExp('node_modules/')
-                // Ignore all node_modules except evolution-frontend and evolution-common, 
-                // and also specifically ignore the lib/styles directory of evolution-frontend 
-                // (which we override via an alias to our src/styles).
-                : new RegExp(
-                    `(node_modules\\/(?!evolution-frontend|evolution-common)|${path.join(evolutionFrontendRoot, 'lib', 'styles').replace(/\\/g, '/').replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`
-                  ),
-            aggregateTimeout: 600
-        },
-        module: {
-            rules: [
-                {
-                    use: 'json-loader',
-                    test: /\.geojson$/,
-                    include: includeDirectories
-                },
-                {
-                    test: /\.(ttf|woff2|woff|eot|svg)$/,
-                    type: 'asset'
-                },
-                {
-                    test: /\.glsl$/,
-                    use: 'ts-shader-loader'
-                },
-                {
-                    test: /\.s?css$/,
-                    use: [
-                        styleLoader,
-                        {
-                            loader: 'css-loader',
-                            options: {
-                                sourceMap: true
-                            }
-                        },
-                        {
-                            loader: 'sass-loader',
-                            options: {
-                                sourceMap: true
-                            }
-                        }
-                    ]
-                },
-                {
-                    test: /locales/,
-                    loader: '@alienfast/i18next-loader',
-                    options: {
-                        basenameAsNamespace: true,
-                        overrides: fs.existsSync(customLocalesFilePath) ? [customLocalesFilePath] : []
-                    }
-                },
-                {
-                    test: /\.js$/,
-                    enforce: 'pre',
-                    loader: 'source-map-loader',
-                    include: includeDirectories
-                },
-                {
-                    test: /\.tsx?$/,
-                    use: 'ts-loader',
-                    exclude: /node_modules/,
-                    include: ['/node_modules/evolution-frontend/src', '/node_modules/evolution-common/src']
-                }
-            ]
-        },
-        plugins: [
-            new CleanWebpackPlugin({
-                dry: !isProduction,
-                verbose: true,
-                cleanAfterEveryBuildPatterns: ['**/*', '!images/**', '!icons/**', '!*.html']
-            }),
-            new HtmlWebpackPlugin({
-                title: process.env.DEFAULT_TITLE || 'Evolution - Admin',
-                noindex: true, // we should never index the admin dashboard
-                filename: path.join(`index-survey-${config.projectShortname}.html`),
-                template: path.join(__dirname, '..', '..', 'public', 'index.html')
-            }),
-            new MiniCssExtractPlugin({
-                filename: isProduction
-                    ? `survey-${config.projectShortname}-styles.[contenthash].css`
-                    : `survey-${config.projectShortname}-styles.dev.css` //,
-            }),
-            new webpack.DefinePlugin({
-                'process.env': {
-                    IS_BROWSER: JSON.stringify(true),
-                    HOST: JSON.stringify(process.env.HOST),
-                    APP_NAME: JSON.stringify(appIncludeName),
-                    IS_TESTING: JSON.stringify(env === 'test'),
-                    GOOGLE_API_KEY: JSON.stringify(process.env.GOOGLE_API_KEY)
-                },
-                __CONFIG__: JSON.stringify({
-                    ...config
-                })
-            }),
-            new webpack.optimize.AggressiveMergingPlugin(), //Merge chunks
-            new CompressionPlugin({
-                filename: '[path][base].gz[query]',
-                algorithm: 'gzip',
-                test: /\.js$|\.css$/,
-                threshold: 0,
-                minRatio: 0.8
-            }),
-            new webpack.ContextReplacementPlugin(/moment[\/\\]locale$/, new RegExp(momentLanguagesFilter)),
-            new CopyWebpackPlugin({
-                patterns: [
-                    {
-                        context: path.join(__dirname, '..', '..', 'node_modules', 'chaire-lib-frontend', 'lib', 'assets'),
-                        from: "**/*",
-                        to: "",
-                        noErrorOnMissing: true
-                    },
-                    {
-                        context: path.join(
-                            __dirname,
-                            '..',
-                            '..',
-                            'node_modules',
-                            'evolution-frontend',
-                            'lib',
-                            'assets'
-                        ),
-                        from: '**/*',
-                        to: '',
-                        noErrorOnMissing: true
-                    },
-                    {
-                        context: path.join(__dirname, 'assets'),
-                        from: '**/*',
-                        to: '',
-                        noErrorOnMissing: true
-                    }
-                ]
-            })
-        ],
-        resolve: {
-            mainFields: ['browser', 'main', 'module'],
-            modules: ['node_modules'],
-            extensions: ['.json', '.js', '.ts', '.tsx'],
-            // In dev, read SCSS from evolution-frontend source so changes apply without running copy-files
-            alias: isProduction ? {} : {
-                [path.join(evolutionFrontendRoot, 'lib', 'styles')]: path.join(evolutionFrontendRoot, 'src', 'styles')
-            },
-            // These modules are not used in the frontend, don't try to resolve them as they are nodejs only and don't have a browser counterpart (but they may be used in transition-legacy which is still not cleanly separated)
-            fallback: { path: false, buffer: false }
-        },
-        devtool: isProduction ? 'cheap-source-map' : 'eval-source-map',
-        devServer: {
-            contentBase: publicDirectory,
-            historyApiFallback: true,
-            publicPath: '/dist/' + config.projectShortname
-        }
-    };
+    const htmlPages = [{
+        title: process.env.DEFAULT_TITLE || 'Evolution - Admin',
+        noindex: true, // we should never index the admin dashboard
+        filename: path.join(`index-survey-${config.projectShortname}.html`),
+        template: path.join(publicDirectory, 'index.html')
+    }];
+
+    return createAdminWebpackConfig({
+        env: env,
+        projectSrcDir: __dirname,
+        publicDirectory: publicDirectory,
+        config: config,
+        adminEntryFile: path.join(__dirname, 'lib', 'admin', 'app-admin.js'),
+        includeDirectories: includeDirectories,
+        htmlPages,
+        customStylesFilePath: customStylesFilePath,
+        projectLocalesFilePath: customLocalesFilePath
+    });
 };

--- a/example/demo_generator/webpack.config.js
+++ b/example/demo_generator/webpack.config.js
@@ -1,22 +1,14 @@
-// TODO: We should remove everything that is not used anymore in this file
-
-const fs = require('fs');
-const path = require('path');
-const webpack = require('webpack');
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const CopyWebpackPlugin = require('copy-webpack-plugin');
-const HtmlWebpackPlugin = require('html-webpack-plugin');
-const { CleanWebpackPlugin } = require('clean-webpack-plugin');
-const CompressionPlugin = require('compression-webpack-plugin');
+const path                    = require('path');
+const { createParticipantWebpackConfig } = require('evolution-frontend/lib/utils/dev/webpackParticipant');
 
 // Ensure server config is found regardless of cwd (fixes serve:dev when run from any directory)
 if (!process.env.PROJECT_CONFIG) {
-    process.env.PROJECT_CONFIG = path.join(__dirname, 'config.js');
+  process.env.PROJECT_CONFIG = path.join(__dirname, 'config.js');
 }
 require('chaire-lib-backend/lib/config/dotenv.config');
 
 if (!process.env.NODE_ENV) {
-    process.env.NODE_ENV = 'development';
+  process.env.NODE_ENV = 'development';
 }
 
 const configuration = require('chaire-lib-backend/lib/config/server.config');
@@ -24,207 +16,36 @@ const config = configuration.default ? configuration.default : configuration;
 
 // Public directory from which files are served
 const publicDirectory = path.join(__dirname, '..', '..', 'public');
-const bundleOutputPath = path.join(publicDirectory, 'dist', config.projectShortname, 'survey');
-
-const appIncludeName = 'survey';
 
 module.exports = (env) => {
-    console.log(`building js for project ${config.projectShortname}`);
 
-    const isProduction = process.env.NODE_ENV === 'production';
-    console.log('process.env.NODE_ENV', process.env.NODE_ENV);
-
-    // In dev, style-loader injects CSS via <style> so SCSS changes apply after reload without a separate .css file
-    const styleLoader = isProduction ? MiniCssExtractPlugin.loader : 'style-loader';
-
-    const languages = config.languages || ['fr', 'en'];
-    const momentLanguagesFilter = `/${languages.join('|')}/`;
-
-    const entryFileName = './lib/app-survey.js';
-    const customStylesFilePath = `${__dirname}/lib/styles/styles.scss`;
+    const customStylesFilePath  = `${__dirname}/lib/styles/styles.scss`;
     const customLocalesFilePath = `${__dirname}/locales`;
-    const entry = [entryFileName, customStylesFilePath];
-    const evolutionFrontendRoot = path.dirname(require.resolve('evolution-frontend/package.json'));
-    const includeDirectories = [
+    const includeDirectories    = [
         path.join(__dirname, 'lib', 'survey'),
-
         path.join(__dirname, 'locales'),
         path.join(__dirname, 'assets')
     ];
 
-    return {
-        // Controls which information to display (see https://webpack.js.org/configuration/stats/)
-        stats: {
-            errorDetails: true,
-            children: true
-        },
-        node: {
-            // global will be deprecated at next major release, see where it is being used
-            global: 'warn'
-        },
-        mode: process.env.NODE_ENV,
-        entry: entry,
-        output: {
-            path: bundleOutputPath,
-            filename: isProduction
-                ? `survey-${config.projectShortname}-bundle-${process.env.NODE_ENV}.[contenthash].js`
-                : `survey-${config.projectShortname}-bundle-${process.env.NODE_ENV}.dev.js`,
-            publicPath: '/dist/'
-        },
-        watchOptions: {
-            // In dev, watch evolution-frontend and evolution-common so CSS/TS changes trigger rebuild
-            // Exclude lib/styles from evolution-frontend since we use alias to point to src/styles
-            ignored: isProduction
-                // In production, ignore all node_modules to avoid rebuilding the whole project
-                ? new RegExp('node_modules/')
-                // Ignore all node_modules except evolution-frontend and evolution-common, 
-                // and also specifically ignore the lib/styles directory of evolution-frontend 
-                // (which we override via an alias to our src/styles).
-                : new RegExp(
-                    `(node_modules\\/(?!evolution-frontend|evolution-common)|${path.join(evolutionFrontendRoot, 'lib', 'styles').replace(/\\/g, '/').replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`
-                ),
-            aggregateTimeout: 600
-        },
-        module: {
-            rules: [
-                {
-                    use: 'json-loader',
-                    test: /\.geojson$/,
-                    include: includeDirectories
-                },
-                {
-                    test: /\.(ttf|woff2|woff|eot|svg)$/,
-                    type: 'asset'
-                },
-                {
-                    test: /\.glsl$/,
-                    use: 'ts-shader-loader'
-                },
-                {
-                    test: /\.s?css$/,
-                    use: [
-                        styleLoader, // In dev, style-loader injects CSS via <style> so SCSS changes apply after reload without a separate .css file
-                        {
-                            loader: 'css-loader',
-                            options: {
-                                sourceMap: true
-                            }
-                        },
-                        {
-                            loader: 'sass-loader',
-                            options: {
-                                sourceMap: true
-                            }
-                        }
-                    ]
-                },
-                {
-                    test: /locales/,
-                    loader: '@alienfast/i18next-loader',
-                    options: {
-                        basenameAsNamespace: true,
-                        overrides: fs.existsSync(customLocalesFilePath) ? [customLocalesFilePath] : []
-                    }
-                },
-                {
-                    test: /\.js$/,
-                    enforce: 'pre',
-                    loader: 'source-map-loader',
-                    include: includeDirectories
-                },
-                {
-                    test: /\.tsx?$/,
-                    use: 'ts-loader',
-                    exclude: /node_modules/,
-                    include: ['/node_modules/evolution-frontend/src', '/node_modules/evolution-common/src']
-                }
-            ]
-        },
-        plugins: [
-            new CleanWebpackPlugin({
-                dry: !isProduction,
-                verbose: true,
-                cleanAfterEveryBuildPatterns: ['**/*', '!images/**', '!icons/**', '!*.html']
-            }),
-            new HtmlWebpackPlugin({
-                title: process.env.DEFAULT_TITLE || 'Evolution',
-                noindex: process.env.NOINDEX === 'true',
-                filename: path.join(`index-survey-${config.projectShortname}.html`),
-                template: path.join(publicDirectory, 'index.html')
-            }),
-            new MiniCssExtractPlugin({
-                filename: isProduction
-                    ? `survey-${config.projectShortname}-styles.[contenthash].css`
-                    : `survey-${config.projectShortname}-styles.dev.css` //,
-            }),
-            new webpack.DefinePlugin({
-                'process.env': {
-                    IS_BROWSER: JSON.stringify(true),
-                    HOST: JSON.stringify(process.env.HOST),
-                    APP_NAME: JSON.stringify(appIncludeName),
-                    IS_TESTING: JSON.stringify(env === 'test'),
-                    GOOGLE_API_KEY: JSON.stringify(process.env.GOOGLE_API_KEY)
-                },
-                __CONFIG__: JSON.stringify({
-                    ...config
-                })
-            }),
-            new webpack.optimize.AggressiveMergingPlugin(), //Merge chunks
-            new CompressionPlugin({
-                filename: '[path][base].gz[query]',
-                algorithm: 'gzip',
-                test: /\.js$|\.css$/,
-                threshold: 0,
-                minRatio: 0.8
-            }),
-            new webpack.ContextReplacementPlugin(/moment[\/\\]locale$/, new RegExp(momentLanguagesFilter)),
-            new CopyWebpackPlugin({
-                patterns: [
-                    {
-                        context: path.join(__dirname, '..', '..', 'node_modules', 'chaire-lib-frontend', 'lib', 'assets'),
-                        from: "**/*",
-                        to: "",
-                        noErrorOnMissing: true
-                    },
-                    {
-                        context: path.join(
-                            __dirname,
-                            '..',
-                            '..',
-                            'node_modules',
-                            'evolution-frontend',
-                            'lib',
-                            'assets'
-                        ),
-                        from: '**/*',
-                        to: '',
-                        noErrorOnMissing: true
-                    },
-                    {
-                        context: path.join(__dirname, 'assets'),
-                        from: '**/*',
-                        to: '',
-                        noErrorOnMissing: true
-                    }
-                ]
-            })
-        ],
-        resolve: {
-            mainFields: ['browser', 'main', 'module'],
-            modules: ['node_modules'],
-            extensions: ['.json', '.js', '.ts', '.tsx'],
-            // In dev, read SCSS from evolution-frontend source so changes apply without running copy-files
-            alias: isProduction ? {} : {
-                [path.join(evolutionFrontendRoot, 'lib', 'styles')]: path.join(evolutionFrontendRoot, 'src', 'styles')
-            },
-            // These modules are not used in the frontend, don't try to resolve them as they are nodejs only and don't have a browser counterpart (but they may be used in transition-legacy which is still not cleanly separated)
-            fallback: { path: false, buffer: false }
-        },
-        devtool: isProduction ? 'cheap-source-map' : 'eval-source-map',
-        devServer: {
-            contentBase: publicDirectory,
-            historyApiFallback: true,
-            publicPath: '/dist/' + config.projectShortname
+    const htmlPages = [{
+        title: process.env.DEFAULT_TITLE || 'Evolution',
+        noindex: process.env.NOINDEX === 'true',
+        filename: path.join(`index-survey-${config.projectShortname}.html`),
+        template: path.join(publicDirectory, 'index.html')
+    }];
+
+    return createParticipantWebpackConfig({
+        env: env,
+        projectSrcDir: __dirname,
+        publicDirectory: publicDirectory,
+        config: config,
+        participantEntryFile: path.join(__dirname, 'lib', 'app-survey.js'),
+        includeDirectories: includeDirectories,
+        htmlPages,
+        customStylesFilePath: customStylesFilePath,
+        projectLocalesFilePath: customLocalesFilePath,
+        extraEnvs: {
+            EV_VARIANT: 'demo_generator'
         }
-    };
+    });
 };

--- a/example/demo_survey/package.json
+++ b/example/demo_survey/package.json
@@ -51,28 +51,12 @@
         "uuid": "^11.1.0"
     },
     "devDependencies": {
-        "@alienfast/i18next-loader": "^2.0.2",
         "@types/geojson": "^7946.0.16",
         "@types/lodash": "^4.17.23",
         "@types/node": "^24.10.4",
-        "clean-webpack-plugin": "^4.0.0",
-        "compression-webpack-plugin": "^11.1.0",
-        "copy-webpack-plugin": "^13.0.1",
         "cross-env": "^10.1.0",
-        "css-loader": "^7.1.2",
-        "html-webpack-plugin": "^5.6.5",
         "jest": "^30.2.0",
         "jest-each": "^30.2.0",
-        "json-loader": "^0.5.7",
-        "mini-css-extract-plugin": "^2.9.4",
-        "sass": "^1.97.0",
-        "sass-loader": "^16.0.6",
-        "style-loader": "^4.0.0",
-        "source-map-loader": "^5.0.0",
-        "ts-loader": "^9.5.4",
-        "ts-shader-loader": "^2.0.2",
-        "typescript": "^5.9.3",
-        "webpack": "^5.104.1",
-        "webpack-cli": "^6.0.1"
+        "typescript": "^5.9.3"
     }
 }

--- a/example/demo_survey/webpack.admin.config.js
+++ b/example/demo_survey/webpack.admin.config.js
@@ -1,234 +1,48 @@
-const fs                      = require('fs');
-const path                    = require('path');
-const webpack                 = require('webpack');
-const MiniCssExtractPlugin    = require("mini-css-extract-plugin");
-const CopyWebpackPlugin       = require('copy-webpack-plugin');
-const HtmlWebpackPlugin       = require('html-webpack-plugin');
-const { CleanWebpackPlugin }  = require("clean-webpack-plugin");
-const CompressionPlugin       = require('compression-webpack-plugin');
+const path = require('path');
+const { createAdminWebpackConfig } = require('evolution-frontend/lib/utils/dev/webpackAdmin');
 
 // Ensure server config is found regardless of cwd
 if (!process.env.PROJECT_CONFIG) {
-  process.env.PROJECT_CONFIG = path.join(__dirname, 'config.js');
+    process.env.PROJECT_CONFIG = path.join(__dirname, 'config.js');
 }
 require('chaire-lib-backend/lib/config/dotenv.config');
 
 if (!process.env.NODE_ENV) {
-  process.env.NODE_ENV = 'development';
+    process.env.NODE_ENV = 'development';
 }
 
 const configuration = require('chaire-lib-backend/lib/config/server.config');
 const config = configuration.default ? configuration.default : configuration;
-// For the admin app, the adminAuth should replace the auth configuration
-// FIXME This is the kind of config that should come from the server, not be inserted in the client in webpack
-if (!config.adminAuth) {
-    console.warn('Configuration error: you need to specify the adminAuth key in the config.js file. Will use default values.');
-    config.adminAuth = {
-        localLogin: {
-            registerWithPassword: true,
-            registerWithEmailOnly: true,
-            confirmEmail: false,
-            forgotPasswordPage: true
-        }
-    };
-}
-config.auth = config.adminAuth;
-delete config.adminAuth;
 
 // Public directory from which files are served
 const publicDirectory = path.join(__dirname, '..', '..', 'public');
-const bundleOutputPath = path.join(publicDirectory, 'dist', config.projectShortname, 'admin');
-
-const appIncludeName = 'survey';
 
 module.exports = (env) => {
-  console.log(`building js for project ${config.projectShortname}`);
-  
-  const isProduction = process.env.NODE_ENV === 'production';
-  console.log('process.env.NODE_ENV', process.env.NODE_ENV);
+    const customStylesFilePath = `${__dirname}/lib/styles/styles.scss`;
+    const customLocalesFilePath = `${__dirname}/locales`;
+    const includeDirectories = [
+        path.join(__dirname, 'lib', 'admin'),
+        path.join(__dirname, 'lib', 'survey'),
+        path.join(__dirname, 'locales'),
+        path.join(__dirname, 'assets')
+    ];
 
-  // In dev, style-loader injects CSS via <style> so SCSS changes apply after reload
-  const styleLoader = isProduction ? MiniCssExtractPlugin.loader : 'style-loader';
-  const evolutionFrontendRoot = path.dirname(require.resolve('evolution-frontend/package.json'));
-
-  const languages = config.languages || ['fr', 'en'];
-  const momentLanguagesFilter = `/${languages.join("|")}/`;
-
-  const entryFileName =  './lib/admin/app-admin.js';
-  const customStylesFilePath  = `${__dirname}/lib/styles/styles.scss`;
-  const customLocalesFilePath = `${__dirname}/locales`;
-  const entry                 = [entryFileName, customStylesFilePath];
-  const includeDirectories    = [
-    path.join(__dirname, 'lib', 'admin'),
-    path.join(__dirname, 'lib', 'survey'),
-    
-    path.join(__dirname, 'locales'),
-    path.join(__dirname, 'assets')
-  ];
-
-  return {
-    // Controls which information to display (see https://webpack.js.org/configuration/stats/)
-    stats: {
-      errorDetails: true,
-      children: true,
-    },
-    node: {
-      // global will be deprecated at next major release, see where it is being used
-      global: 'warn'
-    },
-    mode: process.env.NODE_ENV,
-    entry: entry,
-    output: {
-      path: bundleOutputPath,
-      filename: isProduction ? `survey-admin-${config.projectShortname}-bundle-${process.env.NODE_ENV}.[contenthash].js` : `survey-admin-${config.projectShortname}-bundle-${process.env.NODE_ENV}.dev.js`,
-      publicPath: '/dist/'
-    },
-    watchOptions: {
-      // In dev, watch evolution-frontend and evolution-common so CSS/TS changes trigger rebuild
-      // Exclude lib/styles from evolution-frontend since we use alias to point to src/styles
-      ignored: isProduction
-        // In production, ignore all node_modules to avoid rebuilding the whole project
-        ? new RegExp('node_modules/')
-        // Ignore all node_modules except evolution-frontend and evolution-common, 
-        // and also specifically ignore the lib/styles directory of evolution-frontend 
-        // (which we override via an alias to our src/styles).
-        : new RegExp(
-            `(node_modules\\/(?!evolution-frontend|evolution-common)|${path.join(evolutionFrontendRoot, 'lib', 'styles').replace(/\\/g, '/').replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`
-          ),
-      aggregateTimeout: 600
-    },
-    module: {
-      rules: [
-        {
-          use: 'json-loader',
-          test: /\.geojson$/,
-          include: includeDirectories
-        },
-        { 
-          test: /\.(ttf|woff2|woff|eot|svg)$/,
-          type: 'asset'
-        },
-        {
-          test: /\.glsl$/,
-          use: 'ts-shader-loader'
-        },
-        {
-          test: /\.s?css$/,
-          use: [
-            styleLoader,
-            {
-              loader: 'css-loader',
-              options: {
-                sourceMap: true
-              }
-            },
-            {
-              loader: 'sass-loader',
-              options: {
-                sourceMap: true,
-              }
-            }
-          ]
-        },
-        {
-          test: /locales/,
-          loader: '@alienfast/i18next-loader',
-          options: { 
-            basenameAsNamespace: true,
-            overrides: (fs.existsSync(customLocalesFilePath) ? [customLocalesFilePath] : [])
-          }
-        },
-        {
-            test: /\.js$/,
-            enforce: 'pre',
-            loader: 'source-map-loader',
-            include: includeDirectories
-        },
-        {
-          test: /\.tsx?$/,
-          use: 'ts-loader',
-          exclude: /node_modules/,
-          include: ["/node_modules/evolution-frontend/src", "/node_modules/evolution-common/src"]
-        },
-      ]
-    },
-    plugins: [
-      new CleanWebpackPlugin({
-        dry: !isProduction,
-        verbose: true,
-        cleanAfterEveryBuildPatterns: ['**/*', '!images/**', '!icons/**', '!*.html'],
-      }),
-      new HtmlWebpackPlugin({
+    const htmlPages = [{
         title: process.env.DEFAULT_TITLE || 'Evolution - Admin',
         noindex: true, // we should never index the admin dashboard
         filename: path.join(`index-survey-${config.projectShortname}.html`),
-        template: path.join(__dirname, '..', '..', 'public', 'index.html'),
-      }),
-      new MiniCssExtractPlugin({
-        filename: isProduction ? `survey-${config.projectShortname}-styles.[contenthash].css` : `survey-${config.projectShortname}-styles.dev.css`//,
-      }),
-      new webpack.DefinePlugin({
-        'process.env': {
-          'IS_BROWSER'                  : JSON.stringify(true),
-          'HOST'                        : JSON.stringify(process.env.HOST),
-          'APP_NAME'                    : JSON.stringify(appIncludeName),
-          'IS_TESTING'                  : JSON.stringify(env === 'test'),
-          'GOOGLE_API_KEY'              : JSON.stringify(process.env.GOOGLE_API_KEY)
-        },
-        '__CONFIG__': JSON.stringify({
-            ...config
-        })
-      }),
-      new webpack.optimize.AggressiveMergingPlugin(),//Merge chunks 
-      new CompressionPlugin({
-        filename: "[path][base].gz[query]",
-        algorithm: "gzip",
-        test: /\.js$|\.css$/,
-        threshold: 0,
-        minRatio: 0.8
-      }),
-      new webpack.ContextReplacementPlugin(/moment[\/\\]locale$/, new RegExp(momentLanguagesFilter)),
-      new CopyWebpackPlugin(
-        {
-          patterns: [
-            {
-              context: path.join(__dirname, '..', '..', 'node_modules', 'chaire-lib-frontend', 'lib', 'assets'),
-              from: "**/*",
-              to: "",
-              noErrorOnMissing: true
-            },
-            {
-              context: path.join(__dirname, '..', '..', 'node_modules', 'evolution-frontend', 'lib', 'assets'),
-              from: "**/*",
-              to: "",
-              noErrorOnMissing: true
-            },
-            { 
-              context: path.join(__dirname, 'assets',),
-              from: "**/*",
-              to: "",
-              noErrorOnMissing: true
-            }
-          ]
-        }
-      )
-    ],
-    resolve: {
-      mainFields: ['browser', 'main', 'module'],
-      modules: ['node_modules'],
-      extensions: ['.json', '.js', '.ts', '.tsx'],
-      // In dev, read SCSS from evolution-frontend source so changes apply without running copy-files
-      alias: isProduction ? {} : {
-        [path.join(evolutionFrontendRoot, 'lib', 'styles')]: path.join(evolutionFrontendRoot, 'src', 'styles')
-      },
-      // These modules are not used in the frontend, don't try to resolve them as they are nodejs only and don't have a browser counterpart (but they may be used in transition-legacy which is still not cleanly separated)
-      fallback: { path: false, buffer: false }
-    },
-    devtool: isProduction ? 'cheap-source-map' : 'eval-source-map',
-    devServer: {
-      contentBase: publicDirectory,
-      historyApiFallback: true,
-      publicPath: '/dist/' + config.projectShortname
-    }
-  };
+        template: path.join(publicDirectory, 'index.html')
+    }];
+
+    return createAdminWebpackConfig({
+        env: env,
+        projectSrcDir: __dirname,
+        publicDirectory: publicDirectory,
+        config: config,
+        adminEntryFile: path.join(__dirname, 'lib', 'admin', 'app-admin.js'),
+        includeDirectories: includeDirectories,
+        htmlPages,
+        customStylesFilePath: customStylesFilePath,
+        projectLocalesFilePath: customLocalesFilePath
+    });
 };

--- a/example/demo_survey/webpack.config.js
+++ b/example/demo_survey/webpack.config.js
@@ -1,11 +1,5 @@
-const fs                      = require('fs');
 const path                    = require('path');
-const webpack                 = require('webpack');
-const MiniCssExtractPlugin    = require("mini-css-extract-plugin");
-const CopyWebpackPlugin       = require('copy-webpack-plugin');
-const HtmlWebpackPlugin       = require('html-webpack-plugin');
-const { CleanWebpackPlugin }  = require("clean-webpack-plugin");
-const CompressionPlugin       = require('compression-webpack-plugin');
+const { createParticipantWebpackConfig } = require('evolution-frontend/lib/utils/dev/webpackParticipant');
 
 // Ensure server config is found regardless of cwd (fixes serve:dev when run from any directory)
 if (!process.env.PROJECT_CONFIG) {
@@ -22,208 +16,42 @@ const config = configuration.default ? configuration.default : configuration;
 
 // Public directory from which files are served
 const publicDirectory = path.join(__dirname, '..', '..', 'public');
-const bundleOutputPath = path.join(publicDirectory, 'dist', config.projectShortname, 'survey');
 
 module.exports = (env) => {
-  console.log(`building js for project ${config.projectShortname}`);
-  
-  const isProduction = process.env.NODE_ENV === 'production';
-  console.log('process.env.NODE_ENV', process.env.NODE_ENV);
 
-  // In dev, style-loader injects CSS via <style> so SCSS changes apply after reload without a separate .css file
-  const styleLoader = isProduction ? MiniCssExtractPlugin.loader : 'style-loader';
+    const customStylesFilePath  = `${__dirname}/lib/styles/styles.scss`;
+    const customLocalesFilePath = `${__dirname}/locales`;
+    const includeDirectories    = [
+        path.join(__dirname, 'lib', 'survey'),
+        path.join(__dirname, 'locales'),
+        path.join(__dirname, 'assets')
+    ];
 
-  const languages = config.languages || ['fr', 'en'];
-  const momentLanguagesFilter = `/${languages.join("|")}/`;
-
-  const customStylesFilePath  = `${__dirname}/lib/styles/styles.scss`;
-  const customLocalesFilePath = `${__dirname}/locales`;
-  const evolutionFrontendRoot = path.dirname(require.resolve('evolution-frontend/package.json'));
-  const includeDirectories    = [
-    path.join(__dirname, 'lib', 'survey'),
-    
-    path.join(__dirname, 'locales'),
-    path.join(__dirname, 'assets')
-  ];
-
-  return {
-    // Controls which information to display (see https://webpack.js.org/configuration/stats/)
-    stats: {
-      errorDetails: true,
-      children: true,
-    },
-    node: {
-      // global will be deprecated at next major release, see where it is being used
-      global: 'warn'
-    },
-    mode: process.env.NODE_ENV,
-    // Multiple entry points for different apps
-    entry: {
-      survey: ['./lib/app-survey.js', customStylesFilePath],
-      'survey-ended': [path.join(__dirname, '..', '..', 'packages', 'evolution-frontend', 'lib', 'apps', 'participant', 'app-survey-ended.js'), customStylesFilePath]
-    },
-    output: {
-      path: bundleOutputPath,
-      filename: isProduction ? `[name]-${config.projectShortname}-bundle-${process.env.NODE_ENV}.[contenthash].js` : `[name]-${config.projectShortname}-bundle-${process.env.NODE_ENV}.dev.js`,
-      publicPath: '/dist/'
-    },
-    watchOptions: {
-      // In dev, watch evolution-frontend and evolution-common so CSS/TS changes trigger rebuild
-      // Exclude lib/styles from evolution-frontend since we use alias to point to src/styles
-      ignored: isProduction
-        // In production, ignore all node_modules to avoid rebuilding the whole project
-        ? new RegExp('node_modules/')
-        // Ignore all node_modules except evolution-frontend and evolution-common, 
-        // and also specifically ignore the lib/styles directory of evolution-frontend 
-        // (which we override via an alias to our src/styles).
-        : new RegExp(
-            `(node_modules\\/(?!evolution-frontend|evolution-common)|${path.join(evolutionFrontendRoot, 'lib', 'styles').replace(/\\/g, '/').replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`
-          ),
-      aggregateTimeout: 600
-    },
-    module: {
-      rules: [
-        {
-          use: 'json-loader',
-          test: /\.geojson$/,
-          include: includeDirectories
-        },
-        { 
-          test: /\.(ttf|woff2|woff|eot|svg)$/,
-          type: 'asset'
-        },
-        {
-          test: /\.glsl$/,
-          use: 'ts-shader-loader'
-        },
-        {
-          test: /\.s?css$/,
-          use: [
-            styleLoader, // In dev, style-loader injects CSS via <style> so SCSS changes apply after reload without a separate .css file
-            {
-              loader: 'css-loader',
-              options: {
-                sourceMap: true
-              }
-            },
-            {
-              loader: 'sass-loader',
-              options: {
-                sourceMap: true,
-              }
-            }
-          ]
-        },
-        {
-          test: /locales/,
-          loader: '@alienfast/i18next-loader',
-          options: { 
-            basenameAsNamespace: true,
-            overrides: (fs.existsSync(customLocalesFilePath) ? [customLocalesFilePath] : [])
-          }
-        },
-        {
-            test: /\.js$/,
-            enforce: 'pre',
-            loader: 'source-map-loader',
-            include: includeDirectories
-        },
-        {
-          test: /\.tsx?$/,
-          use: 'ts-loader',
-          exclude: /node_modules/,
-          include: ["/node_modules/evolution-frontend/src", "/node_modules/evolution-common/src"]
-        },
-      ]
-    },
-    plugins: [
-      new CleanWebpackPlugin({
-        dry: !isProduction,
-        verbose: true,
-        cleanAfterEveryBuildPatterns: ['**/*', '!images/**', '!icons/**', '!*.html'],
-      }),
-      // HTML plugin for main survey app
-      new HtmlWebpackPlugin({
+    const htmlPages = [{
         title: process.env.DEFAULT_TITLE || 'Evolution',
         noindex: process.env.NOINDEX === 'true',
         filename: path.join(`index-survey-${config.projectShortname}.html`),
         template: path.join(publicDirectory, 'index.html'),
         chunks: ['survey']
-      }),
-      // HTML plugin for survey ended app
-      new HtmlWebpackPlugin({
+    }, {
         title: process.env.DEFAULT_TITLE || 'Evolution',
         noindex: process.env.NOINDEX === 'true',
         filename: path.join(`index-survey-ended-${config.projectShortname}.html`),
         template: path.join(publicDirectory, 'index.html'),
         chunks: ['survey-ended']
-      }),
-      new MiniCssExtractPlugin({
-        filename: isProduction ? `[name]-${config.projectShortname}-styles.[contenthash].css` : `[name]-${config.projectShortname}-styles.dev.css`
-      }),
-      new webpack.DefinePlugin({
-        'process.env': {
-          'IS_BROWSER'                  : JSON.stringify(true),
-          'HOST'                        : JSON.stringify(process.env.HOST),
-          'APP_NAME'                    : JSON.stringify('survey'),
-          'IS_TESTING'                  : JSON.stringify(env === 'test'),
-          'GOOGLE_API_KEY'              : JSON.stringify(process.env.GOOGLE_API_KEY)
+    }];
 
-        },
-        '__CONFIG__': JSON.stringify({
-            ...config
-        })
-      }),
-      new webpack.optimize.AggressiveMergingPlugin(),//Merge chunks 
-      new CompressionPlugin({
-        filename: "[path][base].gz[query]",
-        algorithm: "gzip",
-        test: /\.js$|\.css$/,
-        threshold: 0,
-        minRatio: 0.8
-      }),
-      new webpack.ContextReplacementPlugin(/moment[\/\\]locale$/, new RegExp(momentLanguagesFilter)),
-      new CopyWebpackPlugin(
-        {
-          patterns: [
-            {
-              context: path.join(__dirname, '..', '..', 'node_modules', 'chaire-lib-frontend', 'lib', 'assets'),
-              from: "**/*",
-              to: "",
-              noErrorOnMissing: true
-            },
-            {
-              context: path.join(__dirname, '..', '..', 'node_modules', 'evolution-frontend', 'lib', 'assets'),
-              from: "**/*",
-              to: "",
-              noErrorOnMissing: true
-            },
-            { 
-              context: path.join(__dirname, 'assets',),
-              from: "**/*",
-              to: "",
-              noErrorOnMissing: true
-            }
-          ]
-        }
-      )
-    ],
-    resolve: {
-      mainFields: ['browser', 'main', 'module'],
-      modules: ['node_modules'],
-      extensions: ['.json', '.js', '.ts', '.tsx'],
-      // In dev, read SCSS from evolution-frontend source so changes apply without running copy-files
-      alias: isProduction ? {} : {
-        [path.join(evolutionFrontendRoot, 'lib', 'styles')]: path.join(evolutionFrontendRoot, 'src', 'styles')
-      },
-      // These modules are not used in the frontend, don't try to resolve them as they are nodejs only and don't have a browser counterpart (but they may be used in transition-legacy which is still not cleanly separated)
-      fallback: { path: false, buffer: false }
-    },
-    devtool: isProduction ? 'cheap-source-map' : 'eval-source-map',
-    devServer: {
-      contentBase: publicDirectory,
-      historyApiFallback: true,
-      publicPath: '/dist/' + config.projectShortname
-    }
-  };
+    return createParticipantWebpackConfig({
+        env: env,
+        projectSrcDir: __dirname,
+        publicDirectory: publicDirectory,
+        config: config,
+        participantEntryFile: path.join(__dirname, 'lib', 'app-survey.js'),
+        surveyEndedEntryFile: path.join(__dirname, '..', '..', 'packages', 'evolution-frontend', 'lib', 'apps', 'participant', 'app-survey-ended.js'),
+        includeDirectories: includeDirectories,
+        htmlPages,
+        customStylesFilePath: customStylesFilePath,
+        projectLocalesFilePath: customLocalesFilePath
+    });
+
 };

--- a/packages/evolution-frontend/package.json
+++ b/packages/evolution-frontend/package.json
@@ -75,6 +75,7 @@
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
+    "@alienfast/i18next-loader": "^2.0.2",
     "@playwright/test": "^1.56.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",
@@ -87,19 +88,34 @@
     "@types/react-dom": "^19.2.3",
     "@typescript-eslint/eslint-plugin": "^8.50.0",
     "@typescript-eslint/parser": "^8.50.0",
+    "clean-webpack-plugin": "^4.0.0",
+    "compression-webpack-plugin": "^11.1.0",
+    "copy-webpack-plugin": "^13.0.1",
     "cross-env": "^10.1.0",
+    "css-loader": "^7.1.2",
     "eslint": "^8.57.1",
     "eslint-plugin-n": "^15.7.0",
     "eslint-plugin-react": "^7.37.2",
+    "html-webpack-plugin": "^5.6.5",
     "i18next-fs-backend": "^2.6.1",
     "jest": "^30.2.0",
     "jest-axe": "^10.0.0",
     "jest-each": "^30.2.0",
     "jest-environment-jsdom": "^30.2.0",
+    "json-loader": "^0.5.7",
+    "mini-css-extract-plugin": "^2.9.4",
     "mockdate": "^3.0.5",
     "prettier-eslint-cli": "^8.0.1",
+    "sass": "^1.97.0",
+    "sass-loader": "^16.0.6",
+    "style-loader": "^4.0.0",
+    "source-map-loader": "^5.0.0",
     "ts-jest": "^29.4.6",
+    "ts-loader": "^9.5.4",
+    "ts-shader-loader": "^2.0.2",
     "typescript": "^5.9.3",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "webpack": "^5.104.1",
+    "webpack-cli": "^6.0.1"
   }
 }

--- a/packages/evolution-frontend/src/utils/dev/webpackAdmin.ts
+++ b/packages/evolution-frontend/src/utils/dev/webpackAdmin.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+// eslint-disable-next-line n/no-unpublished-import
+import type { Configuration } from 'webpack';
+
+import { AdminWebpackConfigParams, createCommonWebpackConfig } from './webpackCommon';
+
+const applyAdminAuthToConfig = (config: any): any => {
+    // For the admin app, the adminAuth should replace the auth configuration
+    // FIXME This is the kind of config that should come from the server, not be inserted in the client in webpack
+    if (!config.adminAuth) {
+        console.warn(
+            'Configuration error: you need to specify the adminAuth key in the config.js file. Will use default values.'
+        );
+        config.adminAuth = {
+            localLogin: {
+                registerWithPassword: true,
+                registerWithEmailOnly: true,
+                confirmEmail: false,
+                forgotPasswordPage: true
+            }
+        };
+    }
+    config.auth = config.adminAuth;
+    delete config.adminAuth;
+    return config;
+};
+
+export const createAdminWebpackConfig = (params: AdminWebpackConfigParams): Configuration => {
+    const currentNodeEnv = params.env.NODE_ENV || process.env.NODE_ENV;
+    const isProduction = currentNodeEnv === 'production';
+
+    // Update config to replace the auth config with the admin auth config
+    const updatedConfig = applyAdminAuthToConfig(params.config);
+
+    const entry = [params.adminEntryFile, params.customStylesFilePath];
+
+    // Name of the output file to generate
+    const outputFilename = isProduction
+        ? `survey-admin-${updatedConfig.projectShortname}-bundle-${currentNodeEnv}.[contenthash].js`
+        : `survey-admin-${updatedConfig.projectShortname}-bundle-${currentNodeEnv}.dev.js`;
+    const outputCssFileName = isProduction
+        ? `survey-${updatedConfig.projectShortname}-styles.[contenthash].css`
+        : `survey-${updatedConfig.projectShortname}-styles.dev.css`;
+
+    return createCommonWebpackConfig({
+        env: params.env,
+        projectSrcDir: params.projectSrcDir,
+        publicDirectory: params.publicDirectory,
+        config: updatedConfig,
+        entry,
+        bundleRelativePath: 'admin',
+        outputFilename,
+        outputCssFileName,
+        includeDirectories: params.includeDirectories,
+        projectLocalesFilePath: params.projectLocalesFilePath,
+        htmlPages: params.htmlPages,
+        extraEnvs: params.extraEnvs || {}
+    });
+};

--- a/packages/evolution-frontend/src/utils/dev/webpackCommon.ts
+++ b/packages/evolution-frontend/src/utils/dev/webpackCommon.ts
@@ -1,0 +1,292 @@
+/*
+ * Copyright 2026, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import fs from 'fs';
+import path from 'path';
+// eslint-disable-next-line n/no-unpublished-import
+import type { Configuration, WebpackPluginInstance } from 'webpack';
+// eslint-disable-next-line n/no-unpublished-import
+import webpack from 'webpack';
+// eslint-disable-next-line n/no-unpublished-import
+import MiniCssExtractPlugin from 'mini-css-extract-plugin';
+// eslint-disable-next-line n/no-unpublished-import
+import CopyWebpackPlugin from 'copy-webpack-plugin';
+// eslint-disable-next-line n/no-unpublished-import
+import HtmlWebpackPlugin from 'html-webpack-plugin';
+// eslint-disable-next-line n/no-unpublished-import
+import { CleanWebpackPlugin } from 'clean-webpack-plugin';
+// eslint-disable-next-line n/no-unpublished-import
+import CompressionPlugin from 'compression-webpack-plugin';
+
+export type ParticipantWebpackConfigParams = CommonWebpackConfigParams & {
+    /** The path to the participant app's entry file */
+    participantEntryFile: string;
+    /** The path to the survey-ended entry file. Leave undefined if no survey end date */
+    surveyEndedEntryFile?: string;
+    /** The custom style file path */
+    customStylesFilePath: string;
+    /** Extra environment variables to be injected into the build: they will be available in the build using `process.env` */
+    extraEnvs?: Record<string, unknown>;
+};
+
+export type AdminWebpackConfigParams = CommonWebpackConfigParams & {
+    /** The path to the admin app's entry file */
+    adminEntryFile: string;
+    /** The custom style file path */
+    customStylesFilePath: string;
+    /** Extra environment variables to be injected into the build: they will be available in the build using `process.env` */
+    extraEnvs?: Record<string, unknown>;
+};
+
+export type CommonWebpackConfigParams = {
+    /** the env object received by the command line, should have precedence over process.env */
+    env: Record<string, unknown>;
+    /** The directory containing the sources of the project */
+    projectSrcDir: string;
+    /** The public directory where the built files will be outputted */
+    publicDirectory: string;
+    /**
+     * The project's configuration
+     * FIXME: Properly type
+     * */
+    config: any;
+    /** An array of directories from the project to include with the build, should include assets, locales and lib directories */
+    includeDirectories: string[];
+    /** The path containing the project specific locales */
+    projectLocalesFilePath?: string;
+    /** An array of HTML pages to generate */
+    htmlPages: HtmlWebpackPlugin.Options[];
+};
+
+type WebpackGenerationConfigParams = CommonWebpackConfigParams & {
+    entry: any;
+    bundleRelativePath: string;
+    outputFilename: string;
+    outputCssFileName: string;
+    extraEnvs: Record<string, unknown>;
+};
+
+const stringifyEnvValues = (envs: Record<string, unknown>) => {
+    return Object.fromEntries(Object.entries(envs).map(([key, value]) => [key, JSON.stringify(value)]));
+};
+
+export const createCommonWebpackConfig = (params: WebpackGenerationConfigParams): Configuration => {
+    const currentNodeEnv = params.env.NODE_ENV || process.env.NODE_ENV;
+    const isProduction = currentNodeEnv === 'production';
+
+    console.log(`building js for project ${params.config.projectShortname} for env ${currentNodeEnv}`);
+
+    // Determine which style loader to use
+    const styleLoader = isProduction ? MiniCssExtractPlugin.loader : 'style-loader';
+    // Get root directories of evolution-frontend and chaire-lib-frontend for assets and locales file paths
+    const evolutionFrontendRoot = path.dirname(require.resolve('evolution-frontend/package.json'));
+    const chaireLibFrontendRoot = path.dirname(require.resolve('chaire-lib-frontend/package.json'));
+
+    // Determine which languages to use
+    const languages = params.config.languages || ['fr', 'en'];
+    const momentLanguagesFilter = `/${languages.join('|')}/`;
+
+    // Path where build files will be outputted in the public directory
+    const outputPath = path.join(
+        params.publicDirectory,
+        'dist',
+        params.config.projectShortname,
+        params.bundleRelativePath
+    );
+
+    // Define environment variables to be used in the build, including the project configuration
+    const definePluginValues: Record<string, any> = {
+        'process.env': {
+            IS_BROWSER: JSON.stringify(true),
+            HOST: JSON.stringify(process.env.HOST),
+            APP_NAME: JSON.stringify('survey'),
+            IS_TESTING: JSON.stringify(currentNodeEnv === 'test'),
+            GOOGLE_API_KEY: JSON.stringify(process.env.GOOGLE_API_KEY),
+            ...stringifyEnvValues(params.extraEnvs)
+        },
+        __CONFIG__: JSON.stringify({
+            ...params.config
+        })
+    };
+
+    return {
+        // Controls which information to display (see https://webpack.js.org/configuration/stats/)
+        stats: {
+            errorDetails: true,
+            children: true
+        },
+        node: {
+            // global will be deprecated at next major release, see where it is being used
+            global: 'warn'
+        },
+        mode: process.env.NODE_ENV,
+        // The entry point file(s) for the bundle(s), or an object of entry points for multiple bundles
+        entry: params.entry,
+        output: {
+            path: outputPath,
+            filename: params.outputFilename,
+            publicPath: '/dist/'
+        },
+        watchOptions: {
+            // In dev, watch evolution-frontend and evolution-common so CSS/TS changes trigger rebuild
+            // Exclude lib/styles from evolution-frontend since we use alias to point to src/styles
+            ignored: isProduction
+                ? // In production, ignore all node_modules to avoid rebuilding the whole project
+                new RegExp('node_modules/')
+                : // Ignore all node_modules except evolution-frontend and evolution-common,
+            // and also specifically ignore the lib/styles directory of evolution-frontend
+            // (which we override via an alias to our src/styles).
+                new RegExp(
+                    `(node_modules\\/(?!evolution-frontend|evolution-common)|${path
+                        .join(evolutionFrontendRoot, 'lib', 'styles')
+                        .replace(/\\/g, '/')
+                        .replace(/[.*+?^${}()|[\\]\\]/g, '\\$&')})`
+                ),
+            aggregateTimeout: 600
+        },
+        module: {
+            rules: [
+                {
+                    // Make sure to load geojson files from the project with the json loader
+                    use: 'json-loader',
+                    test: /\.geojson$/,
+                    include: params.includeDirectories
+                },
+                {
+                    // FIXME Confirm what copilot says this: For fonts and icons, use asset module to automatically choose between inlining and separate files based on size (default 8kb)
+                    test: /\.(ttf|woff2|woff|eot|svg)$/,
+                    type: 'asset'
+                },
+                {
+                    // FIXME Do we have glsl shaders in Evolution? If not, we should remove this rule
+                    test: /\.glsl$/,
+                    use: 'ts-shader-loader'
+                },
+                {
+                    // Load SCSS files
+                    test: /\.s?css$/,
+                    use: [
+                        styleLoader, // In dev, style-loader injects CSS via <style> so SCSS changes apply after reload without a separate .css file
+                        {
+                            loader: 'css-loader',
+                            options: {
+                                sourceMap: true
+                            }
+                        },
+                        {
+                            loader: 'sass-loader',
+                            options: {
+                                sourceMap: true
+                            }
+                        }
+                    ]
+                },
+                {
+                    // Build locales keys into the webpack, and allow overriding them with a project specific locales file
+                    test: /locales/,
+                    loader: '@alienfast/i18next-loader',
+                    options: {
+                        basenameAsNamespace: true,
+                        overrides:
+                            params.projectLocalesFilePath !== undefined && fs.existsSync(params.projectLocalesFilePath)
+                                ? [params.projectLocalesFilePath]
+                                : []
+                    }
+                },
+                {
+                    // FIXME: Confirm what copilot says: Process source maps from dependencies, but only for included directories to avoid processing the whole node_modules
+                    test: /\.js$/,
+                    enforce: 'pre',
+                    loader: 'source-map-loader',
+                    include: params.includeDirectories
+                },
+                {
+                    // FIXME Does not seem to work for evolution-frontend and evolution-common.
+                    // Load TypeScript files, but only from the project and evolution-frontend and evolution-common source to avoid processing the whole node_modules
+                    test: /\.tsx?$/,
+                    use: 'ts-loader',
+                    exclude: /node_modules(?!\/(evolution-frontend|evolution-common)\/src)/
+                }
+            ]
+        },
+        plugins: [
+            // Remove any previously generated or intermediary files after production builds
+            new CleanWebpackPlugin({
+                dry: !isProduction,
+                verbose: true,
+                cleanAfterEveryBuildPatterns: ['**/*', '!images/**', '!icons/**', '!*.html']
+            }),
+            // Create the HTML file to serve the webpack bundles, using the provided template and injecting the generated bundles
+            ...params.htmlPages.map((htmlPage) => new HtmlWebpackPlugin(htmlPage)),
+            // Extract CSS in production in separate files, but keep it in the JS bundle in dev for faster builds and hot reload
+            // FIXME This may not be required in dev mode
+            new MiniCssExtractPlugin({
+                filename: params.outputCssFileName
+            }),
+            // Define environment variables to be used in the build, including the project configuration
+            new webpack.DefinePlugin(definePluginValues),
+            // FIXME Confirm what copilot says: Merge chunks in production to reduce the number of generated files and optimize loading, but keep chunks separate in dev for faster builds and better debugging
+            new webpack.optimize.AggressiveMergingPlugin(), // Merge chunks
+            // Compress JS and CSS files to reduce bundle size
+            new CompressionPlugin({
+                filename: '[path][base].gz[query]',
+                algorithm: 'gzip',
+                test: /\.js$|\.css$/,
+                threshold: 0,
+                minRatio: 0.8
+            }),
+            // FIXME: Confirm what copilot says:Only include moment locales for the languages used in the project to reduce bundle size
+            new webpack.ContextReplacementPlugin(/moment[/\\]locale$/, new RegExp(momentLanguagesFilter)),
+            // Copy static assets from the project and from evolution-frontend and chaire-lib-frontend to the output directory
+            new CopyWebpackPlugin({
+                patterns: [
+                    {
+                        context: path.join(chaireLibFrontendRoot, 'lib', 'assets'),
+                        from: '**/*',
+                        to: '',
+                        noErrorOnMissing: true
+                    },
+                    {
+                        context: path.join(evolutionFrontendRoot, 'lib', 'assets'),
+                        from: '**/*',
+                        to: '',
+                        noErrorOnMissing: true
+                    },
+                    {
+                        context: path.join(params.projectSrcDir, 'assets'),
+                        from: '**/*',
+                        to: '',
+                        noErrorOnMissing: true
+                    }
+                ]
+            })
+        ] as WebpackPluginInstance[],
+        resolve: {
+            mainFields: ['browser', 'main', 'module'],
+            modules: ['node_modules'],
+            extensions: ['.json', '.js', '.ts', '.tsx'],
+            // In dev, read SCSS from evolution-frontend source so changes apply without running copy-files
+            alias: isProduction
+                ? {}
+                : {
+                    [path.join(evolutionFrontendRoot, 'lib', 'styles')]: path.join(
+                        evolutionFrontendRoot,
+                        'src',
+                        'styles'
+                    )
+                },
+            // These modules are not used in the frontend, don't try to resolve them as they are nodejs only and don't have a browser counterpart
+            fallback: { path: false, buffer: false }
+        },
+        devtool: isProduction ? 'cheap-source-map' : 'eval-source-map',
+        // FIXME: What does this do? Do we need this?
+        devServer: {
+            contentBase: params.publicDirectory,
+            historyApiFallback: true,
+            publicPath: '/dist/' + params.config.projectShortname
+        }
+    } as Configuration;
+};

--- a/packages/evolution-frontend/src/utils/dev/webpackParticipant.ts
+++ b/packages/evolution-frontend/src/utils/dev/webpackParticipant.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+// eslint-disable-next-line n/no-unpublished-import
+import type { Configuration } from 'webpack';
+
+import { createCommonWebpackConfig, ParticipantWebpackConfigParams } from './webpackCommon';
+
+export const createParticipantWebpackConfig = (params: ParticipantWebpackConfigParams): Configuration => {
+    const currentNodeEnv = params.env.NODE_ENV || process.env.NODE_ENV;
+    const isProduction = currentNodeEnv === 'production';
+
+    const entry =
+        params.surveyEndedEntryFile !== undefined
+            ? {
+                survey: [params.participantEntryFile, params.customStylesFilePath],
+                'survey-ended': [params.surveyEndedEntryFile || '', params.customStylesFilePath]
+            }
+            : [params.participantEntryFile, params.customStylesFilePath];
+    // Use [name] in output filename only if there are multiple entry points
+    const namePartOfOutputFilename = params.surveyEndedEntryFile !== undefined ? '[name]' : 'survey';
+
+    // Name of the output files to generate
+    const outputFilename = isProduction
+        ? `${namePartOfOutputFilename}-${params.config.projectShortname}-bundle-${currentNodeEnv}.[contenthash].js`
+        : `${namePartOfOutputFilename}-${params.config.projectShortname}-bundle-${currentNodeEnv}.dev.js`;
+    const outputCssFileName = isProduction
+        ? `survey-${params.config.projectShortname}-styles.[contenthash].css`
+        : `survey-${params.config.projectShortname}-styles.dev.css`;
+
+    return createCommonWebpackConfig({
+        env: params.env,
+        projectSrcDir: params.projectSrcDir,
+        publicDirectory: params.publicDirectory,
+        config: params.config,
+        entry,
+        bundleRelativePath: 'survey',
+        outputFilename,
+        outputCssFileName,
+        includeDirectories: params.includeDirectories,
+        projectLocalesFilePath: params.projectLocalesFilePath,
+        htmlPages: params.htmlPages,
+        extraEnvs: params.extraEnvs || {}
+    });
+};


### PR DESCRIPTION
fixes #1405

This extracts the common webpack configuration, as well as base function to create the webpack config for participant and admin apps.

Projects can simply call those utility functions to generate the webpack instead of copy-pasting identical webpack configuration files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized frontend build configuration by delegating example projects to shared builders.
* **Chores**
  * Simplified example project build setups and removed several example dev dependencies (including a removed style-loader entry).
* **New Features**
  * Added reusable webpack builder utilities to standardize asset, locale, and environment handling for participant and admin frontends.
* **Documentation**
  * Recorded the new utilities and migration guidance in the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->