### PR TITLE
i18n: make sure project's locales files overwrite Evolution's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Allow to effectively override locales from Evolution by survey specifics with the same key. Fix is applied automatically on projects calling the `createParticipantWebpackConfig` and `createAdminWebpackConfig` webpack helpers. (#1426)
 
 ### Security
 

--- a/packages/evolution-frontend/src/config/__tests__/fixtures/customLocales.js
+++ b/packages/evolution-frontend/src/config/__tests__/fixtures/customLocales.js
@@ -1,0 +1,16 @@
+module.exports = {
+    en: {
+        main: {
+            NotFoundPageTitle: 'Page Not Found - 404',
+            Cancel: 'Abort',
+            CustomOnlyKey: 'Custom only (en)'
+        }
+    },
+    fr: {
+        main: {
+            NotFoundPageTitle: 'Page non trouvée - 404',
+            Cancel: 'Annuler (custom)',
+            CustomOnlyKey: 'Seulement custom (fr)'
+        }
+    }
+};

--- a/packages/evolution-frontend/src/config/__tests__/i18n.config.test.ts
+++ b/packages/evolution-frontend/src/config/__tests__/i18n.config.test.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import path from 'path';
+
+declare global {
+    // eslint-disable-next-line no-var
+    var __CUSTOM_LOCALES_PATH__: string | undefined;
+    var __CONFIG__: Record<string, any> | undefined
+}
+
+// NotFoundPageTitle is only in base, Cancel is in both base and custom
+const baseResources = {
+    en: {
+        main: {
+            NotFoundPageTitle: 'Page Not Found - 404',
+            Cancel: 'Cancel'
+        }
+    },
+    fr: {
+        main: {
+            NotFoundPageTitle: 'Page non trouvée - 404',
+            Cancel: 'Annuler'
+        }
+    }
+};
+
+const customLocalesPath = path.resolve(__dirname, './fixtures/customLocales.js');
+
+const sharedKey = 'Cancel';
+const customOnlyKey = 'CustomOnlyKey';
+
+const loadI18n = (customPath?: string) => {
+    jest.resetModules();
+
+    if (customPath === undefined) {
+        delete global.__CUSTOM_LOCALES_PATH__;
+    } else {
+        global.__CUSTOM_LOCALES_PATH__ = customPath;
+    }
+    // Need to mock the locales resources before loading the i18n config, as
+    // webpack does the packing of the locales in a module, which is not the
+    // case here. virtual because the module doesn't actually exist at this
+    // moment, but it allows us to mock it for testing purposes.
+    jest.doMock('../../../../../locales/', () => baseResources, { virtual: true });
+
+    let instance: any;
+    jest.isolateModules(() => {
+        instance = require('../i18n.config').default;
+    });
+    return instance;
+};
+
+describe('i18n.config custom locales override', () => {
+    beforeEach(() => {
+        (global as any).document = {
+            documentElement: {
+                setAttribute: jest.fn()
+            }
+        };
+        global.__CONFIG__ = { languages: ['en', 'fr'], defaultLocale: 'en', detectLanguage: false, detectLanguageFromUrl: false };
+    });
+
+    afterEach(() => {
+        delete global.__CUSTOM_LOCALES_PATH__;
+        jest.clearAllMocks();
+    });
+
+    test.each([{
+        title: 'without __CUSTOM_LOCALES_PATH__',
+        customPath: undefined,
+        expectWarn: false,
+        expectedShared: 'Cancel',
+        expectedCustom: undefined
+    },
+    {
+        title: 'with invalid __CUSTOM_LOCALES_PATH__',
+        customPath: '/path/does/not/exist',
+        expectWarn: true,
+        expectedShared: 'Cancel',
+        expectedCustom: undefined
+    },
+    {
+        title: 'with valid __CUSTOM_LOCALES_PATH__',
+        customPath: customLocalesPath,
+        expectWarn: false,
+        expectedShared: 'Abort',
+        expectedCustom: 'Custom only (en)'
+    }])('$title', ({ customPath, expectWarn, expectedShared, expectedCustom }) => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+        const i18n = loadI18n(customPath);
+        const resources = i18n?.options?.resources as any;
+
+        expect(resources?.en?.main?.[sharedKey]).toBe(expectedShared);
+        expect(resources?.en?.main?.[customOnlyKey]).toBe(expectedCustom);
+
+        if (expectWarn) {
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+        } else {
+            expect(warnSpy).not.toHaveBeenCalled();
+        }
+
+        warnSpy.mockRestore();
+    });
+});
+
+export {};
+

--- a/packages/evolution-frontend/src/config/i18n.config.ts
+++ b/packages/evolution-frontend/src/config/i18n.config.ts
@@ -9,9 +9,28 @@ import { initReactI18next } from 'react-i18next';
 import moment from 'moment';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import config from 'chaire-lib-frontend/lib/config/project.config';
-// TODO: importing a whole directory is allowed in javascript but not in typescript, find another way to import only the needed locales anyway.
-// eslint-disable-next-line
+
+// Declare custom locales path from webpack
+declare const __CUSTOM_LOCALES_PATH__: string | undefined;
+
+// Webpack will have replaced the locales folder with a module that exports the
+// locales resources, so at runtime, this is not a folder, but a module that we
+// can import. But at compile time, typescript complains.
+// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, n/no-unpublished-require
 const resources = require('../../../../locales/');
+
+// Load custom locales, webpack will have already merged with the base locales
+let customResources: any = null;
+if (typeof __CUSTOM_LOCALES_PATH__ !== 'undefined') {
+    try {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, n/no-unpublished-require
+        customResources = require(__CUSTOM_LOCALES_PATH__);
+    } catch (e) {
+        console.warn('Custom locales path defined but could not load:', __CUSTOM_LOCALES_PATH__, e);
+        customResources = null;
+    }
+}
+
 const detectorOrder = config.detectLanguageFromUrl
     ? ['querystring', 'path', 'cookie', 'localStorage']
     : config.detectLanguage
@@ -33,7 +52,7 @@ i18n.use(LanguageDetector)
             preload: config.languages,
             supportedLngs: config.languages,
             nonExplicitSupportedLngs: false,
-            resources: resources,
+            resources: customResources === null ? resources : customResources,
             fallbackLng: config.defaultLocale || 'en',
             debug: false,
             interpolation: {

--- a/packages/evolution-frontend/src/utils/dev/webpackCommon.ts
+++ b/packages/evolution-frontend/src/utils/dev/webpackCommon.ts
@@ -85,6 +85,11 @@ export const createCommonWebpackConfig = (params: WebpackGenerationConfigParams)
     const evolutionFrontendRoot = path.dirname(require.resolve('evolution-frontend/package.json'));
     const chaireLibFrontendRoot = path.dirname(require.resolve('chaire-lib-frontend/package.json'));
 
+    // Determine if there is project locales path to override evolution's
+    const evolutionLocaleFiles = path.join(evolutionFrontendRoot, '..', '..', 'locales');
+    const hasProjectLocales =
+        params.projectLocalesFilePath !== undefined && fs.existsSync(params.projectLocalesFilePath);
+
     // Determine which languages to use
     const languages = params.config.languages || ['fr', 'en'];
     const momentLanguagesFilter = `/${languages.join('|')}/`;
@@ -111,6 +116,10 @@ export const createCommonWebpackConfig = (params: WebpackGenerationConfigParams)
             ...params.config
         })
     };
+
+    if (hasProjectLocales) {
+        definePluginValues['__CUSTOM_LOCALES_PATH__'] = JSON.stringify(params.projectLocalesFilePath);
+    }
 
     return {
         // Controls which information to display (see https://webpack.js.org/configuration/stats/)
@@ -190,10 +199,8 @@ export const createCommonWebpackConfig = (params: WebpackGenerationConfigParams)
                     loader: '@alienfast/i18next-loader',
                     options: {
                         basenameAsNamespace: true,
-                        overrides:
-                            params.projectLocalesFilePath !== undefined && fs.existsSync(params.projectLocalesFilePath)
-                                ? [params.projectLocalesFilePath]
-                                : []
+                        // The custom locales will override evolution's
+                        overrides: hasProjectLocales ? [evolutionLocaleFiles] : []
                     }
                 },
                 {


### PR DESCRIPTION
fixes #1426

This adds a `__CUSTOM_LOCALES_PATH__` environment variable, defined in the webpack, who advertise where the project-specific locale files are.

In the example surveys, we update the `overrides` option, which was used wrongly, it should specify the locales _to_ override and not the locales _that_ overrides. The result is that the locales loaded from the `__CUSTOM_LOCALES_PATH__` folder will have been merged with the evolution's locale and can be used directly by the application if available.

Add tests for `i18n.config.ts` with/without valid custom locales file path.