### PR TITLE
i18n: fix missing module file in project's locales folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added utility functions for webpack generation in evolution-frontend: `createParticipantWebpackConfig` and `createAdminWebpackConfig`. The example projects implement this approach. Projects should consider using those for simlicity. (#1405)
 
 ### Changed
+- BREAKING: if using the webpack generation functions and the project has a `locales` folder, make sure an empty module file is present in the folder for build time import. An empty file named `index.js` at the root of the project's `locales` folder is enough. Webpack will replace it with the actual translations in the build. (#1426)
 
 ### Deprecated
 

--- a/example/demo_generator/locales/index.js
+++ b/example/demo_generator/locales/index.js
@@ -1,0 +1,1 @@
+// Empty file that must exists for the locales to be imported correctly at build time. Webpack config will create and fill this file in the bundle, but it must exist.

--- a/example/demo_survey/locales/index.js
+++ b/example/demo_survey/locales/index.js
@@ -1,0 +1,1 @@
+// Empty file that must exists for the locales to be imported correctly at build time. Webpack config will create and fill this file in the bundle, but it must exist.


### PR DESCRIPTION
eb38bb8cd95df4b1ef3720c4cfa732134c6a9ac3 changed the way locales are built into the client bundle. Webpack now requires a module file to be present in the project's `locales` folder as it is imported by the client at build time. Webpack will fill its content at build time with the actual translations, but the code needs to be able to import this module _before_ the actual file content is updated.

The `yarn build:dev` of the previous commit silently failed to warn about missing files and local installs had it.

Document this as a breaking change in the Changelog file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * When using webpack generation functions with a locales folder, an empty module placeholder must be added at the locales root for build-time imports to work correctly. Webpack will populate this during bundling.

* **Documentation**
  * Added changelog entry documenting the locales setup requirement for webpack builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->