### PR TITLE
Format: Update Prettier configuration to include singleAttributePerLine option

### DIFF
--- a/configs/base.prettierrc.js
+++ b/configs/base.prettierrc.js
@@ -5,5 +5,6 @@ module.exports = {
     "bracketSpacing": true,
     "trailingComma": "none",
     "printWidth": 120,
+    "singleAttributePerLine": false,
 }
   


### PR DESCRIPTION
# Pull request

## Description

Format: Update Prettier configuration to include singleAttributePerLine option
- Added "singleAttributePerLine": false to the Prettier configuration file to enhance formatting consistency with auto-save from some developer.

## Justification
I tested on my computer, and now it won't allow me to have every parameter on a single line if it's less than 120 px. Before, I could (and there were no modifications with prettier).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated code formatting configuration to allow multiple attributes on a single line in JSX/HTML markup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->