### PR TITLE
odSurvey: add helper functions to get gender and id strings

### DIFF
--- a/locales/en/survey.yml
+++ b/locales/en/survey.yml
@@ -51,9 +51,14 @@ hisHerTheir: their
 hisHerTheir_male: his
 hisHerTheir_female: her
 hisHerTheir_custom: their
-personWithSequenceAndAge: "Person #{{sequence}} ({{age}} years old)"
-personWithSequenceAndAge_male: "Person #{{sequence}} (man, {{age}} years old)"
-personWithSequenceAndAge_female: "Person #{{sequence}} (woman, {{age}} years old)"
+personWithSequenceAndAge: "Person #{{sequence}} ($t(survey:age, {\"count\": {{age}} }))"
+personWithSequenceAndAge_male: "Person #{{sequence}} (man, $t(survey:age, {\"count\": {{age}} }))"
+personWithSequenceAndAge_female: "Person #{{sequence}} (woman, $t(survey:age, {\"count\": {{age}} }))"
+age_one: "1 year old"
+age: "{{count}} years old"
+personWithSequence: "Person #{{sequence}}"
+personWithSequence_male: "Person #{{sequence}} (man)"
+personWithSequence_female: "Person #{{sequence}} (woman)"
 
 # generic label contents
 noNickname: this person

--- a/locales/fr/survey.yml
+++ b/locales/fr/survey.yml
@@ -59,9 +59,15 @@ hisHerTheir: ""
 hisHerTheir_male: "son"
 hisHerTheir_female: "sa"
 hisHerTheir_custom: "ses"
-personWithSequenceAndAge: "Personne #{{sequence}} ({{age}} ans)"
-personWithSequenceAndAge_male: "Personne #{{sequence}} (homme, {{age}} ans)"
-personWithSequenceAndAge_female: "Personne #{{sequence}} (femme, {{age}} ans)"
+personWithSequenceAndAge: "Personne #{{sequence}} ($t(survey:age, {\"count\": {{age}} }))"
+personWithSequenceAndAge_male: "Personne #{{sequence}} (homme, $t(survey:age, {\"count\": {{age}} }))"
+personWithSequenceAndAge_female: "Personne #{{sequence}} (femme, $t(survey:age, {\"count\": {{age}} }))"
+age_zero: "0 an"
+age_one: "1 an"
+age: "{{count}} ans"
+personWithSequence: "Personne #{{sequence}}"
+personWithSequence_male: "Personne #{{sequence}} (homme)"
+personWithSequence_female: "Personne #{{sequence}} (femme)"
 
 # generic label contents
 noNickname: cette personne

--- a/packages/evolution-common/src/services/odSurvey/__tests__/helpers.test.ts
+++ b/packages/evolution-common/src/services/odSurvey/__tests__/helpers.test.ts
@@ -765,6 +765,48 @@ each([
     expect(Helpers.getCountOrSelfDeclared({ interview, person })).toEqual(expected);
 });
 
+describe('getPersonGenderContext', () => {
+    it.each([
+        [{ gender: 'male', sexAssignedAtBirth: 'male' }, 'male'],
+        [{ gender: 'female', sexAssignedAtBirth: 'male' }, 'female'],
+        [{ gender: undefined, sexAssignedAtBirth: 'female' }, 'female'],
+        [{ gender: 'non-binary', sexAssignedAtBirth: undefined }, 'non-binary'],
+        [{ gender: undefined, sexAssignedAtBirth: undefined }, undefined],
+        [{}, undefined]
+    ])
+    ('returns %s for person %o', (person: any, expected) => {
+        expect(Helpers.getPersonGenderContext({ person })).toBe(expected);
+    });
+});
+
+
+describe('getPersonIdentificationString', () => {
+    const mockT = jest.fn() as unknown as jest.MockedFunction<TFunction>;
+    mockT.mockImplementation(((key: any, options?: any) => {
+        if (key === 'survey:personWithSequenceAndAge') {
+            return `Person ${options.sequence}, Age ${options.age}, Gender ${options.context}`;
+        } else if (key === 'survey:personWithSequence') {
+            return `Person ${options.sequence}, Gender ${options.context}`;
+        }
+        return '';
+    }) as any);
+
+    it.each([
+        [{ nickname: 'Bob', _sequence: 1, age: 30 }, 'Bob'],
+        [{ nickname: '<strong>Bob!!</strong>', _sequence: 1, age: 30 }, '&lt;strong&gt;Bob!!&lt;/strong&gt;'],
+        [{ nickname: '', _sequence: 2, age: 25 }, 'Person 2, Age 25, Gender undefined'],
+        [{ nickname: '  ', _sequence: 2, age: 25 }, 'Person 2, Age 25, Gender undefined'],
+        [{ nickname: '  ', _sequence: 2, age: 25, gender: 'female' as const }, 'Person 2, Age 25, Gender female'],
+        [{ _sequence: 3, age: undefined }, 'Person 3, Gender undefined'],
+        [{ _sequence: 3, age: null }, 'Person 3, Gender undefined'],
+        [{ _sequence: 3, gender: 'male' }, 'Person 3, Gender male'],
+        [{ _sequence: 3 }, 'Person 3, Gender undefined'],
+    ])
+    ('returns correct identification for person %o', (person: any, expected) => {
+        expect(Helpers.getPersonIdentificationString({ person, t: mockT })).toEqual(expected);
+    });
+});
+
 each([
     ['Explicit yes, no age needed', { _uuid: 'personId1', _sequence: 1, drivingLicenseOwnership: 'yes' }, 18, true],
     ['Explicit no, adult age', { _uuid: 'personId1', _sequence: 1, age: 35, drivingLicenseOwnership: 'no' }, 18, false],

--- a/packages/evolution-common/src/services/odSurvey/helpers.ts
+++ b/packages/evolution-common/src/services/odSurvey/helpers.ts
@@ -6,6 +6,7 @@
  */
 
 import _get from 'lodash/get';
+import _escape from 'lodash/escape';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { getResponse } from '../../utils/helpers';
 import {
@@ -243,7 +244,7 @@ export const isSelfDeclared = ({
  *
  * @param {Object} options - The options object.
  * @param {UserInterviewAttributes} options.interview The interview
- * @param {Person} options.person The current person being interviews
+ * @param {Person} options.person The current person being interviewed
  * @returns {number} The number of persons in the household or 1 if the person is self-declared.
  */
 export const getCountOrSelfDeclared = ({
@@ -258,6 +259,48 @@ export const getCountOrSelfDeclared = ({
         return 1;
     }
     return personsCount;
+};
+
+/**
+ * Get the gender context for a person. This can be used for localization
+ * purposes, in the `context` field of the translation function.
+ *
+ * // FIXME Evolution questionnaires do not currently support
+ * gender/sexAssignedAtBirth in a satisfactory way. Make sure this is still
+ * correct when we have full support
+ *
+ * @param {Object} options - The options object.
+ * @param {Person} options.person The current person being interviewed
+ * @returns {string | undefined} The gender context for the person, or
+ * `undefined` if not available.
+ */
+export const getPersonGenderContext = ({ person }: { person: Person }): string | undefined =>
+    person.gender ?? person.sexAssignedAtBirth ?? undefined;
+
+/**
+ * Get a html-safe string that identifies a person, either by their nickname or
+ * by their sequence and age.
+ *
+ * @param {Object} options - The options object.
+ * @param {Person} options.person The person to identify
+ * @param {TFunction} options.t The translation function
+ * @returns {string} A translated and/or escaped string that identifies the
+ * person, either by their nickname or by their sequence and age.
+ */
+export const getPersonIdentificationString = ({ person, t }: { person: Person; t: TFunction }): string => {
+    if (typeof person.nickname === 'string' && !_isBlank(person.nickname.trim())) {
+        return _escape(person.nickname);
+    }
+    return _isBlank(person.age)
+        ? t('survey:personWithSequence', {
+            sequence: person._sequence,
+            context: getPersonGenderContext({ person })
+        })
+        : t('survey:personWithSequenceAndAge', {
+            sequence: person._sequence,
+            age: person.age,
+            context: getPersonGenderContext({ person })
+        });
 };
 
 /* Various functions related to a person's occupation */

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetDriver.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetDriver.test.ts
@@ -101,7 +101,7 @@ describe('widgetDriver choices', () => {
             groupShortname: '',
             groupLabel: '',
             choices: [
-                { value: 'personId2', label: 'The Dude' },
+                { value: 'personId2', label: expect.any(Function) },
                 { value: 'personId3', label: expect.any(Function) }
             ]
         }, {
@@ -123,6 +123,17 @@ describe('widgetDriver choices', () => {
                 { value: 'dontKnow', label: expect.any(Function), conditional: expect.any(Function) }
             ]
         }]);
+
+        // Make sure the labels for household drivers are correctly generated using the person helper
+        const mockedT = jest.fn();
+        // person ID2 should return the nickname since it is defined
+        const personId2Choice = choices[0].choices.find((choice: any) => choice.value === 'personId2');
+        expect(translateString(personId2Choice.label, { t: mockedT } as any, interview, 'some.path.driver')).toEqual('The Dude');
+        expect(mockedT).not.toHaveBeenCalled();
+        // person ID3 should call the `t` function with the personWithSequence key since there is no nickname and no age defined
+        const personId3Choice = choices[0].choices.find((choice: any) => choice.value === 'personId3');
+        translateString(personId3Choice.label, { t: mockedT } as any, interview, 'some.path.driver');
+        expect(mockedT).toHaveBeenCalledWith('survey:personWithSequence', { sequence: 3, context: undefined });
 	});
 
     test('should not contain household members if the person is the only driver in the household', () => {

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/widgetDriver.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/widgetDriver.ts
@@ -90,16 +90,7 @@ const getDriverChoices = (interview: UserInterviewAttributes): (GroupedChoiceTyp
         if (typeof driver._uuid === 'string' && driver._uuid !== person._uuid) {
             hhDrivers.push({
                 value: driver._uuid,
-                label:
-                    typeof driver.nickname === 'string' && !_isBlank(driver.nickname.trim())
-                        ? driver.nickname
-                        : // FIXME Evolution questionnaires do not currently support gender/sexAssignedAtBirth in a satisfactory way. Make sure this is still correct when we have full support
-                        (t: TFunction) =>
-                            t('survey:personWithSequenceAndAge', {
-                                sequence: driver['_sequence'],
-                                age: driver['age'] ?? '-',
-                                context: driver.gender ?? driver.sexAssignedAtBirth
-                            })
+                label: (t: TFunction) => odHelpers.getPersonIdentificationString({ person: driver, t })
             });
         }
     }


### PR DESCRIPTION
* Add the `getPersonGenderContext` to get the `i18n` context to use for gendered strings. It uses either the `gender` ro `sexAssignedAtBirth` field.
* Add the `getPersonIdentificationString` function, which returns either the nickname if set or a generic string using the sequence, age and gender person data
* Update the `widgetDriver` to use those 2 new helper functions for the driver identification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Person labels now prefer HTML-escaped nicknames and derive a gender-aware localization context; when nickname is blank, labels fall back to sequence or sequence+age formatting, omitting age if unknown.

* **Translation**
  * Person-with-age strings now use count-based age keys with pluralization; added gendered and sequence-only variants.

* **Tests**
  * Added coverage for gender-context precedence, nickname trimming/escaping, age-omission behavior, and updated household-label tests.

* **Refactor**
  * Consolidated person-identification label logic into a shared helper for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->