### PR TITLE
Add SurveyObject base class including completable attributes

### DIFF
--- a/packages/evolution-common/src/services/baseObjects/Address.ts
+++ b/packages/evolution-common/src/services/baseObjects/Address.ts
@@ -6,8 +6,8 @@
  */
 
 import { Optional } from '../../types/Optional.type';
-import { IValidatable, ValidatebleAttributes } from './IValidatable';
-import { Uuidable, UuidableAttributes } from './Uuidable';
+import { IValidatable, type ValidatableAttributes, validatableAttributeNames } from './IValidatable';
+import { Uuidable, type UuidableAttributes, uuidableAttributeNames } from './Uuidable';
 import { Result, createErrors, createOk } from '../../types/Result.type';
 import { ParamsValidatorUtils } from '../../utils/ParamsValidatorUtils';
 import { ConstructorUtils } from '../../utils/ConstructorUtils';
@@ -17,8 +17,8 @@ import { SurveyObjectsRegistry } from './SurveyObjectsRegistry';
 // TODO: make this class more international. For now, it fits Canadian addresses only.
 
 export const addressAttributes = [
-    '_uuid',
-    '_isValid',
+    ...uuidableAttributeNames,
+    ...validatableAttributeNames,
     'fullAddress', // full address string, when coming from the survey and/or entered by humans
     'civicNumber',
     'civicNumberSuffix',
@@ -74,7 +74,7 @@ export type AddressAttributes = {
      */
     combinedAddressUuid?: Optional<string>;
 } & UuidableAttributes &
-    ValidatebleAttributes;
+    ValidatableAttributes;
 
 export type ExtendedAddressAttributes = AddressAttributes & { [key: string]: unknown };
 

--- a/packages/evolution-common/src/services/baseObjects/Household.ts
+++ b/packages/evolution-common/src/services/baseObjects/Household.ts
@@ -9,9 +9,11 @@ import _omit from 'lodash/omit';
 
 import { Optional } from '../../types/Optional.type';
 import { PreData } from '../../types/shared';
-import { IValidatable, ValidatebleAttributes } from './IValidatable';
-import { WeightableAttributes, Weight, validateWeights } from './Weight';
-import { Uuidable, UuidableAttributes } from './Uuidable';
+import { validatableAttributeNames, type ValidatableAttributes } from './IValidatable';
+import { completableAttributeNames, type CompletableAttributes } from './attributeTypes/CompletableAttributes';
+import { SurveyObject } from './SurveyObject';
+import { weightableAttributeNames, type WeightableAttributes, type Weight, validateWeights } from './Weight';
+import { uuidableAttributeNames, type UuidableAttributes, Uuidable } from './Uuidable';
 import { Person, ExtendedPersonAttributes, SerializedExtendedPersonAttributes } from './Person';
 import * as HAttr from './attributeTypes/HouseholdAttributes';
 import { Result, createErrors, createOk } from '../../types/Result.type';
@@ -24,9 +26,10 @@ import { Home } from './Home';
 import { Interview } from './interview/Interview';
 
 export const householdAttributes = [
-    '_weights',
-    '_isValid',
-    '_uuid',
+    ...weightableAttributeNames,
+    ...validatableAttributeNames,
+    ...uuidableAttributeNames,
+    ...completableAttributeNames,
     'size',
     'carNumber',
     'twoWheelNumber',
@@ -66,7 +69,8 @@ export type HouseholdAttributes = {
     preData?: Optional<PreData>;
 } & UuidableAttributes &
     WeightableAttributes &
-    ValidatebleAttributes;
+    ValidatableAttributes &
+    CompletableAttributes;
 
 export type HouseholdWithComposedAttributes = HouseholdAttributes & {
     _members?: Optional<ExtendedPersonAttributes[]>;
@@ -87,7 +91,7 @@ export type SerializedExtendedHouseholdAttributes = {
  * the members composed array includes Person objects.
  * uuid for the household must be equal to the uuid of the interview
  */
-export class Household extends Uuidable implements IValidatable {
+export class Household extends SurveyObject {
     private _surveyObjectsRegistry: SurveyObjectsRegistry;
     private _attributes: HouseholdAttributes;
     private _customAttributes: { [key: string]: unknown };
@@ -138,14 +142,6 @@ export class Household extends Uuidable implements IValidatable {
 
     get customAttributes(): { [key: string]: unknown } {
         return this._customAttributes;
-    }
-
-    get _isValid(): Optional<boolean> {
-        return this._attributes._isValid;
-    }
-
-    set _isValid(value: Optional<boolean>) {
-        this._attributes._isValid = value;
     }
 
     get _weights(): Optional<Weight[]> {
@@ -355,15 +351,6 @@ export class Household extends Uuidable implements IValidatable {
         return createOk(household as Household);
     }
 
-    validate(): Optional<boolean> {
-        this._attributes._isValid = true;
-        return true;
-    }
-
-    isValid(): Optional<boolean> {
-        return this._isValid;
-    }
-
     static validateParams(dirtyParams: { [key: string]: unknown }, displayName = 'Household'): Error[] {
         const errors: Error[] = [];
 
@@ -373,6 +360,7 @@ export class Household extends Uuidable implements IValidatable {
         errors.push(...Uuidable.validateParams(dirtyParams));
 
         errors.push(...ParamsValidatorUtils.isBoolean('_isValid', dirtyParams._isValid, displayName));
+        errors.push(...SurveyObject.validateCompletableParams(dirtyParams, displayName));
 
         errors.push(...validateWeights(dirtyParams._weights as Optional<Weight[]>));
 

--- a/packages/evolution-common/src/services/baseObjects/IValidatable.ts
+++ b/packages/evolution-common/src/services/baseObjects/IValidatable.ts
@@ -7,7 +7,9 @@
 
 import { Optional } from '../../types/Optional.type';
 
-export type ValidatebleAttributes = {
+export const validatableAttributeNames = ['_isValid'];
+
+export type ValidatableAttributes = {
     _isValid?: Optional<boolean>; // undefined means not yet validated
 };
 

--- a/packages/evolution-common/src/services/baseObjects/Journey.ts
+++ b/packages/evolution-common/src/services/baseObjects/Journey.ts
@@ -9,9 +9,11 @@ import _omit from 'lodash/omit';
 
 import { Optional } from '../../types/Optional.type';
 import { PreData } from '../../types/shared';
-import { IValidatable, ValidatebleAttributes } from './IValidatable';
-import { WeightableAttributes, Weight, validateWeights } from './Weight';
-import { Uuidable, UuidableAttributes } from './Uuidable';
+import { validatableAttributeNames, type ValidatableAttributes } from './IValidatable';
+import { completableAttributeNames, type CompletableAttributes } from './attributeTypes/CompletableAttributes';
+import { SurveyObject } from './SurveyObject';
+import { weightableAttributeNames, type WeightableAttributes, type Weight, validateWeights } from './Weight';
+import { uuidableAttributeNames, type UuidableAttributes, Uuidable } from './Uuidable';
 import * as JAttr from './attributeTypes/JourneyAttributes';
 import * as PAttr from './attributeTypes/PersonAttributes';
 import { Result, createErrors, createOk } from '../../types/Result.type';
@@ -29,9 +31,10 @@ import { Household } from './Household';
 
 export const journeyAttributes = [
     ...startEndDateAndTimesAttributes,
-    '_weights',
-    '_isValid',
-    '_uuid',
+    ...weightableAttributeNames,
+    ...validatableAttributeNames,
+    ...uuidableAttributeNames,
+    ...completableAttributeNames,
     '_sequence',
     'name',
     'type',
@@ -77,7 +80,8 @@ export type JourneyAttributes = {
 } & StartEndDateAndTimesAttributes &
     UuidableAttributes &
     WeightableAttributes &
-    ValidatebleAttributes;
+    ValidatableAttributes &
+    CompletableAttributes;
 
 export type JourneyWithComposedAttributes = JourneyAttributes & {
     _visitedPlaces?: Optional<ExtendedVisitedPlaceAttributes[]>;
@@ -99,7 +103,7 @@ export type SerializedExtendedJourneyAttributes = {
  * They can be all the visited places for a single person for a day, part of a day,
  * a week, a weekend or a long distance trip
  */
-export class Journey extends Uuidable implements IValidatable {
+export class Journey extends SurveyObject {
     private _surveyObjectsRegistry: SurveyObjectsRegistry;
     private _attributes: JourneyAttributes;
     private _customAttributes: { [key: string]: unknown };
@@ -162,14 +166,6 @@ export class Journey extends Uuidable implements IValidatable {
 
     get customAttributes(): { [key: string]: unknown } {
         return this._customAttributes;
-    }
-
-    get _isValid(): Optional<boolean> {
-        return this._attributes._isValid;
-    }
-
-    set _isValid(value: Optional<boolean>) {
-        this._attributes._isValid = value;
     }
 
     get _weights(): Optional<Weight[]> {
@@ -576,15 +572,6 @@ export class Journey extends Uuidable implements IValidatable {
         return createOk(journey as Journey);
     }
 
-    validate(): Optional<boolean> {
-        this._attributes._isValid = true;
-        return true;
-    }
-
-    isValid(): Optional<boolean> {
-        return this._isValid;
-    }
-
     static validateParams(dirtyParams: { [key: string]: unknown }, displayName = 'Journey'): Error[] {
         const errors: Error[] = [];
 
@@ -597,6 +584,8 @@ export class Journey extends Uuidable implements IValidatable {
         errors.push(...ParamsValidatorUtils.isPositiveInteger('_sequence', dirtyParams._sequence, displayName));
 
         errors.push(...ParamsValidatorUtils.isBoolean('_isValid', dirtyParams._isValid, displayName));
+
+        errors.push(...SurveyObject.validateCompletableParams(dirtyParams, displayName));
 
         errors.push(...validateWeights(dirtyParams._weights as Optional<Weight[]>));
 

--- a/packages/evolution-common/src/services/baseObjects/Junction.ts
+++ b/packages/evolution-common/src/services/baseObjects/Junction.ts
@@ -9,9 +9,11 @@ import _omit from 'lodash/omit';
 
 import { Optional } from '../../types/Optional.type';
 import { PreData } from '../../types/shared';
-import { IValidatable, ValidatebleAttributes } from './IValidatable';
-import { Uuidable, UuidableAttributes } from './Uuidable';
-import { WeightableAttributes, Weight, validateWeights } from './Weight';
+import { validatableAttributeNames, type ValidatableAttributes } from './IValidatable';
+import { completableAttributeNames, type CompletableAttributes } from './attributeTypes/CompletableAttributes';
+import { SurveyObject } from './SurveyObject';
+import { weightableAttributeNames, type WeightableAttributes, type Weight, validateWeights } from './Weight';
+import { uuidableAttributeNames, type UuidableAttributes, Uuidable } from './Uuidable';
 import * as PlAttr from './attributeTypes/PlaceAttributes';
 import { ParamsValidatorUtils } from '../../utils/ParamsValidatorUtils';
 import { Place, ExtendedPlaceAttributes, SerializedExtendedPlaceAttributes } from './Place';
@@ -25,9 +27,10 @@ import { Trip } from './Trip';
 
 export const junctionAttributes = [
     ...startEndDateAndTimesAttributes,
-    '_weights',
-    '_isValid',
-    '_uuid',
+    ...weightableAttributeNames,
+    ...validatableAttributeNames,
+    ...uuidableAttributeNames,
+    ...completableAttributeNames,
     'parkingType',
     'parkingFeeType',
     'transitPlaceType',
@@ -44,7 +47,8 @@ export type JunctionAttributes = {
 } & StartEndDateAndTimesAttributes &
     UuidableAttributes &
     WeightableAttributes &
-    ValidatebleAttributes;
+    ValidatableAttributes &
+    CompletableAttributes;
 
 export type JunctionWithComposedAttributes = JunctionAttributes & {
     _place?: Optional<ExtendedPlaceAttributes>;
@@ -63,7 +67,7 @@ export type SerializedExtendedJunctionAttributes = {
  * Usually, junctions are used as origin and/or destination for segments
  * Junctions are optional in most surveys
  */
-export class Junction extends Uuidable implements IValidatable {
+export class Junction extends SurveyObject {
     private _surveyObjectsRegistry: SurveyObjectsRegistry;
     private _attributes: JunctionAttributes;
     private _customAttributes: { [key: string]: unknown };
@@ -106,14 +110,6 @@ export class Junction extends Uuidable implements IValidatable {
 
     get customAttributes(): { [key: string]: unknown } {
         return this._customAttributes;
-    }
-
-    get _isValid(): Optional<boolean> {
-        return this._attributes._isValid;
-    }
-
-    set _isValid(value: Optional<boolean>) {
-        this._attributes._isValid = value;
     }
 
     get _weights(): Optional<Weight[]> {
@@ -252,15 +248,6 @@ export class Junction extends Uuidable implements IValidatable {
         return createOk(junction as Junction);
     }
 
-    validate(): Optional<boolean> {
-        this._attributes._isValid = true;
-        return true;
-    }
-
-    isValid(): Optional<boolean> {
-        return this._isValid;
-    }
-
     /**
      * Validates attributes types for Junction.
      * @param dirtyParams The parameters to validate.
@@ -279,6 +266,8 @@ export class Junction extends Uuidable implements IValidatable {
 
         // Validate _isValid:
         errors.push(...ParamsValidatorUtils.isBoolean('_isValid', dirtyParams._isValid, displayName));
+
+        errors.push(...SurveyObject.validateCompletableParams(dirtyParams, displayName));
 
         // Validate _weights:
         errors.push(...validateWeights(dirtyParams._weights as Optional<Weight[]>));

--- a/packages/evolution-common/src/services/baseObjects/Organization.ts
+++ b/packages/evolution-common/src/services/baseObjects/Organization.ts
@@ -9,9 +9,11 @@ import _omit from 'lodash/omit';
 
 import { Optional } from '../../types/Optional.type';
 import { PreData } from '../../types/shared';
-import { IValidatable, ValidatebleAttributes } from './IValidatable';
-import { WeightableAttributes, Weight, validateWeights } from './Weight';
-import { Uuidable, UuidableAttributes } from './Uuidable';
+import { validatableAttributeNames, type ValidatableAttributes } from './IValidatable';
+import { completableAttributeNames, type CompletableAttributes } from './attributeTypes/CompletableAttributes';
+import { SurveyObject } from './SurveyObject';
+import { weightableAttributeNames, type WeightableAttributes, type Weight, validateWeights } from './Weight';
+import { uuidableAttributeNames, type UuidableAttributes, Uuidable } from './Uuidable';
 import * as OAttr from './attributeTypes/OrganizationAttributes';
 import { Result, createErrors, createOk } from '../../types/Result.type';
 import { ParamsValidatorUtils } from '../../utils/ParamsValidatorUtils';
@@ -23,9 +25,10 @@ import { SurveyObjectsRegistry } from './SurveyObjectsRegistry';
 import { Interview } from './interview/Interview';
 
 export const organizationAttributes = [
-    '_weights',
-    '_isValid',
-    '_uuid',
+    ...weightableAttributeNames,
+    ...validatableAttributeNames,
+    ...uuidableAttributeNames,
+    ...completableAttributeNames,
     'name',
     'shortname',
     'numberOfEmployees',
@@ -53,7 +56,8 @@ export type OrganizationAttributes = {
     preData?: Optional<PreData>;
 } & UuidableAttributes &
     WeightableAttributes &
-    ValidatebleAttributes;
+    ValidatableAttributes &
+    CompletableAttributes;
 
 export type OrganizationWithComposedAttributes = OrganizationAttributes & {
     /**
@@ -80,7 +84,7 @@ export type SerializedExtendedOrganizationAttributes = {
  * Organization is a base object that represents an organization,
  * a company, a place with employees, or a group of persons other than a household.
  */
-export class Organization extends Uuidable implements IValidatable {
+export class Organization extends SurveyObject {
     private _surveyObjectsRegistry: SurveyObjectsRegistry;
     private _attributes: OrganizationAttributes;
     private _customAttributes: { [key: string]: unknown };
@@ -129,14 +133,6 @@ export class Organization extends Uuidable implements IValidatable {
 
     get customAttributes(): { [key: string]: unknown } {
         return this._customAttributes;
-    }
-
-    get _isValid(): Optional<boolean> {
-        return this._attributes._isValid;
-    }
-
-    set _isValid(value: Optional<boolean>) {
-        this._attributes._isValid = value;
     }
 
     get _weights(): Optional<Weight[]> {
@@ -283,15 +279,6 @@ export class Organization extends Uuidable implements IValidatable {
         return createOk(organization as Organization);
     }
 
-    validate(): Optional<boolean> {
-        this._attributes._isValid = true;
-        return true;
-    }
-
-    isValid(): Optional<boolean> {
-        return this._isValid;
-    }
-
     static validateParams(dirtyParams: { [key: string]: unknown }, displayName = 'Organization'): Error[] {
         const errors: Error[] = [];
 
@@ -301,6 +288,8 @@ export class Organization extends Uuidable implements IValidatable {
         errors.push(...Uuidable.validateParams(dirtyParams));
 
         errors.push(...ParamsValidatorUtils.isBoolean('_isValid', dirtyParams._isValid, displayName));
+
+        errors.push(...SurveyObject.validateCompletableParams(dirtyParams, displayName));
 
         errors.push(...validateWeights(dirtyParams._weights as Optional<Weight[]>));
 

--- a/packages/evolution-common/src/services/baseObjects/Person.ts
+++ b/packages/evolution-common/src/services/baseObjects/Person.ts
@@ -9,9 +9,11 @@ import _omit from 'lodash/omit';
 
 import { Optional } from '../../types/Optional.type';
 import { PreData } from '../../types/shared';
-import { IValidatable, ValidatebleAttributes } from './IValidatable';
-import { WeightableAttributes, Weight, validateWeights } from './Weight';
-import { Uuidable, UuidableAttributes } from './Uuidable';
+import { validatableAttributeNames, type ValidatableAttributes } from './IValidatable';
+import { completableAttributeNames, type CompletableAttributes } from './attributeTypes/CompletableAttributes';
+import { SurveyObject } from './SurveyObject';
+import { weightableAttributeNames, type WeightableAttributes, type Weight, validateWeights } from './Weight';
+import { uuidableAttributeNames, type UuidableAttributes, Uuidable } from './Uuidable';
 import { WorkPlace } from './WorkPlace';
 import { SchoolPlace } from './SchoolPlace';
 import { ExtendedPlaceAttributes } from './Place';
@@ -29,9 +31,10 @@ import { SurveyObjectsRegistry } from './SurveyObjectsRegistry';
 import { Household } from './Household';
 
 export const personAttributes = [
-    '_weights',
-    '_isValid',
-    '_uuid',
+    ...weightableAttributeNames,
+    ...validatableAttributeNames,
+    ...uuidableAttributeNames,
+    ...completableAttributeNames,
     '_sequence',
     '_color',
     '_keepDiscard',
@@ -82,6 +85,7 @@ export const nonStringAttributes = [
     '_weights',
     '_isValid',
     '_uuid',
+    ...completableAttributeNames,
     '_sequence',
     'age',
     'transitPasses',
@@ -140,7 +144,8 @@ export type PersonAttributes = {
     preData?: Optional<PreData>;
 } & UuidableAttributes &
     WeightableAttributes &
-    ValidatebleAttributes;
+    ValidatableAttributes &
+    CompletableAttributes;
 
 export type PersonWithComposedAttributes = PersonAttributes & {
     _workPlaces?: Optional<ExtendedPlaceAttributes[]>;
@@ -164,7 +169,7 @@ export type SerializedExtendedPersonAttributes = {
  * A person is a member of a household. it can have these composed objects:
  * workPlaces, schoolPlaces, journeys, vehicles
  */
-export class Person extends Uuidable implements IValidatable {
+export class Person extends SurveyObject {
     private _surveyObjectsRegistry: SurveyObjectsRegistry;
     private _attributes: PersonAttributes;
     private _customAttributes: { [key: string]: unknown };
@@ -241,14 +246,6 @@ export class Person extends Uuidable implements IValidatable {
 
     get customAttributes(): { [key: string]: unknown } {
         return this._customAttributes;
-    }
-
-    get _isValid(): Optional<boolean> {
-        return this._attributes._isValid;
-    }
-
-    set _isValid(value: Optional<boolean>) {
-        this._attributes._isValid = value;
     }
 
     get _weights(): Optional<Weight[]> {
@@ -864,16 +861,6 @@ export class Person extends Uuidable implements IValidatable {
         return createOk(person as Person);
     }
 
-    validate(): Optional<boolean> {
-        // TODO: implement:
-        this._attributes._isValid = true;
-        return true;
-    }
-
-    isValid(): Optional<boolean> {
-        return this._isValid;
-    }
-
     /**
      * Validates attributes types for Person.
      * @param dirtyParams The parameters to validate.
@@ -892,6 +879,8 @@ export class Person extends Uuidable implements IValidatable {
 
         // Validate _isValid:
         errors.push(...ParamsValidatorUtils.isBoolean('_isValid', dirtyParams._isValid, displayName));
+
+        errors.push(...SurveyObject.validateCompletableParams(dirtyParams, displayName));
 
         errors.push(...ParamsValidatorUtils.isPositiveInteger('_sequence', dirtyParams._sequence, displayName));
 

--- a/packages/evolution-common/src/services/baseObjects/Place.ts
+++ b/packages/evolution-common/src/services/baseObjects/Place.ts
@@ -16,18 +16,21 @@ import { Address, AddressAttributes } from './Address';
 import { Device } from './attributeTypes/InterviewParadataAttributes';
 import { Result, createErrors, createOk } from '../../types/Result.type';
 import { ParamsValidatorUtils } from '../../utils/ParamsValidatorUtils';
-import { Uuidable, UuidableAttributes } from './Uuidable';
-import { IValidatable, ValidatebleAttributes } from './IValidatable';
-import { WeightableAttributes, Weight, validateWeights } from './Weight';
+import { validatableAttributeNames, type ValidatableAttributes } from './IValidatable';
+import { completableAttributeNames, type CompletableAttributes } from './attributeTypes/CompletableAttributes';
+import { SurveyObject } from './SurveyObject';
+import { weightableAttributeNames, type WeightableAttributes, type Weight, validateWeights } from './Weight';
+import { uuidableAttributeNames, type UuidableAttributes, Uuidable } from './Uuidable';
 import { ConstructorUtils } from '../../utils/ConstructorUtils';
 import { SerializedExtendedAddressAttributes } from './Address';
 import { SurveyObjectUnserializer } from './SurveyObjectUnserializer';
 import { SurveyObjectsRegistry } from './SurveyObjectsRegistry';
 
 export const placeAttributes = [
-    '_weights',
-    '_isValid',
-    '_uuid',
+    ...weightableAttributeNames,
+    ...validatableAttributeNames,
+    ...uuidableAttributeNames,
+    ...completableAttributeNames,
     'geography',
     'name',
     'shortname',
@@ -71,7 +74,8 @@ export type PlaceAttributes = {
     preGeography?: Optional<GeoJSON.Feature<GeoJSON.Point>>;
 } & UuidableAttributes &
     WeightableAttributes &
-    ValidatebleAttributes;
+    ValidatableAttributes &
+    CompletableAttributes;
 
 export type PlaceWithComposedAttributes = PlaceAttributes & {
     _address?: Optional<AddressAttributes>;
@@ -89,7 +93,7 @@ export type SerializedExtendedPlaceAttributes = {
  * A place is a location (GeoJSON point) with attributes.
  * Classes can inherit this class and add their own attributes (like a work place, a school place, a junction, etc.).
  */
-export class Place extends Uuidable implements IValidatable {
+export class Place extends SurveyObject {
     private _surveyObjectsRegistry: SurveyObjectsRegistry;
     protected _attributes: ExtendedPlaceAttributes;
     protected _customAttributes: { [key: string]: unknown };
@@ -149,14 +153,6 @@ export class Place extends Uuidable implements IValidatable {
 
     get customAttributes(): { [key: string]: unknown } {
         return this._customAttributes;
-    }
-
-    get _isValid(): Optional<boolean> {
-        return this._attributes._isValid;
-    }
-
-    set _isValid(value: Optional<boolean>) {
-        this._attributes._isValid = value;
     }
 
     get _weights(): Optional<Weight[]> {
@@ -352,16 +348,6 @@ export class Place extends Uuidable implements IValidatable {
         return createOk(place as Place);
     }
 
-    validate(): Optional<boolean> {
-        // TODO: implement:
-        this._attributes._isValid = true;
-        return true;
-    }
-
-    isValid(): Optional<boolean> {
-        return this._isValid;
-    }
-
     /**
      * Validates attributes types
      * @param dirtyParams The params input
@@ -380,6 +366,8 @@ export class Place extends Uuidable implements IValidatable {
 
         // Validate _isValid:
         errors.push(...ParamsValidatorUtils.isBoolean('_isValid', dirtyParams._isValid, displayName));
+
+        errors.push(...SurveyObject.validateCompletableParams(dirtyParams, displayName));
 
         // Validate _weights:
         errors.push(...validateWeights(dirtyParams._weights as Optional<Weight[]>));

--- a/packages/evolution-common/src/services/baseObjects/Segment.ts
+++ b/packages/evolution-common/src/services/baseObjects/Segment.ts
@@ -9,9 +9,11 @@ import _omit from 'lodash/omit';
 
 import { Optional } from '../../types/Optional.type';
 import { PreData } from '../../types/shared';
-import { IValidatable, ValidatebleAttributes } from './IValidatable';
-import { Uuidable, UuidableAttributes } from './Uuidable';
-import { WeightableAttributes, Weight, validateWeights } from './Weight';
+import { validatableAttributeNames, type ValidatableAttributes } from './IValidatable';
+import { completableAttributeNames, type CompletableAttributes } from './attributeTypes/CompletableAttributes';
+import { SurveyObject } from './SurveyObject';
+import { weightableAttributeNames, type WeightableAttributes, type Weight, validateWeights } from './Weight';
+import { uuidableAttributeNames, type UuidableAttributes, Uuidable } from './Uuidable';
 import * as SAttr from './attributeTypes/SegmentAttributes';
 import { Junction, ExtendedJunctionAttributes, SerializedExtendedJunctionAttributes } from './Junction';
 import { Routing, RoutingAttributes, SerializedExtendedRoutingAttributes } from './Routing';
@@ -29,9 +31,10 @@ import { Household } from './Household';
 
 export const segmentAttributes = [
     ...startEndDateAndTimesAttributes,
-    '_weights',
-    '_isValid',
-    '_uuid',
+    ...weightableAttributeNames,
+    ...validatableAttributeNames,
+    ...uuidableAttributeNames,
+    ...completableAttributeNames,
     '_sequence',
     'mode',
     'modeOtherSpecify',
@@ -93,7 +96,8 @@ export type SegmentAttributes = {
 } & StartEndDateAndTimesAttributes &
     UuidableAttributes &
     WeightableAttributes &
-    ValidatebleAttributes;
+    ValidatableAttributes &
+    CompletableAttributes;
 
 export type ExtendedSegmentAttributes = SegmentAttributes & SegmentWithComposedAttributes & { [key: string]: unknown };
 
@@ -119,7 +123,7 @@ export type SerializedExtendedSegmentAttributes = {
  * like subway station, a parking or another or the trip origin
  * and/or destination when the segment is first or last for the trip
  */
-export class Segment extends Uuidable implements IValidatable {
+export class Segment extends SurveyObject {
     private _surveyObjectsRegistry: SurveyObjectsRegistry;
     private _attributes: SegmentAttributes;
     private _customAttributes: { [key: string]: unknown };
@@ -249,14 +253,6 @@ export class Segment extends Uuidable implements IValidatable {
 
     get customAttributes(): { [key: string]: unknown } {
         return this._customAttributes;
-    }
-
-    get _isValid(): Optional<boolean> {
-        return this._attributes._isValid;
-    }
-
-    set _isValid(value: Optional<boolean>) {
-        this._attributes._isValid = value;
     }
 
     get _weights(): Optional<Weight[]> {
@@ -530,15 +526,6 @@ export class Segment extends Uuidable implements IValidatable {
         return createOk(segment as Segment);
     }
 
-    validate(): Optional<boolean> {
-        this._attributes._isValid = true;
-        return true;
-    }
-
-    isValid(): Optional<boolean> {
-        return this._isValid;
-    }
-
     /**
      * Validates attributes types for Segment.
      * @param dirtyParams The parameters to validate.
@@ -557,6 +544,8 @@ export class Segment extends Uuidable implements IValidatable {
         errors.push(...ParamsValidatorUtils.isPositiveInteger('_sequence', dirtyParams._sequence, displayName));
 
         errors.push(...ParamsValidatorUtils.isBoolean('_isValid', dirtyParams._isValid, displayName));
+
+        errors.push(...SurveyObject.validateCompletableParams(dirtyParams, displayName));
 
         errors.push(...validateWeights(dirtyParams._weights as Optional<Weight[]>));
 

--- a/packages/evolution-common/src/services/baseObjects/SurveyObject.ts
+++ b/packages/evolution-common/src/services/baseObjects/SurveyObject.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import type { Optional } from '../../types/Optional.type';
+import { ParamsValidatorUtils } from '../../utils/ParamsValidatorUtils';
+import { IValidatable, ValidatableAttributes } from './IValidatable';
+import { Uuidable } from './Uuidable';
+import { completableAttributeNames, type CompletableAttributes } from './attributeTypes/CompletableAttributes';
+
+type InstanceWithCompletableAttributes = {
+    _attributes: CompletableAttributes;
+};
+
+type InstanceWithValidationAttributes = {
+    _attributes: ValidatableAttributes;
+};
+
+/**
+ * Base class for survey entities registered in {@link SurveyObjectsRegistry}.
+ * Implements {@link IValidatable}: `_isValid` on `_attributes`, plus {@link validate} / {@link isValid}.
+ * Extends {@link Uuidable} and holds **completeness** flags (`hasMinimum`, `isStarted`, `isCompleted`)
+ * on the subclass `_attributes` object (see {@link CompletableAttributes}).
+ *
+ * **Subclass contract:** concrete classes must expose a `_attributes` object that includes
+ * `CompletableAttributes`; the constructor should list completable keys in the attribute list passed
+ * to {@link ConstructorUtils.initializeAttributes} (or equivalent) so values are not treated as custom attributes.
+ *
+ * **Good candidates to move here later (not done yet):** shared references such as
+ * `SurveyObjectsRegistry`, common serialization hooks, or generic `validateParams` fragments—only
+ * where every survey entity behaves identically—to avoid pulling composed-only types
+ * (e.g. {@link Address}, {@link Routing}) into this hierarchy.
+ */
+export abstract class SurveyObject extends Uuidable implements IValidatable {
+    constructor(_uuid?: Optional<string>) {
+        super(_uuid);
+    }
+
+    protected getValidatableAttributes(): ValidatableAttributes {
+        return (this as unknown as InstanceWithValidationAttributes)._attributes;
+    }
+
+    get _isValid(): Optional<boolean> {
+        return this.getValidatableAttributes()._isValid;
+    }
+
+    set _isValid(value: Optional<boolean>) {
+        this.getValidatableAttributes()._isValid = value;
+    }
+
+    validate(): Optional<boolean> {
+        this.getValidatableAttributes()._isValid = true;
+        return true;
+    }
+
+    isValid(): Optional<boolean> {
+        return this._isValid;
+    }
+
+    protected getCompletableAttributes(): CompletableAttributes {
+        return (this as unknown as InstanceWithCompletableAttributes)._attributes;
+    }
+
+    get hasMinimum(): Optional<boolean> {
+        return this.getCompletableAttributes().hasMinimum;
+    }
+
+    set hasMinimum(value: Optional<boolean>) {
+        this.getCompletableAttributes().hasMinimum = value;
+    }
+
+    get isCompleted(): Optional<boolean> {
+        return this.getCompletableAttributes().isCompleted;
+    }
+
+    set isCompleted(value: Optional<boolean>) {
+        this.getCompletableAttributes().isCompleted = value;
+    }
+
+    get isStarted(): Optional<boolean> {
+        return this.getCompletableAttributes().isStarted;
+    }
+
+    set isStarted(value: Optional<boolean>) {
+        this.getCompletableAttributes().isStarted = value;
+    }
+
+    /**
+     * Validates completable boolean fields on a plain params object (for `create` / `validateParams`).
+     */
+    static validateCompletableParams(dirtyParams: { [key: string]: unknown }, displayName = 'Completable'): Error[] {
+        const errors: Error[] = [];
+        for (const attribute of completableAttributeNames) {
+            errors.push(...ParamsValidatorUtils.isBoolean(attribute, dirtyParams[attribute], displayName));
+        }
+        return errors;
+    }
+}

--- a/packages/evolution-common/src/services/baseObjects/Trip.ts
+++ b/packages/evolution-common/src/services/baseObjects/Trip.ts
@@ -10,9 +10,11 @@ import _uniq from 'lodash/uniq';
 
 import { Optional } from '../../types/Optional.type';
 import { PreData } from '../../types/shared';
-import { IValidatable, ValidatebleAttributes } from './IValidatable';
-import { WeightableAttributes, Weight, validateWeights } from './Weight';
-import { Uuidable, UuidableAttributes } from './Uuidable';
+import { validatableAttributeNames, type ValidatableAttributes } from './IValidatable';
+import { completableAttributeNames, type CompletableAttributes } from './attributeTypes/CompletableAttributes';
+import { SurveyObject } from './SurveyObject';
+import { weightableAttributeNames, type WeightableAttributes, type Weight, validateWeights } from './Weight';
+import { uuidableAttributeNames, type UuidableAttributes, Uuidable } from './Uuidable';
 import { Result, createErrors, createOk } from '../../types/Result.type';
 import { ParamsValidatorUtils } from '../../utils/ParamsValidatorUtils';
 import { ConstructorUtils } from '../../utils/ConstructorUtils';
@@ -32,9 +34,10 @@ import { Household } from './Household';
 
 export const tripAttributes = [
     ...startEndDateAndTimesAttributes,
-    '_weights',
-    '_isValid',
-    '_uuid',
+    ...weightableAttributeNames,
+    ...validatableAttributeNames,
+    ...uuidableAttributeNames,
+    ...completableAttributeNames,
     '_sequence',
     'preData'
 ];
@@ -59,7 +62,8 @@ export type TripAttributes = {
 } & StartEndDateAndTimesAttributes &
     UuidableAttributes &
     WeightableAttributes &
-    ValidatebleAttributes;
+    ValidatableAttributes &
+    CompletableAttributes;
 
 export type TripWithComposedAttributes = TripAttributes & {
     _startPlace?: Optional<ExtendedVisitedPlaceAttributes>; // origin
@@ -83,7 +87,7 @@ export type SerializedExtendedTripAttributes = {
  * A trip include the travelling action between two places (visited places: origin|destination)
  * Start and end dates and times could be generated from the origin and destination data
  */
-export class Trip extends Uuidable implements IValidatable {
+export class Trip extends SurveyObject {
     private _surveyObjectsRegistry: SurveyObjectsRegistry;
     private _attributes: TripAttributes;
     private _customAttributes: { [key: string]: unknown };
@@ -294,14 +298,6 @@ export class Trip extends Uuidable implements IValidatable {
 
     get customAttributes(): { [key: string]: unknown } {
         return this._customAttributes;
-    }
-
-    get _isValid(): Optional<boolean> {
-        return this._attributes._isValid;
-    }
-
-    set _isValid(value: Optional<boolean>) {
-        this._attributes._isValid = value;
     }
 
     get _weights(): Optional<Weight[]> {
@@ -575,15 +571,6 @@ export class Trip extends Uuidable implements IValidatable {
         return createOk(trip as Trip);
     }
 
-    validate(): Optional<boolean> {
-        this._attributes._isValid = true;
-        return true;
-    }
-
-    isValid(): Optional<boolean> {
-        return this._isValid;
-    }
-
     static validateParams(dirtyParams: { [key: string]: unknown }, displayName = 'Trip'): Error[] {
         const errors: Error[] = [];
 
@@ -596,6 +583,8 @@ export class Trip extends Uuidable implements IValidatable {
         errors.push(...ParamsValidatorUtils.isPositiveInteger('_sequence', dirtyParams._sequence, displayName));
 
         errors.push(...ParamsValidatorUtils.isBoolean('_isValid', dirtyParams._isValid, displayName));
+
+        errors.push(...SurveyObject.validateCompletableParams(dirtyParams, displayName));
 
         errors.push(...validateWeights(dirtyParams._weights as Optional<Weight[]>));
 

--- a/packages/evolution-common/src/services/baseObjects/TripChain.ts
+++ b/packages/evolution-common/src/services/baseObjects/TripChain.ts
@@ -9,9 +9,11 @@ import _omit from 'lodash/omit';
 
 import { Optional } from '../../types/Optional.type';
 import { PreData } from '../../types/shared';
-import { IValidatable, ValidatebleAttributes } from './IValidatable';
-import { WeightableAttributes, Weight, validateWeights } from './Weight';
-import { Uuidable, UuidableAttributes } from './Uuidable';
+import { validatableAttributeNames, type ValidatableAttributes } from './IValidatable';
+import { completableAttributeNames, type CompletableAttributes } from './attributeTypes/CompletableAttributes';
+import { SurveyObject } from './SurveyObject';
+import { weightableAttributeNames, type WeightableAttributes, type Weight, validateWeights } from './Weight';
+import { uuidableAttributeNames, type UuidableAttributes, Uuidable } from './Uuidable';
 import * as TCAttr from './attributeTypes/TripChainAttributes';
 import * as VPAttr from './attributeTypes/VisitedPlaceAttributes';
 import { Result, createErrors, createOk } from '../../types/Result.type';
@@ -29,9 +31,10 @@ import { Household } from './Household';
 
 export const tripChainAttributes = [
     ...startEndDateAndTimesAttributes,
-    '_weights',
-    '_isValid',
-    '_uuid',
+    ...weightableAttributeNames,
+    ...validatableAttributeNames,
+    ...uuidableAttributeNames,
+    ...completableAttributeNames,
     'category',
     'isMultiLoop',
     'isConstrained',
@@ -52,7 +55,8 @@ export type TripChainAttributes = {
 } & StartEndDateAndTimesAttributes &
     UuidableAttributes &
     WeightableAttributes &
-    ValidatebleAttributes;
+    ValidatableAttributes &
+    CompletableAttributes;
 
 export type TripChainWithComposedAttributes = TripChainAttributes & {
     _trips?: Optional<ExtendedTripAttributes[]>;
@@ -79,7 +83,7 @@ export type SerializedExtendedTripChainAttributes = {
  * for which the timing and/or location is usually fixed/not flexible
  * TODO: document the official academic/students definition of the trip chain with more examples
  */
-export class TripChain extends Uuidable implements IValidatable {
+export class TripChain extends SurveyObject {
     private _surveyObjectsRegistry: SurveyObjectsRegistry;
     private _attributes: TripChainAttributes;
     private _customAttributes: { [key: string]: unknown };
@@ -128,14 +132,6 @@ export class TripChain extends Uuidable implements IValidatable {
 
     get customAttributes(): { [key: string]: unknown } {
         return this._customAttributes;
-    }
-
-    get _isValid(): Optional<boolean> {
-        return this._attributes._isValid;
-    }
-
-    set _isValid(value: Optional<boolean>) {
-        this._attributes._isValid = value;
     }
 
     get _weights(): Optional<Weight[]> {
@@ -306,15 +302,6 @@ export class TripChain extends Uuidable implements IValidatable {
         return createOk(tripChain as TripChain);
     }
 
-    validate(): Optional<boolean> {
-        this._attributes._isValid = true;
-        return true;
-    }
-
-    isValid(): Optional<boolean> {
-        return this._isValid;
-    }
-
     static validateParams(dirtyParams: { [key: string]: unknown }, displayName = 'TripChain'): Error[] {
         const errors: Error[] = [];
 
@@ -325,6 +312,8 @@ export class TripChain extends Uuidable implements IValidatable {
         errors.push(...StartEndable.validateParams(dirtyParams, displayName));
 
         errors.push(...ParamsValidatorUtils.isBoolean('_isValid', dirtyParams._isValid, displayName));
+
+        errors.push(...SurveyObject.validateCompletableParams(dirtyParams, displayName));
 
         errors.push(...validateWeights(dirtyParams._weights as Optional<Weight[]>));
 

--- a/packages/evolution-common/src/services/baseObjects/Uuidable.ts
+++ b/packages/evolution-common/src/services/baseObjects/Uuidable.ts
@@ -9,11 +9,13 @@ import { v4 as uuidV4, validate as uuidValidate } from 'uuid';
 import { Optional } from '../../types/Optional.type';
 import { ParamsValidatorUtils } from '../../utils/ParamsValidatorUtils';
 
+export const uuidableAttributeNames = ['_uuid'];
+
 export type UuidableAttributes = {
     _uuid?: Optional<string>; // UUID v4
 };
 
-export class Uuidable {
+export abstract class Uuidable {
     readonly _uuid?: Optional<string>; // UUID v4 // required, will be generated if undefined in constructor
 
     constructor(_uuid?: Optional<string>) {

--- a/packages/evolution-common/src/services/baseObjects/Vehicle.ts
+++ b/packages/evolution-common/src/services/baseObjects/Vehicle.ts
@@ -9,9 +9,11 @@ import _omit from 'lodash/omit';
 
 import { Optional } from '../../types/Optional.type';
 import { PreData } from '../../types/shared';
-import { IValidatable, ValidatebleAttributes } from './IValidatable';
-import { WeightableAttributes, Weight, validateWeights } from './Weight';
-import { Uuidable, UuidableAttributes } from './Uuidable';
+import { validatableAttributeNames, type ValidatableAttributes } from './IValidatable';
+import { completableAttributeNames, type CompletableAttributes } from './attributeTypes/CompletableAttributes';
+import { SurveyObject } from './SurveyObject';
+import { weightableAttributeNames, type WeightableAttributes, type Weight, validateWeights } from './Weight';
+import { uuidableAttributeNames, type UuidableAttributes, Uuidable } from './Uuidable';
 import * as VAttr from './attributeTypes/VehicleAttributes';
 import { Result, createErrors, createOk } from '../../types/Result.type';
 import { ParamsValidatorUtils } from '../../utils/ParamsValidatorUtils';
@@ -21,9 +23,10 @@ import { Organization } from './Organization';
 import { Person } from './Person';
 
 export const vehicleAttributes = [
-    '_weights',
-    '_isValid',
-    '_uuid',
+    ...weightableAttributeNames,
+    ...validatableAttributeNames,
+    ...uuidableAttributeNames,
+    ...completableAttributeNames,
     'make',
     'model',
     'type',
@@ -57,7 +60,8 @@ export type VehicleAttributes = {
     preData?: Optional<PreData>;
 } & UuidableAttributes &
     WeightableAttributes &
-    ValidatebleAttributes;
+    ValidatableAttributes &
+    CompletableAttributes;
 
 export type ExtendedVehicleAttributes = VehicleAttributes & { [key: string]: unknown };
 
@@ -71,7 +75,7 @@ export type SerializedExtendedVehicleAttributes = {
  * and could be used during a trip or a segment of a trip
  * It could include cars, trucks, planes, buses, boats, bicycles, scooters, etc.
  */
-export class Vehicle extends Uuidable implements IValidatable {
+export class Vehicle extends SurveyObject {
     private _surveyObjectsRegistry: SurveyObjectsRegistry;
     private _attributes: VehicleAttributes;
     private _customAttributes: { [key: string]: unknown };
@@ -108,14 +112,6 @@ export class Vehicle extends Uuidable implements IValidatable {
 
     get customAttributes(): { [key: string]: unknown } {
         return this._customAttributes;
-    }
-
-    get _isValid(): Optional<boolean> {
-        return this._attributes._isValid;
-    }
-
-    set _isValid(value: Optional<boolean>) {
-        this._attributes._isValid = value;
     }
 
     get _weights(): Optional<Weight[]> {
@@ -293,15 +289,6 @@ export class Vehicle extends Uuidable implements IValidatable {
         return createOk(vehicle as Vehicle);
     }
 
-    validate(): Optional<boolean> {
-        this._attributes._isValid = true;
-        return true;
-    }
-
-    isValid(): Optional<boolean> {
-        return this._isValid;
-    }
-
     static validateParams(dirtyParams: { [key: string]: unknown }, displayName = 'Vehicle'): Error[] {
         const errors: Error[] = [];
 
@@ -311,6 +298,8 @@ export class Vehicle extends Uuidable implements IValidatable {
         errors.push(...Uuidable.validateParams(dirtyParams));
 
         errors.push(...ParamsValidatorUtils.isBoolean('_isValid', dirtyParams._isValid, displayName));
+
+        errors.push(...SurveyObject.validateCompletableParams(dirtyParams, displayName));
 
         errors.push(...validateWeights(dirtyParams._weights as Optional<Weight[]>));
 

--- a/packages/evolution-common/src/services/baseObjects/VisitedPlace.ts
+++ b/packages/evolution-common/src/services/baseObjects/VisitedPlace.ts
@@ -9,9 +9,11 @@ import _omit from 'lodash/omit';
 
 import { Optional } from '../../types/Optional.type';
 import { PreData } from '../../types/shared';
-import { IValidatable, ValidatebleAttributes } from './IValidatable';
-import { Uuidable, UuidableAttributes } from './Uuidable';
-import { WeightableAttributes, Weight, validateWeights } from './Weight';
+import { validatableAttributeNames, type ValidatableAttributes } from './IValidatable';
+import { completableAttributeNames, type CompletableAttributes } from './attributeTypes/CompletableAttributes';
+import { SurveyObject } from './SurveyObject';
+import { weightableAttributeNames, type WeightableAttributes, type Weight, validateWeights } from './Weight';
+import { uuidableAttributeNames, type UuidableAttributes, Uuidable } from './Uuidable';
 import { Place, ExtendedPlaceAttributes, SerializedExtendedPlaceAttributes } from './Place';
 import * as VPAttr from './attributeTypes/VisitedPlaceAttributes';
 import { ParamsValidatorUtils } from '../../utils/ParamsValidatorUtils';
@@ -28,9 +30,10 @@ import { SurveyObjectsRegistry } from './SurveyObjectsRegistry';
 
 export const visitedPlaceAttributes = [
     ...startEndDateAndTimesAttributes,
-    '_weights',
-    '_isValid',
-    '_uuid',
+    ...weightableAttributeNames,
+    ...validatableAttributeNames,
+    ...uuidableAttributeNames,
+    ...completableAttributeNames,
     '_sequence',
     'activity',
     'activityCategory',
@@ -58,7 +61,8 @@ export type VisitedPlaceAttributes = {
 } & StartEndDateAndTimesAttributes &
     UuidableAttributes &
     WeightableAttributes &
-    ValidatebleAttributes;
+    ValidatableAttributes &
+    CompletableAttributes;
 
 export type VisitedPlaceWithComposedAttributes = VisitedPlaceAttributes & {
     _place?: Optional<ExtendedPlaceAttributes>;
@@ -78,7 +82,7 @@ export type SerializedExtendedVisitedPlaceAttributes = {
  * It could be home, a work place, a school place, a restaurant, a place of leisure,
  * a shopping place, etc.
  */
-export class VisitedPlace extends Uuidable implements IValidatable {
+export class VisitedPlace extends SurveyObject {
     private _surveyObjectsRegistry: SurveyObjectsRegistry;
     private _attributes: VisitedPlaceAttributes;
     private _customAttributes: { [key: string]: unknown };
@@ -120,14 +124,6 @@ export class VisitedPlace extends Uuidable implements IValidatable {
 
     get customAttributes(): { [key: string]: unknown } {
         return this._customAttributes;
-    }
-
-    get _isValid(): Optional<boolean> {
-        return this._attributes._isValid;
-    }
-
-    set _isValid(value: Optional<boolean>) {
-        this._attributes._isValid = value;
     }
 
     get _weights(): Optional<Weight[]> {
@@ -298,15 +294,6 @@ export class VisitedPlace extends Uuidable implements IValidatable {
         return createOk(visitedPlace as VisitedPlace);
     }
 
-    validate(): Optional<boolean> {
-        this._attributes._isValid = true;
-        return true;
-    }
-
-    isValid(): Optional<boolean> {
-        return this._isValid;
-    }
-
     static validateParams(dirtyParams: { [key: string]: unknown }, displayName = 'VisitedPlace'): Error[] {
         const errors: Error[] = [];
 
@@ -319,6 +306,8 @@ export class VisitedPlace extends Uuidable implements IValidatable {
 
         // Validate _isValid:
         errors.push(...ParamsValidatorUtils.isBoolean('_isValid', dirtyParams._isValid, displayName));
+
+        errors.push(...SurveyObject.validateCompletableParams(dirtyParams, displayName));
 
         errors.push(...validateWeights(dirtyParams._weights as Optional<Weight[]>));
 

--- a/packages/evolution-common/src/services/baseObjects/Weight.ts
+++ b/packages/evolution-common/src/services/baseObjects/Weight.ts
@@ -12,6 +12,8 @@ import { Optional } from '../../types/Optional.type';
  * This is for interview objects that can be individually weighted after validation, using a specific weight method.
  */
 
+export const weightableAttributeNames = ['_weights'];
+
 export type Weight = {
     weight: number;
     method?: Optional<WeightMethod>;

--- a/packages/evolution-common/src/services/baseObjects/__tests__/Home.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/Home.test.ts
@@ -11,6 +11,10 @@ import { v4 as uuidV4 } from 'uuid';
 import { WeightMethod, WeightMethodAttributes } from '../WeightMethod';
 import { isOk, hasErrors } from '../../../types/Result.type';
 import { SurveyObjectsRegistry } from '../SurveyObjectsRegistry';
+import {
+    describeCompletableSurveyObjectMixinValues,
+    describeCreateRejectsNonBooleanCompletableParams
+} from './completableSurveyObjectTestHelpers';
 
 describe('Home', () => {
     let registry: SurveyObjectsRegistry;
@@ -118,6 +122,12 @@ describe('Home', () => {
             expect(registry.getPlace(home.uuid!)).toBe(home);
         });
     });
+
+    describeCompletableSurveyObjectMixinValues<Home>({
+        createDefault: () => new Home(createValidHomeAttributes(), registry)
+    });
+
+    describeCreateRejectsNonBooleanCompletableParams('Home', Home.create, createValidHomeAttributes, () => registry);
 
     describe('create', () => {
         it('should create a Home instance with valid attributes', () => {

--- a/packages/evolution-common/src/services/baseObjects/__tests__/Household.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/Household.test.ts
@@ -12,6 +12,12 @@ import { v4 as uuidV4 } from 'uuid';
 import { WeightMethod, WeightMethodAttributes } from '../WeightMethod';
 import { isOk, hasErrors, unwrap } from '../../../types/Result.type';
 import { SurveyObjectsRegistry } from '../SurveyObjectsRegistry';
+import { completableAttributeNames, type CompletableAttributeName } from '../attributeTypes/CompletableAttributes';
+import {
+    completableInvalidParamRows,
+    describeCompletableSurveyObjectMixinValues,
+    describeCreateRejectsNonBooleanCompletableParams
+} from './completableSurveyObjectTestHelpers';
 
 describe('Household', () => {
     let registry: SurveyObjectsRegistry;
@@ -47,7 +53,6 @@ describe('Household', () => {
         _weights: [{ weight: 1.5, method: new WeightMethod(weightMethodAttributes) }],
         _isValid: true,
     };
-
     const extendedAttributes: { [key: string]: unknown } = {
         ...validAttributes,
         customAttribute: 'custom value',
@@ -93,9 +98,16 @@ describe('Household', () => {
 
     test('should have a validateParams section for each attribute', () => {
         const validateParamsCode = Household.validateParams.toString();
-        householdAttributes.filter((attribute) => attribute !== '_uuid' && attribute !== '_weights').forEach((attributeName) => {
-            expect(validateParamsCode).toContain('\'' + attributeName + '\'');
-        });
+        householdAttributes
+            .filter(
+                (attribute) =>
+                    attribute !== '_uuid' &&
+                    attribute !== '_weights' &&
+                    !completableAttributeNames.includes(attribute as CompletableAttributeName)
+            )
+            .forEach((attributeName) => {
+                expect(validateParamsCode).toContain('\'' + attributeName + '\'');
+            });
     });
 
     test('should get uuid', () => {
@@ -161,11 +173,12 @@ describe('Household', () => {
         ['contactPhoneNumber', 123],
         ['contactEmail', 123],
         ['atLeastOnePersonWithDisability', 123],
+        ...completableInvalidParamRows(),
         ['preData', 'invalid'],
         ['preData', []],
         ['preData', new Date() as any],
         ['preData', true as any]
-    ])('should return an error for invalid %s', (param, value) => {
+    ] as [string, unknown][])('should return an error for invalid %s', (param, value) => {
         const invalidAttributes = { ...validAttributes, [param]: value };
         const errors = Household.validateParams(invalidAttributes);
         expect(errors[0].toString()).toContain(param);
@@ -189,6 +202,12 @@ describe('Household', () => {
         expect(household.validate()).toBe(true);
         expect(household.isValid()).toBe(true);
     });
+
+    describeCompletableSurveyObjectMixinValues<Household>({
+        createDefault: () => new Household(validAttributes, registry)
+    });
+
+    describeCreateRejectsNonBooleanCompletableParams('Household', Household.create, () => validAttributes, () => registry);
 
     test('should create a Household instance with custom attributes', () => {
         const customAttributes = {

--- a/packages/evolution-common/src/services/baseObjects/__tests__/Journey.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/Journey.test.ts
@@ -14,6 +14,11 @@ import { WeightMethod, WeightMethodAttributes } from '../WeightMethod';
 import { isOk, hasErrors, unwrap } from '../../../types/Result.type';
 import { startEndDateAndTimesAttributes } from '../StartEndable';
 import { SurveyObjectsRegistry } from '../SurveyObjectsRegistry';
+import { completableAttributeNames, type CompletableAttributeName } from '../attributeTypes/CompletableAttributes';
+import {
+    describeCompletableSurveyObjectMixinValues,
+    describeCreateRejectsNonBooleanCompletableParams
+} from './completableSurveyObjectTestHelpers';
 
 describe('Journey', () => {
     let registry: SurveyObjectsRegistry;
@@ -91,9 +96,17 @@ describe('Journey', () => {
 
     test('should have a validateParams section for each attribute', () => {
         const validateParamsCode = Journey.validateParams.toString();
-        journeyAttributes.filter((attribute) => attribute !== '_uuid' && attribute !== '_weights' && !(startEndDateAndTimesAttributes as unknown as string[]).includes(attribute)).forEach((attributeName) => {
-            expect(validateParamsCode).toContain('\'' + attributeName + '\'');
-        });
+        journeyAttributes
+            .filter(
+                (attribute) =>
+                    attribute !== '_uuid' &&
+                    attribute !== '_weights' &&
+                    !completableAttributeNames.includes(attribute as CompletableAttributeName) &&
+                    !(startEndDateAndTimesAttributes as unknown as string[]).includes(attribute)
+            )
+            .forEach((attributeName) => {
+                expect(validateParamsCode).toContain('\'' + attributeName + '\'');
+            });
     });
 
     test('should get uuid', () => {
@@ -150,6 +163,12 @@ describe('Journey', () => {
         expect(journey.isValid()).toBe(true);
     });
 
+    describeCompletableSurveyObjectMixinValues<Journey>({
+        createDefault: () => new Journey(validAttributes, registry)
+    });
+
+    describeCreateRejectsNonBooleanCompletableParams('Journey', Journey.create, () => validAttributes, () => registry);
+
     test('should create a Journey instance with custom attributes', () => {
         const customAttributes = {
             customAttribute1: 'value1',
@@ -182,6 +201,9 @@ describe('Journey', () => {
             ['didTrips', 123],
             ['previousWeekRemoteWorkDays', 'invalid'],
             ['previousWeekTravelToWorkDays', 'invalid'],
+            ['hasMinimum', 'invalid'],
+            ['isCompleted', 'invalid'],
+            ['isStarted', 'invalid'],
             ['preData', 'invalid'],
             ['preData', []],
             ['preData', new Date() as any],

--- a/packages/evolution-common/src/services/baseObjects/__tests__/Junction.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/Junction.test.ts
@@ -12,6 +12,11 @@ import { WeightMethod, WeightMethodAttributes } from '../WeightMethod';
 import { isOk, hasErrors, unwrap } from '../../../types/Result.type';
 import { startEndDateAndTimesAttributes } from '../StartEndable';
 import { SurveyObjectsRegistry } from '../SurveyObjectsRegistry';
+import { completableAttributeNames, type CompletableAttributeName } from '../attributeTypes/CompletableAttributes';
+import {
+    describeCompletableSurveyObjectMixinValues,
+    describeCreateRejectsNonBooleanCompletableParams
+} from './completableSurveyObjectTestHelpers';
 
 describe('Junction', () => {
     let registry: SurveyObjectsRegistry;
@@ -88,9 +93,17 @@ describe('Junction', () => {
 
     test('should have a validateParams section for each attribute', () => {
         const validateParamsCode = Junction.validateParams.toString();
-        junctionAttributes.filter((attribute) => attribute !== '_uuid' && attribute !== '_weights' && !(startEndDateAndTimesAttributes as unknown as string[]).includes(attribute)).forEach((attributeName) => {
-            expect(validateParamsCode).toContain('\'' + attributeName + '\'');
-        });
+        junctionAttributes
+            .filter(
+                (attribute) =>
+                    attribute !== '_uuid' &&
+                    attribute !== '_weights' &&
+                    !completableAttributeNames.includes(attribute as CompletableAttributeName) &&
+                    !(startEndDateAndTimesAttributes as unknown as string[]).includes(attribute)
+            )
+            .forEach((attributeName) => {
+                expect(validateParamsCode).toContain('\'' + attributeName + '\'');
+            });
     });
 
     test('should get uuid', () => {
@@ -147,6 +160,17 @@ describe('Junction', () => {
         expect(junction.isValid()).toBe(true);
     });
 
+    describeCompletableSurveyObjectMixinValues<Junction>({
+        createDefault: () => new Junction(validJunctionAttributesWithPlace, registry)
+    });
+
+    describeCreateRejectsNonBooleanCompletableParams(
+        'Junction',
+        Junction.create,
+        () => validJunctionAttributesWithPlace,
+        () => registry
+    );
+
     test('should create a Junction instance with custom attributes', () => {
         const customAttributes = {
             customAttribute1: 'value1',
@@ -173,6 +197,9 @@ describe('Junction', () => {
             ['parkingType', 123],
             ['parkingFeeType', 123],
             ['transitPlaceType', 123],
+            ['hasMinimum', 'invalid'],
+            ['isCompleted', 'invalid'],
+            ['isStarted', 'invalid'],
             ['preData', 'invalid'],
             ['preData', []],
             ['preData', new Date() as any],

--- a/packages/evolution-common/src/services/baseObjects/__tests__/Organization.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/Organization.test.ts
@@ -12,6 +12,11 @@ import { v4 as uuidV4 } from 'uuid';
 import { WeightMethod, WeightMethodAttributes } from '../WeightMethod';
 import { isOk, hasErrors, unwrap } from '../../../types/Result.type';
 import { SurveyObjectsRegistry } from '../SurveyObjectsRegistry';
+import { completableAttributeNames, type CompletableAttributeName } from '../attributeTypes/CompletableAttributes';
+import {
+    describeCompletableSurveyObjectMixinValues,
+    describeCreateRejectsNonBooleanCompletableParams
+} from './completableSurveyObjectTestHelpers';
 
 describe('Organization', () => {
     let registry: SurveyObjectsRegistry;
@@ -78,9 +83,16 @@ describe('Organization', () => {
 
     test('should have a validateParams section for each attribute', () => {
         const validateParamsCode = Organization.validateParams.toString();
-        organizationAttributes.filter((attribute) => attribute !== '_uuid' && attribute !== '_weights').forEach((attributeName) => {
-            expect(validateParamsCode).toContain('\'' + attributeName + '\'');
-        });
+        organizationAttributes
+            .filter(
+                (attribute) =>
+                    attribute !== '_uuid' &&
+                    attribute !== '_weights' &&
+                    !completableAttributeNames.includes(attribute as CompletableAttributeName)
+            )
+            .forEach((attributeName) => {
+                expect(validateParamsCode).toContain('\'' + attributeName + '\'');
+            });
     });
 
     test('should get uuid', () => {
@@ -137,6 +149,17 @@ describe('Organization', () => {
         expect(organization.isValid()).toBe(true);
     });
 
+    describeCompletableSurveyObjectMixinValues<Organization>({
+        createDefault: () => new Organization(validAttributes, registry)
+    });
+
+    describeCreateRejectsNonBooleanCompletableParams(
+        'Organization',
+        Organization.create,
+        () => validAttributes,
+        () => registry
+    );
+
     test('should create an Organization instance with custom attributes', () => {
         const customAttributes = {
             customAttribute1: 'value1',
@@ -163,6 +186,9 @@ describe('Organization', () => {
             ['contactPhoneNumber', 123],
             ['contactEmail', 123],
             ['revenueLevel', 123],
+            ['hasMinimum', 'invalid'],
+            ['isCompleted', 'invalid'],
+            ['isStarted', 'invalid'],
             ['preData', 'invalid'],
             ['preData', []],
             ['preData', new Date() as any],

--- a/packages/evolution-common/src/services/baseObjects/__tests__/Person.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/Person.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { Person, nonStringAttributes, stringAttributes } from '../Person';
+import { completableAttributeNames, type CompletableAttributeName } from '../attributeTypes/CompletableAttributes';
 import { v4 as uuidV4 } from 'uuid';
 import { Weight } from '../Weight';
 import { WorkPlace } from '../WorkPlace';
@@ -16,6 +17,10 @@ import { VisitedPlace } from '../VisitedPlace';
 import { isOk, hasErrors, unwrap } from '../../../types/Result.type';
 import { WeightMethod, WeightMethodAttributes } from '../WeightMethod';
 import { SurveyObjectsRegistry } from '../SurveyObjectsRegistry';
+import {
+    describeCompletableSurveyObjectMixinValues,
+    describeCreateRejectsNonBooleanCompletableParams
+} from './completableSurveyObjectTestHelpers';
 
 describe('Person', () => {
     let registry: SurveyObjectsRegistry;
@@ -107,9 +112,16 @@ describe('Person', () => {
     test('should have a validateParams section for each attribute', () => {
         const validateParamsCode = Person.validateParams.toString();
         // exclude string attributes, since they are validated automatically in a loop:
-        nonStringAttributes.filter((attribute) => attribute !== '_uuid' && attribute !== '_weights').forEach((attributeName) => {
-            expect(validateParamsCode).toContain('\'' + attributeName + '\'');
-        });
+        nonStringAttributes
+            .filter(
+                (attribute) =>
+                    attribute !== '_uuid' &&
+                    attribute !== '_weights' &&
+                    !completableAttributeNames.includes(attribute as CompletableAttributeName)
+            )
+            .forEach((attributeName) => {
+                expect(validateParamsCode).toContain('\'' + attributeName + '\'');
+            });
     });
 
     nonStringAttributes.forEach((attribute) => {
@@ -151,6 +163,12 @@ describe('Person', () => {
         expect(person.validate()).toBe(true);
         expect(person.isValid()).toBe(true);
     });
+
+    describeCompletableSurveyObjectMixinValues<Person>({
+        createDefault: () => new Person(validAttributes, registry)
+    });
+
+    describeCreateRejectsNonBooleanCompletableParams('Person', Person.create, () => validAttributes, () => registry);
 
     test('should get uuid', () => {
         const person = new Person({ ...validAttributes, _uuid: '11b78eb3-a5d8-484d-805d-1f947160bb9e' }, registry);
@@ -222,6 +240,9 @@ describe('Person', () => {
             ['age', 'invalid'],
             ['_isValid', 'invalid'],
             ['_weights', 'invalid'],
+            ['hasMinimum', 'invalid'],
+            ['isCompleted', 'invalid'],
+            ['isStarted', 'invalid'],
             ['whoWillAnswerForThisPerson', 'invalid-uuid'],
             ['isProxy', 'invalid'],
         ])('should return an error for invalid %s', (param, value) => {

--- a/packages/evolution-common/src/services/baseObjects/__tests__/Place.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/Place.test.ts
@@ -6,12 +6,17 @@
  */
 
 import { Place, ExtendedPlaceAttributes, placeAttributes } from '../Place';
+import { completableAttributeNames, type CompletableAttributeName } from '../attributeTypes/CompletableAttributes';
 import { v4 as uuidV4 } from 'uuid';
 import { Weight } from '../Weight';
 import { WeightMethod, WeightMethodAttributes } from '../WeightMethod';
 import { isOk, hasErrors, unwrap } from '../../../types/Result.type';
 import { Address, AddressAttributes } from '../Address';
 import { SurveyObjectsRegistry } from '../SurveyObjectsRegistry';
+import {
+    describeCompletableSurveyObjectMixinValues,
+    describeCreateRejectsNonBooleanCompletableParams
+} from './completableSurveyObjectTestHelpers';
 
 describe('Place', () => {
     let registry: SurveyObjectsRegistry;
@@ -100,9 +105,16 @@ describe('Place', () => {
 
     test('should have a validateParams section for each attribute', () => {
         const validateParamsCode = Place.validateParams.toString();
-        placeAttributes.filter((attribute) => attribute !== '_uuid' && attribute !== '_weights').forEach((attributeName) => {
-            expect(validateParamsCode).toContain('\'' + attributeName + '\'');
-        });
+        placeAttributes
+            .filter(
+                (attribute) =>
+                    attribute !== '_uuid' &&
+                    attribute !== '_weights' &&
+                    !completableAttributeNames.includes(attribute as CompletableAttributeName)
+            )
+            .forEach((attributeName) => {
+                expect(validateParamsCode).toContain('\'' + attributeName + '\'');
+            });
     });
 
     test('should create a Place instance with valid attributes using constructor', () => {
@@ -174,6 +186,12 @@ describe('Place', () => {
         expect(place.isValid()).toBe(true);
     });
 
+    describeCompletableSurveyObjectMixinValues<Place>({
+        createDefault: () => new Place(validPlaceAttributes, registry)
+    });
+
+    describeCreateRejectsNonBooleanCompletableParams('Place', Place.create, () => validPlaceAttributes, () => registry);
+
     test('should create a Place instance with custom attributes', () => {
         const customAttributes = {
             customAttribute1: 'value1',
@@ -229,6 +247,9 @@ describe('Place', () => {
             ['preData', new Date() as any],
             ['preData', true as any],
             ['preGeography', 'invalid'],
+            ['hasMinimum', 'invalid'],
+            ['isCompleted', 'invalid'],
+            ['isStarted', 'invalid'],
         ])('should return an error for invalid %s', (param, value) => {
             const invalidAttributes = { ...validPlaceAttributes, [param]: value };
             const errors = Place.validateParams(invalidAttributes);

--- a/packages/evolution-common/src/services/baseObjects/__tests__/SchoolPlace.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/SchoolPlace.test.ts
@@ -7,6 +7,12 @@
 
 import { SchoolPlace } from '../SchoolPlace';
 import { placeAttributes } from '../Place';
+import { completableAttributeNames, type CompletableAttributeName } from '../attributeTypes/CompletableAttributes';
+import {
+    completableInvalidParamRows,
+    describeCompletableSurveyObjectMixinValues,
+    describeCreateRejectsNonBooleanCompletableParams
+} from './completableSurveyObjectTestHelpers';
 import { v4 as uuidV4 } from 'uuid';
 import { WeightMethod, WeightMethodAttributes } from '../WeightMethod';
 import { isOk, hasErrors, unwrap } from '../../../types/Result.type';
@@ -73,9 +79,16 @@ describe('SchoolPlace', () => {
 
     test('should have a validateParams section for each attribute', () => {
         const validateParamsCode = SchoolPlace.validateParams.toString();
-        placeAttributes.filter((attribute) => attribute !== '_uuid' && attribute !== '_weights').forEach((attributeName) => {
-            expect(validateParamsCode).toContain('\''+attributeName+'\'');
-        });
+        placeAttributes
+            .filter(
+                (attribute) =>
+                    attribute !== '_uuid' &&
+                    attribute !== '_weights' &&
+                    !completableAttributeNames.includes(attribute as CompletableAttributeName)
+            )
+            .forEach((attributeName) => {
+                expect(validateParamsCode).toContain('\'' + attributeName + '\'');
+            });
     });
 
     test('should get uuid', () => {
@@ -132,6 +145,17 @@ describe('SchoolPlace', () => {
         expect(schoolPlace.isValid()).toBe(true);
     });
 
+    describeCompletableSurveyObjectMixinValues<SchoolPlace>({
+        createDefault: () => new SchoolPlace(validSchoolPlaceAttributes, registry)
+    });
+
+    describeCreateRejectsNonBooleanCompletableParams(
+        'SchoolPlace',
+        SchoolPlace.create,
+        () => validSchoolPlaceAttributes,
+        () => registry
+    );
+
     test('should create a SchoolPlace instance with custom attributes', () => {
         const customAttributes = {
             customAttribute1: 'value1',
@@ -148,10 +172,13 @@ describe('SchoolPlace', () => {
     });
 
     describe('validateParams', () => {
-        test.each([
-            ['parkingType', 123],
-            ['parkingFeeType', 123],
-        ])('should return an error for invalid %s', (param, value) => {
+        test.each(
+            [
+                ['parkingType', 123],
+                ['parkingFeeType', 123],
+                ...completableInvalidParamRows()
+            ] as [string, string | number][]
+        )('should return an error for invalid %s', (param, value) => {
             const invalidAttributes = { ...validSchoolPlaceAttributes, [param]: value };
             const errors = SchoolPlace.validateParams(invalidAttributes);
             expect(errors[0].toString()).toContain(param);

--- a/packages/evolution-common/src/services/baseObjects/__tests__/Segment.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/Segment.test.ts
@@ -14,6 +14,11 @@ import { Routing } from '../Routing';
 import { startEndDateAndTimesAttributes } from '../StartEndable';
 import { modeValues, mapModeToModeCategory, modeCategoryValues, Mode } from '../attributeTypes/SegmentAttributes';
 import { SurveyObjectsRegistry } from '../SurveyObjectsRegistry';
+import { completableAttributeNames, type CompletableAttributeName } from '../attributeTypes/CompletableAttributes';
+import {
+    describeCompletableSurveyObjectMixinValues,
+    describeCreateRejectsNonBooleanCompletableParams
+} from './completableSurveyObjectTestHelpers';
 
 describe('Segment', () => {
     let registry: SurveyObjectsRegistry;
@@ -73,9 +78,17 @@ describe('Segment', () => {
 
     test('should have a validateParams section for each attribute', () => {
         const validateParamsCode = Segment.validateParams.toString();
-        segmentAttributes.filter((attribute) => attribute !== '_uuid' && attribute !== '_weights' && !(startEndDateAndTimesAttributes as unknown as string[]).includes(attribute)).forEach((attributeName) => {
-            expect(validateParamsCode).toContain('\'' + attributeName + '\'');
-        });
+        segmentAttributes
+            .filter(
+                (attribute) =>
+                    attribute !== '_uuid' &&
+                    attribute !== '_weights' &&
+                    !completableAttributeNames.includes(attribute as CompletableAttributeName) &&
+                    !(startEndDateAndTimesAttributes as unknown as string[]).includes(attribute)
+            )
+            .forEach((attributeName) => {
+                expect(validateParamsCode).toContain('\'' + attributeName + '\'');
+            });
     });
 
     test('should get uuid', () => {
@@ -125,6 +138,12 @@ describe('Segment', () => {
         expect(segment.isValid()).toBe(true);
     });
 
+    describeCompletableSurveyObjectMixinValues<Segment>({
+        createDefault: () => new Segment(validAttributes, registry)
+    });
+
+    describeCreateRejectsNonBooleanCompletableParams('Segment', Segment.create, () => validAttributes, () => registry);
+
     test('should create a Segment instance with custom attributes', () => {
         const customAttributes = {
             customAttribute1: 'value1',
@@ -158,6 +177,9 @@ describe('Segment', () => {
             ['onDemandType', 123],
             ['busLines', 'invalid'],
             ['busLines', [undefined, 'Line']],
+            ['hasMinimum', 'invalid'],
+            ['isCompleted', 'invalid'],
+            ['isStarted', 'invalid'],
             ['preData', 'invalid'],
             ['preData', []],
             ['preData', new Date() as any],

--- a/packages/evolution-common/src/services/baseObjects/__tests__/SurveyObject.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/SurveyObject.test.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { v4 as uuidV4 } from 'uuid';
+
+import { SurveyObject } from '../SurveyObject';
+import {
+    completableAttributeNames,
+    type CompletableAttributeName,
+    type CompletableAttributes
+} from '../attributeTypes/CompletableAttributes';
+import type { ValidatableAttributes } from '../IValidatable';
+
+/** Minimal concrete subclass to exercise {@link SurveyObject} instance behavior. */
+class TestSurveyObject extends SurveyObject {
+    readonly _attributes: ValidatableAttributes & CompletableAttributes & { _uuid?: string };
+
+    constructor(initial?: ValidatableAttributes & CompletableAttributes & { _uuid?: string }) {
+        super(initial?._uuid ?? uuidV4());
+        this._attributes = { ...initial };
+    }
+}
+
+describe('SurveyObject', () => {
+    describe('validateCompletableParams', () => {
+        test('should accept missing completable keys', () => {
+            expect(SurveyObject.validateCompletableParams({ _uuid: uuidV4() })).toHaveLength(0);
+        });
+
+        test('should accept boolean values for all completable keys', () => {
+            const params = Object.fromEntries(
+                completableAttributeNames.map((name) => [name, true])
+            ) as Record<string, boolean>;
+            expect(SurveyObject.validateCompletableParams(params)).toHaveLength(0);
+        });
+
+        test.each(completableAttributeNames)('should reject non-boolean %s', (attribute) => {
+            const errors = SurveyObject.validateCompletableParams({ [attribute]: 'not-bool' }, 'TestObject');
+            expect(errors.length).toBeGreaterThan(0);
+            expect(errors[0].message).toContain(attribute);
+            expect(errors[0].message).toContain('TestObject');
+        });
+    });
+
+    describe('instance', () => {
+        test.each(completableAttributeNames)(
+            'should map completable accessor %s to _attributes',
+            (key) => {
+                const obj = new TestSurveyObject({ _isValid: true });
+                const o = obj as Pick<TestSurveyObject, CompletableAttributeName>;
+                o[key] = true;
+                expect(obj._attributes[key]).toBe(true);
+                expect(o[key]).toBe(true);
+                o[key] = false;
+                expect(obj._attributes[key]).toBe(false);
+                expect(o[key]).toBe(false);
+                o[key] = undefined;
+                expect(obj._attributes[key]).toBeUndefined();
+                expect(o[key]).toBeUndefined();
+            }
+        );
+
+        test('should expose IValidatable behavior', () => {
+            const obj = new TestSurveyObject();
+            expect(obj.isValid()).toBeUndefined();
+            expect(obj.validate()).toBe(true);
+            expect(obj.isValid()).toBe(true);
+            obj._isValid = false;
+            expect(obj.isValid()).toBe(false);
+        });
+    });
+});

--- a/packages/evolution-common/src/services/baseObjects/__tests__/Trip.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/Trip.test.ts
@@ -14,6 +14,11 @@ import { WeightMethod, WeightMethodAttributes } from '../WeightMethod';
 import { isOk, hasErrors, unwrap } from '../../../types/Result.type';
 import { startEndDateAndTimesAttributes } from '../StartEndable';
 import { SurveyObjectsRegistry } from '../SurveyObjectsRegistry';
+import { completableAttributeNames, type CompletableAttributeName } from '../attributeTypes/CompletableAttributes';
+import {
+    describeCompletableSurveyObjectMixinValues,
+    describeCreateRejectsNonBooleanCompletableParams
+} from './completableSurveyObjectTestHelpers';
 
 describe('Trip', () => {
     let registry: SurveyObjectsRegistry;
@@ -148,9 +153,17 @@ describe('Trip', () => {
 
     test('should have a validateParams section for each attribute', () => {
         const validateParamsCode = Trip.validateParams.toString();
-        tripAttributes.filter((attribute) => attribute !== '_uuid' && attribute !== '_weights' && !(startEndDateAndTimesAttributes as unknown as string[]).includes(attribute)).forEach((attributeName) => {
-            expect(validateParamsCode).toContain('\'' + attributeName + '\'');
-        });
+        tripAttributes
+            .filter(
+                (attribute) =>
+                    attribute !== '_uuid' &&
+                    attribute !== '_weights' &&
+                    !completableAttributeNames.includes(attribute as CompletableAttributeName) &&
+                    !(startEndDateAndTimesAttributes as unknown as string[]).includes(attribute)
+            )
+            .forEach((attributeName) => {
+                expect(validateParamsCode).toContain('\'' + attributeName + '\'');
+            });
     });
 
     test('should get uuid', () => {
@@ -207,6 +220,12 @@ describe('Trip', () => {
         expect(trip.isValid()).toBe(true);
     });
 
+    describeCompletableSurveyObjectMixinValues<Trip>({
+        createDefault: () => new Trip(validAttributes, registry)
+    });
+
+    describeCreateRejectsNonBooleanCompletableParams('Trip', Trip.create, () => validAttributes, () => registry);
+
     test('should create a Trip instance with custom attributes', () => {
         const customAttributes = {
             customAttribute1: 'value1',
@@ -230,6 +249,9 @@ describe('Trip', () => {
             ['endTime', 'invalid'],
             ['startTimePeriod', 123],
             ['endTimePeriod', 123],
+            ['hasMinimum', 'invalid'],
+            ['isCompleted', 'invalid'],
+            ['isStarted', 'invalid'],
             ['preData', 'invalid'],
             ['preData', []],
             ['preData', new Date() as any],

--- a/packages/evolution-common/src/services/baseObjects/__tests__/TripChain.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/TripChain.test.ts
@@ -12,6 +12,11 @@ import { WeightMethod, WeightMethodAttributes } from '../WeightMethod';
 import { isOk, hasErrors, unwrap } from '../../../types/Result.type';
 import { startEndDateAndTimesAttributes } from '../StartEndable';
 import { SurveyObjectsRegistry } from '../SurveyObjectsRegistry';
+import { completableAttributeNames, type CompletableAttributeName } from '../attributeTypes/CompletableAttributes';
+import {
+    describeCompletableSurveyObjectMixinValues,
+    describeCreateRejectsNonBooleanCompletableParams
+} from './completableSurveyObjectTestHelpers';
 
 let registry: SurveyObjectsRegistry;
 
@@ -105,9 +110,17 @@ describe('TripChain', () => {
 
     test('should have a validateParams section for each attribute', () => {
         const validateParamsCode = TripChain.validateParams.toString();
-        tripChainAttributes.filter((attribute) => attribute !== '_uuid' && attribute !== '_weights' && !(startEndDateAndTimesAttributes as unknown as string[]).includes(attribute)).forEach((attributeName) => {
-            expect(validateParamsCode).toContain('\'' + attributeName + '\'');
-        });
+        tripChainAttributes
+            .filter(
+                (attribute) =>
+                    attribute !== '_uuid' &&
+                    attribute !== '_weights' &&
+                    !completableAttributeNames.includes(attribute as CompletableAttributeName) &&
+                    !(startEndDateAndTimesAttributes as unknown as string[]).includes(attribute)
+            )
+            .forEach((attributeName) => {
+                expect(validateParamsCode).toContain('\'' + attributeName + '\'');
+            });
     });
 
     test('should get uuid', () => {
@@ -164,6 +177,17 @@ describe('TripChain', () => {
         expect(tripChain.isValid()).toBe(true);
     });
 
+    describeCompletableSurveyObjectMixinValues<TripChain>({
+        createDefault: () => new TripChain(validAttributes, registry)
+    });
+
+    describeCreateRejectsNonBooleanCompletableParams(
+        'TripChain',
+        TripChain.create,
+        () => validAttributes,
+        () => registry
+    );
+
     test('should create a TripChain instance with custom attributes', () => {
         const customAttributes = {
             customAttribute1: 'value1',
@@ -192,6 +216,9 @@ describe('TripChain', () => {
             ['isConstrained', 'invalid'],
             ['mainActivity', 123],
             ['mainActivityCategory', 123],
+            ['hasMinimum', 'invalid'],
+            ['isCompleted', 'invalid'],
+            ['isStarted', 'invalid'],
             ['preData', 'invalid'],
             ['preData', []],
             ['preData', new Date() as any],

--- a/packages/evolution-common/src/services/baseObjects/__tests__/Uuidable.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/Uuidable.test.ts
@@ -8,15 +8,18 @@
 import { Uuidable } from '../Uuidable';
 import { validate as uuidValidate, v4 as uuidV4 } from 'uuid';
 
+/** Minimal subclass so tests can instantiate the abstract {@link Uuidable} base. */
+class TestUuidable extends Uuidable {}
+
 describe('Uuidable Class', () => {
 
     it('should have a _uuid property when instantiated without parameters', () => {
-        const uuidBaseInstance = new Uuidable();
+        const uuidBaseInstance = new TestUuidable();
         expect(uuidBaseInstance).toHaveProperty('_uuid');
     });
 
     it('should have a valid UUID for the _uuid property when instantiated without parameters', () => {
-        const uuidBaseInstance = new Uuidable();
+        const uuidBaseInstance = new TestUuidable();
         expect(typeof uuidBaseInstance._uuid).toEqual('string');
         const isValidUUID = uuidValidate(uuidBaseInstance._uuid as string);
         expect(isValidUUID).toBeTruthy();
@@ -24,13 +27,13 @@ describe('Uuidable Class', () => {
 
     it('should accept and use a valid UUID provided as a parameter', () => {
         const validUuid = uuidV4();
-        const uuidBaseInstance = new Uuidable(validUuid);
+        const uuidBaseInstance = new TestUuidable(validUuid);
         expect(uuidBaseInstance._uuid).toEqual(validUuid);
     });
 
     it('should throw an error when provided with an invalid UUID', () => {
         const invalidUuid = 'invalid-uuid';
-        expect(() => new Uuidable(invalidUuid)).toThrow('Uuidable: invalid uuid');
+        expect(() => new TestUuidable(invalidUuid)).toThrow('Uuidable: invalid uuid');
     });
 
     it('should return errors for invalid params and accept empty or valid uuid', () => {

--- a/packages/evolution-common/src/services/baseObjects/__tests__/Vehicle.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/Vehicle.test.ts
@@ -10,6 +10,11 @@ import { v4 as uuidV4 } from 'uuid';
 import { WeightMethod, WeightMethodAttributes } from '../WeightMethod';
 import { isOk, hasErrors, unwrap } from '../../../types/Result.type';
 import { SurveyObjectsRegistry } from '../SurveyObjectsRegistry';
+import { completableAttributeNames, type CompletableAttributeName } from '../attributeTypes/CompletableAttributes';
+import {
+    describeCompletableSurveyObjectMixinValues,
+    describeCreateRejectsNonBooleanCompletableParams
+} from './completableSurveyObjectTestHelpers';
 
 describe('Vehicle', () => {
     let registry: SurveyObjectsRegistry;
@@ -57,9 +62,16 @@ describe('Vehicle', () => {
 
     test('should have a validateParams section for each attribute', () => {
         const validateParamsCode = Vehicle.validateParams.toString();
-        vehicleAttributes.filter((attribute) => attribute !== '_uuid' && attribute !== '_weights').forEach((attributeName) => {
-            expect(validateParamsCode).toContain('\'' + attributeName + '\'');
-        });
+        vehicleAttributes
+            .filter(
+                (attribute) =>
+                    attribute !== '_uuid' &&
+                    attribute !== '_weights' &&
+                    !completableAttributeNames.includes(attribute as CompletableAttributeName)
+            )
+            .forEach((attributeName) => {
+                expect(validateParamsCode).toContain('\'' + attributeName + '\'');
+            });
     });
 
     test('should get uuid', () => {
@@ -114,6 +126,9 @@ describe('Vehicle', () => {
         ['isElectric', 'invalid'],
         ['isPluginHybrid', 'invalid'],
         ['isHybrid', 'invalid'],
+        ['hasMinimum', 'invalid'],
+        ['isCompleted', 'invalid'],
+        ['isStarted', 'invalid'],
         ['acquiredYear', 'invalid'],
         ['licensePlateNumber', 123],
         ['internalId', 123],
@@ -133,6 +148,12 @@ describe('Vehicle', () => {
         expect(vehicle.validate()).toBe(true);
         expect(vehicle.isValid()).toBe(true);
     });
+
+    describeCompletableSurveyObjectMixinValues<Vehicle>({
+        createDefault: () => new Vehicle(validAttributes, registry)
+    });
+
+    describeCreateRejectsNonBooleanCompletableParams('Vehicle', Vehicle.create, () => validAttributes, () => registry);
 
     test('should create a Vehicle instance with custom attributes', () => {
         const customAttributes = {

--- a/packages/evolution-common/src/services/baseObjects/__tests__/VisitedPlace.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/VisitedPlace.test.ts
@@ -12,6 +12,11 @@ import { WeightMethod, WeightMethodAttributes } from '../WeightMethod';
 import { isOk, hasErrors, unwrap } from '../../../types/Result.type';
 import { startEndDateAndTimesAttributes } from '../StartEndable';
 import { SurveyObjectsRegistry } from '../SurveyObjectsRegistry';
+import { completableAttributeNames, type CompletableAttributeName } from '../attributeTypes/CompletableAttributes';
+import {
+    describeCompletableSurveyObjectMixinValues,
+    describeCreateRejectsNonBooleanCompletableParams
+} from './completableSurveyObjectTestHelpers';
 
 describe('VisitedPlace', () => {
     let registry: SurveyObjectsRegistry;
@@ -89,9 +94,17 @@ describe('VisitedPlace', () => {
 
     test('should have a validateParams section for each attribute', () => {
         const validateParamsCode = VisitedPlace.validateParams.toString();
-        visitedPlaceAttributes.filter((attribute) => attribute !== '_uuid' && attribute !== '_weights' && !(startEndDateAndTimesAttributes as unknown as string[]).includes(attribute)).forEach((attributeName) => {
-            expect(validateParamsCode).toContain('\'' + attributeName + '\'');
-        });
+        visitedPlaceAttributes
+            .filter(
+                (attribute) =>
+                    attribute !== '_uuid' &&
+                    attribute !== '_weights' &&
+                    !completableAttributeNames.includes(attribute as CompletableAttributeName) &&
+                    !(startEndDateAndTimesAttributes as unknown as string[]).includes(attribute)
+            )
+            .forEach((attributeName) => {
+                expect(validateParamsCode).toContain('\'' + attributeName + '\'');
+            });
     });
 
     test('should get uuid', () => {
@@ -162,6 +175,17 @@ describe('VisitedPlace', () => {
         expect(visitedPlace.isValid()).toBe(true);
     });
 
+    describeCompletableSurveyObjectMixinValues<VisitedPlace>({
+        createDefault: () => new VisitedPlace(validVisitedPlaceAttributesWithPlace, registry)
+    });
+
+    describeCreateRejectsNonBooleanCompletableParams(
+        'VisitedPlace',
+        VisitedPlace.create,
+        () => validVisitedPlaceAttributesWithPlace,
+        () => registry
+    );
+
     test('should create a VisitedPlace instance with custom attributes', () => {
         const customAttributes = {
             customAttribute1: 'value1',
@@ -189,6 +213,9 @@ describe('VisitedPlace', () => {
             ['activityCategory', 123],
             ['shortcut', 'invalid-uuid'],
             ['_sequence', 'invalid'],
+            ['hasMinimum', 'invalid'],
+            ['isCompleted', 'invalid'],
+            ['isStarted', 'invalid'],
             ['preData', 'invalid'],
             ['preData', []],
             ['preData', new Date() as any],

--- a/packages/evolution-common/src/services/baseObjects/__tests__/WorkPlace.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/WorkPlace.test.ts
@@ -7,6 +7,12 @@
 
 import { WorkPlace } from '../WorkPlace';
 import { placeAttributes } from '../Place';
+import { completableAttributeNames, type CompletableAttributeName } from '../attributeTypes/CompletableAttributes';
+import {
+    completableInvalidParamRows,
+    describeCompletableSurveyObjectMixinValues,
+    describeCreateRejectsNonBooleanCompletableParams
+} from './completableSurveyObjectTestHelpers';
 import { v4 as uuidV4 } from 'uuid';
 import { WeightMethod, WeightMethodAttributes } from '../WeightMethod';
 import { isOk, hasErrors, unwrap } from '../../../types/Result.type';
@@ -74,9 +80,16 @@ describe('WorkPlace', () => {
 
     test('should have a validateParams section for each attribute', () => {
         const validateParamsCode = WorkPlace.validateParams.toString();
-        placeAttributes.filter((attribute) => attribute !== '_uuid' && attribute !== '_weights').forEach((attributeName) => {
-            expect(validateParamsCode).toContain('\''+attributeName+'\'');
-        });
+        placeAttributes
+            .filter(
+                (attribute) =>
+                    attribute !== '_uuid' &&
+                    attribute !== '_weights' &&
+                    !completableAttributeNames.includes(attribute as CompletableAttributeName)
+            )
+            .forEach((attributeName) => {
+                expect(validateParamsCode).toContain('\'' + attributeName + '\'');
+            });
     });
 
     test('should get uuid', () => {
@@ -133,6 +146,17 @@ describe('WorkPlace', () => {
         expect(workPlace.isValid()).toBe(true);
     });
 
+    describeCompletableSurveyObjectMixinValues<WorkPlace>({
+        createDefault: () => new WorkPlace(validWorkPlaceAttributes, registry)
+    });
+
+    describeCreateRejectsNonBooleanCompletableParams(
+        'WorkPlace',
+        WorkPlace.create,
+        () => validWorkPlaceAttributes,
+        () => registry
+    );
+
     test('should create a WorkPlace instance with custom attributes', () => {
         const customAttributes = {
             customAttribute1: 'value1',
@@ -149,10 +173,13 @@ describe('WorkPlace', () => {
     });
 
     describe('validateParams', () => {
-        test.each([
-            ['parkingType', 123],
-            ['parkingFeeType', 123],
-        ])('should return an error for invalid %s', (param, value) => {
+        test.each(
+            [
+                ['parkingType', 123],
+                ['parkingFeeType', 123],
+                ...completableInvalidParamRows()
+            ] as [string, string | number][]
+        )('should return an error for invalid %s', (param, value) => {
             const invalidAttributes = { ...validWorkPlaceAttributes, [param]: value };
             const errors = WorkPlace.validateParams(invalidAttributes);
             expect(errors[0].toString()).toContain(param);

--- a/packages/evolution-common/src/services/baseObjects/__tests__/completableSurveyObjectTestHelpers.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/completableSurveyObjectTestHelpers.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { hasErrors, type Result } from '../../../types/Result.type';
+import {
+    completableAttributeNames,
+    type CompletableAttributeName
+} from '../attributeTypes/CompletableAttributes';
+import type { SurveyObject } from '../SurveyObject';
+import type { SurveyObjectsRegistry } from '../SurveyObjectsRegistry';
+
+/**
+ * Rows for `test.each` when asserting `validateParams` rejects non-boolean completable fields.
+ */
+export function completableInvalidParamRows(): [string, string][] {
+    return completableAttributeNames.map((name) => [name, 'invalid']);
+}
+
+const COMPLETABLE_GET_SET_VALUES = [undefined, true, false] as const;
+
+/**
+ * Completability helpers on {@link SurveyObject}: defaults stay empty, then getters/setters round-trip
+ * `undefined`, `true`, and `false` for every name in {@link completableAttributeNames}.
+ */
+export function describeCompletableSurveyObjectMixinValues<T extends SurveyObject>(options: {
+    createDefault: () => T;
+}): void {
+    describe('completeness mixin values', () => {
+        test('should leave every completable attribute undefined when not provided', () => {
+            const o = options.createDefault();
+            for (const name of completableAttributeNames) {
+                expect(o[name]).toBeUndefined();
+            }
+        });
+
+        const getSetCases = completableAttributeNames.flatMap((key) =>
+            COMPLETABLE_GET_SET_VALUES.map((value) => [key, value] as const)
+        );
+
+        test.each(getSetCases)('should get and set %s as %s', (key, value) => {
+            const instance = options.createDefault();
+            const o = instance as Pick<T, CompletableAttributeName>;
+            o[key] = value;
+            expect(o[key]).toBe(value);
+        });
+    });
+}
+
+/**
+ * Runs one test per completable key; use the callback to assert validation/create fails.
+ */
+export function describeEachCompletableKeyRejectsNonBoolean(
+    describeTitle: string,
+    testNameTemplate: string,
+    fn: (key: CompletableAttributeName) => void
+): void {
+    describe(describeTitle, () => {
+        test.each(completableAttributeNames)(testNameTemplate, (key) => {
+            fn(key as CompletableAttributeName);
+        });
+    });
+}
+
+/**
+ * Shared suite: the class’s static `create` method must reject non-boolean values for each completable field.
+ * Use for every {@link SurveyObject} subclass that exposes `create(dirtyParams, registry): Result<T>`.
+ * Example: `describeCreateRejectsNonBooleanCompletableParams('Household', Household.create, () => validAttrs, () => registry)`.
+ */
+export function describeCreateRejectsNonBooleanCompletableParams<T>(
+    classLabel: string,
+    create: (
+        dirtyParams: { [key: string]: unknown },
+        surveyObjectsRegistry: SurveyObjectsRegistry
+    ) => Result<T>,
+    buildValidParams: () => { [key: string]: unknown },
+    getRegistry: () => SurveyObjectsRegistry,
+    describeTitle = 'validateParams (completable)'
+): void {
+    const testNameTemplate = `should reject non-boolean %s via ${classLabel}.create`;
+
+    describe(describeTitle, () => {
+        test.each(completableAttributeNames)(testNameTemplate, (key) => {
+            const result = create(
+                { ...buildValidParams(), [key]: 'not-a-boolean' },
+                getRegistry()
+            );
+            expect(hasErrors(result)).toBe(true);
+            if (hasErrors(result)) {
+                expect(result.errors[0].message).toContain(key);
+            }
+        });
+    });
+}

--- a/packages/evolution-common/src/services/baseObjects/attributeTypes/CompletableAttributes.ts
+++ b/packages/evolution-common/src/services/baseObjects/attributeTypes/CompletableAttributes.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { Optional } from '../../../types/Optional.type';
+
+/*
+hasMinimum: whether the object has minimum required attributes to be kept for export
+isCompleted: whether the object has all required attributes
+isStarted: whether the object has at least one attribute filled
+*/
+export const completableAttributeNames = ['hasMinimum', 'isCompleted', 'isStarted'] as const;
+
+export type CompletableAttributeName = (typeof completableAttributeNames)[number];
+
+export type CompletableAttributes = {
+    [K in CompletableAttributeName]?: Optional<boolean>;
+};


### PR DESCRIPTION
Completable attributes make it possible to know the completeness of a survey object. 3 fields are added to the SurveyObject base class: hasMinimum, isStarted, and isCompleted.

The calculation of the completeness will be implemented in the audit process (not included in this PR).

The Uuidable class has been converted to abstract

Imports have been updated to use types when the full content is not required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added completion tracking capabilities with status flags for survey objects to monitor progress.
  * Introduced standardized attribute naming conventions across all survey object types.

* **Bug Fixes**
  * Corrected type naming inconsistency in validation attributes.

* **Tests**
  * Expanded test coverage to validate completion status tracking and related parameter validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->