### PR TITLE
Chore: Correct python unit test in the root package.json

### DIFF
--- a/.github/workflows/evolution-generator.yml
+++ b/.github/workflows/evolution-generator.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Run Python unit tests
       working-directory: packages/evolution-generator
       run: |
-        poetry run pytest -v --disable-warnings --tb=short
+        yarn test:python
     - name: Generate survey
       run: yarn generateSurvey:generator
     - name: Install

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "test": "yarn workspace evolution-common run test && yarn workspace evolution-backend run test && yarn workspace evolution-frontend run test && yarn workspace evolution-interviewer run test",
         "test:unit": "yarn workspace evolution-common run test:unit && yarn workspace evolution-backend run test:unit && yarn workspace evolution-frontend run test:unit && yarn workspace evolution-interviewer run test:unit",
         "test:sequential": "yarn workspace evolution-common run test:sequential && yarn workspace evolution-backend run test:sequential && yarn workspace evolution-frontend run test:sequential && yarn workspace evolution-interviewer run test:sequential",
-        "test:generator": "python -m pytest -s -W ignore packages/evolution-generator/src/tests/",
+        "test:python": "yarn workspace evolution-generator run test:python",
         "test:ui": "yarn workspace demo_survey run test:ui",
         "test:ui:generator": "yarn workspace demo_generator run test:ui",
         "test:ui:install-dependencies": "yarn workspace demo_survey run playwright install-deps && yarn workspace demo_survey run playwright install",

--- a/packages/evolution-generator/package.json
+++ b/packages/evolution-generator/package.json
@@ -13,7 +13,7 @@
     "compile": "echo 'no Typescript to compile for this workspace'",
     "compile:dev": "echo 'no Typescript to compile for this workspace'",
     "test": "echo 'no tests to run for this workspace'",
-    "test:unit": "echo 'no tests to run for this workspace'",
+    "test:python": "poetry run pytest -v --disable-warnings --tb=short",
     "test:sequential": "echo 'no tests to run for this workspace'",
     "test:ui": "echo 'no tests to run for this workspace'",
     "lint": "eslint .",
@@ -21,7 +21,6 @@
     "format:python": "poetry run black .",
     "format:all": "yarn format && yarn format:python",
     "generateSurvey": "poetry run generateSurvey",
-    "verifyExcel": "poetry run verifyExcel",
-    "test:python": "poetry run pytest -v --disable-warnings --tb=short"
+    "verifyExcel": "poetry run verifyExcel"
   }
 }


### PR DESCRIPTION
# Pull request

## Description
Chore: Add python unit test in the root package.json
- Replace python command with Poetry, because it's working better with project that download Poetry like this one.
- Replace the "test:generator" script with "test:python" in the root package.json for consistency with Python command.
- Update the "test:unit" script in the evolution-generator package to "test:python" for consistency in running Python tests using Poetry.
- Update the Evolution generator CI with the new command (same command than before but with a shortcut).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized and unified Python test scripts across the repo, replacing direct test invocation with a workspace-delegated test command.
  * Consolidated duplicate/placeholder test and verification script entries so each script is defined once.
  * CI workflow updated to run tests via the unified workspace script for more consistent test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->