### PR TITLE
visitedPlaces: add the personVisitedPlaceTitle and nextPlaceCategory widgets

### DIFF
--- a/example/demo_survey/src/survey/helper.ts
+++ b/example/demo_survey/src/survey/helper.ts
@@ -87,7 +87,9 @@ export const segmentSectionConfig: SegmentSectionConfiguration = {
 // FIXME As sections and their widgets become more builtin, this thould be moved elsewhere. For now, it just needs to be available for both widgets.ts and sections.ts files
 export const visitedPlacesSectionConfig: VisitedPlacesSectionConfiguration = {
     type: 'visitedPlaces' as const,
-    enabled: true
+    enabled: true,
+    tripDiaryMaxTimeOfDay: 28 * 60 * 60, // 28h in seconds (i.e. 4h the next day)
+    tripDiaryMinTimeOfDay: 4 * 60 * 60 // 4h in seconds
 };
 
 // FIXME Move elsewhere. It is not here to be available for widgets.ts, sections.ts and questionnaire.ts files

--- a/locales/en/survey.yml
+++ b/locales/en/survey.yml
@@ -157,3 +157,9 @@ geography:
         <strong>The location name used for searching {{geocodingTextInput}} is
         not specific enough.</strong> Please add more information or specify the
         location more precisely using the map.
+placeWithSequenceGeneric: 'place #{{sequence}}'
+atThisPlace: at this place
+atThisPlace_home: home
+atThisPlace_schoolUsual: at school
+atThisPlace_workUsual: at work
+atPlace: at {{placeName}}

--- a/locales/en/visitedPlaces.yml
+++ b/locales/en/visitedPlaces.yml
@@ -96,3 +96,9 @@ locationIsNotPreciseError: >-
 ConfirmDeleteVisitedPlace: Do you confirm that you want to remove this location?
 dayScheduleFor: Day schedule for <strong>{{nickname}}</strong>
 dayScheduleFor_one: Your day schedule
+personVisitedPlacesTitle: >-
+    Places {{nickname}} went on {{journeyDate}}:<br />Chronological order must
+    be respected (i.e. sequence matters).
+personVisitedPlacesTitle_one: >-
+    Places you went on {{journeyDate}}:<br />Chronological order must be respected
+    (i.e. sequence matters).

--- a/locales/en/visitedPlaces.yml
+++ b/locales/en/visitedPlaces.yml
@@ -102,3 +102,12 @@ personVisitedPlacesTitle: >-
 personVisitedPlacesTitle_one: >-
     Places you went on {{journeyDate}}:<br />Chronological order must be respected
     (i.e. sequence matters).
+nextPlaceCategory: >-
+    After being {{atPlace}}, {{nickname}}…
+nextPlaceCategory_one: >-
+    After being {{atPlace}}, you…
+nextPlaceRadioChoices.stayedHomeUntilTheNextDay: Stayed home until the next day
+nextPlaceRadioChoices.stayedThereUntilTheNextDay: Stayed at this place until the next
+    day
+nextPlaceRadioChoices.visitedAnotherPlace: Went or stopped elsewhere
+nextPlaceRadioChoices.wentBackHome: Returned home directly ({{address}})

--- a/locales/fr/survey.yml
+++ b/locales/fr/survey.yml
@@ -168,3 +168,9 @@ geography:
         <strong>Le nom du lieu utilisé pour effectuer la recherche
         {{geocodingTextInput}} n'est pas assez précis.</strong> Ajoutez de
         l'information ou précisez l'emplacement à l'aide de la carte.
+placeWithSequenceGeneric: 'lieu #{{sequence}}'
+atThisPlace: à cet endroit
+atThisPlace_home: au domicile
+atThisPlace_schoolUsual: au lieu d'études/école
+atThisPlace_workUsual: au travail
+atPlace: à {{placeName}}

--- a/locales/fr/visitedPlaces.yml
+++ b/locales/fr/visitedPlaces.yml
@@ -95,3 +95,21 @@ locationIsNotPreciseError: >-
 ConfirmDeleteVisitedPlace: Confirmez-vous que vous voulez retirer ce lieu?
 dayScheduleFor: Horaire de la journée de <strong>{{nickname}}</strong>
 dayScheduleFor_one: Votre horaire de la journée
+personVisitedPlacesTitle: >-
+    Lieux où {{nickname}} est allé(e) le {{journeyDate}}:<br />L'ordre
+    chronologique doit être respecté.
+personVisitedPlacesTitle_male: >-
+    Lieux où {{nickname}} est allé le {{journeyDate}}:<br />L'ordre chronologique
+    doit être respecté.
+personVisitedPlacesTitle_female: >-
+    Lieux où {{nickname}} est allée le {{journeyDate}}:<br />L'ordre chronologique
+    doit être respecté.
+personVisitedPlacesTitle_one: >-
+    Lieux où vous êtes allé(e) le {{journeyDate}}:<br />L'ordre chronologique doit
+    être respecté.
+personVisitedPlacesTitle_male_one: >-
+    Lieux où vous êtes allé le {{journeyDate}}:<br />L'ordre chronologique doit être
+    respecté.
+personVisitedPlacesTitle_female_one: >-
+    Lieux où vous êtes allée le {{journeyDate}}:<br />L'ordre chronologique doit
+    être respecté.

--- a/locales/fr/visitedPlaces.yml
+++ b/locales/fr/visitedPlaces.yml
@@ -113,3 +113,23 @@ personVisitedPlacesTitle_male_one: >-
 personVisitedPlacesTitle_female_one: >-
     Lieux où vous êtes allée le {{journeyDate}}:<br />L'ordre chronologique doit
     être respecté.
+nextPlaceCategory: >-
+    Après avoir été {{atPlace}}, {{nickname}} est…
+nextPlaceCategory_one: >-
+    Après avoir été {{atPlace}}, vous êtes…
+nextPlaceRadioChoices.stayedHomeUntilTheNextDay: Resté(e) au domicile jusqu'au lendemain
+nextPlaceRadioChoices.stayedHomeUntilTheNextDay_male: Resté au domicile jusqu'au lendemain
+nextPlaceRadioChoices.stayedHomeUntilTheNextDay_female: Restée au domicile jusqu'au
+    lendemain
+nextPlaceRadioChoices.stayedThereUntilTheNextDay: Resté(e) à cet endroit jusqu'au
+    lendemain
+nextPlaceRadioChoices.stayedThereUntilTheNextDay_male: Resté à cet endroit jusqu'au
+    lendemain
+nextPlaceRadioChoices.stayedThereUntilTheNextDay_female: Restée à cet endroit jusqu'au
+    lendemain
+nextPlaceRadioChoices.visitedAnotherPlace: Allé(e) ou arrêté(e) à un autre endroit
+nextPlaceRadioChoices.visitedAnotherPlace_male: Allé ou arrêté à un autre endroit
+nextPlaceRadioChoices.visitedAnotherPlace_female: Allée ou arrêtée à un autre endroit
+nextPlaceRadioChoices.wentBackHome: Retourné(e) au domicile directement ({{address}})
+nextPlaceRadioChoices.wentBackHome_male: Retourné au domicile directement ({{address}})
+nextPlaceRadioChoices.wentBackHome_female: Retournée au domicile directement ({{address}})

--- a/packages/evolution-common/src/services/odSurvey/__tests__/helpers.test.ts
+++ b/packages/evolution-common/src/services/odSurvey/__tests__/helpers.test.ts
@@ -2577,45 +2577,66 @@ describe('getOrigin/getDestination', () => {
 describe('getVisitedPlaceNames', () => {
     const mockedT = jest.fn().mockReturnValue('mocked') as unknown as jest.MockedFunction<TFunction>;
 
+    // Add a name with html tags to one of the places
+    const testInterviewCopy = _cloneDeep(interviewAttributesForTestCases);
+    testInterviewCopy.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!.workPlace1P1.name =
+        'mocked <b>place</b>';
+
     each([
-        [
-            'Home place',
-            interviewAttributesForTestCases.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!
+        {
+            title: 'Home place',
+            interview: interviewAttributesForTestCases,
+            visitedPlace: interviewAttributesForTestCases.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!
                 .homePlace1P1,
-            'survey:visitedPlace:activityCategories:home',
-            'mocked'
-        ],
-        [
-            'Place with a name',
-            interviewAttributesForTestCases.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!
+            expectedTVal: 'survey:visitedPlace:activityCategories:home',
+            expected: 'mocked'
+        },
+        {
+            title: 'Place with a name',
+            interview: interviewAttributesForTestCases,
+            visitedPlace: interviewAttributesForTestCases.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!
                 .workPlace1P1,
-            undefined,
-            interviewAttributesForTestCases.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!
+            expectedTVal: undefined,
+            expected: interviewAttributesForTestCases.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!
                 .workPlace1P1.name
-        ],
-        [
-            'Place with a shortcut',
-            interviewAttributesForTestCases.response.household!.persons!.personId2.journeys!.journeyId2.visitedPlaces!
+        },
+        {
+            title: 'Place with a name to escape',
+            interview: testInterviewCopy,
+            visitedPlace: testInterviewCopy.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!
+                .workPlace1P1,
+            expectedTVal: undefined,
+            expected: 'mocked &lt;b&gt;place&lt;/b&gt;'
+        },
+        {
+            title: 'Place with a shortcut',
+            interview: interviewAttributesForTestCases,
+            visitedPlace: interviewAttributesForTestCases.response.household!.persons!.personId2.journeys!.journeyId2.visitedPlaces!
                 .shoppingPlace1P2,
-            undefined,
-            interviewAttributesForTestCases.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!
+            expectedTVal: undefined,
+            expected: interviewAttributesForTestCases.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!
                 .otherPlace2P1.name
-        ],
-        [
-            'Place with neither name or shortcut',
-            interviewAttributesForTestCases.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!
+        },
+        {
+            title: 'Place with neither name or shortcut',
+            interview: interviewAttributesForTestCases,
+            visitedPlace: interviewAttributesForTestCases.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!
                 .otherPlaceP1,
-            'survey:placeGeneric',
-            'mocked 4'
-        ]
-    ]).test('%s', (_title, visitedPlace, mockedTVal, expected) => {
+            expectedTVal: ['survey:placeWithSequenceGeneric', { sequence: 4 }],
+            expected: 'mocked'
+        }
+    ]).test('$title', ({ title, interview, visitedPlace, expectedTVal, expected }) => {
         const name = Helpers.getVisitedPlaceName({
             t: mockedT,
             visitedPlace,
-            interview: interviewAttributesForTestCases
+            interview
         });
-        if (mockedTVal) {
-            expect(mockedT).toHaveBeenCalledWith(mockedTVal);
+        if (expectedTVal) {
+            if (Array.isArray(expectedTVal)) {
+                expect(mockedT).toHaveBeenCalledWith(...expectedTVal);
+            } else {
+                expect(mockedT).toHaveBeenCalledWith(expectedTVal);
+            }
         } else {
             expect(mockedT).not.toHaveBeenCalled();
         }

--- a/packages/evolution-common/src/services/odSurvey/__tests__/helpers.test.ts
+++ b/packages/evolution-common/src/services/odSurvey/__tests__/helpers.test.ts
@@ -809,6 +809,101 @@ describe('getPersonIdentificationString', () => {
     });
 });
 
+describe('getHomeAddressOneLine', () => {
+    each([
+        {
+            title: 'returns one-line address with default options',
+            home: {
+                address: '123 main st',
+                city: 'montreal',
+                region: 'Quebec',
+                country: 'Canada',
+                postalCode: 'h2x 1y4'
+            },
+            options: undefined,
+            expected: '123 main st, Montreal'
+        },
+        {
+            title: 'includes region, country and uppercased postal code',
+            home: {
+                address: '123 main st',
+                city: 'montreal',
+                region: 'Quebec',
+                country: 'Canada',
+                postalCode: 'h2x 1y4'
+            },
+            options: {
+                includeRegion: true,
+                includeCountry: true,
+                includePostalCode: true
+            },
+            expected: '123 main st, Montreal, Quebec, Canada, H2X 1Y4'
+        },
+        {
+            title: 'includes only postal code',
+            home: {
+                address: '123 main st',
+                city: 'montreal',
+                region: 'Quebec',
+                country: 'Canada',
+                postalCode: 'h2x 1y4'
+            },
+            options: {
+                includePostalCode: true
+            },
+            expected: '123 main st, Montreal, H2X 1Y4'
+        },
+        {
+            title: 'escapes HTML and trims fields for all',
+            home: {
+                address: '   123 <strong>main</strong> st    ',
+                city: '   <b>montreal</b>    ',
+                region: '   <span>Quebec</span>   ',
+                country: '  <script injectedScript/>Canada   ',
+                postalCode: '   <strong>h2x 1y4</strong>  '
+            },
+            options: {
+                includeRegion: true,
+                includeCountry: true,
+                includePostalCode: true
+            },
+            expected: '123 &lt;strong&gt;main&lt;/strong&gt; st, &lt;b&gt;montreal&lt;/b&gt;, &lt;span&gt;Quebec&lt;/span&gt;, &lt;script injectedScript/&gt;Canada, &lt;STRONG&gt;H2X 1Y4&lt;/STRONG&gt;'
+        },
+        {
+            title: 'returns empty string when home object is missing',
+            home: undefined,
+            options: undefined,
+            expected: ''
+        },
+        {
+            title: 'returns empty string when required fields are empty',
+            home: { address: '', city: '' },
+            options: undefined,
+            expected: ''
+        },
+        {
+            title: 'returns only the address part when city is missing',
+            home: { address: '123 main st' },
+            options: undefined,
+            expected: '123 main st'
+        },
+        {
+            title: 'returns only the city part when civic number/street is missing',
+            home: { city: 'montreal' },
+            options: undefined,
+            expected: 'Montreal'
+        }
+    ]).test('getHomeAddressOneLine: $title', ({ title, home, options = {}, expected }) => {
+        const interview = _cloneDeep(interviewAttributesWithHh);
+        if (home === undefined) {
+            delete (interview.response as any).home;
+        } else {
+            (interview.response as any).home = home;
+        }
+        expect(Helpers.getHomeAddressOneLine({ interview, ...options})).toEqual(expected);
+    });
+});
+
 each([
     ['Explicit yes, no age needed', { _uuid: 'personId1', _sequence: 1, drivingLicenseOwnership: 'yes' }, 18, true],
     ['Explicit no, adult age', { _uuid: 'personId1', _sequence: 1, age: 35, drivingLicenseOwnership: 'no' }, 18, false],

--- a/packages/evolution-common/src/services/odSurvey/helpers.ts
+++ b/packages/evolution-common/src/services/odSurvey/helpers.ts
@@ -13,6 +13,7 @@ import {
     Household,
     Journey,
     Person,
+    PlaceAddress,
     Segment,
     StartAddGroupedObjects,
     StartRemoveGroupedObjects,
@@ -304,6 +305,84 @@ export const getPersonIdentificationString = ({ person, t }: { person: Person; t
             age: person.age,
             context: getPersonGenderContext({ person })
         });
+};
+
+/**
+ * Return an html-safe address as a one line string, including all the requested
+ * parts
+ *
+ * @param obj The object from which to extract address parts
+ * @param options Options for which parts of the address to include
+ * @param {boolean} [options.includeRegion=false] Whether to include the region
+ * in the address string
+ * @param {boolean} [options.includeCountry=false] Whether to include the
+ * country in the address string
+ * @param {boolean} [options.includePostalCode=false] Whether to include the
+ * postal code in the address string
+ * @returns The address as a one line string, or an empty string if none of the
+ * requested fields is available
+ */
+const getAddressOneLine = (
+    obj: PlaceAddress,
+    {
+        includeRegion = false,
+        includeCountry = false,
+        includePostalCode = false
+    }: { includeRegion?: boolean; includeCountry?: boolean; includePostalCode?: boolean } = {}
+): string => {
+    if (!obj) {
+        return '';
+    }
+    const addressParts: string[] = [];
+    if (typeof obj.address === 'string' && !_isBlank(obj.address.trim())) {
+        addressParts.push(obj.address.trim());
+    }
+    if (typeof obj.city === 'string' && !_isBlank(obj.city.trim())) {
+        const cityString = obj.city.trim();
+        addressParts.push(cityString[0].toUpperCase() + cityString.substring(1));
+    }
+    if (includeRegion && typeof obj.region === 'string' && !_isBlank(obj.region.trim())) {
+        addressParts.push(obj.region.trim());
+    }
+    if (includeCountry && typeof obj.country === 'string' && !_isBlank(obj.country.trim())) {
+        addressParts.push(obj.country.trim());
+    }
+    if (includePostalCode && typeof obj.postalCode === 'string' && !_isBlank(obj.postalCode.trim())) {
+        addressParts.push(obj.postalCode.trim().toUpperCase());
+    }
+    return _escape(addressParts.join(', '));
+};
+
+/**
+ * Return the home address as a one line html-safe string, including all the
+ * requested parts
+ *
+ * @param options Options for which parts of the address to include
+ * @param {UserInterviewAttributes} options.interview The interview object
+ * @param {boolean} [options.includeRegion=false] Whether to include the region
+ * in the address string
+ * @param {boolean} [options.includeCountry=false] Whether to include the
+ * country in the address string
+ * @param {boolean} [options.includePostalCode=false] Whether to include the
+ * postal code in the address string
+ * @returns The home address as a one line string, or an empty string if the
+ * home address is not available
+ */
+export const getHomeAddressOneLine = ({
+    interview,
+    includeRegion = false,
+    includeCountry = false,
+    includePostalCode = false
+}: {
+    interview: UserInterviewAttributes;
+    includeRegion?: boolean;
+    includeCountry?: boolean;
+    includePostalCode?: boolean;
+}): string => {
+    const homeObj = getResponse(interview, 'home', undefined);
+    return homeObj !== undefined
+        ? getAddressOneLine(homeObj as PlaceAddress, { includeRegion, includeCountry, includePostalCode })
+        : '';
 };
 
 /* Various functions related to a person's occupation */

--- a/packages/evolution-common/src/services/odSurvey/helpers.ts
+++ b/packages/evolution-common/src/services/odSurvey/helpers.ts
@@ -758,10 +758,10 @@ export const getVisitedPlaceName = function ({
             ? getResponse(interview, visitedPlace.shortcut, null)
             : visitedPlace;
     if (actualVisitedPlace && (actualVisitedPlace as VisitedPlace).name) {
-        return (actualVisitedPlace as VisitedPlace).name as string;
+        return _escape((actualVisitedPlace as VisitedPlace).name as string);
     }
 
-    return `${t('survey:placeGeneric')} ${visitedPlace._sequence}`;
+    return t('survey:placeWithSequenceGeneric', { sequence: visitedPlace._sequence });
 };
 
 /**

--- a/packages/evolution-common/src/services/questionnaire/sections/types.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/types.ts
@@ -54,10 +54,17 @@ export type WidgetFactoryOptions = {
     /**
      * Formats a date string to a display string, in the appropriate format. The
      * frontend will provide this function.
-     * @param date The date string to format
-     * @returns The formatted date string
+     * @param date The date string, formatted YYYY-MM-DD
+     * @param options The options
+     * @param {boolean} [options.withRelative] Whether to add a relative date (eg. yesterday, day before yesterday)
+     * @param {string} [options.locale] The locale to use or undefined to use the default locale
+     * @param {boolean} [options.withDayOfWeek] Whether to add the day of the week
+     * @returns
      */
-    getFormattedDate: (date: string) => string;
+    getFormattedDate: (
+        date: string,
+        options?: { withRelative?: boolean; locale?: string; withDayOfWeek?: boolean }
+    ) => string;
     /**
      * Actions for buttons that may be used in widgets. These often contain
      * frontend code, so they can be mapped to each button action when creating

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/helpers.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/helpers.test.ts
@@ -12,23 +12,29 @@ import { setResponse } from '../../../../../utils/helpers';
 import * as helpers from '../helpers';
 import { VisitedPlacesSectionConfiguration } from '../../../types';
 
+const defaultVisitedPlaceConfig = {
+    type: 'visitedPlaces' as const,
+    enabled: true,
+    tripDiaryMinTimeOfDay: 4 * 60 * 60, // 4h in seconds
+    tripDiaryMaxTimeOfDay: 28 * 60 * 60 // 28h in seconds (i.e. 4h the next day)
+}
+
 describe('Visited places helpers - activity/activityCategory filtering', () => {
     test('getFilteredActivities should return no activities when section is disabled', () => {
-        const visitedPlacesConfig = { type: 'visitedPlaces' as const, enabled: false };
+        const visitedPlacesConfig = { ...defaultVisitedPlaceConfig, enabled: false };
         const filteredActivities = helpers.getFilteredActivities(visitedPlacesConfig);
         expect(filteredActivities).toEqual([]);
     });
 
     test('getFilteredActivities should return all activities when section is enabled without restrictions', () => {
-        const visitedPlacesConfig = { type: 'visitedPlaces' as const, enabled: true };
+        const visitedPlacesConfig = { ...defaultVisitedPlaceConfig };
         const filteredActivities = helpers.getFilteredActivities(visitedPlacesConfig);
         expect(filteredActivities).toEqual(activityValues);
     });
 
     test('getFilteredActivities should filter with activitiesIncludeOnly and keep entered order', () => {
         const visitedPlacesConfig: VisitedPlacesSectionConfiguration = {
-            type: 'visitedPlaces' as const,
-            enabled: true,
+            ...defaultVisitedPlaceConfig,
             activitiesIncludeOnly: ['shopping', 'workUsual', 'dontKnow']
         };
         const filteredActivities = helpers.getFilteredActivities(visitedPlacesConfig);
@@ -38,8 +44,7 @@ describe('Visited places helpers - activity/activityCategory filtering', () => {
 
     test('getFilteredActivities should filter with activityExclude', () => {
         const visitedPlacesConfig: VisitedPlacesSectionConfiguration = {
-            type: 'visitedPlaces' as const,
-            enabled: true,
+            ...defaultVisitedPlaceConfig,
             activityExclude: ['other', 'dontKnow', 'preferNotToAnswer']
         };
         const filteredActivities = helpers.getFilteredActivities(visitedPlacesConfig);
@@ -54,8 +59,7 @@ describe('Visited places helpers - activity/activityCategory filtering', () => {
 
     test('getFilteredActivities should filter with activitiesIncludeOnly and keep entered order and ignore excluded ones', () => {
         const visitedPlacesConfig: VisitedPlacesSectionConfiguration = {
-            type: 'visitedPlaces' as const,
-            enabled: true,
+            ...defaultVisitedPlaceConfig,
             activitiesIncludeOnly: ['shopping', 'workUsual', 'dontKnow'],
             activityExclude: ['dontKnow'] // This should be ignored since dontKnow is in the include list
         };
@@ -71,8 +75,7 @@ describe('Visited places helpers - activity/activityCategory filtering', () => {
 
     test('getFilteredActivities should ignore non-existent activities in activitiesIncludeOnly', () => {
         const visitedPlacesConfig: VisitedPlacesSectionConfiguration = {
-            type: 'visitedPlaces' as const,
-            enabled: true,
+            ...defaultVisitedPlaceConfig,
             activitiesIncludeOnly: ['shopping', 'nonExistentActivity' as any, 'workUsual'] as any
         };
         const filteredActivities = helpers.getFilteredActivities(visitedPlacesConfig);

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/index.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/index.test.ts
@@ -12,7 +12,9 @@ import { WidgetConfig, VisitedPlacesSectionConfiguration, QuestionWidgetConfig, 
 
 const visitedPlacesSectionConfig: VisitedPlacesSectionConfiguration = {
     type: 'visitedPlaces' as const,
-    enabled: true
+    enabled: true,
+    tripDiaryMinTimeOfDay: 4 * 60 * 60, // 4h in seconds
+    tripDiaryMaxTimeOfDay: 28 * 60 * 60 // 28h in seconds (i.e. 4h the next day)
 };
 
 describe('ActivityWidgetFactory', () => {
@@ -49,7 +51,7 @@ describe('ActivityWidgetFactory', () => {
 
         test('should throw when section is disabled and no activities available', () => {
             const disabledConfig: VisitedPlacesSectionConfiguration = {
-                type: 'visitedPlaces',
+                ...visitedPlacesSectionConfig,
                 enabled: false
             };
             const factory = new ActivityWidgetFactory(disabledConfig, widgetFactoryOptions);
@@ -59,8 +61,7 @@ describe('ActivityWidgetFactory', () => {
 
         test('should respect activities filter in returned configs', () => {
             const filteredConfig: VisitedPlacesSectionConfiguration = {
-                type: 'visitedPlaces',
-                enabled: true,
+                ...visitedPlacesSectionConfig,
                 activitiesIncludeOnly: ['home', 'workUsual', 'shopping']
             };
             const factory = new ActivityWidgetFactory(filteredConfig, widgetFactoryOptions);
@@ -78,8 +79,7 @@ describe('ActivityWidgetFactory', () => {
 
         test('should respect activities exclude in returned configs', () => {
             const excludeConfig: VisitedPlacesSectionConfiguration = {
-                type: 'visitedPlaces',
-                enabled: true,
+                ...visitedPlacesSectionConfig,
                 activityExclude: ['dontKnow', 'preferNotToAnswer']
             };
             const factory = new ActivityWidgetFactory(excludeConfig, widgetFactoryOptions);
@@ -99,13 +99,11 @@ describe('ActivityWidgetFactory', () => {
     describe('multiple instances', () => {
         test('should create independent instances with different configs', () => {
             const config1: VisitedPlacesSectionConfiguration = {
-                type: 'visitedPlaces',
-                enabled: true,
+                ...visitedPlacesSectionConfig,
                 activitiesIncludeOnly: ['home', 'shopping']
             };
             const config2: VisitedPlacesSectionConfiguration = {
-                type: 'visitedPlaces',
-                enabled: true,
+                ...visitedPlacesSectionConfig,
                 activitiesIncludeOnly: ['workUsual', 'schoolUsual']
             };
 

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetActivity.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetActivity.test.ts
@@ -20,7 +20,9 @@ import { getActivityWidgetConfig } from '../widgetActivity';
 
 const visitedPlacesSectionConfig = {
     type: 'visitedPlaces' as const,
-    enabled: true
+    enabled: true,
+    tripDiaryMinTimeOfDay: 4 * 60 * 60, // 4h in seconds
+    tripDiaryMaxTimeOfDay: 28 * 60 * 60 // 28h in seconds (i.e. 4h the next day)
 };
 
 const setActiveVisitedPlace = (
@@ -63,7 +65,7 @@ describe('getActivityWidgetConfig', () => {
         expect(() =>
             getActivityWidgetConfig(
                 {
-                    type: 'visitedPlaces',
+                    ...visitedPlacesSectionConfig,
                     enabled: false
                 },
                 widgetFactoryOptions

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetActivityCategory.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetActivityCategory.test.ts
@@ -14,7 +14,9 @@ import { getActivityCategoryWidgetConfig } from '../widgetActivityCategory';
 
 const visitedPlacesSectionConfig = {
 	type: 'visitedPlaces' as const,
-	enabled: true
+	enabled: true,
+    tripDiaryMinTimeOfDay: 4 * 60 * 60, // 4h in seconds
+    tripDiaryMaxTimeOfDay: 28 * 60 * 60 // 28h in seconds (i.e. 4h the next day)
 };
 
 const setActiveVisitedPlace = (

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetNextPlaceCategory.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetNextPlaceCategory.test.ts
@@ -1,0 +1,362 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import _cloneDeep from 'lodash/cloneDeep';
+import each from 'jest-each';
+import { InputRadioType, QuestionWidgetConfig, RadioChoiceType } from '../../../../questionnaire/types';
+import { interviewAttributesForTestCases, widgetFactoryOptions } from '../../../../../tests/surveys';
+import { setResponse, translateString } from '../../../../../utils/helpers';
+import * as odHelpers from '../../../../odSurvey/helpers';
+import { getNextPlaceCategoryWidgetConfig } from '../widgetNextPlaceCategory';
+
+const visitedPlacesSectionConfig = {
+    type: 'visitedPlaces' as const,
+    enabled: true,
+    tripDiaryMinTimeOfDay: 4 * 60 * 60, // 4 AM in seconds
+    tripDiaryMaxTimeOfDay: 28 * 60 * 60 // 4 AM the next day, in seconds
+};
+
+const setActiveVisitedPlace = (
+    interview: typeof interviewAttributesForTestCases,
+    personId: string | undefined,
+    journeyId: string | undefined,
+    visitedPlaceId: string | undefined
+) => {
+    setResponse(interview, '_activePersonId', personId);
+    setResponse(interview, '_activeJourneyId', journeyId);
+    setResponse(interview, '_activeVisitedPlaceId', visitedPlaceId);
+};
+
+describe('getNextPlaceCategoryWidgetConfig', () => {
+    test('should return the correct widget config', () => {
+        const widgetConfig = getNextPlaceCategoryWidgetConfig(visitedPlacesSectionConfig, widgetFactoryOptions);
+
+        expect(widgetConfig).toEqual({
+            type: 'question',
+            inputType: 'radio',
+            path: 'nextPlaceCategory',
+            datatype: 'string',
+            twoColumns: false,
+            sameLine: false,
+            containsHtml: true,
+            label: expect.any(Function),
+            choices: expect.any(Array),
+            validations: expect.any(Function),
+            conditional: expect.any(Function)
+        });
+    });
+
+    test('should have 4 choice options', () => {
+        const widgetConfig = getNextPlaceCategoryWidgetConfig(
+            visitedPlacesSectionConfig,
+            widgetFactoryOptions
+        ) as QuestionWidgetConfig & InputRadioType;
+
+        expect(widgetConfig.choices).toHaveLength(4);
+        const choiceValues = (widgetConfig.choices as RadioChoiceType[]).map((c) => c.value);
+        expect(choiceValues).toContain('wentBackHome');
+        expect(choiceValues).toContain('visitedAnotherPlace');
+        expect(choiceValues).toContain('stayedThereUntilTheNextDay');
+        expect(choiceValues).toContain('wentToUsualWorkPlace');
+    });
+});
+
+describe('NextPlaceCategory choices conditionals', () => {
+    const widgetConfig = getNextPlaceCategoryWidgetConfig(
+        visitedPlacesSectionConfig,
+        widgetFactoryOptions
+    ) as QuestionWidgetConfig & InputRadioType;
+    const choices = widgetConfig.choices as RadioChoiceType[];
+
+    test('wentBackHome conditional should return false when active place is home', () => {
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'homePlace1P1');
+
+        const wentBackHomeChoice = choices.find((c) => c.value === 'wentBackHome');
+        expect(wentBackHomeChoice).toBeDefined();
+        expect(
+            wentBackHomeChoice?.conditional?.(
+                interview,
+                'household.persons.personId1.journeys.journeyId1.visitedPlaces.homePlace1P1.nextPlaceCategory'
+            )
+        ).toEqual(false);
+    });
+
+    test('wentBackHome conditional should return false when active place is workOnTheRoad', () => {
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'workPlace1P1');
+        const visitedPlace = interview.response.household!.persons!.personId1!.journeys!.journeyId1!
+            .visitedPlaces!.workPlace1P1;
+        (visitedPlace as any).activity = 'workOnTheRoad';
+
+        const wentBackHomeChoice = choices.find((c) => c.value === 'wentBackHome');
+        expect(wentBackHomeChoice).toBeDefined();
+        expect(
+            wentBackHomeChoice?.conditional?.(
+                interview,
+                'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.nextPlaceCategory'
+            )
+        ).toEqual(false);
+    });
+
+    test('wentBackHome conditional should return true when active place is not home or workOnTheRoad', () => {
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'workPlace1P1');
+
+        const wentBackHomeChoice = choices.find((c) => c.value === 'wentBackHome');
+        expect(wentBackHomeChoice).toBeDefined();
+        expect(
+            wentBackHomeChoice?.conditional?.(
+                interview,
+                'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.nextPlaceCategory'
+            )
+        ).toEqual(true);
+    });
+
+    test.each([
+        ['not last place', false, 'homePlace1P1'],
+        ['last place', true, 'otherPlace2P1']
+    ])('stayedThereUntilTheNextDay conditional: case %s should return %s for place %s', (_, expected, placeUuid) => {
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        const stayedChoice = (choices as RadioChoiceType[]).find((c) => c.value === 'stayedThereUntilTheNextDay');
+
+        // Test the requested place
+        setActiveVisitedPlace(interview, 'personId1', 'journeyId1', placeUuid);
+        expect(stayedChoice).toBeDefined();
+        expect(
+            stayedChoice?.conditional?.(
+                interview,
+                `household.persons.personId1.journeys.journeyId1.visitedPlaces.${placeUuid}.nextPlaceCategory`
+            )
+        ).toEqual(expected);
+
+    });
+});
+
+describe('NextPlaceCategory choices labels', () => {
+    const widgetConfig = getNextPlaceCategoryWidgetConfig(
+        visitedPlacesSectionConfig,
+        widgetFactoryOptions
+    ) as QuestionWidgetConfig & InputRadioType;
+    const choices = widgetConfig.choices as RadioChoiceType[];
+    let interview = _cloneDeep(interviewAttributesForTestCases);
+
+    beforeEach(() => {
+        interview = _cloneDeep(interviewAttributesForTestCases);
+        setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'workPlace1P1');
+    });
+
+    test('wentBackHome label should include home address', () => {
+        const mockedT = jest.fn();
+        const wentBackHomeChoice = choices.find((c) => c.value === 'wentBackHome');
+        expect(wentBackHomeChoice).toBeDefined();
+
+        translateString(wentBackHomeChoice?.label, { t: mockedT } as any, interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.nextPlaceCategory');
+        expect(mockedT).toHaveBeenCalledWith(
+            'visitedPlaces:nextPlaceRadioChoices.wentBackHome',
+            expect.objectContaining({
+                address: '1234 Main St, Montreal',
+                context: undefined
+            })
+        );
+    });
+
+    test('visitedAnotherPlace label should be called with correct key', () => {
+        const mockedT = jest.fn();
+        const visitedAnotherChoice = choices.find((c) => c.value === 'visitedAnotherPlace');
+        expect(visitedAnotherChoice).toBeDefined();
+
+        translateString(visitedAnotherChoice?.label, { t: mockedT } as any, interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.nextPlaceCategory');
+        expect(mockedT).toHaveBeenCalledWith(
+            'visitedPlaces:nextPlaceRadioChoices.visitedAnotherPlace',
+            expect.objectContaining({
+                context: undefined
+            })
+        );
+    });
+
+    test.each([
+        ['home', 'homePlace1P1', 'visitedPlaces:nextPlaceRadioChoices.stayedHomeUntilTheNextDay'],
+        ['other', 'workPlace1P1', 'visitedPlaces:nextPlaceRadioChoices.stayedThereUntilTheNextDay']
+    ])('stayedThereUntilTheNextDay label should be called with right label when activity is %s', (_, placeUuid, expectedKey) => {
+        const mockedT = jest.fn();
+        
+        const stayedChoice = (choices as RadioChoiceType[]).find((c) => c.value === 'stayedThereUntilTheNextDay');
+        expect(stayedChoice).toBeDefined();
+
+        translateString(stayedChoice?.label, { t: mockedT } as any, interview, `household.persons.personId1.journeys.journeyId1.visitedPlaces.${placeUuid}.nextPlaceCategory`);
+        expect(mockedT).toHaveBeenCalledWith(
+            expectedKey,
+            expect.objectContaining({
+                context: undefined
+            })
+        );
+    });
+
+    test('wentToUsualWorkPlace should be hidden', () => {
+        const wentToUsualWorkChoice = choices.find((c) => c.value === 'wentToUsualWorkPlace');
+        expect(wentToUsualWorkChoice).toBeDefined();
+        expect(wentToUsualWorkChoice?.hidden).toEqual(true);
+    });
+});
+
+describe('NextPlaceCategory widget label', () => {
+    const widgetConfig = getNextPlaceCategoryWidgetConfig(
+        visitedPlacesSectionConfig,
+        widgetFactoryOptions
+    ) as QuestionWidgetConfig & InputRadioType;
+    const label = widgetConfig.label;
+    let interview = _cloneDeep(interviewAttributesForTestCases);
+    const mockedT = jest.fn().mockImplementation((str) => str);
+
+    beforeEach(() => {
+        interview = _cloneDeep(interviewAttributesForTestCases);
+        jest.clearAllMocks();
+        setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'workPlace1P1');
+    });
+
+    test('should call translation function with correct key and context', () => {
+        translateString(label, { t: mockedT } as any, interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.nextPlaceCategory');
+        expect(mockedT).toHaveBeenCalledWith(
+            'visitedPlaces:nextPlaceCategory',
+            expect.objectContaining({
+                context: undefined,
+                nickname: expect.any(String),
+                atPlace: expect.any(String),
+                count: expect.any(Number)
+            })
+        );
+    });
+
+    test('should throw error if active person is missing', () => {
+        setResponse(interview, '_activePersonId', null);
+
+        expect(() =>
+            translateString(label, { t: mockedT } as any, interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.nextPlaceCategory')
+        ).toThrow('Active person or visited place not found in interview response');
+    });
+
+    test('should use visited place name in atPlace when name exists', () => {
+        translateString(label, { t: mockedT } as any, interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.nextPlaceCategory');
+        expect(mockedT).toHaveBeenCalledWith('survey:atPlace', expect.objectContaining({
+            placeName: expect.any(String)
+        }));
+    });
+});
+
+describe('NextPlaceCategory validations', () => {
+    const widgetConfig = getNextPlaceCategoryWidgetConfig(
+        visitedPlacesSectionConfig,
+        widgetFactoryOptions
+    ) as QuestionWidgetConfig & InputRadioType;
+    const validations = widgetConfig.validations;
+    const interview = _cloneDeep(interviewAttributesForTestCases);
+
+    test('should return error when value is blank', () => {
+        expect(validations!(undefined, null, interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.nextPlaceCategory')).toEqual([
+            {
+                validation: true,
+                errorMessage: expect.any(Object)
+            }
+        ]);
+    });
+
+    test('should return no error when value is set', () => {
+        const validation = validations!('wentBackHome', null, interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.nextPlaceCategory');
+        expect(validation).toEqual([
+            {
+                validation: false,
+                errorMessage: expect.any(Object)
+            }
+        ]);
+    });
+});
+
+describe('NextPlaceCategory widget conditional', () => {
+    const widgetConfig = getNextPlaceCategoryWidgetConfig(
+        visitedPlacesSectionConfig,
+        widgetFactoryOptions
+    ) as QuestionWidgetConfig & InputRadioType;
+    const conditional = widgetConfig.conditional;
+    let interview = _cloneDeep(interviewAttributesForTestCases);
+
+    beforeEach(() => {
+        interview = _cloneDeep(interviewAttributesForTestCases);
+        // By default, set the last place as active
+        setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'otherPlace2P1');
+    });
+
+    test('should return auto-filled stayedThereUntilTheNextDay when arrival time equals max time of day', () => {
+        const visitedPlace = interview.response.household!.persons!.personId1!.journeys!.journeyId1!
+            .visitedPlaces!.otherPlace2P1;
+        (visitedPlace as any).arrivalTime = visitedPlacesSectionConfig.tripDiaryMaxTimeOfDay;
+
+        expect(conditional?.(interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.otherPlace2P1.nextPlaceCategory')).toEqual([
+            false,
+            'stayedThereUntilTheNextDay'
+        ]);
+    });
+
+    test('should return auto-filled stayedThereUntilTheNextDay for loop activity with onTheRoadArrivalType to stayed there', () => {
+        const visitedPlace = interview.response.household!.persons!.personId1!.journeys!.journeyId1!
+            .visitedPlaces!.otherPlace2P1;
+        (visitedPlace as any).activity = 'workOnTheRoad';
+        (visitedPlace as any).activityCategory = 'work';
+        (visitedPlace as any).onTheRoadArrivalType = 'stayedThereUntilTheNextDay';
+
+        setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'otherPlace2P1');
+        expect(
+            conditional?.(interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.otherPlace2P1.nextPlaceCategory')
+        ).toEqual([false, 'stayedThereUntilTheNextDay']);
+    });
+
+    test('should hide widget when no activity is set', () => {
+        const visitedPlace = interview.response.household!.persons!.personId1!.journeys!.journeyId1!
+            .visitedPlaces!.otherPlace2P1;
+        delete (visitedPlace as any).activity;
+
+        expect(
+            conditional?.(interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.otherPlace2P1.nextPlaceCategory')
+        ).toEqual([false, null]);
+    });
+
+    test('should hide widget when active place is not the last', () => {
+        setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'homePlace1P1');
+        expect(
+            conditional?.(interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.homePlace1P1.nextPlaceCategory')
+        ).toEqual([false, null]);
+    });
+
+    test('should hide widget when last place is workOnTheRoad', () => {
+       const visitedPlace = interview.response.household!.persons!.personId1!.journeys!.journeyId1!
+            .visitedPlaces!.otherPlace2P1;
+        (visitedPlace as any).activity = 'workOnTheRoad';
+
+        expect(
+            conditional?.(interview, `household.persons.personId1.journeys.journeyId1.visitedPlaces.${visitedPlace._uuid}.nextPlaceCategory`)
+        ).toEqual([false, null]);
+    });
+
+    each([
+        ['work', 'workUsual'],
+        ['shopping', 'shopping'],
+        ['leisure', 'leisureStroll']
+    ]).test(
+        'should show widget when last place has activity %s and is not workOnTheRoad',
+        (_title, activity) => {
+            const journey = interview.response.household!.persons!.personId1!.journeys!.journeyId1!;
+            const visitedPlacesArray = odHelpers.getVisitedPlacesArray({ journey });
+            const lastPlace = visitedPlacesArray[visitedPlacesArray.length - 1];
+
+            setActiveVisitedPlace(interview, 'personId1', 'journeyId1', lastPlace._uuid);
+            (lastPlace as any).activity = activity;
+
+            expect(
+                conditional?.(interview, `household.persons.personId1.journeys.journeyId1.visitedPlaces.${lastPlace._uuid}.nextPlaceCategory`)
+            ).toEqual([true, null]);
+        }
+    );
+});

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetPersonVisitedPlaceTitle.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetPersonVisitedPlaceTitle.test.ts
@@ -12,7 +12,9 @@ const mockGetFormattedDate = widgetFactoryOptions.getFormattedDate as jest.Mocke
 
 const visitedPlacesSectionConfig = {
     type: 'visitedPlaces' as const,
-    enabled: true
+    enabled: true,
+    tripDiaryMinTimeOfDay: 4 * 60 * 60, // 4h in seconds
+    tripDiaryMaxTimeOfDay: 28 * 60 * 60 // 28h in seconds (i.e. 4h the next day)
 };
 
 const setActiveJourney = (

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetPersonVisitedPlaceTitle.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetPersonVisitedPlaceTitle.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import _cloneDeep from 'lodash/cloneDeep';
+import { getPersonVisitedPlacesTitleWidgetConfig } from '../widgetPersonVisitedPlacesTitle';
+import { interviewAttributesForTestCases, widgetFactoryOptions } from '../../../../../tests/surveys';
+
+const mockGetFormattedDate = widgetFactoryOptions.getFormattedDate as jest.MockedFunction<typeof widgetFactoryOptions.getFormattedDate>;
+
+const visitedPlacesSectionConfig = {
+    type: 'visitedPlaces' as const,
+    enabled: true
+};
+
+const setActiveJourney = (
+    interview: typeof interviewAttributesForTestCases,
+    personId: string | undefined,
+    journeyId: string | undefined
+) => {
+    interview.response._activePersonId = personId;
+    interview.response._activeJourneyId = journeyId;
+};
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+describe('getPersonVisitedPlacesTitleWidgetConfig', () => {
+    it('should return the correct widget config', () => {
+
+        const widgetConfig = getPersonVisitedPlacesTitleWidgetConfig(visitedPlacesSectionConfig, widgetFactoryOptions);
+
+        expect(widgetConfig).toEqual({
+            type: 'text',
+            align: 'left',
+            containsHtml: true,
+            text: expect.any(Function)
+        });
+    });
+});
+
+describe('personsTripsTitleWidgetConfig text', () => {
+
+    const widgetText = getPersonVisitedPlacesTitleWidgetConfig(visitedPlacesSectionConfig, widgetFactoryOptions).text as any;
+    // Mock the translation function to just return the key for easier testing of parameters
+    const mockedT = jest.fn().mockImplementation((str: any) => str);
+    // Extract the journey date for use in expected parameters in tests
+    const journeyDate = interviewAttributesForTestCases.response.household!.persons!.personId1.journeys!.journeyId1.startDate;
+   
+    test('should call translation with correct parameters if no active journey', () => {
+        const testInterview = _cloneDeep(interviewAttributesForTestCases);
+        setActiveJourney(testInterview, 'personId1', undefined);
+        expect(() => widgetText(mockedT, testInterview, 'path')).toThrow('Active person or journey not found in interview response');
+        expect(mockedT).not.toHaveBeenCalled();
+        expect(widgetFactoryOptions.getFormattedDate).not.toHaveBeenCalled();
+    });
+
+    test('should call translation with correct parameters if one person household and no journey dates', () => {
+        const testInterview = _cloneDeep(interviewAttributesForTestCases);
+        setActiveJourney(testInterview, 'personId1', 'journeyId1');
+        // Delete other persons
+        delete testInterview.response.household!.persons!.personId2;
+        delete testInterview.response.household!.persons!.personId3;
+        expect(widgetText(mockedT, testInterview, 'path')).toEqual('visitedPlaces:personVisitedPlacesTitle');
+        expect(mockedT).toHaveBeenCalledWith('visitedPlaces:personVisitedPlacesTitle', {
+            context: undefined,
+            count: 1,
+            nickname: 'survey:personWithSequenceAndAge', // Default nickname for person without one
+            journeyDate
+        });
+        expect(widgetFactoryOptions.getFormattedDate).toHaveBeenCalledWith(
+            journeyDate,
+            { withDayOfWeek: true, withRelative: true }
+        );
+    });
+
+    test('should call translation with correct parameters if multiple person household and journey with start date', () => {
+        const testInterview = _cloneDeep(interviewAttributesForTestCases);
+        setActiveJourney(testInterview, 'personId1', 'journeyId1');
+        // Set a nickname for the person
+        testInterview.response.household!.persons!.personId1.nickname = 'Jane';
+
+        expect(widgetText(mockedT, testInterview, 'path')).toEqual('visitedPlaces:personVisitedPlacesTitle');
+        expect(mockedT).toHaveBeenCalledWith('visitedPlaces:personVisitedPlacesTitle', {
+            context: undefined,
+            count: 3,
+            nickname: 'Jane',
+            journeyDate
+        });
+        expect(widgetFactoryOptions.getFormattedDate).toHaveBeenCalledWith(
+            journeyDate,
+            { withDayOfWeek: true, withRelative: true }
+        );
+    });
+});

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetsGeography.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetsGeography.test.ts
@@ -18,7 +18,9 @@ import { homeGeographyCoordinates, shoppingPlace1P2Coordinates } from '../../../
 
 const visitedPlacesSectionConfig = {
     type: 'visitedPlaces' as const,
-    enabled: true
+    enabled: true,
+    tripDiaryMinTimeOfDay: 4 * 60 * 60, // 4h in seconds
+    tripDiaryMaxTimeOfDay: 28 * 60 * 60 // 28h in seconds (i.e. 4h the next day)
 };
 
 const setActiveVisitedPlace = (

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetNextPlaceCategory.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetNextPlaceCategory.ts
@@ -1,0 +1,166 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import _escape from 'lodash/escape';
+import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
+import type {
+    Journey,
+    RadioChoiceType,
+    VisitedPlace,
+    VisitedPlacesSectionConfiguration,
+    WidgetConfig
+} from '../../../questionnaire/types';
+import type { TFunction } from 'i18next';
+import { requiredValidation } from '../../../widgets/validations/validations';
+import * as odHelpers from '../../../odSurvey/helpers';
+import type { WidgetFactoryOptions } from '../types';
+import { getResponse } from '../../../../utils/helpers';
+
+const nextPlaceCategoryChoices: RadioChoiceType[] = [
+    {
+        value: 'wentBackHome',
+        label: (t: TFunction, interview) => {
+            const person = odHelpers.getActivePerson({ interview });
+            const homeAddress = odHelpers.getHomeAddressOneLine({ interview });
+            return t('visitedPlaces:nextPlaceRadioChoices.wentBackHome', {
+                address: homeAddress,
+                context: odHelpers.getPersonGenderContext({ person: person! })
+            });
+        },
+        conditional: function (interview, path) {
+            const activeVisitedPlace = getResponse(interview, path, undefined, '../') as VisitedPlace;
+            // Do not show if the current place is already home or work on the road (for work on the road trips)
+            // FIXME Work on the road has different questions that we do not yet manage in the builtin questionnaire. Revisit when we support that
+            return activeVisitedPlace.activity !== 'home' && activeVisitedPlace.activity !== 'workOnTheRoad';
+        }
+    },
+    {
+        value: 'visitedAnotherPlace',
+        label: (t: TFunction, interview) => {
+            const person = odHelpers.getActivePerson({ interview });
+            return t('visitedPlaces:nextPlaceRadioChoices.visitedAnotherPlace', {
+                context: odHelpers.getPersonGenderContext({ person: person! })
+            });
+        }
+    },
+    {
+        value: 'stayedThereUntilTheNextDay',
+        label: (t: TFunction, interview, path) => {
+            const person = odHelpers.getActivePerson({ interview });
+            const activeVisitedPlace = getResponse(interview, path, undefined, '../') as VisitedPlace;
+            if (activeVisitedPlace.activityCategory === 'home') {
+                return t('visitedPlaces:nextPlaceRadioChoices.stayedHomeUntilTheNextDay', {
+                    context: odHelpers.getPersonGenderContext({ person: person! })
+                });
+            } else {
+                return t('visitedPlaces:nextPlaceRadioChoices.stayedThereUntilTheNextDay', {
+                    context: odHelpers.getPersonGenderContext({ person: person! })
+                });
+            }
+        },
+        conditional: function (interview, path) {
+            const journey = odHelpers.getActiveJourney({ interview });
+            if (!journey) {
+                throw new Error('Active journey not found in interview response');
+            }
+            const activeVisitedPlace = getResponse(interview, path, undefined, '../') as VisitedPlace;
+            const visitedPlacesArray = odHelpers.getVisitedPlacesArray({ journey });
+            // Display only if the current visited place is the last one in the
+            // list and there is more than one visited place (otherwise, the
+            // person did not make any trips, as the first place is where they
+            // were at the beginning of the day)
+            return (
+                visitedPlacesArray.length > 1 &&
+                visitedPlacesArray[visitedPlacesArray.length - 1]._uuid === activeVisitedPlace._uuid
+            );
+        }
+    },
+    {
+        label: '',
+        value: 'wentToUsualWorkPlace',
+        hidden: true // used for workOnTheRoad trips only, imputed
+    }
+];
+
+/**
+ * Get the next place category widget configuration for the visited place
+ * section.
+ *
+ * @param {VisitedPlacesSectionConfiguration} sectionConfig
+ * @param {WidgetFactoryOptions} _options
+ * @returns {WidgetConfig} The configuration for the next place activity widget
+ */
+export const getNextPlaceCategoryWidgetConfig = (
+    sectionConfig: VisitedPlacesSectionConfiguration,
+    _options: WidgetFactoryOptions
+): WidgetConfig => ({
+    type: 'question',
+    inputType: 'radio',
+    path: 'nextPlaceCategory',
+    datatype: 'string',
+    twoColumns: false,
+    sameLine: false,
+    containsHtml: true,
+    label: (t: TFunction, interview, path) => {
+        const person = odHelpers.getActivePerson({ interview });
+        const activeVisitedPlace = getResponse(interview, path, undefined, '../') as VisitedPlace;
+        if (!person || !activeVisitedPlace) {
+            throw new Error('Active person or visited place not found in interview response');
+        }
+        // Escape the visited place name. Do not use the `getVisitedPlaceName`
+        // helper as it will return a translated name if not set and we want to
+        // use our own custom name for the place here.
+        const visitedPlaceName = activeVisitedPlace?.name;
+        const atPlace = !_isBlank(visitedPlaceName)
+            ? t('survey:atPlace', { placeName: _escape(visitedPlaceName) })
+            : t('survey:atThisPlace', { context: activeVisitedPlace.activity });
+        return t('visitedPlaces:nextPlaceCategory', {
+            context: odHelpers.getPersonGenderContext({ person }),
+            nickname: odHelpers.getPersonIdentificationString({ person, t }),
+            atPlace,
+            count: odHelpers.getCountOrSelfDeclared({ interview, person })
+        });
+    },
+    choices: nextPlaceCategoryChoices,
+    validations: requiredValidation,
+    conditional: function (interview, path) {
+        const journey = odHelpers.getActiveJourney({ interview }) as Journey;
+        const activeVisitedPlace = getResponse(interview, path, undefined, '../') as VisitedPlace;
+        const visitedPlacesArray = odHelpers.getVisitedPlacesArray({ journey });
+        // If the arrival time of the visited place is exactly at the max time
+        // of day for the trip diary, we can assume that the person stayed there
+        // until the next day, even if they did not explicitly say it (we ask
+        // this question in that case to confirm and get the right category, but
+        // we can already hide the other options)
+        if (
+            typeof activeVisitedPlace.arrivalTime === 'number' &&
+            activeVisitedPlace.arrivalTime === sectionConfig.tripDiaryMaxTimeOfDay
+        ) {
+            return [false, 'stayedThereUntilTheNextDay'];
+        }
+        // If the arrival type of the work on the road is
+        // stayedThereUntilTheNextDay, we can also assume that the person stayed
+        // there until the next day, even if they did not explicitly say it
+        if (
+            odHelpers.isLoopActivity({ visitedPlace: activeVisitedPlace }) &&
+            (activeVisitedPlace as any).onTheRoadArrivalType === 'stayedThereUntilTheNextDay'
+        ) {
+            return [false, 'stayedThereUntilTheNextDay'];
+        }
+        // Show the question if there is an activity that is not workOnTheRoad
+        // and it is the last visited place
+        if (
+            !_isBlank(activeVisitedPlace.activity) &&
+            visitedPlacesArray[visitedPlacesArray.length - 1]._uuid === activeVisitedPlace._uuid &&
+            activeVisitedPlace.activity !== 'workOnTheRoad'
+        ) {
+            // last visited place and not work on the road
+            return [true, null];
+        }
+        // Do not show otherwise
+        return [false, null];
+    }
+});

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetPersonVisitedPlacesTitle.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetPersonVisitedPlacesTitle.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { TextWidgetConfig, VisitedPlacesSectionConfiguration } from '../../types';
+import * as odHelpers from '../../../odSurvey/helpers';
+import { TFunction } from 'i18next';
+import { UserInterviewAttributes } from '../../types';
+import { WidgetFactoryOptions } from '../types';
+import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
+
+export const getPersonVisitedPlacesTitleWidgetConfig = (
+    _sectionConfig: VisitedPlacesSectionConfiguration,
+    options: WidgetFactoryOptions
+): TextWidgetConfig => {
+    return {
+        type: 'text',
+        align: 'left',
+        containsHtml: true,
+        text: (t: TFunction, interview: UserInterviewAttributes, _path: string) => {
+            const person = odHelpers.getActivePerson({ interview });
+            const journey = odHelpers.getActiveJourney({ interview });
+            if (!person || !journey) {
+                throw new Error('Active person or journey not found in interview response');
+            }
+            // Format the journey start date for context in the title
+            // FIXME Update to support multiple days journeys when we support them in builtin questionnaire
+            const assignedDay = journey.startDate;
+            const journeyDate = !_isBlank(assignedDay)
+                ? options.getFormattedDate(assignedDay!, { withDayOfWeek: true, withRelative: true })
+                : undefined;
+
+            return t('visitedPlaces:personVisitedPlacesTitle', {
+                nickname: odHelpers.getPersonIdentificationString({ person, t }),
+                context: odHelpers.getPersonGenderContext({ person }),
+                journeyDate,
+                count: odHelpers.getCountOrSelfDeclared({ interview, person })
+            });
+        }
+    };
+};

--- a/packages/evolution-common/src/services/questionnaire/types/Data.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/Data.ts
@@ -171,6 +171,18 @@ type SectionStatus = {
 };
 
 /**
+ * Type that objects with complete address fields in the response can use for
+ * those fields.
+ */
+export type PlaceAddress = {
+    address?: string;
+    city?: string;
+    region?: string;
+    country?: string;
+    postalCode?: string;
+};
+
+/**
  * Type the common response fields for any survey
  *
  * TODO Update to use new types in surveyObjects
@@ -214,9 +226,7 @@ export type InterviewResponse = {
 
     // Actual response
     household?: Household;
-    home?: {
-        region?: string;
-        country?: string;
+    home?: PlaceAddress & {
         geography?: GeoJSON.Feature<GeoJSON.Point, SurveyPointProperties>;
     };
     // TODO Refactor the types to use the new types in surveyObjects

--- a/packages/evolution-common/src/services/questionnaire/types/SectionConfig.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/SectionConfig.ts
@@ -551,6 +551,18 @@ export type VisitedPlacesSectionConfiguration = {
      * `activitiesIncludeOnly` and `activityExclude` can be set, not both.
      */
     activityExclude?: Activity[];
+    /**
+     * The minimum time of day for the trip diary, in seconds since midnight.
+     *
+     * TODO When we support daily or multi-day diaries, this configuration should go only for daily ones. (https://github.com/chairemobilite/evolution/issues/1458)
+     */
+    tripDiaryMinTimeOfDay: number;
+    /**
+     * The maximum time of day for the trip diary, in seconds since midnight.
+     *
+     * TODO When we support daily or multi-day diaries, this configuration should go only for daily ones. (https://github.com/chairemobilite/evolution/issues/1458)
+     */
+    tripDiaryMaxTimeOfDay: number;
 };
 
 // TODO Add more section configuration types as we support more

--- a/packages/evolution-common/src/tests/surveys/testCasesInterview.ts
+++ b/packages/evolution-common/src/tests/surveys/testCasesInterview.ts
@@ -71,6 +71,7 @@ export const interviewAttributesForTestCases: UserRuntimeInterviewAttributes = {
                         journeyId1: {
                             _uuid: 'journeyId1',
                             _sequence: 1,
+                            startDate: '2026-04-08',
                             visitedPlaces: {
                                 homePlace1P1: {
                                     _uuid: 'homePlace1P1',

--- a/packages/evolution-common/src/tests/surveys/testCasesInterview.ts
+++ b/packages/evolution-common/src/tests/surveys/testCasesInterview.ts
@@ -53,6 +53,8 @@ export const interviewAttributesForTestCases: UserRuntimeInterviewAttributes = {
     ...baseInterviewAttributes,
     response: {
         home: {
+            address: '1234 Main St',
+            city: 'montreal',
             geography: {
                 type: 'Feature',
                 geometry: { type: 'Point', coordinates: homeGeographyCoordinates },


### PR DESCRIPTION
part of #1485 

* escape the visited place name when returning it in the od survey helper function
* Update the signature of the `getFormattedDate` widget factory option, which actually takes a second parameter with a few options to add to the formatted date
* Add a function to return an address as a one line string. A new type `PlaceAddress` is added to the questionnaire for objects that require addresses entered as multiple fields (address, city, region, country). Builtin widget factories can eventually provide those widgets.
* Add a min/max trip diary times to the trip diary configuration. This allows to parameterize the start and end of a day for the survey (in Québec surveys, this usually defaults to 4AM to 4AM the next day).
* Add the `widgetPersonVisitedPlacesTitle` and `widgetNextPlaceCategory` configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visited-places flow: added person-title and next-place-category questions with end-of-day/next-day handling and automatic pre-selection.

* **Translations**
  * Added English and French strings for place labels, at-place variants, visited-places titles, prompts, and radio-choice labels.

* **Data & Formatting**
  * Improved home-address one-line formatting and HTML-escaping of place names; date formatting accepts extra display options; section config now includes trip-diary min/max time-of-day.

* **Data Model**
  * Expanded address type to include common address fields; visited-places section config requires time-of-day bounds.

* **Tests**
  * Expanded coverage for visited-places widgets, next-place logic, address formatting, and related behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->