### PR TITLE
visitedPlaces: add the `groupPersonVisitedPlaces` group config

### DIFF
--- a/locales/en/visitedPlaces.yml
+++ b/locales/en/visitedPlaces.yml
@@ -111,3 +111,6 @@ nextPlaceRadioChoices.stayedThereUntilTheNextDay: Stayed at this place until the
     day
 nextPlaceRadioChoices.visitedAnotherPlace: Went or stopped elsewhere
 nextPlaceRadioChoices.wentBackHome: Returned home directly ({{address}})
+personVisitedPlacesGroupTitle: Visited places
+VisitedPlaceSequence: 'Location #{{count}}'
+VisitedPlaceSequence_one: Departure place for this day

--- a/locales/fr/visitedPlaces.yml
+++ b/locales/fr/visitedPlaces.yml
@@ -133,3 +133,6 @@ nextPlaceRadioChoices.visitedAnotherPlace_female: Allée ou arrêtée à un autr
 nextPlaceRadioChoices.wentBackHome: Retourné(e) au domicile directement ({{address}})
 nextPlaceRadioChoices.wentBackHome_male: Retourné au domicile directement ({{address}})
 nextPlaceRadioChoices.wentBackHome_female: Retournée au domicile directement ({{address}})
+personVisitedPlacesGroupTitle: Lieux visités
+VisitedPlaceSequence: 'Lieu #{{count}}'
+VisitedPlaceSequence_one: Lieu de départ de la journée

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/groupPersonVisitedPlaces.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/groupPersonVisitedPlaces.test.ts
@@ -1,0 +1,283 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import _cloneDeep from 'lodash/cloneDeep';
+
+import { PersonVisitedPlacesGroupConfigFactory } from '../groupPersonVisitedPlaces';
+import { interviewAttributesForTestCases, maskFunctions, widgetFactoryOptions } from '../../../../../tests/surveys';
+import * as utilHelpers from '../../../../../utils/helpers';
+import { GroupConfig, VisitedPlacesSectionConfiguration, WidgetConfig } from '../../../types';
+import { getActivityCategoryWidgetConfig } from '../widgetActivityCategory';
+import { getActivityWidgetConfig } from '../widgetActivity';
+import { getNextPlaceCategoryWidgetConfig } from '../widgetNextPlaceCategory';
+import { VisitedPlaceGeographyWidgetFactory } from '../widgetsGeography';
+
+const visitedPlacesSectionConfig: VisitedPlacesSectionConfiguration = {
+    type: 'visitedPlaces',
+    enabled: true,
+    tripDiaryMinTimeOfDay: 4 * 60 * 60, // 4h in seconds
+    tripDiaryMaxTimeOfDay: 28 * 60 * 60
+};
+
+describe('PersonVisitedPlacesGroupConfigFactory widgets', () => {
+    test.each([
+        'personVisitedPlaces',
+        'visitedPlaceActivityCategory',
+        'visitedPlaceActivity',
+        'visitedPlaceName',
+        'visitedPlaceGeography',
+        'visitedPlaceNextPlaceCategory'
+    ])('should have a widget named %s', (widgetName) => {
+        const widgetConfigs = new PersonVisitedPlacesGroupConfigFactory(
+            visitedPlacesSectionConfig,
+            widgetFactoryOptions
+        ).getWidgetConfigs();
+        const widgetNames = Object.keys(widgetConfigs);
+        expect(widgetNames).toContain(widgetName);
+    });
+
+    test('should not return extra widgets', () => {
+        const widgetConfigs = new PersonVisitedPlacesGroupConfigFactory(
+            visitedPlacesSectionConfig,
+            widgetFactoryOptions
+        ).getWidgetConfigs();
+        expect(Object.keys(widgetConfigs)).toHaveLength(6);
+    });
+
+    test.each([
+        {
+            widgetName: 'visitedPlaceActivityCategory',
+            expected: (config: VisitedPlacesSectionConfiguration) =>
+                getActivityCategoryWidgetConfig(config, widgetFactoryOptions)
+        },
+        {
+            widgetName: 'visitedPlaceActivity',
+            expected: (config: VisitedPlacesSectionConfiguration) => getActivityWidgetConfig(config, widgetFactoryOptions)
+        },
+        {
+            widgetName: 'visitedPlaceNextPlaceCategory',
+            expected: (config: VisitedPlacesSectionConfiguration) =>
+                getNextPlaceCategoryWidgetConfig(config, widgetFactoryOptions)
+        },
+        {
+            widgetName: 'visitedPlaceName',
+            expected: (config: VisitedPlacesSectionConfiguration) =>
+                new VisitedPlaceGeographyWidgetFactory(config, widgetFactoryOptions).getWidgetConfigs().visitedPlaceName
+        },
+        {
+            widgetName: 'visitedPlaceGeography',
+            expected: (config: VisitedPlacesSectionConfiguration) =>
+                new VisitedPlaceGeographyWidgetFactory(config, widgetFactoryOptions).getWidgetConfigs()
+                    .visitedPlaceGeography
+        }
+    ])(
+        'should return the correct widget config for $widgetName',
+        ({
+            widgetName,
+            expected
+        }: {
+            widgetName: string;
+            expected: (config: VisitedPlacesSectionConfiguration) => WidgetConfig;
+        }) => {
+            const widgetConfigs = new PersonVisitedPlacesGroupConfigFactory(
+                visitedPlacesSectionConfig,
+                widgetFactoryOptions
+            ).getWidgetConfigs();
+            const widgetConfig = widgetConfigs[widgetName];
+            const expectedWidgetConfig = expected(visitedPlacesSectionConfig);
+            expect(maskFunctions(widgetConfig)).toEqual(maskFunctions(expectedWidgetConfig));
+        }
+    );
+});
+
+describe('PersonVisitedPlacesGroupConfigFactory personVisitedPlaces GroupConfig widget', () => {
+    const widgetConfig = new PersonVisitedPlacesGroupConfigFactory(
+        visitedPlacesSectionConfig,
+        widgetFactoryOptions
+    ).getWidgetConfigs().personVisitedPlaces as GroupConfig;
+
+    test('should return the correct widget config', () => {
+        expect(widgetConfig).toEqual({
+            type: 'group',
+            path: 'household.persons.{_activePersonId}.journeys.{_activeJourneyId}.visitedPlaces',
+            title: expect.any(Function),
+            filter: expect.any(Function),
+            name: expect.any(Function),
+            showGroupedObjectDeleteButton: false,
+            deleteConfirmPopup: {
+                content: expect.any(Function)
+            },
+            showGroupedObjectAddButton: true,
+            addButtonLocation: 'both',
+            widgets: [
+                'visitedPlaceActivityCategory',
+                'visitedPlaceActivity',
+                'visitedPlaceName',
+                'visitedPlaceGeography',
+                'visitedPlaceNextPlaceCategory'
+            ]
+        });
+    });
+
+    describe('labels', () => {
+        test('should return the right label for title', () => {
+            const mockedT = jest.fn();
+            const title = widgetConfig.title;
+            expect(title).toBeDefined();
+            utilHelpers.translateString(title, { t: mockedT } as any, interviewAttributesForTestCases, 'path');
+            expect(mockedT).toHaveBeenCalledWith('visitedPlaces:personVisitedPlacesGroupTitle');
+        });
+
+        test.each([
+            {
+                title: 'uses escaped name when available',
+                groupedObject: { name: '<b>Work place</b>', activity: 'shopping' },
+                sequence: 2,
+                expected: 'VisitedPlaceSequence-2 • **&lt;b&gt;Work place&lt;/b&gt;**'
+            },
+            {
+                title: 'uses translated activity when name is missing',
+                groupedObject: { activity: 'shopping' },
+                sequence: 3,
+                expected: 'VisitedPlaceSequence-3 • **visitedPlaces:activities:shopping**'
+            },
+            {
+                title: 'returns sequence only when name and activity are missing',
+                groupedObject: {},
+                sequence: 1,
+                expected: 'VisitedPlaceSequence-1'
+            }
+        ])('group name: %s', ({ title, groupedObject, sequence, expected }) => {
+            const name = widgetConfig.name;
+            expect(name).toBeDefined();
+            const mockedT = jest.fn().mockImplementation((key, options) => {
+                if (key === 'visitedPlaces:VisitedPlaceSequence') {
+                    return `VisitedPlaceSequence-${options.count}`;
+                }
+                return key; // for other keys, just return the key to simplify testing
+            });
+
+            expect((name as any)(mockedT, groupedObject, sequence)).toEqual(expected);
+        });
+
+        test('should return the right label for delete confirm popup', () => {
+            const deleteConfirmPopup = widgetConfig.deleteConfirmPopup;
+            expect(deleteConfirmPopup).toBeDefined();
+            const mockedT = jest.fn();
+            utilHelpers.translateString(
+                deleteConfirmPopup?.content,
+                { t: mockedT } as any,
+                interviewAttributesForTestCases,
+                'path'
+            );
+            expect(mockedT).toHaveBeenCalledWith('visitedPlaces:ConfirmDeleteVisitedPlace');
+        });
+    });
+
+    describe('filter', () => {
+        test('should keep only the active visited place when it exists', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            utilHelpers.setResponse(interview, '_activePersonId', 'personId1');
+            utilHelpers.setResponse(interview, '_activeJourneyId', 'journeyId1');
+            utilHelpers.setResponse(interview, '_activeVisitedPlaceId', 'workPlace1P1');
+
+            const groupedObjects = interview.response.household!.persons!.personId1!.journeys!.journeyId1!.visitedPlaces!;
+            const filter = widgetConfig.filter;
+            expect(filter).toBeDefined();
+            expect((filter as any)(interview, groupedObjects)).toEqual({
+                workPlace1P1: groupedObjects.workPlace1P1
+            });
+        });
+
+        test('should return an empty object when there is no active visited place', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            utilHelpers.setResponse(interview, '_activePersonId', 'personId1');
+            utilHelpers.setResponse(interview, '_activeJourneyId', 'journeyId1');
+            utilHelpers.setResponse(interview, '_activeVisitedPlaceId', null);
+
+            const groupedObjects = interview.response.household!.persons!.personId1!.journeys!.journeyId1!.visitedPlaces!;
+            const filter = widgetConfig.filter;
+            expect(filter).toBeDefined();
+            expect((filter as any)(interview, groupedObjects)).toEqual({});
+        });
+    });
+});
+
+describe('PersonVisitedPlacesGroupConfigFactory personVisitedPlaces GroupConfig widget with additional widget names', () => {
+    test('should return correct widget names when no duplicate', () => {
+        const configWithWidgets = _cloneDeep(visitedPlacesSectionConfig);
+        configWithWidgets.additionalVisitedPlacesWidgetNames = ['customWidget1', 'customWidget2'];
+
+        const widgetConfig = new PersonVisitedPlacesGroupConfigFactory(
+            configWithWidgets,
+            widgetFactoryOptions
+        ).getWidgetConfigs().personVisitedPlaces as GroupConfig;
+
+        expect(widgetConfig).toEqual({
+            type: 'group',
+            path: 'household.persons.{_activePersonId}.journeys.{_activeJourneyId}.visitedPlaces',
+            title: expect.any(Function),
+            filter: expect.any(Function),
+            name: expect.any(Function),
+            showGroupedObjectDeleteButton: false,
+            deleteConfirmPopup: {
+                content: expect.any(Function)
+            },
+            showGroupedObjectAddButton: true,
+            addButtonLocation: 'both',
+            widgets: [
+                'visitedPlaceActivityCategory',
+                'visitedPlaceActivity',
+                'visitedPlaceName',
+                'visitedPlaceGeography',
+                'customWidget1',
+                'customWidget2',
+                'visitedPlaceNextPlaceCategory'
+            ]
+        });
+    });
+
+    test('should not return duplicate widget names', () => {
+        const configWithWidgets = _cloneDeep(visitedPlacesSectionConfig);
+        // Include some builtin widget names in the additional widgets to test
+        // that duplicates are removed and original order is preserved
+        configWithWidgets.additionalVisitedPlacesWidgetNames = [
+            'customWidget1',
+            'visitedPlaceActivity',
+            'customWidget2',
+            'visitedPlaceGeography',
+            'visitedPlaceNextPlaceCategory'
+        ];
+
+        const widgetConfig = new PersonVisitedPlacesGroupConfigFactory(
+            configWithWidgets,
+            widgetFactoryOptions
+        ).getWidgetConfigs().personVisitedPlaces as GroupConfig;
+
+        expect(widgetConfig).toEqual({
+            type: 'group',
+            path: 'household.persons.{_activePersonId}.journeys.{_activeJourneyId}.visitedPlaces',
+            title: expect.any(Function),
+            filter: expect.any(Function),
+            name: expect.any(Function),
+            showGroupedObjectDeleteButton: false,
+            deleteConfirmPopup: {
+                content: expect.any(Function)
+            },
+            showGroupedObjectAddButton: true,
+            addButtonLocation: 'both',
+            widgets: [
+                'visitedPlaceActivityCategory',
+                'visitedPlaceName',
+                'customWidget1',
+                'visitedPlaceActivity',
+                'customWidget2',
+                'visitedPlaceGeography',
+                'visitedPlaceNextPlaceCategory'
+            ]
+        });
+    });
+});

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/groupPersonVisitedPlaces.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/groupPersonVisitedPlaces.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import _escape from 'lodash/escape';
+import type { GroupConfig, VisitedPlacesSectionConfiguration, WidgetConfig } from '../../../questionnaire/types';
+import * as odHelpers from '../../../odSurvey/helpers';
+import { TFunction } from 'i18next';
+import { WidgetConfigFactory, WidgetFactoryOptions } from '../types';
+import { getActivityCategoryWidgetConfig } from './widgetActivityCategory';
+import { getActivityWidgetConfig } from './widgetActivity';
+import { VisitedPlaceGeographyWidgetFactory } from './widgetsGeography';
+import { getNextPlaceCategoryWidgetConfig } from './widgetNextPlaceCategory';
+import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
+
+/**
+ * Widget config factory for the person visited places group. It represents the
+ * group of questions related to each visited place of the person. It returns
+ * all builtin widgets necessary for the visited place questions, according to
+ * the trip diary configuration.
+ */
+export class PersonVisitedPlacesGroupConfigFactory implements WidgetConfigFactory {
+    constructor(
+        private sectionConfig: VisitedPlacesSectionConfiguration,
+        private options: WidgetFactoryOptions
+    ) {
+        /** Nothing to do */
+    }
+
+    private getGroupWidgetNames = (): string[] => {
+        const additionalWidgetNames = this.sectionConfig.additionalVisitedPlacesWidgetNames || [];
+        // Make sure all mandatory questions of the group are included, they
+        // could be listed in the additional widgets to control their order, but
+        // if not there, we should add them at the right place.
+        const allWidgetNames = [...additionalWidgetNames];
+        // Add the geography and activity widgets at the beginning of the groups, listed in reverse order of appearance to unshift them in the right order
+        // FIXME Allow to fine-tune where to put the additional widgets, for example, shortcuts, that are not yet builtin should got between the categories and geography
+        const widgetsAtTheBeginning = [
+            'visitedPlaceGeography',
+            'visitedPlaceName',
+            'visitedPlaceActivity',
+            'visitedPlaceActivityCategory'
+        ];
+        for (const widgetName of widgetsAtTheBeginning) {
+            if (!allWidgetNames.includes(widgetName)) {
+                allWidgetNames.unshift(widgetName);
+            }
+        }
+        const widgetsAtTheEnd = ['visitedPlaceNextPlaceCategory'];
+        for (const widgetName of widgetsAtTheEnd) {
+            if (!allWidgetNames.includes(widgetName)) {
+                allWidgetNames.push(widgetName);
+            }
+        }
+        return Array.from(new Set(allWidgetNames));
+    };
+
+    private getVisitedPlacesGroupConfig = (): GroupConfig => {
+        return {
+            type: 'group',
+            path: 'household.persons.{_activePersonId}.journeys.{_activeJourneyId}.visitedPlaces',
+            title: (t: TFunction) => t('visitedPlaces:personVisitedPlacesGroupTitle'),
+            filter: function (interview, groupedObjects) {
+                // Keep only the grouped object that corresponds to the active
+                // visited place, so that only one is shown at a time in the
+                // group, and it is always the same one as the one shown in the
+                // title widget that is outside of the group.
+                const journey = odHelpers.getActiveJourney({ interview }); // Ensure the active journey is set
+                const activeVisitedPlace = odHelpers.getActiveVisitedPlace({ interview, journey });
+                if (activeVisitedPlace) {
+                    const filteredGroupedObject = {};
+                    for (const groupedObjectId in groupedObjects) {
+                        if (groupedObjectId === activeVisitedPlace._uuid) {
+                            filteredGroupedObject[groupedObjectId] = groupedObjects[groupedObjectId];
+                        }
+                    }
+                    return filteredGroupedObject;
+                } else {
+                    return {};
+                }
+            },
+            name: (t: TFunction, groupedObject: unknown, sequence: number) => {
+                const groupNameStrings = [t('visitedPlaces:VisitedPlaceSequence', { count: sequence })];
+                const placeString = (groupedObject as any).name
+                    ? `**${_escape((groupedObject as any).name)}**`
+                    : (groupedObject as any).activity
+                        ? `**${t(`visitedPlaces:activities:${(groupedObject as any).activity}`)}**`
+                        : undefined;
+                if (!_isBlank(placeString)) {
+                    groupNameStrings.push(placeString as string);
+                }
+                return groupNameStrings.join(' • ');
+            },
+            showGroupedObjectDeleteButton: false,
+            deleteConfirmPopup: {
+                content: (t: TFunction) => t('visitedPlaces:ConfirmDeleteVisitedPlace')
+            },
+            showGroupedObjectAddButton: true,
+            addButtonLocation: 'both',
+            widgets: this.getGroupWidgetNames()
+        };
+    };
+
+    getWidgetConfigs = (): Record<string, WidgetConfig> => {
+        const geographyWidgetFactory = new VisitedPlaceGeographyWidgetFactory(this.sectionConfig, this.options);
+        return {
+            personVisitedPlaces: this.getVisitedPlacesGroupConfig(),
+            visitedPlaceActivityCategory: getActivityCategoryWidgetConfig(this.sectionConfig, this.options),
+            visitedPlaceActivity: getActivityWidgetConfig(this.sectionConfig, this.options),
+            ...geographyWidgetFactory.getWidgetConfigs(),
+            visitedPlaceNextPlaceCategory: getNextPlaceCategoryWidgetConfig(this.sectionConfig, this.options)
+        };
+    };
+}

--- a/packages/evolution-common/src/services/questionnaire/types/SectionConfig.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/SectionConfig.ts
@@ -563,6 +563,26 @@ export type VisitedPlacesSectionConfiguration = {
      * TODO When we support daily or multi-day diaries, this configuration should go only for daily ones. (https://github.com/chairemobilite/evolution/issues/1458)
      */
     tripDiaryMaxTimeOfDay: number;
+    /**
+     * Names of additional widgets to include in the visited places group of the
+     * section besides the default ones (activity, activityCategory, etc). The
+     * widgets need to be defined by these names in the survey's widget
+     * configuration. They will be added after the activity and geography
+     * widgets, before the nextPlaceCategory question. The array can contain the
+     * names of the default widgets to be able to configure the order of the
+     * widgets in the section.  If they are not included here, they will be
+     * added automatically either at the beginning or end of the list, depending
+     * on the widget.
+     *
+     * FIXME Allow to fine-tune the placements of the additional widgets, for
+     * example with a `beforeWidget` or `afterWidget` property in an object
+     * instead of strings, to avoid having to include the default widgets here
+     * just to place the additional widgets in the right order. This will be
+     * especially useful when we will have more default widgets in the section
+     * and more complex configurations of the section with some default widgets
+     * that can be removed and others that cannot, etc.
+     */
+    additionalVisitedPlacesWidgetNames?: string[];
 };
 
 // TODO Add more section configuration types as we support more


### PR DESCRIPTION
completes #1485

Add the `additionalVisitedPlacesWidgetNames` configuration option to the visited place section config. This allows to add custom widgets and specify the order of appearance of widgets in the visited places group.

Add the `PersonVisitedPlacesGroupConfigFactory` class to return the person visited places group config, as well as all the builtin widgets it requires.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Visited Places" group with sequence-based labeling and improved display/name composition.
  * Added optional configuration to include extra visited-places widgets and control their ordering.
  * Added English and French locale entries for visited-places UI.

* **Tests**
  * Added comprehensive test coverage for the visited-places group configuration and widget ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->