### PR TITLE
visitedPlaces: add button goto next section

### DIFF
--- a/locales/en/visitedPlaces.yml
+++ b/locales/en/visitedPlaces.yml
@@ -9,6 +9,7 @@ deleteThisGroupedObject: Delete this location
 cancelEditVisitedPlaces: Cancel
 editVisitedPlace: Edit
 insertVisitedPlace: Insert a location here
+saveAndContinue: Confirm locations and continue
 activities:
     accompanySomeone: Accompany someone
     carElectricChargingStation: Car charging station

--- a/locales/fr/visitedPlaces.yml
+++ b/locales/fr/visitedPlaces.yml
@@ -9,6 +9,7 @@ deleteVisitedPlace: Supprimer
 deleteThisGroupedObject: Supprimer ce lieu
 insertVisitedPlace: Insérer un lieu ici
 addVisitedPlace: Ajouter le prochain lieu
+saveAndContinue: Confirmer les lieux et continuer
 activities:
     accompanySomeone: Accompagner quelqu'un
     carElectricChargingStation: Borne de recharge de véhicule électrique

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/buttonConfirmGotoNextSection.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/buttonConfirmGotoNextSection.test.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import _cloneDeep from 'lodash/cloneDeep';
+
+import { getButtonConfirmGotoNextSectionWidgetConfig } from '../buttonConfirmGotoNextSection';
+import { interviewAttributesForTestCases, setActiveSurveyObjects, widgetFactoryOptions } from '../../../../../tests/surveys';
+import * as utilHelpers from '../../../../../utils/helpers';
+import * as odHelpers from '../../../../odSurvey/helpers';
+
+const visitedPlacesSectionConfig = {
+    type: 'visitedPlaces' as const,
+    enabled: true,
+    tripDiaryMinTimeOfDay: 4 * 60 * 60, // 4h in seconds
+    tripDiaryMaxTimeOfDay: 28 * 60 * 60 // 28h in seconds (i.e. 4h the next day)
+};
+
+beforeEach(() => {
+    jest.clearAllMocks();
+})
+
+describe('getButtonConfirmGotoNextSectionWidgetConfig', () => {
+
+    test('should return the correct widget config', () => {
+        const widgetConfig = getButtonConfirmGotoNextSectionWidgetConfig(visitedPlacesSectionConfig, widgetFactoryOptions);
+        expect(widgetConfig).toEqual({
+            type: 'button',
+            color: 'green',
+            label: expect.any(Function),
+            hideWhenRefreshing: true,
+            path: 'buttonValidateGotoNextSection',
+            icon: 'check-circle',
+            align: 'center',
+            action: widgetFactoryOptions.buttonActions.validateButtonActionWithCompleteSection,
+            conditional: expect.any(Function)
+        });
+    });
+
+});
+
+describe('getButtonConfirmGotoNextSectionWidgetConfig label', () => {
+    const widgetConfig = getButtonConfirmGotoNextSectionWidgetConfig(visitedPlacesSectionConfig, widgetFactoryOptions);
+
+    test('should return the right label for title', () => {
+        const mockedT = jest.fn();
+        const title = widgetConfig.label;
+        expect(title).toBeDefined();
+        utilHelpers.translateString(title, { t: mockedT } as any, interviewAttributesForTestCases, 'path');
+        // FIXME Base button had the old custom survey translation. Change when #1441 is fixed
+        expect(mockedT).toHaveBeenCalledWith(['customSurvey:visitedPlaces:saveAndContinue', 'visitedPlaces:saveAndContinue']);
+    });
+
+});
+
+describe('ButtonConfirmGotoNextSectionWidget widget conditional', () => {
+    const widgetConfig = getButtonConfirmGotoNextSectionWidgetConfig(visitedPlacesSectionConfig, widgetFactoryOptions);
+    const conditional = widgetConfig.conditional;
+    let interview = _cloneDeep(interviewAttributesForTestCases);
+
+    beforeEach(() => {
+        interview = _cloneDeep(interviewAttributesForTestCases);
+        // Set the active journey
+        setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1' });
+    });
+
+    test.each([{
+        title: 'no active journey',
+        setup: () => setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: undefined }),
+        expected: false
+    }, {
+        title: 'last visited place has nextPlaceCategory different from stayedThereUntilTheNextDay',
+        setup: () => {
+            const journey = interview.response.household!.persons!.personId1!.journeys!.journeyId1!;
+            const visitedPlacesArray = odHelpers.getVisitedPlacesArray({ journey });
+            const lastPlace = visitedPlacesArray[visitedPlacesArray.length - 1];
+            lastPlace.nextPlaceCategory = 'wentBackHome';
+        },
+        expected: false
+    }, {
+        title: 'last visited place has nextPlaceCategory stayedThereUntilTheNextDay',
+        setup: () => {
+            const journey = interview.response.household!.persons!.personId1!.journeys!.journeyId1!;
+            const visitedPlacesArray = odHelpers.getVisitedPlacesArray({ journey });
+            const lastPlace = visitedPlacesArray[visitedPlacesArray.length - 1];
+            lastPlace.nextPlaceCategory = 'stayedThereUntilTheNextDay';
+        },
+        expected: true
+    }])('$title', ({ setup, expected }) => {
+        setup();
+
+        expect(conditional?.(interview, 'unimportant path')).toEqual(expected);
+    });
+
+});

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/helpers.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/helpers.test.ts
@@ -7,7 +7,7 @@
 
 import { Activity, activityValues } from '../../../../odSurvey/types';
 import _cloneDeep from 'lodash/cloneDeep';
-import { interviewAttributesForTestCases } from '../../../../../tests/surveys';
+import { interviewAttributesForTestCases, setActiveSurveyObjects } from '../../../../../tests/surveys';
 import { setResponse } from '../../../../../utils/helpers';
 import * as helpers from '../helpers';
 import { VisitedPlacesSectionConfiguration } from '../../../types';
@@ -113,16 +113,6 @@ describe('Visited places helpers - activity/activityCategory filtering', () => {
 });
 
 describe('Visited places helpers - validatePreviousNextPlaceIsNotActivities', () => {
-    const setActiveVisitedPlace = (
-        interview: typeof interviewAttributesForTestCases,
-        personId: string,
-        journeyId: string,
-        visitedPlaceId: string
-    ) => {
-        setResponse(interview, '_activePersonId', personId);
-        setResponse(interview, '_activeJourneyId', journeyId);
-        setResponse(interview, '_activeVisitedPlaceId', visitedPlaceId);
-    };
 
     test('should warn and return true when there is no active journey', () => {
         const interview = _cloneDeep(interviewAttributesForTestCases);
@@ -146,7 +136,7 @@ describe('Visited places helpers - validatePreviousNextPlaceIsNotActivities', ()
         [
             'previous place activity is incompatible',
             (interview: typeof interviewAttributesForTestCases) => {
-                setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'workPlace1P1');
+                setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
                 return {
                     visitedPlace:
                         interview.response.household!.persons!.personId1!.journeys!.journeyId1!.visitedPlaces!
@@ -159,7 +149,7 @@ describe('Visited places helpers - validatePreviousNextPlaceIsNotActivities', ()
         [
             'next place activity is incompatible',
             (interview: typeof interviewAttributesForTestCases) => {
-                setActiveVisitedPlace(interview, 'personId2', 'journeyId2', 'otherWorkPlace1P2');
+                setActiveSurveyObjects(interview, { personId: 'personId2', journeyId: 'journeyId2', visitedPlaceId: 'otherWorkPlace1P2' });
                 return {
                     visitedPlace:
                         interview.response.household!.persons!.personId2!.journeys!.journeyId2!.visitedPlaces!
@@ -172,7 +162,7 @@ describe('Visited places helpers - validatePreviousNextPlaceIsNotActivities', ()
         [
             'previous and next activities are not incompatible',
             (interview: typeof interviewAttributesForTestCases) => {
-                setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'workPlace1P1');
+                setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
                 return {
                     visitedPlace:
                         interview.response.household!.persons!.personId1!.journeys!.journeyId1!.visitedPlaces!
@@ -185,7 +175,7 @@ describe('Visited places helpers - validatePreviousNextPlaceIsNotActivities', ()
         [
             'adjacent places have blank activities',
             (interview: typeof interviewAttributesForTestCases) => {
-                setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'workPlace1P1');
+                setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
                 const journey = interview.response.household!.persons!.personId1!.journeys!.journeyId1!;
                 journey.visitedPlaces!.homePlace1P1.activity = undefined;
                 journey.visitedPlaces!.homePlace2P1.activity = undefined;

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetActivity.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetActivity.test.ts
@@ -7,7 +7,7 @@
 import _cloneDeep from 'lodash/cloneDeep';
 import each from 'jest-each';
 import { InputRadioType, QuestionWidgetConfig, RadioChoiceType } from '../../../../questionnaire/types';
-import { interviewAttributesForTestCases, widgetFactoryOptions } from '../../../../../tests/surveys';
+import { interviewAttributesForTestCases, setActiveSurveyObjects, widgetFactoryOptions } from '../../../../../tests/surveys';
 import { setResponse, translateString } from '../../../../../utils/helpers';
 import {
     Activity,
@@ -23,17 +23,6 @@ const visitedPlacesSectionConfig = {
     enabled: true,
     tripDiaryMinTimeOfDay: 4 * 60 * 60, // 4h in seconds
     tripDiaryMaxTimeOfDay: 28 * 60 * 60 // 28h in seconds (i.e. 4h the next day)
-};
-
-const setActiveVisitedPlace = (
-    interview: typeof interviewAttributesForTestCases,
-    personId: string | undefined,
-    journeyId: string | undefined,
-    visitedPlaceId: string | undefined
-) => {
-    setResponse(interview, '_activePersonId', personId);
-    setResponse(interview, '_activeJourneyId', journeyId);
-    setResponse(interview, '_activeVisitedPlaceId', visitedPlaceId);
 };
 
 describe('getActivityWidgetConfig', () => {
@@ -148,7 +137,7 @@ describe('Activity per-choice conditionals', () => {
         const workUsualChoice = choices.find((c) => c.value === 'workUsual');
         expect(workUsualChoice).toBeDefined();
 
-        setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'workPlace1P1');
+        setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
         interview.response.household!.persons!.personId1!.occupation = 'fullTimeStudent';
         (interview.response.household!.persons!.personId1! as any).usualWorkPlace = undefined;
 
@@ -160,7 +149,7 @@ describe('Activity per-choice conditionals', () => {
         const workUsualChoice = choices.find((c) => c.value === 'workUsual');
         expect(workUsualChoice).toBeDefined();
 
-        setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'workPlace1P1');
+        setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
         interview.response.household!.persons!.personId1!.occupation = 'fullTimeWorker';
         (interview.response.household!.persons!.personId1! as any).usualWorkPlace = {
             geography: {
@@ -178,7 +167,7 @@ describe('Activity per-choice conditionals', () => {
         const workUsualChoice = choices.find((c) => c.value === 'workUsual');
         expect(workUsualChoice).toBeDefined();
 
-        setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'workPlace1P1');
+        setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
         interview.response.household!.persons!.personId1!.occupation = undefined;
         (interview.response.household!.persons!.personId1! as any).usualWorkPlace = undefined;
 
@@ -188,7 +177,7 @@ describe('Activity per-choice conditionals', () => {
     test('schoolUsual conditional should return false when active person is missing', () => {
         const interview = _cloneDeep(interviewAttributesForTestCases);
         // Set wrong active person to trigger invalid person condition in the conditional function
-        setActiveVisitedPlace(interview, 'personId4', 'journeyId4', 'schoolPlace1P4');
+        setActiveSurveyObjects(interview, { personId: 'personId4', journeyId: 'journeyId4', visitedPlaceId: 'schoolPlace1P4' });
         const schoolUsualChoice = choices.find((c) => c.value === 'schoolUsual');
         expect(schoolUsualChoice).toBeDefined();
 
@@ -200,7 +189,7 @@ describe('Activity per-choice conditionals', () => {
         const schoolUsualChoice = choices.find((c) => c.value === 'schoolUsual');
         expect(schoolUsualChoice).toBeDefined();
 
-        setActiveVisitedPlace(interview, 'personId3', 'journeyId3', 'schoolPlace1P3');
+        setActiveSurveyObjects(interview, { personId: 'personId3', journeyId: 'journeyId3', visitedPlaceId: 'schoolPlace1P3' });
         interview.response.household!.persons!.personId3!.schoolType = 'kindergarten';
 
         expect(schoolUsualChoice?.conditional?.(interview, 'household.persons.personId3.journeys.journeyId3.visitedPlaces.schoolPlace1P3.activity')).toEqual(true);
@@ -211,7 +200,7 @@ describe('Activity per-choice conditionals', () => {
         const schoolUsualChoice = choices.find((c) => c.value === 'schoolUsual');
         expect(schoolUsualChoice).toBeDefined();
 
-        setActiveVisitedPlace(interview, 'personId3', 'journeyId3', 'schoolPlace1P3');
+        setActiveSurveyObjects(interview, { personId: 'personId3', journeyId: 'journeyId3', visitedPlaceId: 'schoolPlace1P3' });
         interview.response.household!.persons!.personId3!.occupation = undefined;
 
         expect(schoolUsualChoice?.conditional?.(interview, 'household.persons.personId3.journeys.journeyId3.visitedPlaces.schoolPlace1P3.activity')).toEqual(true);
@@ -222,7 +211,7 @@ describe('Activity per-choice conditionals', () => {
         const schoolUsualChoice = choices.find((c) => c.value === 'schoolUsual');
         expect(schoolUsualChoice).toBeDefined();
 
-        setActiveVisitedPlace(interview, 'personId3', 'journeyId3', 'schoolPlace1P3');
+        setActiveSurveyObjects(interview, { personId: 'personId3', journeyId: 'journeyId3', visitedPlaceId: 'schoolPlace1P3' });
         interview.response.household!.persons!.personId3!.occupation = 'fullTimeWorker';
         interview.response.household!.persons!.personId3!.age = 30;
         (interview.response.household!.persons!.personId3! as any).usualSchoolPlace = undefined;
@@ -236,7 +225,7 @@ describe('Activity per-choice conditionals', () => {
         expect(choice).toBeDefined();
 
         const hasDrivingLicenseSpy = jest.spyOn(odHelpers, 'hasOrUnknownDrivingLicense').mockReturnValueOnce(true);
-        setActiveVisitedPlace(interview, 'personId2', 'journeyId2', 'otherWorkPlace1P2');
+        setActiveSurveyObjects(interview, { personId: 'personId2', journeyId: 'journeyId2', visitedPlaceId: 'otherWorkPlace1P2' });
 
         expect(choice?.conditional?.(interview, 'household.persons.personId2.journeys.journeyId2.visitedPlaces.otherWorkPlace1P2.activity')).toEqual(true);
         expect(hasDrivingLicenseSpy).toHaveBeenCalledWith({
@@ -264,7 +253,7 @@ describe('Activity per-choice conditionals', () => {
         const membersCountSpy = jest
             .spyOn(odHelpers, 'getCarsharingMembersCount')
             .mockReturnValueOnce(membersCount);
-        setActiveVisitedPlace(interview, 'personId2', 'journeyId2', 'otherWorkPlace1P2');
+        setActiveSurveyObjects(interview, { personId: 'personId2', journeyId: 'journeyId2', visitedPlaceId: 'otherWorkPlace1P2' });
 
         expect(choice?.conditional?.(interview, 'household.persons.personId2.journeys.journeyId2.visitedPlaces.otherWorkPlace1P2.activity')).toEqual(expected);
         expect(membersCountSpy).toHaveBeenCalledWith({ interview });
@@ -361,7 +350,7 @@ describe('Activity next/previous incompatibility validations', () => {
         ]
     ]).test('%s', (_title, visitedPlaces, activity: Activity, expected) => {
         const interview = _cloneDeep(interviewAttributesForTestCases);
-        setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'currentPlace');
+        setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'currentPlace' });
         interview.response.household!.persons!.personId1!.journeys!.journeyId1!.visitedPlaces = visitedPlaces as any;
         interview.response.household!.persons!.personId1!.occupation = undefined;
 

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetActivityCategory.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetActivityCategory.test.ts
@@ -7,7 +7,7 @@
 import _cloneDeep from 'lodash/cloneDeep';
 import each from 'jest-each';
 import { InputRadioType, QuestionWidgetConfig, RadioChoiceType } from '../../../../questionnaire/types';
-import { interviewAttributesForTestCases, widgetFactoryOptions } from '../../../../../tests/surveys';
+import { interviewAttributesForTestCases, setActiveSurveyObjects, widgetFactoryOptions } from '../../../../../tests/surveys';
 import { setResponse, translateString } from '../../../../../utils/helpers';
 import * as odHelpers from '../../../../odSurvey/helpers';
 import { getActivityCategoryWidgetConfig } from '../widgetActivityCategory';
@@ -17,17 +17,6 @@ const visitedPlacesSectionConfig = {
 	enabled: true,
     tripDiaryMinTimeOfDay: 4 * 60 * 60, // 4h in seconds
     tripDiaryMaxTimeOfDay: 28 * 60 * 60 // 28h in seconds (i.e. 4h the next day)
-};
-
-const setActiveVisitedPlace = (
-	interview: typeof interviewAttributesForTestCases,
-	personId: string,
-	journeyId: string,
-	visitedPlaceId: string
-) => {
-	setResponse(interview, '_activePersonId', personId);
-	setResponse(interview, '_activeJourneyId', journeyId);
-	setResponse(interview, '_activeVisitedPlaceId', visitedPlaceId);
 };
 
 describe('getActivityCategoryWidgetConfig', () => {
@@ -98,7 +87,7 @@ describe('Activity category choices labels', () => {
 		const mockedT = jest.fn();
 		const schoolChoice = choices.find((c) => c.value === 'school');
 		expect(schoolChoice).toBeDefined();
-		setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'workPlace1P1');
+		setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
 		interview.response.household!.persons!.personId1!.schoolType = schoolType as any;
 		translateString(schoolChoice?.label, { t: mockedT } as any, interview, 'path');
 		expect(mockedT).toHaveBeenCalledWith(expectedLabel);
@@ -132,7 +121,7 @@ describe('Activity category choices conditionals', () => {
 			middlePlace: { _uuid: 'middlePlace', _sequence: 2, activity: 'other', activityCategory: 'leisure' },
 			lastPlace: { _uuid: 'lastPlace', _sequence: 3, activity: 'workUsual', activityCategory: 'work' }
 		};
-		setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'middlePlace');
+		setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'middlePlace' });
 		const homeChoice = choices.find((c) => c.value === 'home');
 		expect(homeChoice).toBeDefined();
 		expect(homeChoice?.conditional?.(interview, 'path')).toEqual(true);
@@ -140,7 +129,7 @@ describe('Activity category choices conditionals', () => {
 
 	test('home conditional should return false when previous place activityCategory is home', () => {
 		const interview = _cloneDeep(interviewAttributesForTestCases);
-		setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'workPlace1P1');
+		setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
 		const homeChoice = choices.find((c) => c.value === 'home');
 		expect(homeChoice).toBeDefined();
 		expect(homeChoice?.conditional?.(interview, 'path')).toEqual(false);
@@ -148,7 +137,7 @@ describe('Activity category choices conditionals', () => {
 
     test('home conditional should return false when next place activityCategory is home', () => {
 		const interview = _cloneDeep(interviewAttributesForTestCases);
-		setActiveVisitedPlace(interview, 'personId2', 'journeyId2', 'otherWorkPlace1P2');
+		setActiveSurveyObjects(interview, { personId: 'personId2', journeyId: 'journeyId2', visitedPlaceId: 'otherWorkPlace1P2' });
 		const homeChoice = choices.find((c) => c.value === 'home');
 		expect(homeChoice).toBeDefined();
 		expect(homeChoice?.conditional?.(interview, 'path')).toEqual(false);
@@ -167,7 +156,7 @@ describe('Activity category choices conditionals', () => {
 		if (age === null) {
 			setResponse(interview, '_activePersonId', null);
 		} else {
-			setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'workPlace1P1');
+			setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
 			interview.response.household!.persons!.personId1!.age = age;
 		}
 
@@ -197,7 +186,7 @@ describe('Activity category choices conditionals', () => {
 			if (age === null) {
 				setResponse(interview, '_activePersonId', null);
 			} else {
-				setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'workPlace1P1');
+				setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
 				interview.response.household!.persons!.personId1!.age = age;
 				interview.response.household!.persons!.personId1!.occupation = occupation as any;
 				if (isStudentFromEnrolledValue !== undefined) {
@@ -237,7 +226,7 @@ describe('Activity category choices conditionals', () => {
         if (age === null) {
             setResponse(interview, '_activePersonId', null);
         } else {
-            setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'workPlace1P1');
+            setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
             interview.response.household!.persons!.personId1!.age = age;
             // Set the visitedPlaces if provided, otherwise, use the default ones
             if (visitedPlaces) {
@@ -276,7 +265,7 @@ describe('Activity category widget label', () => {
 	test('should use first location label for first visited place', () => {
 		const interview = _cloneDeep(interviewAttributesForTestCases);
 		const mockedT = jest.fn().mockReturnValue('translatedLabel');
-		setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'homePlace1P1');
+		setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'homePlace1P1' });
 		expect(translateString(label, { t: mockedT } as any, interview, 'path')).toEqual('translatedLabel');
 		expect(mockedT).toHaveBeenCalledWith('visitedPlaces:ActivityCategoryFirstLocation');
 	});
@@ -284,7 +273,7 @@ describe('Activity category widget label', () => {
 	test('should use after home label for second place when first place activity is home', () => {
 		const interview = _cloneDeep(interviewAttributesForTestCases);
 		const mockedT = jest.fn().mockReturnValue('translatedLabel');
-		setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'workPlace1P1');
+		setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
 		expect(translateString(label, { t: mockedT } as any, interview, 'path')).toEqual('translatedLabel');
 		expect(mockedT).toHaveBeenCalledWith('visitedPlaces:ActivityCategoryAfterHome');
 	});
@@ -292,7 +281,7 @@ describe('Activity category widget label', () => {
 	test('should use default activity category label for other places', () => {
 		const interview = _cloneDeep(interviewAttributesForTestCases);
 		const mockedT = jest.fn().mockReturnValue('translatedLabel');
-		setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'homePlace2P1');
+		setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'homePlace2P1' });
 		expect(translateString(label, { t: mockedT } as any, interview, 'path')).toEqual('translatedLabel');
 		expect(mockedT).toHaveBeenCalledWith('visitedPlaces:ActivityCategory');
 	});
@@ -340,7 +329,7 @@ describe('Activity category widget conditional', () => {
 
 	test('should hide widget and assign home when active visited place is a new home place', () => {
 		const interview = _cloneDeep(interviewAttributesForTestCases);
-		setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'homePlace2P1');
+		setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'homePlace2P1' });
 		const activeVisitedPlace = interview.response.household!.persons!.personId1!.journeys!.journeyId1!.visitedPlaces!
 			.homePlace2P1!;
 		(activeVisitedPlace as any)._isNew = true;
@@ -351,7 +340,7 @@ describe('Activity category widget conditional', () => {
 
 	test('should show widget in regular case', () => {
 		const interview = _cloneDeep(interviewAttributesForTestCases);
-		setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'workPlace1P1');
+		setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
 		expect(conditional!(interview, 'path')).toEqual([true]);
 	});
 });

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetNextPlaceCategory.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetNextPlaceCategory.test.ts
@@ -7,7 +7,7 @@
 import _cloneDeep from 'lodash/cloneDeep';
 import each from 'jest-each';
 import { InputRadioType, QuestionWidgetConfig, RadioChoiceType } from '../../../../questionnaire/types';
-import { interviewAttributesForTestCases, widgetFactoryOptions } from '../../../../../tests/surveys';
+import { interviewAttributesForTestCases, setActiveSurveyObjects, widgetFactoryOptions } from '../../../../../tests/surveys';
 import { setResponse, translateString } from '../../../../../utils/helpers';
 import * as odHelpers from '../../../../odSurvey/helpers';
 import { getNextPlaceCategoryWidgetConfig } from '../widgetNextPlaceCategory';
@@ -17,17 +17,6 @@ const visitedPlacesSectionConfig = {
     enabled: true,
     tripDiaryMinTimeOfDay: 4 * 60 * 60, // 4 AM in seconds
     tripDiaryMaxTimeOfDay: 28 * 60 * 60 // 4 AM the next day, in seconds
-};
-
-const setActiveVisitedPlace = (
-    interview: typeof interviewAttributesForTestCases,
-    personId: string | undefined,
-    journeyId: string | undefined,
-    visitedPlaceId: string | undefined
-) => {
-    setResponse(interview, '_activePersonId', personId);
-    setResponse(interview, '_activeJourneyId', journeyId);
-    setResponse(interview, '_activeVisitedPlaceId', visitedPlaceId);
 };
 
 describe('getNextPlaceCategoryWidgetConfig', () => {
@@ -73,7 +62,7 @@ describe('NextPlaceCategory choices conditionals', () => {
 
     test('wentBackHome conditional should return false when active place is home', () => {
         const interview = _cloneDeep(interviewAttributesForTestCases);
-        setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'homePlace1P1');
+        setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'homePlace1P1' });
 
         const wentBackHomeChoice = choices.find((c) => c.value === 'wentBackHome');
         expect(wentBackHomeChoice).toBeDefined();
@@ -87,7 +76,7 @@ describe('NextPlaceCategory choices conditionals', () => {
 
     test('wentBackHome conditional should return false when active place is workOnTheRoad', () => {
         const interview = _cloneDeep(interviewAttributesForTestCases);
-        setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'workPlace1P1');
+        setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
         const visitedPlace = interview.response.household!.persons!.personId1!.journeys!.journeyId1!
             .visitedPlaces!.workPlace1P1;
         (visitedPlace as any).activity = 'workOnTheRoad';
@@ -104,7 +93,7 @@ describe('NextPlaceCategory choices conditionals', () => {
 
     test('wentBackHome conditional should return true when active place is not home or workOnTheRoad', () => {
         const interview = _cloneDeep(interviewAttributesForTestCases);
-        setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'workPlace1P1');
+        setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
 
         const wentBackHomeChoice = choices.find((c) => c.value === 'wentBackHome');
         expect(wentBackHomeChoice).toBeDefined();
@@ -124,7 +113,7 @@ describe('NextPlaceCategory choices conditionals', () => {
         const stayedChoice = (choices as RadioChoiceType[]).find((c) => c.value === 'stayedThereUntilTheNextDay');
 
         // Test the requested place
-        setActiveVisitedPlace(interview, 'personId1', 'journeyId1', placeUuid);
+        setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: placeUuid });
         expect(stayedChoice).toBeDefined();
         expect(
             stayedChoice?.conditional?.(
@@ -146,7 +135,7 @@ describe('NextPlaceCategory choices labels', () => {
 
     beforeEach(() => {
         interview = _cloneDeep(interviewAttributesForTestCases);
-        setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'workPlace1P1');
+        setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
     });
 
     test('wentBackHome label should include home address', () => {
@@ -215,7 +204,7 @@ describe('NextPlaceCategory widget label', () => {
     beforeEach(() => {
         interview = _cloneDeep(interviewAttributesForTestCases);
         jest.clearAllMocks();
-        setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'workPlace1P1');
+        setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
     });
 
     test('should call translation function with correct key and context', () => {
@@ -286,7 +275,7 @@ describe('NextPlaceCategory widget conditional', () => {
     beforeEach(() => {
         interview = _cloneDeep(interviewAttributesForTestCases);
         // By default, set the last place as active
-        setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'otherPlace2P1');
+        setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'otherPlace2P1' });
     });
 
     test('should return auto-filled stayedThereUntilTheNextDay when arrival time equals max time of day', () => {
@@ -307,7 +296,7 @@ describe('NextPlaceCategory widget conditional', () => {
         (visitedPlace as any).activityCategory = 'work';
         (visitedPlace as any).onTheRoadArrivalType = 'stayedThereUntilTheNextDay';
 
-        setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'otherPlace2P1');
+        setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'otherPlace2P1' });
         expect(
             conditional?.(interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.otherPlace2P1.nextPlaceCategory')
         ).toEqual([false, 'stayedThereUntilTheNextDay']);
@@ -324,7 +313,7 @@ describe('NextPlaceCategory widget conditional', () => {
     });
 
     test('should hide widget when active place is not the last', () => {
-        setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'homePlace1P1');
+        setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'homePlace1P1' });
         expect(
             conditional?.(interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.homePlace1P1.nextPlaceCategory')
         ).toEqual([false, null]);
@@ -351,7 +340,7 @@ describe('NextPlaceCategory widget conditional', () => {
             const visitedPlacesArray = odHelpers.getVisitedPlacesArray({ journey });
             const lastPlace = visitedPlacesArray[visitedPlacesArray.length - 1];
 
-            setActiveVisitedPlace(interview, 'personId1', 'journeyId1', lastPlace._uuid);
+            setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: lastPlace._uuid });
             (lastPlace as any).activity = activity;
 
             expect(

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetsGeography.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetsGeography.test.ts
@@ -8,7 +8,7 @@
 import _cloneDeep from 'lodash/cloneDeep';
 import  i18n from 'i18next';
 import config from '../../../../../config/project.config';
-import { interviewAttributesForTestCases, widgetFactoryOptions } from '../../../../../tests/surveys';
+import { interviewAttributesForTestCases, setActiveSurveyObjects, widgetFactoryOptions } from '../../../../../tests/surveys';
 import { setResponse, translateString } from '../../../../../utils/helpers';
 import { InputMapFindPlaceType, InputStringType, QuestionWidgetConfig } from '../../../types';
 import { loopActivities } from '../../../../odSurvey/types';
@@ -21,17 +21,6 @@ const visitedPlacesSectionConfig = {
     enabled: true,
     tripDiaryMinTimeOfDay: 4 * 60 * 60, // 4h in seconds
     tripDiaryMaxTimeOfDay: 28 * 60 * 60 // 28h in seconds (i.e. 4h the next day)
-};
-
-const setActiveVisitedPlace = (
-    interview: typeof interviewAttributesForTestCases,
-    personId: string | null,
-    journeyId: string | null,
-    visitedPlaceId: string | null
-) => {
-    setResponse(interview, '_activePersonId', personId);
-    setResponse(interview, '_activeJourneyId', journeyId);
-    setResponse(interview, '_activeVisitedPlaceId', visitedPlaceId);
 };
 
 describe('VisitedPlaceGeographyWidgetFactory', () => {
@@ -174,7 +163,7 @@ describe('visitedPlaceName widget', () => {
 
         test('should hide widget and return usual work place name for workUsual activity', () => {
             const interview = _cloneDeep(interviewAttributesForTestCases);
-            setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'workPlace1P1');
+            setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
             // Add the person's usual work place
             (interview.response.household!.persons!.personId1 as any).usualWorkPlace = { name: 'My usual work place' };
 
@@ -188,7 +177,7 @@ describe('visitedPlaceName widget', () => {
 
         test('should hide widget and return usual school place name for schoolUsual activity', () => {
             const interview = _cloneDeep(interviewAttributesForTestCases);
-            setActiveVisitedPlace(interview, 'personId3', 'journeyId3', 'schoolPlace1P3');
+            setActiveSurveyObjects(interview, { personId: 'personId3', journeyId: 'journeyId3', visitedPlaceId: 'schoolPlace1P3' });
             // Set the person's usual school place
             (interview.response.household!.persons!.personId3 as any).usualSchoolPlace = {
                 name: 'My usual school place'
@@ -242,7 +231,7 @@ describe('visitedPlaceName widget', () => {
 
         test('should show widget for workUsual activity, but no usual work place set', () => {
             const interview = _cloneDeep(interviewAttributesForTestCases);
-            setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'workPlace1P1');
+            setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
             // Set the person's usual work place to undefined
             (interview.response.household!.persons!.personId1 as any).usualWorkPlace = undefined;
 
@@ -346,7 +335,7 @@ describe('visitedPlaceGeography widget', () => {
             const interview = _cloneDeep(interviewAttributesForTestCases);
             // Coordinates are those of shoppingPlace1P2
             const expectedCoordinates = shoppingPlace1P2Coordinates;
-            setActiveVisitedPlace(interview, 'personId2', 'journeyId2', 'otherWorkPlace1P2');
+            setActiveSurveyObjects(interview, { personId: 'personId2', journeyId: 'journeyId2', visitedPlaceId: 'otherWorkPlace1P2' });
 
             expect(defaultCenter(interview, 'path')).toEqual({ lat: expectedCoordinates[1], lon: expectedCoordinates[0] });
         });
@@ -357,14 +346,14 @@ describe('visitedPlaceGeography widget', () => {
             delete interview.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!.homePlace1P1;
             // Coordinates are those of home
             const expectedCoordinates = homeGeographyCoordinates;
-            setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'homePlace1P1');
+            setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'homePlace1P1' });
 
             expect(defaultCenter(interview, 'path')).toEqual({ lat: expectedCoordinates[1], lon: expectedCoordinates[0] });
         });
 
         test('should fallback to default map center when no home geography is available', () => {
             const interview = _cloneDeep(interviewAttributesForTestCases);
-            setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'homePlace1P1');
+            setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'homePlace1P1' });
             // Set place geography to undefined
             setResponse(interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.homePlace1P1.geography', undefined);
             setResponse(interview, 'home.geography.geometry.coordinates', undefined);
@@ -511,7 +500,7 @@ describe('visitedPlaceGeography widget', () => {
 
         test('should hide widget and return usual work place geography for workUsual activity', () => {
             const interview = _cloneDeep(interviewAttributesForTestCases);
-            setActiveVisitedPlace(interview, 'personId1', 'journeyId1', 'workPlace1P1');
+            setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
             const usualWorkPlaceGeography = {
                 type: 'Feature',
                 geometry: { type: 'Point', coordinates: [-72.9, 46.2] },
@@ -532,7 +521,7 @@ describe('visitedPlaceGeography widget', () => {
 
         test('should hide widget and return usual school place geography for schoolUsual activity', () => {
             const interview = _cloneDeep(interviewAttributesForTestCases);
-            setActiveVisitedPlace(interview, 'personId3', 'journeyId3', 'schoolPlace1P3');
+            setActiveSurveyObjects(interview, { personId: 'personId3', journeyId: 'journeyId3', visitedPlaceId: 'schoolPlace1P3' });
             const usualSchoolPlaceGeography = {
                 type: 'Feature',
                 geometry: { type: 'Point', coordinates: [-71.6, 46.7] },

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/buttonConfirmGotoNextSection.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/buttonConfirmGotoNextSection.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import type { ButtonWidgetConfig, VisitedPlacesSectionConfiguration } from '../../types';
+import * as odHelpers from '../../../odSurvey/helpers';
+import type { UserInterviewAttributes } from '../../types';
+import type { WidgetFactoryOptions } from '../types';
+import { getButtonValidateAndGotoNextSection } from '../common/buttonValidateAndGotoNextSection';
+
+export const getButtonConfirmGotoNextSectionWidgetConfig = (
+    _sectionConfig: VisitedPlacesSectionConfiguration,
+    options: WidgetFactoryOptions
+): ButtonWidgetConfig => {
+    const gotoNextDefaultButtonConfig = getButtonValidateAndGotoNextSection('visitedPlaces:saveAndContinue', options);
+    return {
+        ...gotoNextDefaultButtonConfig,
+        conditional: (interview: UserInterviewAttributes) => {
+            const person = odHelpers.getPerson({ interview }) as any;
+            const currentJourney = odHelpers.getActiveJourney({ interview, person });
+            if (!currentJourney) {
+                // This button should only be shown in the context of a journey
+                return false;
+            }
+            const visitePlacesArray = odHelpers.getVisitedPlacesArray({ journey: currentJourney });
+            const lastVisitedPlace = visitePlacesArray[visitePlacesArray.length - 1];
+            return (
+                lastVisitedPlace !== undefined && lastVisitedPlace.nextPlaceCategory === 'stayedThereUntilTheNextDay'
+            );
+        }
+    };
+};

--- a/packages/evolution-common/src/tests/surveys/index.ts
+++ b/packages/evolution-common/src/tests/surveys/index.ts
@@ -6,8 +6,46 @@
  */
 
 import { WidgetFactoryOptions } from '../../services/questionnaire/sections/types';
+import { setResponse } from '../../utils/helpers';
+import { interviewAttributesForTestCases } from './testCasesInterview';
 
 export { interviewAttributesForTestCases } from './testCasesInterview';
+
+/**
+ * Set active survey objects in an interview. This is useful for testing
+ * various cases related to active elements. The active objects can be unset by
+ * passing undefined for the corresponding parameters.
+ *
+ * @param interview The interview object
+ * @param options The object IDs to set as active
+ * @param [options.personId] The ID of the person to set as active
+ * @param [options.journeyId] The ID of the journey to set as active
+ * @param [options.visitedPlaceId] The ID of the visited place to set as active
+ * @param [options.activeTripId] The ID of the active trip to set as active
+ * @param [options.activeSegmentId] The ID of the active segment to set as active
+ */
+export const setActiveSurveyObjects = (
+    interview: typeof interviewAttributesForTestCases,
+    {
+        personId,
+        journeyId,
+        visitedPlaceId,
+        activeTripId,
+        activeSegmentId
+    }: {
+        personId?: string;
+        journeyId?: string;
+        visitedPlaceId?: string;
+        activeTripId?: string;
+        activeSegmentId?: string;
+    }
+) => {
+    setResponse(interview, '_activePersonId', personId);
+    setResponse(interview, '_activeJourneyId', journeyId);
+    setResponse(interview, '_activeVisitedPlaceId', visitedPlaceId);
+    setResponse(interview, '_activeTripId', activeTripId);
+    setResponse(interview, '_activeSegmentId', activeSegmentId);
+};
 
 /**
  * Change all function properties in an object (or array) to


### PR DESCRIPTION
* Extract a `setActiveSurveyObject` test function to set the various active objects in a test interview
* Add the button to goto next section after all visited places are entered. It is based on the default goto next section button, except that it has a conditional on the last visited place's nextplaceCategory, to make sure the trip diary is complete

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Confirm locations and continue" button to the visited places section, which appears conditionally based on the last visited place's details.

* **Tests**
  * Added comprehensive test coverage for the new confirmation button functionality and updated test utilities across visited places tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->