### PR TITLE
Generator: Introduce built-in widgets for questionnaire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased (0.6.0)] - YYYY-MM-DD
 
 ### Added
+
 - **CSS refresh in dev mode**: Changes to `.scss` files are automatically picked up by `yarn build:dev` and apply after a page reload (fixes [#1403](https://github.com/chairemobilite/evolution/issues/1403)). Survey projects that want the same: see [#1407](https://github.com/chairemobilite/evolution/pull/1407) for the webpack modifications.
-- Added `maxAccessEgressTravelTimeMinutes` and `walkingSpeedKmPerHour` to accessibility map calculation parameters (#1379)
-- Added utility functions for webpack generation in evolution-frontend: `createParticipantWebpackConfig` and `createAdminWebpackConfig`. The example projects implement this approach. Projects should consider using those for simlicity. (#1405)
-- **Generator custom labels support**: Widget generation can now import and use custom labels, allowing label overrides without a full custom widget. In the `Widgets` Excel sheet, set this in the `parameters` column: `customLabels={{yourCustomLabelsKey}}` (fixes #1035)
+- Added `maxAccessEgressTravelTimeMinutes` and `walkingSpeedKmPerHour` to accessibility map calculation parameters ([#1379](https://github.com/chairemobilite/evolution/pull/1379))
+- Added utility functions for webpack generation in evolution-frontend: `createParticipantWebpackConfig` and `createAdminWebpackConfig`. The example projects implement this approach. Projects should consider using those for simlicity. ([#1405](https://github.com/chairemobilite/evolution/issues/1405))
+- **Generator custom labels support**: Widget generation can now import and use custom labels, allowing label overrides without a full custom widget. In the `Widgets` Excel sheet, set this in the `parameters` column: `customLabels={{yourCustomLabelsKey}}` (fixes [#1035](https://github.com/chairemobilite/evolution/issues/1035))
+- **Generator built-in widgets**: In the `Widgets` Excel sheet, set `inputType=BuiltIn` and add `builtInFunction={{yourBuiltInFunctionName}}` in the `parameters` column (Part [#902](https://github.com/chairemobilite/evolution/issues/902)).
 
 ### Changed
+
 - BREAKING: if using the webpack generation functions and the project has a `locales` folder, make sure an empty module file is present in the folder for build time import. An empty file named `index.js` at the root of the project's `locales` folder is enough. Webpack will replace it with the actual translations in the build. (#1426)
 - BREAKING: the `addGroupedObjects` function now returns an object of type `{ valuesByPath: Record<string, unknown>, newObjects: QuestionnaireObjectWithUuidAndSequence[] }` instead of only the values by path. Previous code can simply use the response's `valuesByPath` field to have the same data as before.
 
@@ -22,21 +25,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+
 - Allow to effectively override locales from Evolution by survey specifics with the same key. Fix is applied automatically on projects calling the `createParticipantWebpackConfig` and `createAdminWebpackConfig` webpack helpers. (#1426)
 
 ### Security
 
 ### Dependency updates
+
 - style-loader: 4.0.0
 - lodash: 4.17.21 => 4.17.23
 - @types/lodash: 4.17.21 => 4.17.23
 - yargs: 17.7.2 => 18.0.0
 - In the root `package.json` add a resolution of `kdbush` to 3.0.0 to avoid compilation errors with some packages depending on a more recent version. This requirement comes from Transition, who does the same (see https://github.com/chairemobilite/transition/issues/921 to track issue to upgrade/remove `kdbush`).
 
-
 ## [Unreleased (0.5.1)] - YYYY-MM-DD
 
 ### Added
+
 - Added `platform`, `os`, `browser` and `language` fields to each record of the exported paradata (#1395)
 
 ### Changed
@@ -51,15 +56,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Dependency updates
 
-
 ## [0.5.0] - 2026-01-30
 
 ### Added
+
 - Initial CHANGELOG.md structure
-- Navigation between section is now handled through a `SectionConfig` type (see #976, _needs documentation_) 
+- Navigation between section is now handled through a `SectionConfig` type (see #976, _needs documentation_)
 - The `startNavigate` redux action was introduced for section changes instead of `startUpdateInterview` with a `response._activeSection` (0541f0663fa9ba521d384359eacc99392c509dee)
 
 ### Changed
+
 - BREAKING: rename `requestResponses` to `requestedFields` in the `downloadCsvFile` function call (f5d33f73b930a4ceb3741bd165a0d0b46680def4)
 - BREAKING: The generator now escapes label with nicknames. Projects using this feature need to make sure to have the `lodash/escape` dependency (fe502f657335aed90c86750f4405a6a1ae13eecd)
 - BREAKING: In generated surveys, the `preload` functions need to be renamed to `customPreload` (b4086b1d0ed07cd020cb6ba20d836ddf74fa5b9b)
@@ -70,6 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update sass stylesheets (ee6efc8a788bbc3bd00c7377957ff5e818142ff2)
 
 ### Deprecated
+
 - Navigating to another section by calling `startUpdateInterview` with a `response._activeSection` is now deprecated, use the `startNavigate` action instead (0541f0663fa9ba521d384359eacc99392c509dee)
 
 ### Removed
@@ -85,6 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Guidelines for updating this changelog
 
 ### Types of changes
+
 - **Added** for new features
 - **Changed** for changes in existing functionality
 - **Deprecated** for soon-to-be removed features
@@ -93,17 +101,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Security** for vulnerability fixes
 
 ### Version format
+
 - Use semantic versioning (MAJOR.MINOR.PATCH)
 - MAJOR: incompatible API changes
 - MINOR: backwards-compatible functionality additions
 - PATCH: backwards-compatible bug fixes
 
 ### Best practices
+
 - Keep an "Unreleased" section at the top for upcoming changes
 - Add release date in YYYY-MM-DD format when publishing a version
 - Group changes by type (Added, Changed, etc.)
 - Write from the user's perspective
 - Be concise but descriptive
 - Link to issues/PRs when relevant
-
-

--- a/packages/evolution-generator/README.md
+++ b/packages/evolution-generator/README.md
@@ -230,7 +230,7 @@ Widgets are the building blocks of your survey. They define the structure and in
 <!-- TODO: Document the join_with option in the appearance column. Example: appearance: join_with=${questionName} -->
 <!-- TODO: Document the parameters column (e.g. min=0 max=6 overMaxAllowed, separated by newline, semicolon, or space, with the possibility to either support a number or a response field) -->
 
-> <span id="input">**Note:**</span> The `inputType` field specifies the type of input for the question and can be one of the following: Custom, Radio, RadioNumber, Select, String, Number, InfoText, Range, Checkbox, NextButton, or Text
+> <span id="input">**Note:**</span> The `inputType` field specifies the type of input for the question and can be one of the following: Custom, BuiltIn, Radio, RadioNumber, Select, String, Number, InfoText, Range, Checkbox, NextButton, or Text
 
 > <span id="cond">**Note:**</span> The `conditional` field allows you to define conditional logic for displaying the widget based on other response. For example, you can specify a condition like `nbPersonsSevenOrMoreConditional` to show the widget only if the number of people is 7 or more.
 
@@ -242,7 +242,7 @@ Widgets are the building blocks of your survey. They define the structure and in
 
 > <span id="range">**Note:**</span> The `inputRange` field is optional and allows you to define the valid range of values for `Range` input.
 
-> <span id="paramsWidgets">**Note:**</span> The `parameters` field is optional but can include a `customLabels` override in the format `customLabels={{someCustomLabels}}`.
+> <span id="paramsWidgets">**Note:**</span> The `parameters` field is optional but can include a `customLabels` override in the format `customLabels={{someCustomLabels}}`. For `inputType=BuiltIn`, set `builtInFunction={{yourBuiltInFunctionName}}`.
 
 ### Widgets Example
 

--- a/packages/evolution-generator/src/scripts/generate_widgets.py
+++ b/packages/evolution-generator/src/scripts/generate_widgets.py
@@ -27,6 +27,7 @@ class ImportFlags:
     has_conditionals_import: bool = False
     has_input_range_import: bool = False
     has_custom_widgets_import: bool = False
+    has_built_in_widgets_import: bool = False
     has_validations_import: bool = (
         True  # Default to True for validations.requiredValidation
     )
@@ -240,6 +241,11 @@ def generate_widget_statement(row, gender_fields: GenderFields = None) -> Widget
 
     if input_type == "Custom":
         result["statement"] = generate_custom_widget(question_name)
+    elif input_type == "BuiltIn":
+        parameters = row.get("parameters", "") or ""
+        result["statement"] = generate_built_in_widget(
+            question_name=question_name, parameters=parameters
+        )
     elif input_type == "Radio":
         result["statement"] = generate_radio_widget(
             question_name,
@@ -480,6 +486,7 @@ def generate_import_statements(import_flags: ImportFlags) -> str:
         f"import {{ defaultConditional }} from 'evolution-common/lib/services/widgets/conditionals/defaultConditional';\n"
         f"import * as WidgetConfig from 'evolution-common/lib/services/questionnaire/types';\n"
         f"{validations_import}"
+        # TODO: Add built-in widgets import when we are ready to support them
         f"{od_survey_helpers_import}"
         f"{survey_helper_import}"
         f"{choices_import}"
@@ -500,6 +507,35 @@ def generate_import_statements(import_flags: ImportFlags) -> str:
 # Generate Custom widget
 def generate_custom_widget(question_name):
     return f"export const {question_name} = customWidgets.{question_name};"
+
+
+# TODO: Change this when we are ready to support built-in widgets, right now we are just emitting a comment placeholder.
+# Generate built-in widget
+def generate_built_in_widget(question_name: str, parameters: str) -> str:
+    param_dict = parse_parameters(parameters or "")
+    # parse_parameters lowercases keys, so builtInFunction becomes builtinfunction
+    raw_value = param_dict.get("builtinfunction")
+
+    # Extract the built-in function name from the parameters
+    built_in_function_name: str | None = None
+    if raw_value and isinstance(raw_value, str):
+        built_in_function_name = raw_value.strip()
+        if built_in_function_name.startswith("{{") and built_in_function_name.endswith(
+            "}}"
+        ):
+            built_in_function_name = built_in_function_name[2:-2].strip()
+
+    if built_in_function_name:
+        return (
+            f"// Built-in widget placeholder for '{question_name}' (builtInFunction: {built_in_function_name}).\n"
+            f"// export const {question_name} = {built_in_function_name}();"
+        )
+    else:
+        # TODO: Uncomment this when we are ready to support built-in widgets
+        # print(
+        #     f"Warning: BuiltIn widget '{question_name}' not generated yet (missing/invalid parameters: builtInFunction={{...}})."
+        # )
+        return ""
 
 
 # Generate comma and skip line
@@ -1167,6 +1203,8 @@ def get_widgets_file_import_flags(section_rows) -> ImportFlags:
             import_flags.has_input_range_import = True
         if row["inputType"] == "Custom":
             import_flags.has_custom_widgets_import = True
+        if row["inputType"] == "BuiltIn":
+            import_flags.has_built_in_widgets_import = True
         if row.get("help_popup") or row.get("confirm_popup"):
             import_flags.has_help_popup_import = True
 

--- a/packages/evolution-generator/src/tests/test_generate_widgets.py
+++ b/packages/evolution-generator/src/tests/test_generate_widgets.py
@@ -23,6 +23,7 @@ from scripts.generate_widgets import (
 
 # TODO: Test generate_widgets
 # TODO: Test generate_widget_statement
+# TODO: Test generate_built_in_widget when we are ready to support them
 # TODO: Test generate_widget_name
 # TODO: Test generate_widgets_names_statements
 


### PR DESCRIPTION
# Issue

## Todos

- [x] Update the Generator Readme
- [x] Update the ChangeLogs
- [x] Seperate the homeGeography widget in another PR
- [x] Fix the bug with the rendering bug

## Description
- Added a new file `builtInWidgets.ts` to export configurations and factories for built-in questionnaire widgets.
- Implemented the `getHomeGeographyWidgetConfig` function in `widgetHomeGeography.ts` to define the configuration for the home geography widget.
- Updated the `generate_widgets.py` script to support the generation of built-in widgets, including import statements and widget generation logic.