### PR TITLE
questionnaire: preparatory work for the visited place section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - BREAKING: if using the webpack generation functions and the project has a `locales` folder, make sure an empty module file is present in the folder for build time import. An empty file named `index.js` at the root of the project's `locales` folder is enough. Webpack will replace it with the actual translations in the build. (#1426)
+- BREAKING: the `addGroupedObjects` function now returns an object of type `{ valuesByPath: Record<string, unknown>, newObjects: QuestionnaireObjectWithUuidAndSequence[] }` instead of only the values by path. Previous code can simply use the response's `valuesByPath` field to have the same data as before.
 
 ### Deprecated
 

--- a/example/demo_survey/src/survey/sections.ts
+++ b/example/demo_survey/src/survey/sections.ts
@@ -134,7 +134,8 @@ const sections: { [sectionName: string]: SectionConfig } = {
             if (householdSizeIsValid && householdSize) {
                 if (countGroupedObjects < householdSize) {
                     // auto create objects according to household size:
-                    return addGroupedObjects(interview, householdSize - countGroupedObjects, -1, 'household.persons');
+                    return addGroupedObjects(interview, householdSize - countGroupedObjects, -1, 'household.persons')
+                        .valuesByPath;
                 } else if (countGroupedObjects > householdSize) {
                     const pathsToDelete = [];
                     // auto remove empty objects according to household size:
@@ -314,18 +315,14 @@ const sections: { [sectionName: string]: SectionConfig } = {
                     }
                 } else {
                     // Make sure to set initialize a journey for this person if it does not exist
-                    const newJourneysValuesByPath = addGroupedObjects(
+                    const { valuesByPath: newJourneysValuesByPath, newObjects } = addGroupedObjects(
                         interview,
                         1,
                         1,
                         `household.persons.${person._uuid}.journeys`,
                         [{ startDate: getResponse(interview, 'tripsDate') }]
                     );
-                    const newJourneyKey = Object.keys(newJourneysValuesByPath).find((key) =>
-                        key.startsWith(`response.household.persons.${person._uuid}.journeys.`)
-                    );
-                    // From the newJourneyKey, get the journey UUID as the rest of the string after the last dot
-                    const journeyUuid = newJourneyKey.split('.').pop();
+                    const journeyUuid = newObjects[0]._uuid;
                     newJourneysValuesByPath['response._activeJourneyId'] = journeyUuid;
                     return newJourneysValuesByPath;
                 }
@@ -392,7 +389,7 @@ const sections: { [sectionName: string]: SectionConfig } = {
 
             if (visitedPlaces.length === 0) {
                 // Add the first visited place
-                const visitedPlacesValuesByPath = addGroupedObjects(
+                const { valuesByPath: visitedPlacesValuesByPath } = addGroupedObjects(
                     interview,
                     1,
                     1,
@@ -420,6 +417,9 @@ const sections: { [sectionName: string]: SectionConfig } = {
         },
         enableConditional: function (interview) {
             const person = odSurveyHelper.getPerson({ interview });
+            if (person === null) {
+                return false;
+            }
             return (
                 helper.householdMembersSectionComplete(interview) &&
                 helper.tripsIntroForPersonComplete(person, interview)

--- a/packages/evolution-common/src/services/odSurvey/__tests__/helpers.test.ts
+++ b/packages/evolution-common/src/services/odSurvey/__tests__/helpers.test.ts
@@ -1403,6 +1403,74 @@ describe('getJourneys', () => {
     });
 });
 
+describe('shouldShowTripsAndPlacesSections', () => {
+    const baseJourney: Journey = {
+        _uuid: 'arbitraryJourney',
+        _sequence: 1
+    }
+    test.each([{
+        title: 'Journey with personDidTrips unanswered undefined',
+        journey: {
+            ...baseJourney,
+        },
+        expected: false
+    }, {
+        title: 'Journey with personDidTrips unanswered empty string',
+        journey: {
+            ...baseJourney,
+            personDidTrips: ''
+        },
+        expected: false
+    }, {
+        title: 'Journey with personDidTrips answered no',
+        journey: {
+            ...baseJourney,
+            personDidTrips: 'no'
+        },
+        expected: false 
+    }, {
+        title: 'Journey with personDidTrips answered yes',
+        journey: {
+            ...baseJourney,
+            personDidTrips: 'yes'
+        },
+        expected: true  
+    }, {
+        title: 'Journey with personDidTrips answered dontKnow',
+        journey: {
+            ...baseJourney,
+            personDidTrips: 'dontKnow'
+        },
+        expected: false 
+    }, {
+        title: 'Journey with personDidTrips answered no, but personDidTripsConfirm answered yes',
+        journey: {
+            ...baseJourney,
+            personDidTrips: 'no',
+            personDidTripsConfirm: 'yes'
+        },
+        expected: true
+    }, {
+        title: 'Journey with personDidTrips answered yes, but personDidTripsConfirm answered no',
+        journey: {
+            ...baseJourney,
+            personDidTrips: 'yes',
+            personDidTripsConfirm: 'no'
+        },
+        expected: true
+    }, {
+        title: 'Journey with personDidTrips and personDidTripsConfirm both no',
+        journey: {
+            ...baseJourney,
+            personDidTrips: 'no',
+            personDidTripsConfirm: 'no'
+        },
+        expected: false
+    }])('$title', ({ journey, expected }) => {
+        expect(Helpers.shouldShowTripsAndPlacesSections({ journey })).toEqual(expected);
+    });
+});
+
 describe('getVisitedPlaces', () => {
     const journey: Journey = {
         _uuid: 'arbitraryJourney',

--- a/packages/evolution-common/src/services/odSurvey/helpers.ts
+++ b/packages/evolution-common/src/services/odSurvey/helpers.ts
@@ -532,6 +532,24 @@ export const getJourneysArray = function ({ person }: { person: Person }): Journ
     return Object.values(journeys).sort((journeyA, journeyB) => journeyA._sequence - journeyB._sequence);
 };
 
+/**
+ * Determine whether the trips and visited places sections should exist for this
+ * journey, based on the journey's data and prior answers.
+ *
+ * For OD surveys, this is based on the `personDidTrips` question.
+ *
+ * @param {Object} options - The options object.
+ * @param {Journey} options.journey The journey for which to check if visited
+ * places and trips should be shown.
+ * @returns {boolean} `true` if this journey is expected to have trips and
+ * visited places data entered by participants.
+ */
+export const shouldShowTripsAndPlacesSections = ({ journey }: { journey: Journey }): boolean =>
+    // FIXME This implies that the journey has the `personDidTrips` question.
+    // Support surveys with journeys manually created by participant (see issue
+    // #1498)
+    journey.personDidTrips === 'yes' || journey.personDidTripsConfirm === 'yes';
+
 // *** Trip-related functions
 
 /**

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/sectionSegment.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/sectionSegment.test.ts
@@ -12,12 +12,13 @@ import { interviewAttributesForTestCases, maskFunctions, widgetFactoryOptions } 
 import * as utilHelpers from '../../../../../utils/helpers';
 import * as odHelpers from '../../../../odSurvey/helpers';
 import { SegmentSectionConfiguration, VisitedPlace, WidgetConfig } from '../../../types';
-import { Activity, Mode } from '../../../../odSurvey/types';
+import {  Mode } from '../../../../odSurvey/types';
 import { PersonTripsGroupConfigFactory } from '../groupPersonTrips';
 import { getPersonsTripsTitleWidgetConfig } from '../widgetPersonTripsTitle';
 import { getPersonVisitedPlacesMapConfig } from '../../common/widgetPersonVisitedPlacesMap';
 import { getButtonValidateAndGotoNextSection } from '../../common/buttonValidateAndGotoNextSection';
 import { SwitchPersonWidgetsFactory } from '../../common/widgetsSwitchPerson';
+import { tripDiarySectionVisibleConditional } from '../../tripDiary/tripDiaryHelpers';
 
 jest.mock('uuid', () => ({
     v4: jest.fn().mockReturnValue('newTripId')
@@ -53,7 +54,7 @@ describe('SegmentsSectionFactory#getSectionConfig', () => {
         expect(widgetConfig).toEqual({
             previousSection: 'visitedPlaces',
             nextSection: 'travelBehavior',
-            isSectionVisible: expect.any(Function),
+            isSectionVisible: tripDiarySectionVisibleConditional,
             isSectionCompleted: expect.any(Function),
             onSectionEntry: expect.any(Function),
             template: 'tripsAndSegmentsWithMap',
@@ -169,39 +170,6 @@ describe('sectionConfig functionalities', () => {
             expect(mockedT).toHaveBeenCalledWith(['customSurvey:segments:SegmentsTitle', 'segments:SegmentsTitle']);
         });
 
-    });
-
-    describe('getSegmentsSectionConfig isSectionVisible', () => {
-        const sectionFactory = new SegmentsSectionFactory(segmentSectionConfig, widgetFactoryOptions);
-        const widgetConfig = sectionFactory.getSectionConfig();
-        const iterationContext = ['testPerson1'];
-        
-        beforeEach(() => {
-            jest.clearAllMocks();
-        });
-
-        test('should return false if no iteration context', () => {
-            const result = widgetConfig.isSectionVisible!(interviewWithTestPerson, undefined);
-            
-            expect(result).toBe(false);
-        });
-
-        test('should return false if no active journey', () => {
-            const testInterview = _cloneDeep(interviewWithTestPerson);
-            testInterview.response._activeJourneyId = undefined;
-            
-            const result = widgetConfig.isSectionVisible!(testInterview, iterationContext);
-            
-            expect(result).toBe(false);
-        });
-
-        test('should return true if there is an active journey', () => {
-            const testInterview = _cloneDeep(interviewWithTestPerson);
-            
-            const result = widgetConfig.isSectionVisible!(testInterview, iterationContext);
-            
-            expect(result).toBe(true);
-        });
     });
 
     describe('getSegmentsSectionConfig isSectionCompleted', () => {

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/sectionSegments.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/sectionSegments.ts
@@ -17,6 +17,7 @@ import { SwitchPersonWidgetsFactory } from '../common/widgetsSwitchPerson';
 import { PersonTripsGroupConfigFactory } from './groupPersonTrips';
 import { getPersonVisitedPlacesMapConfig } from '../common/widgetPersonVisitedPlacesMap';
 import { getButtonValidateAndGotoNextSection } from '../common/buttonValidateAndGotoNextSection';
+import { tripDiarySectionVisibleConditional } from '../tripDiary/tripDiaryHelpers';
 
 export class SegmentsSectionFactory implements SectionConfigFactory {
     private _sectionConfig: SectionConfig | undefined = undefined;
@@ -34,23 +35,7 @@ export class SegmentsSectionFactory implements SectionConfigFactory {
         return {
             previousSection: 'visitedPlaces',
             nextSection: 'travelBehavior',
-            isSectionVisible: (interview, iterationContext) => {
-                const personId = iterationContext ? iterationContext[iterationContext.length - 1] : undefined;
-                const person = personId === undefined ? null : odHelpers.getPerson({ interview, personId });
-                if (person === null) {
-                    // Log error, that is unexpected
-                    console.error(
-                        `segments section.isSectionVisible: No person found for iteration context: ${JSON.stringify(iterationContext)}`
-                    );
-                    return false;
-                }
-                const currentJourney = odHelpers.getActiveJourney({ interview, person });
-                if (currentJourney === null) {
-                    // Do not display if there is no active journey
-                    return false;
-                }
-                return true;
-            },
+            isSectionVisible: tripDiarySectionVisibleConditional,
             isSectionCompleted: (interview, iterationContext) => {
                 const personId = iterationContext ? iterationContext[iterationContext.length - 1] : undefined;
                 const person = personId === undefined ? null : odHelpers.getPerson({ interview, personId });

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/sectionSegments.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/sectionSegments.ts
@@ -71,8 +71,7 @@ export class SegmentsSectionFactory implements SectionConfigFactory {
                 const tripsPath = `household.persons.${person._uuid}.journeys.${currentJourney!._uuid}.trips`;
                 const visitedPlaces = odHelpers.getVisitedPlacesArray({ journey: currentJourney! });
                 const trips = odHelpers.getTripsArray({ journey: currentJourney! });
-                const nextTrip: Trip | null = odHelpers.selectNextIncompleteTrip({ journey: currentJourney! });
-                let firstInvalidTripId: string | null | undefined = nextTrip ? nextTrip._uuid : null;
+                let nextTripToSelect: Trip | null = odHelpers.selectNextIncompleteTrip({ journey: currentJourney! });
                 let foundFirstInvalidTrip = false;
 
                 // Create the missing trips objects and initialize those that may have changed
@@ -97,44 +96,36 @@ export class SegmentsSectionFactory implements SectionConfigFactory {
                             destination._uuid;
                         // also delete existing segments:
                         responseContent[`response.${tripsPath}.${trip._uuid}.segments`] = undefined;
-                        if (firstInvalidTripId === null || !foundFirstInvalidTrip) {
+                        if (nextTripToSelect === null || !foundFirstInvalidTrip) {
                             // If the first invalid trip is not set, set it to this trip
-                            firstInvalidTripId = trip._uuid;
+                            nextTripToSelect = trip;
                             foundFirstInvalidTrip = true;
                         }
-                    } else if (!foundFirstInvalidTrip && trip._uuid === firstInvalidTripId) {
+                    } else if (!foundFirstInvalidTrip && trip._uuid === nextTripToSelect?._uuid) {
                         // If this is the first invalid trip, we found it
                         foundFirstInvalidTrip = true;
                     }
                 }
                 // If the invalid trip was not found, it is not in the trips array anymore, so we set it to null
-                if (!foundFirstInvalidTrip && nextTrip !== null) {
-                    firstInvalidTripId = null;
+                if (!foundFirstInvalidTrip && nextTripToSelect !== null) {
+                    nextTripToSelect = null;
                 }
                 if (newTrips.length > 0) {
                     // Add the new trips all at once, after the existing ones
-                    const addValuesByPath = addGroupedObjects(
+                    const { valuesByPath, newObjects } = addGroupedObjects(
                         interview,
                         newTrips.length,
                         trips.length + 1,
                         tripsPath,
                         newTrips
                     );
-                    // Set the first invalid trip to the first trip in the new sequence
-                    if (firstInvalidTripId === null) {
-                        // Find trip with lowest sequence number
-                        const newTripKey = Object.keys(addValuesByPath)
-                            .filter((key) => key.startsWith(`response.${tripsPath}`))
-                            .sort(
-                                (tripKeyA, tripKeyB) =>
-                                    (addValuesByPath[tripKeyA] as any)._sequence -
-                                    (addValuesByPath[tripKeyB] as any)._sequence
-                            )[0];
-                        // From the newJourneyKey, get the journey UUID as the rest of the string after the last dot
-                        const tripUuid = newTripKey!.split('.').pop();
-                        firstInvalidTripId = tripUuid;
+                    // Set the next trip to the first trip in the new sequence, if not found yet
+                    if (nextTripToSelect === null && newObjects.length > 0) {
+                        // Find trip with lowest sequence number and select it as next one
+                        const firstNewTrip = newObjects.sort((tripA, tripB) => tripA._sequence - tripB._sequence)[0];
+                        nextTripToSelect = firstNewTrip;
                     }
-                    Object.assign(responseContent, addValuesByPath);
+                    Object.assign(responseContent, valuesByPath);
                 }
 
                 // remove superfluous trips, there should be one less than visited places
@@ -158,15 +149,10 @@ export class SegmentsSectionFactory implements SectionConfigFactory {
                     }
                 }
 
-                if (!_isEmpty(responseContent)) {
-                    return {
-                        ...responseContent,
-                        'response._activeTripId': firstInvalidTripId
-                    };
-                } else {
-                    responseContent['response._activeTripId'] = nextTrip !== null ? nextTrip._uuid : null;
-                    return responseContent;
-                }
+                return {
+                    ...responseContent,
+                    'response._activeTripId': nextTripToSelect !== null ? nextTripToSelect._uuid : null
+                };
             },
 
             // Section specific configuration

--- a/packages/evolution-common/src/services/questionnaire/sections/tripDiary/__tests__/tripDiaryHelpers.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/tripDiary/__tests__/tripDiaryHelpers.test.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import _cloneDeep from 'lodash/cloneDeep';
+
+import { interviewAttributesForTestCases, setActiveSurveyObjects } from '../../../../../tests/surveys';
+import { tripDiarySectionVisibleConditional } from '../tripDiaryHelpers';
+
+describe('tripDiarySectionVisibleConditional', () => {
+        
+    let testInterview = _cloneDeep(interviewAttributesForTestCases);
+    const iterationContext = ['personId1'];
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        testInterview = _cloneDeep(interviewAttributesForTestCases);
+        setActiveSurveyObjects(testInterview, { personId: 'personId1', journeyId: 'journeyId1' });
+    });
+
+    test('should return false if no iteration context', () => {
+        const result = tripDiarySectionVisibleConditional(testInterview, undefined);
+        
+        expect(result).toBe(false);
+    });
+
+    test('should return false if no active journey', () => {
+        setActiveSurveyObjects(testInterview, { personId: 'personId1', journeyId: undefined });
+        
+        const result = tripDiarySectionVisibleConditional(testInterview, iterationContext);
+        
+        expect(result).toBe(false);
+    });
+
+    test('should return true if there is an active journey with trips', () => {
+        const result = tripDiarySectionVisibleConditional(testInterview, iterationContext);
+        
+        expect(result).toBe(true);
+    });
+
+    test('should return false if there is an active journey but with no trips', () => {
+        const journey = testInterview.response.household!.persons!.personId1.journeys!.journeyId1;
+        testInterview.response.household!.persons!.personId1.journeys!.journeyId1 = {
+            ...journey,
+            personDidTrips: 'no',
+            visitedPlaces: undefined,
+            trips: undefined
+        };
+
+        const result = tripDiarySectionVisibleConditional(testInterview, iterationContext);
+
+        expect(result).toBe(false);
+    });
+});

--- a/packages/evolution-common/src/services/questionnaire/sections/tripDiary/tripDiaryHelpers.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/tripDiary/tripDiaryHelpers.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import * as odHelpers from '../../../odSurvey/helpers';
+import type { SectionConfig } from '../../types';
+
+export const tripDiarySectionVisibleConditional: Exclude<SectionConfig['isSectionVisible'], undefined> = (
+    interview,
+    iterationContext
+) => {
+    const personId = iterationContext ? iterationContext[iterationContext.length - 1] : undefined;
+    const person = personId === undefined ? null : odHelpers.getPerson({ interview, personId });
+    if (person === null) {
+        // Log error, that is unexpected
+        console.error(
+            `trip diary section.isSectionVisible: No person found for iteration context: ${JSON.stringify(iterationContext)}`
+        );
+        return false;
+    }
+    const currentJourney = odHelpers.getActiveJourney({ interview, person });
+    if (currentJourney === null) {
+        // Do not display if there is no active journey
+        return false;
+    }
+    return odHelpers.shouldShowTripsAndPlacesSections({ journey: currentJourney });
+};

--- a/packages/evolution-common/src/services/questionnaire/types/Data.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/Data.ts
@@ -15,6 +15,7 @@ import { SegmentAttributes } from '../../baseObjects/Segment';
 import { HouseholdAttributes } from '../../baseObjects/Household';
 import { NavigationSection } from './NavigationTypes';
 import type { Activity, ActivityCategory, Mode, ModePre } from '../../odSurvey/types';
+import { YesNoDontKnow } from '../../baseObjects/attributeTypes/GenericAttributes';
 
 export type ParsingFunction<T> = (interview: UserInterviewAttributes, path: string, user?: CliUser) => T;
 
@@ -113,12 +114,24 @@ export type Person = PersonAttributes & {
  * @typedef {Object} Journey
  * @property {number} _sequence The sequence number of the journey.
  * @property {string} [departurePlaceType] The type of the departure place.
- * @property {{ [tripId: string]: Trip }} [trips] The trips associated with this journey.
- * @property {{ [visitedPlaceId: string]: VisitedPlace }} [visitedPlaces] The visited places associated with this journey.
+ * @property {YesNoDontKnow} [personDidTrips] Answer to the question whether the
+ * person did any trips on the journey date. This question is typically asked in
+ * OD surveys, where a data is assigned to a household and members may or may
+ * not have done trips on that day.
+ * @property {YesNoDontKnow} [personDidTripsConfirm] Answer to the question to
+ * confirm if the person did any trips on the journey date. It is typically a
+ * failsafe question when people change their mind about their mobility after
+ * declaring trips. It also applies to the OD survey case.
+ * @property {{ [tripId: string]: Trip }} [trips] The trips associated with this
+ * journey.
+ * @property {{ [visitedPlaceId: string]: VisitedPlace }} [visitedPlaces] The
+ * visited places associated with this journey.
  */
 export type Journey = JourneyAttributes & {
     _sequence: number;
     departurePlaceType?: string;
+    personDidTrips?: YesNoDontKnow;
+    personDidTripsConfirm?: YesNoDontKnow;
     trips?: {
         [tripId: string]: Trip;
     };

--- a/packages/evolution-common/src/services/questionnaire/types/Data.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/Data.ts
@@ -96,19 +96,34 @@ type SurveyPointProperties = {
 };
 
 /**
+ * Base type for objects in the response, typically used in groups, like
+ * persons, visited places, etc.
+ */
+export type QuestionnaireObjectWithUuidAndSequence = {
+    /**
+     * A uuid to uniquely identify the object.
+     */
+    _uuid: string;
+    /**
+     * Sequence number for ordering objects. First object has sequence 1.
+     */
+    _sequence: number;
+};
+
+/**
  * @typedef {Object} Person
  * @property {number} _sequence The sequence number of the person.
  * @property {string} whoWillAnswerForThisPerson UUID of the person who responds for this person.
  * @property {{ [journeyId: string]: Journey }} [journeys] The journeys associated with this person.
  */
-export type Person = PersonAttributes & {
-    _sequence: number;
-    /** uuid of the person who responds for this person (for household where more than 1 person have more than the minimum self response age) */
-    whoWillAnswerForThisPerson?: string;
-    journeys?: {
-        [journeyId: string]: Journey;
+export type Person = PersonAttributes &
+    QuestionnaireObjectWithUuidAndSequence & {
+        /** uuid of the person who responds for this person (for household where more than 1 person have more than the minimum self response age) */
+        whoWillAnswerForThisPerson?: string;
+        journeys?: {
+            [journeyId: string]: Journey;
+        };
     };
-};
 
 /**
  * @typedef {Object} Journey
@@ -127,23 +142,21 @@ export type Person = PersonAttributes & {
  * @property {{ [visitedPlaceId: string]: VisitedPlace }} [visitedPlaces] The
  * visited places associated with this journey.
  */
-export type Journey = JourneyAttributes & {
-    _sequence: number;
-    departurePlaceType?: string;
-    personDidTrips?: YesNoDontKnow;
-    personDidTripsConfirm?: YesNoDontKnow;
-    trips?: {
-        [tripId: string]: Trip;
+export type Journey = JourneyAttributes &
+    QuestionnaireObjectWithUuidAndSequence & {
+        departurePlaceType?: string;
+        personDidTrips?: YesNoDontKnow;
+        personDidTripsConfirm?: YesNoDontKnow;
+        trips?: {
+            [tripId: string]: Trip;
+        };
+        visitedPlaces?: {
+            [visitedPlaceId: string]: VisitedPlace;
+        };
     };
-    visitedPlaces?: {
-        [visitedPlaceId: string]: VisitedPlace;
-    };
-};
 
 // FIXME We are not using the VisitedPlaceAttributes type here because during survey, most of the data from that type is rather as a property of the geography feature and not as fields of the object
-export type VisitedPlace = {
-    _sequence: number;
-    _uuid: string;
+export type VisitedPlace = QuestionnaireObjectWithUuidAndSequence & {
     activity?: Optional<Activity>;
     activityCategory?: Optional<ActivityCategory>;
     geography?: GeoJSON.Feature<GeoJSON.Point, SurveyPointProperties>;
@@ -156,27 +169,27 @@ export type VisitedPlace = {
      */
     nextPlaceCategory?: 'wentBackHome' | 'visitedAnotherPlace' | 'stayedThereUntilTheNextDay' | 'wentToUsualWorkPlace';
 } & (
-    | { alreadyVisitedBySelfOrAnotherHouseholdMember?: false; name?: string; shortcut?: never }
-    | { alreadyVisitedBySelfOrAnotherHouseholdMember: true; name?: never; shortcut?: string }
-);
+        | { alreadyVisitedBySelfOrAnotherHouseholdMember?: false; name?: string; shortcut?: never }
+        | { alreadyVisitedBySelfOrAnotherHouseholdMember: true; name?: never; shortcut?: string }
+    );
 
-export type Trip = TripAttributes & {
-    _sequence: number;
-    _originVisitedPlaceUuid?: string;
-    _destinationVisitedPlaceUuid?: string;
-    segments?: {
-        [segmentUuid: string]: Segment;
+export type Trip = TripAttributes &
+    QuestionnaireObjectWithUuidAndSequence & {
+        _originVisitedPlaceUuid?: string;
+        _destinationVisitedPlaceUuid?: string;
+        segments?: {
+            [segmentUuid: string]: Segment;
+        };
     };
-};
 
-export type Segment = Omit<SegmentAttributes, 'mode'> & {
-    _sequence: number;
-    _isNew: boolean;
-    modePre?: ModePre;
-    mode?: Mode;
-    sameModeAsReverseTrip?: boolean;
-    hasNextMode?: boolean;
-};
+export type Segment = Omit<SegmentAttributes, 'mode'> &
+    QuestionnaireObjectWithUuidAndSequence & {
+        _isNew: boolean;
+        modePre?: ModePre;
+        mode?: Mode;
+        sameModeAsReverseTrip?: boolean;
+        hasNextMode?: boolean;
+    };
 
 type SectionStatus = {
     _isCompleted?: boolean;

--- a/packages/evolution-common/src/tests/surveys/testCasesInterview.ts
+++ b/packages/evolution-common/src/tests/surveys/testCasesInterview.ts
@@ -74,6 +74,7 @@ export const interviewAttributesForTestCases: UserRuntimeInterviewAttributes = {
                             _uuid: 'journeyId1',
                             _sequence: 1,
                             startDate: '2026-04-08',
+                            personDidTrips: 'yes',
                             visitedPlaces: {
                                 homePlace1P1: {
                                     _uuid: 'homePlace1P1',
@@ -175,6 +176,7 @@ export const interviewAttributesForTestCases: UserRuntimeInterviewAttributes = {
                         journeyId2: {
                             _uuid: 'journeyId2',
                             _sequence: 1,
+                            personDidTrips: 'yes',
                             visitedPlaces: {
                                 homePlace1P2: {
                                     _uuid: 'homePlace1P2',
@@ -267,6 +269,7 @@ export const interviewAttributesForTestCases: UserRuntimeInterviewAttributes = {
                         journeyId3: {
                             _uuid: 'journeyId3',
                             _sequence: 1,
+                            personDidTrips: 'yes',
                             visitedPlaces: {
                                 homePlace1P3: {
                                     _uuid: 'homePlace1P3',

--- a/packages/evolution-common/src/utils/__tests__/helpers.test.ts
+++ b/packages/evolution-common/src/utils/__tests__/helpers.test.ts
@@ -465,89 +465,171 @@ describe('Group functions', () => {
             obj1: { _uuid: 'obj1', _sequence: 1 },
             obj2: { _uuid: 'obj2', _sequence: 2 }
         }, 1, -1, [], {
-            'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj0': { _uuid: 'newObj0', _sequence: 3 },
-            'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj0': { }
+            valuesByPath: {
+                'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj0': { _uuid: 'newObj0', _sequence: 3 },
+                'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj0': { }
+            },
+            newObjects: [{
+                _uuid: 'newObj0',
+                _sequence: 3
+            }]
         }],
         ['0 objects', {
             obj1: { _uuid: 'obj1', _sequence: 1 },
             obj2: { _uuid: 'obj2', _sequence: 2 }
-        }, 0, -1, [], { }],
+        }, 0, -1, [], { valuesByPath: {}, newObjects: [] }],
         ['one object at sequence', {
             obj1: { _uuid: 'obj1', _sequence: 1 },
             obj2: { _uuid: 'obj2', _sequence: 2 }
         }, 1, 2, [], {
-            'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.obj2._sequence': 3,
-            'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj0': { _uuid: 'newObj0', _sequence: 2 },
-            'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj0': { }
+            valuesByPath: {
+                'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.obj2._sequence': 3,
+                'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj0': { _uuid: 'newObj0', _sequence: 2 },
+                'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj0': { }
+            },
+            newObjects: [{
+                _uuid: 'newObj0',
+                _sequence: 2
+            }]
         }],
         ['one object at sequence 0, should be 1', {
             obj1: { _uuid: 'obj1', _sequence: 1 },
             obj2: { _uuid: 'obj2', _sequence: 2 }
         }, 1, 0, [], {
-            'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.obj1._sequence': 2,
-            'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.obj2._sequence': 3,
-            'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj0': { _uuid: 'newObj0', _sequence: 1 },
-            'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj0': { }
+            valuesByPath: {
+                'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.obj1._sequence': 2,
+                'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.obj2._sequence': 3,
+                'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj0': { _uuid: 'newObj0', _sequence: 1 },
+                'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj0': { }
+            },
+            newObjects: [{
+                _uuid: 'newObj0',
+                _sequence: 1
+            }]
         }],
         ['one object at sequence too large', {
             obj1: { _uuid: 'obj1', _sequence: 1 },
             obj2: { _uuid: 'obj2', _sequence: 2 }
         }, 1, 5, [], {
-            'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj0': { _uuid: 'newObj0', _sequence: 3 },
-            'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj0': { }
+            valuesByPath: {
+                'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj0': { _uuid: 'newObj0', _sequence: 3 },
+                'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj0': { }
+            },
+            newObjects: [{
+                _uuid: 'newObj0',
+                _sequence: 3
+            }]
         }],
         ['2 objects, no previous objects', {}, 2, undefined, [], {
-            'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj0': { _uuid: 'newObj0', _sequence: 1 },
-            'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj0': { },
-            'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj1': { _uuid: 'newObj1', _sequence: 2 },
-            'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj1': { }
+            valuesByPath: {
+                'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj0': { _uuid: 'newObj0', _sequence: 1 },
+                'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj0': { },
+                'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj1': { _uuid: 'newObj1', _sequence: 2 },
+                'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj1': { }
+            },
+            newObjects: [{
+                _uuid: 'newObj0',
+                _sequence: 1
+            }, {
+                _uuid: 'newObj1',
+                _sequence: 2
+            }]
         }],
         ['3 objects, at sequence 2', {
             obj1: { _uuid: 'obj1', _sequence: 1 },
             obj2: { _uuid: 'obj2', _sequence: 2 }
         }, 3, 2, [], {
-            'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.obj2._sequence': 5,
-            'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj0': { _uuid: 'newObj0', _sequence: 2 },
-            'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj0': { },
-            'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj1': { _uuid: 'newObj1', _sequence: 3 },
-            'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj1': { },
-            'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj2': { _uuid: 'newObj2', _sequence: 4 },
-            'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj2': { }
+            valuesByPath: {
+                'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.obj2._sequence': 5,
+                'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj0': { _uuid: 'newObj0', _sequence: 2 },
+                'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj0': { },
+                'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj1': { _uuid: 'newObj1', _sequence: 3 },
+                'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj1': { },
+                'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj2': { _uuid: 'newObj2', _sequence: 4 },
+                'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj2': { }
+            },
+            newObjects: [{
+                _uuid: 'newObj0',
+                _sequence: 2
+            }, {
+                _uuid: 'newObj1',
+                _sequence: 3
+            }, {
+                _uuid: 'newObj2',
+                _sequence: 4
+            }]
         }],
         ['with attributes, same count',  {
             obj1: { _uuid: 'obj1', _sequence: 1 },
             obj2: { _uuid: 'obj2', _sequence: 2 }
         }, 3, 2, [{ myVal: 'first' }, { myVal: 'second', other: 'test' }, { myVal: 'third' }], {
-            'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.obj2._sequence': 5,
-            'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj0': { _uuid: 'newObj0', _sequence: 2, myVal: 'first' },
-            'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj0': { },
-            'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj1': { _uuid: 'newObj1', _sequence: 3, myVal: 'second', other: 'test' },
-            'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj1': { },
-            'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj2': { _uuid: 'newObj2', _sequence: 4, myVal: 'third' },
-            'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj2': { }
+            valuesByPath: {
+                'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.obj2._sequence': 5,
+                'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj0': { _uuid: 'newObj0', _sequence: 2, myVal: 'first' },
+                'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj0': { },
+                'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj1': { _uuid: 'newObj1', _sequence: 3, myVal: 'second', other: 'test' },
+                'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj1': { },
+                'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj2': { _uuid: 'newObj2', _sequence: 4, myVal: 'third' },
+                'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj2': { }
+            },
+            newObjects: [{
+                _uuid: 'newObj0',
+                _sequence: 2,
+                myVal: 'first'
+            }, {
+                _uuid: 'newObj1',
+                _sequence: 3,
+                myVal: 'second',
+                other: 'test'
+            }, {
+                _uuid: 'newObj2',
+                _sequence: 4,
+                myVal: 'third'
+            }]
         }],
         ['with attributes, unequal count',  {
             obj1: { _uuid: 'obj1', _sequence: 1 },
             obj2: { _uuid: 'obj2', _sequence: 2 }
         }, 3, 2, [{ myVal: 'first' }, { myVal: 'second', other: 'test' }], {
-            'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.obj2._sequence': 5,
-            'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj0': { _uuid: 'newObj0', _sequence: 2, myVal: 'first' },
-            'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj0': { },
-            'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj1': { _uuid: 'newObj1', _sequence: 3, myVal: 'second', other: 'test' },
-            'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj1': { },
-            'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj2': { _uuid: 'newObj2', _sequence: 4 },
-            'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj2': { }
+            valuesByPath: {
+                'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.obj2._sequence': 5,
+                'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj0': { _uuid: 'newObj0', _sequence: 2, myVal: 'first' },
+                'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj0': { },
+                'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj1': { _uuid: 'newObj1', _sequence: 3, myVal: 'second', other: 'test' },
+                'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj1': { },
+                'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj2': { _uuid: 'newObj2', _sequence: 4 },
+                'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj2': { }
+            },
+            newObjects: [{
+                _uuid: 'newObj0',
+                _sequence: 2,
+                myVal: 'first'
+            }, {
+                _uuid: 'newObj1',
+                _sequence: 3,
+                myVal: 'second',
+                other: 'test'
+            }, {
+                _uuid: 'newObj2',
+                _sequence: 4
+            }]
         }],
         ['negative object count', {
             obj1: { _uuid: 'obj1', _sequence: 1 },
             obj2: { _uuid: 'obj2', _sequence: 2 }
-        }, -1, -1, [], { }],
+        }, -1, -1, [], { valuesByPath: {}, newObjects: [] }],
         ['negative, but not -1, sequence', {
             obj1: { _uuid: 'obj1', _sequence: 1 },
             obj2: { _uuid: 'obj2', _sequence: 2 }
         }, 1, -2, [], {
-            'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj0': { _uuid: 'newObj0', _sequence: 3 },
-            'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj0': { }
+            valuesByPath: {
+                'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj0': { _uuid: 'newObj0', _sequence: 3 },
+                'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.newObj0': { }
+            },
+            newObjects: [{
+                _uuid: 'newObj0',
+                _sequence: 3
+            }]
         }]
     ]).test('add grouped objects: %s', (_title, previousObj, count, seq, attributes, expected) => {
         // Mock the uuid return value

--- a/packages/evolution-common/src/utils/helpers.ts
+++ b/packages/evolution-common/src/utils/helpers.ts
@@ -22,6 +22,7 @@ import {
     I18nData,
     InterviewResponse,
     ParsingFunction,
+    QuestionnaireObjectWithUuidAndSequence,
     RadioChoiceType,
     UserInterviewAttributes,
     WidgetConfig
@@ -546,7 +547,10 @@ export const interviewOnOrAfter = (date: string, interview: UserInterviewAttribu
  * @param {Object[]} [attributes=[]] An array of attributes with which to
  * initialize the objects. Each attributes object in the array will be used to
  * initialize the new objects at the same position.
- * @returns {Object} The changed values by path
+ * @returns {Object} A key-value object containing the changed values by path in
+ * `valuesByPath` and the new objects in `newObjects`. The changed values by
+ * path include the updated sequences of the existing objects after the insert
+ * sequence.
  */
 export const addGroupedObjects = (
     interview: UserInterviewAttributes,
@@ -554,10 +558,12 @@ export const addGroupedObjects = (
     insertSequence: number | undefined,
     path: string,
     attributes: { [key: string]: unknown }[] = []
-): { [modifiedValue: string]: unknown } => {
+): { valuesByPath: { [modifiedValue: string]: unknown }; newObjects: QuestionnaireObjectWithUuidAndSequence[] } => {
     const changedValuesByPath = {};
     const groupedObjects = _get(interview.response, path, {});
-    const groupedObjectsArray = sortBy(Object.values(groupedObjects), ['_sequence']) as Uuidable[];
+    const groupedObjectsArray = sortBy(Object.values(groupedObjects), [
+        '_sequence'
+    ]) as QuestionnaireObjectWithUuidAndSequence[];
     // Make sure sequence is within bounds:
     const objStartSequence =
         typeof insertSequence !== 'number' || insertSequence <= -1
@@ -569,18 +575,22 @@ export const addGroupedObjects = (
         const groupedObject = groupedObjectsArray[seq - 1];
         changedValuesByPath[`response.${path}.${groupedObject._uuid}._sequence`] = seq + newObjectsCount;
     }
+    const newObjects: QuestionnaireObjectWithUuidAndSequence[] = [];
+
     for (let i = 0; i < newObjectsCount; i++) {
         const uniqueId = uuidV4();
         const newSequence = objStartSequence + i;
         const newObjectAttributes = attributes[i] ? attributes[i] : {};
-        changedValuesByPath[`response.${path}.${uniqueId}`] = {
+        const newObject = {
             _sequence: newSequence,
             _uuid: uniqueId,
             ...newObjectAttributes
         };
+        changedValuesByPath[`response.${path}.${uniqueId}`] = newObject;
         changedValuesByPath[`validations.${path}.${uniqueId}`] = {};
+        newObjects.push(newObject);
     }
-    return changedValuesByPath;
+    return { valuesByPath: changedValuesByPath, newObjects };
 };
 
 /**

--- a/packages/evolution-frontend/src/actions/Survey.ts
+++ b/packages/evolution-frontend/src/actions/Survey.ts
@@ -707,7 +707,7 @@ export const startAddGroupedObjects = (
         getState: () => RootState
     ) => {
         const interview = _cloneDeep(getState().survey.interview) as UserRuntimeInterviewAttributes; // needed because we cannot mutate state
-        const changedValuesByPath = surveyHelper.addGroupedObjects(
+        const { valuesByPath } = surveyHelper.addGroupedObjects(
             interview,
             newObjectsCount,
             insertSequence,
@@ -715,9 +715,9 @@ export const startAddGroupedObjects = (
             attributes || []
         );
         if (returnOnly) {
-            return changedValuesByPath;
+            return valuesByPath;
         } else {
-            dispatch(startUpdateInterview({ valuesByPath: changedValuesByPath }, callback));
+            dispatch(startUpdateInterview({ valuesByPath }, callback));
         }
     };
 };

--- a/packages/evolution-frontend/src/actions/SurveyAdmin.ts
+++ b/packages/evolution-frontend/src/actions/SurveyAdmin.ts
@@ -292,7 +292,7 @@ export const startSurveyCorrectedAddGroupedObjects = (
         getState: () => RootState
     ) => {
         const interview = _cloneDeep(getState().survey.interview) as UserRuntimeInterviewAttributes; // needed because we cannot mutate state
-        const changedValuesByPath = surveyHelper.addGroupedObjects(
+        const { valuesByPath } = surveyHelper.addGroupedObjects(
             interview,
             newObjectsCount,
             insertSequence,
@@ -300,9 +300,9 @@ export const startSurveyCorrectedAddGroupedObjects = (
             attributes || []
         );
         if (returnOnly) {
-            return changedValuesByPath;
+            return valuesByPath;
         } else {
-            dispatch(startUpdateSurveyCorrectedInterview({ valuesByPath: changedValuesByPath }, callback));
+            dispatch(startUpdateSurveyCorrectedInterview({ valuesByPath }, callback));
         }
     };
 };

--- a/packages/evolution-frontend/src/actions/__tests__/Survey.test.ts
+++ b/packages/evolution-frontend/src/actions/__tests__/Survey.test.ts
@@ -1299,7 +1299,7 @@ describe('startNavigate', () => {
 });
 
 describe('startAddGroupedObjects', () => {
-    const defaultAddGroupResponse = { 'response.data': { _uuid: 'someuuid' }, 'validations.data': true };
+    const defaultAddGroupResponse = { valuesByPath: { 'response.data': { _uuid: 'someuuid', _sequence: 1 }, 'validations.data': true }, newObjects: [{ _uuid: 'someuuid', _sequence: 1 }] };
     mockedAddGroupedObject.mockReturnValue(defaultAddGroupResponse);
 
     let startUpdateInterviewSpy;
@@ -1327,7 +1327,7 @@ describe('startAddGroupedObjects', () => {
         expect(mockedAddGroupedObject).toHaveBeenCalledTimes(1);
         expect(mockedAddGroupedObject).toHaveBeenCalledWith(interviewAttributes, newObjectCnt, insertSeq, path, []);
         expect(startUpdateInterviewSpy).toHaveBeenCalledTimes(1);
-        expect(startUpdateInterviewSpy).toHaveBeenCalledWith({ valuesByPath: defaultAddGroupResponse }, undefined);
+        expect(startUpdateInterviewSpy).toHaveBeenCalledWith({ valuesByPath: defaultAddGroupResponse.valuesByPath }, undefined);
         expect(mockDispatch).toHaveBeenCalledTimes(1);
         expect(mockDispatch).toHaveBeenCalledWith(startUpdateInterviewMock);
     });
@@ -1348,7 +1348,7 @@ describe('startAddGroupedObjects', () => {
         expect(mockedAddGroupedObject).toHaveBeenCalledTimes(1);
         expect(mockedAddGroupedObject).toHaveBeenCalledWith(interviewAttributes, newObjectCnt, insertSeq, path, attributes);
         expect(startUpdateInterviewSpy).not.toHaveBeenCalled();
-        expect(vals).toEqual(defaultAddGroupResponse);
+        expect(vals).toEqual(defaultAddGroupResponse.valuesByPath);
         expect(mockDispatch).not.toHaveBeenCalled();
     });
 
@@ -1368,7 +1368,7 @@ describe('startAddGroupedObjects', () => {
         expect(mockedAddGroupedObject).toHaveBeenCalledTimes(1);
         expect(mockedAddGroupedObject).toHaveBeenCalledWith(interviewAttributes, newObjectCnt, insertSeq, path, attributes);
         expect(startUpdateInterviewSpy).toHaveBeenCalledTimes(1);
-        expect(startUpdateInterviewSpy).toHaveBeenCalledWith({ valuesByPath: defaultAddGroupResponse }, callback);
+        expect(startUpdateInterviewSpy).toHaveBeenCalledWith({ valuesByPath: defaultAddGroupResponse.valuesByPath }, callback);
         expect(mockDispatch).toHaveBeenCalledTimes(1);
         expect(mockDispatch).toHaveBeenCalledWith(startUpdateInterviewMock);
     });


### PR DESCRIPTION
Commits can be reviewed individually for more clarity

* Add the personDidTrips field to the Journey objects
* Add the `personDeclaredDoingTripsInJourney` helper function
* Extract the segment section's `isSectionVisibled` function
* Extract a type for objects with uuid and sequence
* Let the `addGroupedObjects` helper function return the new objects along with the modified values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Grouped-object creation now returns { valuesByPath, newObjects }; consumers should use valuesByPath to preserve prior behavior.

* **New Features**
  * Journey can record whether a person did trips.
  * Improved trip-diary visibility and more reliable next-trip selection.

* **Refactor**
  * Consolidated shared typing for questionnaire objects.

* **Bug Fixes**
  * Added null-guards to avoid errors when person data is missing.

* **Tests**
  * Expanded coverage for trip/journey visibility and grouping helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->