### PR TITLE
Generator: Add comments above generated code

### DIFF
--- a/packages/evolution-generator/src/scripts/generate_widgets.py
+++ b/packages/evolution-generator/src/scripts/generate_widgets.py
@@ -232,12 +232,14 @@ def generate_widget_statement(row, gender_fields: GenderFields = None) -> Widget
     input_range = row["inputRange"]
     help_popup = row["help_popup"]
     choices = row["choices"]
-    confirm_popup = row["confirm_popup"] if "confirm_popup" in row else None
+    confirm_popup = row.get("confirm_popup", None)  # Optional column
+    comments = row.get("comments", None)  # Optional column
     widget_label = generate_label(section, path, row, gender_fields, key_name="label")
 
     # Initialize result with default values
     result: WidgetResult = {"statement": "", "has_helper_import": False}
 
+    # Generate the widgets statement based on the input type
     if input_type == "Custom":
         result["statement"] = generate_custom_widget(question_name)
     elif input_type == "Radio":
@@ -330,6 +332,12 @@ def generate_widget_statement(row, gender_fields: GenderFields = None) -> Widget
         )
     else:
         result["statement"] = f"// {question_name}"
+
+    # Add the comment line to the statement if it is present
+    if comments:
+        # Support multi-line comments by emitting one `// ...` per line.
+        comment_block = "".join([f"// {line}\n" for line in str(comments).splitlines()])
+        result["statement"] = f"{comment_block}{result['statement']}"
 
     return result
 
@@ -710,7 +718,7 @@ def generate_contains_html(containsHtml, shouldAddContainsHtml):
 
 
 def generate_custom_path(row):
-    custom_path = row["customPath"] if "customPath" in row else None
+    custom_path = row.get("customPath", None)
     if custom_path:
         return f"{INDENT}customPath: '{custom_path}',\n"
     else:
@@ -718,7 +726,7 @@ def generate_custom_path(row):
 
 
 def generate_custom_choice(row):
-    custom_choice = row["customChoice"] if "customChoice" in row else None
+    custom_choice = row.get("customChoice", None)
     if custom_choice:
         return f"{INDENT}customChoice: '{custom_choice}',\n"
     else:
@@ -726,7 +734,7 @@ def generate_custom_choice(row):
 
 
 def generate_default_value(row):
-    default_value = row["defaultValue"] if "defaultValue" in row else None
+    default_value = row.get("defaultValue", None)
     if default_value:
         return f"{INDENT}defaultValue: '{default_value}',\n"
     else:
@@ -742,8 +750,8 @@ def generate_common_properties(
     - Prints a warning if join_with is present but not in the expected pattern.
     - If allow_join_with is False, disables joinWith extraction.
     """
-    twoColumns = row["twoColumns"] if "twoColumns" in row else False
-    containsHtml = row["containsHtml"] if "containsHtml" in row else False
+    twoColumns = row.get("twoColumns", False)
+    containsHtml = row.get("containsHtml", False)
 
     join_with = None
     if allow_join_with:
@@ -949,9 +957,7 @@ def generate_range_widget(
     widget_label,
     row,
 ):
-    includeNotApplicable = (
-        row["includeNotApplicable"] if "includeNotApplicable" in row else False
-    )
+    includeNotApplicable = row.get("includeNotApplicable", False)
     notApplicableConfig = (
         "includeNotApplicable: true,\n" if includeNotApplicable else ""
     )

--- a/packages/evolution-generator/src/tests/test_generate_widgets.py
+++ b/packages/evolution-generator/src/tests/test_generate_widgets.py
@@ -11,6 +11,7 @@ from scripts.generate_widgets import (
     generate_radio_widget,
     generate_radio_number_widget,
     generate_string_widget,
+    generate_widget_statement,
     generate_label,
     parse_parameters,
     get_radio_number_parameters,
@@ -937,6 +938,76 @@ class TestGenerateStringWidget:
         assert result["has_helper_import"] is False
         assert result["has_formatter_import"] is False
         assert result["has_custom_formatter_import"] is True
+
+
+class TestGenerateWidgetStatementComments:
+    def test_single_line_comment_is_preserved(self):
+        row = {
+            "questionName": "acceptToBeContactedForHelp",
+            "inputType": "Radio",
+            "section": "home",
+            "path": "acceptToBeContactedForHelp",
+            "conditional": "",
+            "validation": "",
+            "inputRange": "",
+            "help_popup": "",
+            "choices": "yesNo",
+            "comments": "This is a single line comment",
+            "label::fr": "Acceptez-vous d'être contacté pour de l'aide?",
+            "label::en": "Do you agree to be contacted for help?",
+        }
+
+        result = generate_widget_statement(row, GenderFields())
+        assert result["statement"].startswith("// This is a single line comment\n")
+        assert (
+            "export const acceptToBeContactedForHelp: WidgetConfig.InputRadioType"
+            in result["statement"]
+        )
+
+    def test_multi_line_comment_is_preserved(self):
+        row = {
+            "questionName": "acceptToBeContactedForHelp",
+            "inputType": "Radio",
+            "section": "home",
+            "path": "acceptToBeContactedForHelp",
+            "conditional": "",
+            "validation": "",
+            "inputRange": "",
+            "help_popup": "",
+            "choices": "yesNo",
+            "comments": "First line\nSecond line",
+            "label::fr": "Acceptez-vous d'être contacté pour de l'aide?",
+            "label::en": "Do you agree to be contacted for help?",
+        }
+
+        result = generate_widget_statement(row, GenderFields())
+        assert result["statement"].startswith("// First line\n// Second line\n")
+        assert (
+            "export const acceptToBeContactedForHelp: WidgetConfig.InputRadioType"
+            in result["statement"]
+        )
+
+    def test_no_comments_column_does_not_add_comment(self):
+        row = {
+            "questionName": "acceptToBeContactedForHelp",
+            "inputType": "Radio",
+            "section": "home",
+            "path": "acceptToBeContactedForHelp",
+            "conditional": "",
+            "validation": "",
+            "inputRange": "",
+            "help_popup": "",
+            "choices": "yesNo",
+            "label::fr": "Acceptez-vous d'être contacté pour de l'aide?",
+            "label::en": "Do you agree to be contacted for help?",
+        }
+
+        result = generate_widget_statement(row, GenderFields())
+        assert not result["statement"].startswith("//")
+        assert (
+            "export const acceptToBeContactedForHelp: WidgetConfig.InputRadioType"
+            in result["statement"]
+        )
 
 
 # TODO: Test generate_select_widget


### PR DESCRIPTION
# PR
An easy one for you @tahini 

## Description
Generator: Add comments above generated code
Fix: #1085
- Added functionality to the `generate_widget_statement` function to include comments in the generated widget statements. Comments can now be single or multi-line, and are formatted appropriately in the output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Widget code generation now supports including comments that are automatically prepended to generated statements, with multi-line comment support.

* **Tests**
  * Added comprehensive test coverage for comment handling in widget generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->