### PR TITLE
questionnaire: Add a questionnaire factory and update config type

### DIFF
--- a/example/demo_survey/src/survey/questionnaire.ts
+++ b/example/demo_survey/src/survey/questionnaire.ts
@@ -1,18 +1,28 @@
-import { SegmentsSectionFactory } from 'evolution-common/lib/services/questionnaire/sections/segments/sectionSegments';
-import { VisitedPlacesSectionFactory } from 'evolution-common/lib/services/questionnaire/sections/visitedPlaces/sectionVisitedPlaces';
 import * as odSurveyHelper from 'evolution-common/lib/services/odSurvey/helpers';
-import surveySections from './sections';
-import * as widgetsConfig from './widgets';
+import customSurveySections from './sections';
+import * as customWidgetsConfig from './widgets';
 import helper, { segmentSectionConfig, visitedPlacesSectionConfig, widgetFactoryOptions } from './helper';
 import { getAndValidateSurveySections, SectionConfig } from 'evolution-common/lib/services/questionnaire/types';
 import { addGroupedObjects, getResponse } from 'evolution-common/lib/utils/helpers';
+import { QuestionnaireFactory } from 'evolution-common/lib/services/questionnaire';
+
+const questionnaireConfiguration = {
+    tripDiary: {
+        sections: {
+            segments: segmentSectionConfig,
+            visitedPlaces: visitedPlacesSectionConfig
+        }
+    }
+};
+
+const questionnaireFactory = new QuestionnaireFactory(questionnaireConfiguration, widgetFactoryOptions);
+const { surveySections, widgetsConfig } = questionnaireFactory.buildSectionsAndWidgets();
 
 // FIXME For now this file is here and has quite a bit of code. Eventually, the
 // questionnaire generation should be done in Evolution directly when we have
 // more builtin stuff
 
-const segmentSectionConfigFactory = new SegmentsSectionFactory(segmentSectionConfig, widgetFactoryOptions);
-const segmentSectionConfigFromFactory = segmentSectionConfigFactory.getSectionConfig();
+const segmentSectionConfigFromFactory = surveySections['segments'];
 
 // Add the segments section to the exported configuration
 const segmentConfig: SectionConfig = {
@@ -27,11 +37,7 @@ const segmentConfig: SectionConfig = {
     }
 };
 
-const visitedPlacesSectionConfigFactory = new VisitedPlacesSectionFactory(
-    visitedPlacesSectionConfig,
-    widgetFactoryOptions
-);
-const visitedPlacesSectionConfigFromFactory = visitedPlacesSectionConfigFactory.getSectionConfig();
+const visitedPlacesSectionConfigFromFactory = surveySections['visitedPlaces'];
 
 // Add the visited places section to the exported configuration
 const visitedPlacesConfig: SectionConfig = {
@@ -91,7 +97,7 @@ const visitedPlacesConfig: SectionConfig = {
 };
 
 // FIXME Workaround to satisfy the completion percentage calculation that expects sections to be defined in their order of display in the object (see https://github.com/chairemobilite/evolution/issues/1024)
-const { travelBehavior, end, completed, ...earlierSections } = surveySections;
+const { travelBehavior, end, completed, ...earlierSections } = customSurveySections;
 const validatedSections = getAndValidateSurveySections({
     ...earlierSections,
     visitedPlaces: visitedPlacesConfig,
@@ -102,11 +108,6 @@ const validatedSections = getAndValidateSurveySections({
 });
 
 // Widgets defined in the interview will override the ones from the section factory, if any
-const allWidgetConfig = Object.assign(
-    {},
-    segmentSectionConfigFactory.getWidgetConfigs(),
-    visitedPlacesSectionConfigFactory.getWidgetConfigs(),
-    widgetsConfig
-);
+const allWidgetConfig = Object.assign({}, widgetsConfig, customWidgetsConfig);
 
 export { validatedSections as surveySections, allWidgetConfig as widgetsConfig };

--- a/packages/evolution-common/src/services/questionnaire/__tests__/index.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/__tests__/index.test.ts
@@ -1,0 +1,198 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { QuestionnaireFactory } from '../index';
+import type { QuestionnaireConfiguration } from '../types';
+import type { WidgetFactoryOptions } from '../sections/types';
+
+const baseVisitedPlacesConfig: NonNullable<
+    NonNullable<QuestionnaireConfiguration['tripDiary']>['sections']['visitedPlaces']
+> = {
+    type: 'visitedPlaces',
+    enabled: true,
+    tripDiaryMinTimeOfDay: 4 * 60 * 60,
+    tripDiaryMaxTimeOfDay: 28 * 60 * 60
+};
+
+const baseSegmentsConfig: NonNullable<
+    NonNullable<QuestionnaireConfiguration['tripDiary']>['sections']['segments']
+> = {
+    type: 'segments',
+    enabled: true
+};
+
+const widgetFactoryOptions: WidgetFactoryOptions = {
+    getFormattedDate: (date: string) => date,
+    buttonActions: {
+        validateButtonAction: () => undefined,
+        validateButtonActionWithCompleteSection: () => undefined
+    },
+    iconMapper: { 'check-circle': 'check-circle' as any }
+};
+
+describe('QuestionnaireFactory', () => {
+    describe('buildSectionsAndWidgets', () => {
+        const defaultVisitedPlacesWidgetNames = [
+            'activePersonTitle',
+            'buttonSwitchPerson',
+            'personVisitedPlacesTitle',
+            'personVisitedPlaces',
+            'visitedPlaceActivityCategory',
+            'visitedPlaceActivity',
+            'visitedPlaceNextPlaceCategory',
+            'visitedPlaceName',
+            'visitedPlaceGeography',
+            'personVisitedPlacesMap',
+            'buttonVisitedPlacesConfirmNextSection'
+        ];
+        const defaultSegmentWidgetNames = [
+            'activePersonTitle',
+            'buttonSwitchPerson',
+            'personTripsTitle',
+            'personTrips',
+            'segmentIntro',
+            'buttonSaveTrip',
+            'segments',
+            'segmentSameModeAsReverseTrip',
+            'segmentModePre',
+            'segmentMode',
+            'segmentHasNextMode',
+            'personVisitedPlacesMap',
+            'buttonConfirmNextSection'
+        ];
+
+        test.each([
+            {
+                title: 'should return empty config when tripDiary is undefined',
+                questionnaireConfig: {} as QuestionnaireConfiguration,
+                expectedSectionNames: [] as string[],
+                expectedWidgetNames: [] as string[]
+            },
+            {
+                title: 'should return empty config when tripDiary has no sections',
+                questionnaireConfig: { tripDiary: { sections: {} } } as QuestionnaireConfiguration,
+                expectedSectionNames: [] as string[],
+                expectedWidgetNames: [] as string[]
+            },
+            {
+                title: 'should return empty config when visited places is configured but disabled',
+                questionnaireConfig: {
+                    tripDiary: {
+                        sections: {
+                            visitedPlaces: { ...baseVisitedPlacesConfig, enabled: false }
+                        }
+                    }
+                } as QuestionnaireConfiguration,
+                expectedSectionNames: [] as string[],
+                expectedWidgetNames: [] as string[]
+            },
+            {
+                title: 'should return empty config when segments is configured but disabled',
+                questionnaireConfig: {
+                    tripDiary: {
+                        sections: {
+                            segments: { ...baseSegmentsConfig, enabled: false }
+                        }
+                    }
+                } as QuestionnaireConfiguration,
+                expectedSectionNames: [] as string[],
+                expectedWidgetNames: [] as string[]
+            },
+            {
+                title: 'should return only visited places section and widgets',
+                questionnaireConfig: {
+                    tripDiary: {
+                        sections: {
+                            visitedPlaces: baseVisitedPlacesConfig
+                        }
+                    }
+                } as QuestionnaireConfiguration,
+                expectedSectionNames: ['visitedPlaces'],
+                expectedWidgetNames: defaultVisitedPlacesWidgetNames
+            },
+            {
+                title: 'should return only segments section and widgets',
+                questionnaireConfig: {
+                    tripDiary: {
+                        sections: {
+                            segments: baseSegmentsConfig
+                        }
+                    }
+                } as QuestionnaireConfiguration,
+                expectedSectionNames: ['segments'],
+                expectedWidgetNames: defaultSegmentWidgetNames
+            },
+            {
+                title: 'should return segments section and widgets with optional widgets',
+                questionnaireConfig: {
+                    tripDiary: {
+                        sections: {
+                            segments: {
+                                ...baseSegmentsConfig,
+                                askSegmentDriver: true
+                            }
+                        }
+                    }
+                } as QuestionnaireConfiguration,
+                expectedSectionNames: ['segments'],
+                expectedWidgetNames: [...defaultSegmentWidgetNames, 'segmentDriver']
+            },
+            {
+                title: 'should return both sections and merged widgets',
+                questionnaireConfig: {
+                    tripDiary: {
+                        sections: {
+                            visitedPlaces: baseVisitedPlacesConfig,
+                            segments: baseSegmentsConfig
+                        }
+                    }
+                } as QuestionnaireConfiguration,
+                expectedSectionNames: ['visitedPlaces', 'segments'],
+                expectedWidgetNames: Array.from(new Set([
+                    ...defaultVisitedPlacesWidgetNames,
+                    ...defaultSegmentWidgetNames
+                ]))
+            }
+        ])('$title', ({ questionnaireConfig, expectedSectionNames, expectedWidgetNames }) => {
+            const factory = new QuestionnaireFactory(questionnaireConfig, widgetFactoryOptions);
+            const result = factory.buildSectionsAndWidgets();
+
+            const sectionNames = Object.keys(result.surveySections);
+            expectedSectionNames.forEach((sectionName) => expect(sectionNames).toContain(sectionName));
+            expect(sectionNames).toHaveLength(expectedSectionNames.length);
+
+            const widgetNames = Object.keys(result.widgetsConfig);
+            expectedWidgetNames.forEach((widgetName) => expect(widgetNames).toContain(widgetName));
+            expect(widgetNames).toHaveLength(expectedWidgetNames.length);
+        });
+
+        test('should return section configs with expected templates and navigation', () => {
+            const factory = new QuestionnaireFactory(
+                {
+                    tripDiary: {
+                        sections: {
+                            visitedPlaces: baseVisitedPlacesConfig,
+                            segments: baseSegmentsConfig
+                        }
+                    }
+                },
+                widgetFactoryOptions
+            );
+
+            const result = factory.buildSectionsAndWidgets();
+
+            expect(result.surveySections.visitedPlaces.template).toBe('visitedPlaces');
+            expect(result.surveySections.visitedPlaces.previousSection).toBe('tripsIntro');
+            expect(result.surveySections.visitedPlaces.nextSection).toBe('segments');
+
+            expect(result.surveySections.segments.template).toBe('tripsAndSegmentsWithMap');
+            expect(result.surveySections.segments.previousSection).toBe('visitedPlaces');
+            expect(result.surveySections.segments.nextSection).toBe('travelBehavior');
+        });
+
+    });
+});

--- a/packages/evolution-common/src/services/questionnaire/index.ts
+++ b/packages/evolution-common/src/services/questionnaire/index.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { SegmentsSectionFactory } from './sections/segments/sectionSegments';
+import type { WidgetFactoryOptions } from './sections/types';
+import { VisitedPlacesSectionFactory } from './sections/visitedPlaces/sectionVisitedPlaces';
+import type { QuestionnaireConfiguration, SurveySectionsConfig, WidgetConfig } from './types';
+
+type SectionsAndWidgetConfigs = {
+    surveySections: SurveySectionsConfig;
+    widgetsConfig: Record<string, WidgetConfig>;
+};
+
+export class QuestionnaireFactory {
+    constructor(
+        private questionnaireConfig: QuestionnaireConfiguration,
+        private options: WidgetFactoryOptions
+    ) {
+        /* Nothing to do */
+    }
+
+    private buildTripDiarySectionsAndWidgets = (
+        tripDiaryConfig: Exclude<QuestionnaireConfiguration['tripDiary'], undefined>
+    ): SectionsAndWidgetConfigs => {
+        const sections: SurveySectionsConfig = {};
+        const widgets: Record<string, WidgetConfig> = {};
+
+        if (tripDiaryConfig.sections) {
+            // Add the visited places section and widgets if the section is configured
+            if (tripDiaryConfig.sections.visitedPlaces && tripDiaryConfig.sections.visitedPlaces.enabled) {
+                // Build the visited places section and its widgets
+                const visitedPlacesSectionFactory = new VisitedPlacesSectionFactory(
+                    tripDiaryConfig.sections.visitedPlaces,
+                    this.options
+                );
+                const visitedPlacesSectionConfig = visitedPlacesSectionFactory.getSectionConfig();
+                sections['visitedPlaces'] = visitedPlacesSectionConfig;
+                Object.assign(widgets, visitedPlacesSectionFactory.getWidgetConfigs());
+            }
+            // Add the segments section and widgets if the section is configured
+            if (tripDiaryConfig.sections.segments && tripDiaryConfig.sections.segments.enabled) {
+                // Build the segments section and its widgets
+                const segmentSectionFactory = new SegmentsSectionFactory(
+                    tripDiaryConfig.sections.segments,
+                    this.options
+                );
+                const segmentSectionConfig = segmentSectionFactory.getSectionConfig();
+                sections['segments'] = segmentSectionConfig;
+                Object.assign(widgets, segmentSectionFactory.getWidgetConfigs());
+            }
+        }
+
+        return { surveySections: sections, widgetsConfig: widgets };
+    };
+
+    buildSectionsAndWidgets = (): SectionsAndWidgetConfigs => {
+        const sections: SurveySectionsConfig = {};
+        const widgets: Record<string, WidgetConfig> = {};
+
+        if (this.questionnaireConfig.tripDiary) {
+            const tripDiaryConfig = this.questionnaireConfig.tripDiary;
+
+            if (tripDiaryConfig.sections) {
+                const { surveySections, widgetsConfig } = this.buildTripDiarySectionsAndWidgets(tripDiaryConfig);
+                Object.assign(sections, surveySections);
+                Object.assign(widgets, widgetsConfig);
+            }
+        }
+        return { surveySections: sections, widgetsConfig: widgets };
+    };
+}

--- a/packages/evolution-common/src/services/questionnaire/types/SectionConfig.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/SectionConfig.ts
@@ -522,11 +522,6 @@ export type SegmentSectionConfiguration = {
 
 /**
  * Configuration for the visited places section of the questionnaire
- *
- * TODO Consider merging with the SegmentSectionConfiguration in a single
- * `TripDiaryConfiguration` to configure and build the whole trip diary with one
- * call. We can do this once the whole VisitedPlaces section is available in
- * Evolution.
  */
 export type VisitedPlacesSectionConfiguration = {
     type: 'visitedPlaces';
@@ -585,15 +580,36 @@ export type VisitedPlacesSectionConfiguration = {
     additionalVisitedPlacesWidgetNames?: string[];
 };
 
-// TODO Add more section configuration types as we support more
-export type SectionConfigurationType = SegmentSectionConfiguration | VisitedPlacesSectionConfiguration;
-
 /**
  * Configuration for the questionnaire's builtin sections. The keys are the
  * section names and the values are the configuration for that section.
  *
- * TODO When segments and visited places section are merged, this cannot have a
- * section as key anymore, we'll need a complete questionnaire configuration
- * type to replace it.
+ * FIXME Add more configurations as we have more builtin sections and more
+ * complex configurations.
  */
-export type QuestionnaireConfiguration = Record<string, SectionConfigurationType>;
+export type QuestionnaireConfiguration = {
+    /**
+     * Configuration for the trip diary part of the questionnaire. A trip diary
+     * is a many steps section where, for each applicable participant, the
+     * respondent declare when they have been to during a journey and how they
+     * got there.
+     *
+     * FIXME Many configurations are yet to be added: the type of trip diary
+     * (daily or trip-based, household or single-person), the possibility to not
+     * have all sections, or in different order, the additional sections, like
+     * travelBehavior, tripsIntro, which are currently assumed to exist in the
+     * questionnaire and should come before/after the visited places and
+     * segments section respectively, etc.
+     */
+    tripDiary?: {
+        /**
+         * Lists the section the trip diary should contain and their
+         * configuration. The order of the sections in the trip diary is
+         * currently forced.
+         */
+        sections: {
+            visitedPlaces?: VisitedPlacesSectionConfiguration;
+            segments?: SegmentSectionConfiguration;
+        };
+    };
+};


### PR DESCRIPTION
Update and document the `QuestionnaireConfiguration` type to describe the whole questionnaire. For now, only an optional `tripDiary` configuration exists. Surveys using builtin components will need to provide such a configuration object.

Add the `QuestionnaireFactory` class, which takes the questionnaire configuration and builds the section and widget configurations, with all builtin components necessary for the questionnaire.

Update the demo_survey to automatically build the questionnaire

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a factory-based system to build questionnaire sections and widget configurations dynamically.

* **Tests**
  * Added comprehensive tests covering multiple questionnaire/trip-diary scenarios and navigation wiring.

* **Refactor**
  * Restructured questionnaire configuration to a clearer trip-diary sections layout (visited places & segments).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->