### PR TITLE
server: remove the `nolog` from requests

### DIFF
--- a/packages/evolution-backend/src/apps/admin/serverApp.ts
+++ b/packages/evolution-backend/src/apps/admin/serverApp.ts
@@ -64,11 +64,8 @@ export const setupServerApp = (app: Express, serverSetupFct?: (app: Express) => 
 
     const passport = configurePassport(userAuthModel) as PassportStatic;
 
-    app.use(
-        morgan('combined', {
-            skip: (req: Request, _res: Response) => req.url.indexOf('nolog=true') !== -1
-        })
-    );
+    // Standard Apache combined log output
+    app.use(morgan('combined'));
     app.use(express.json({ limit: '500mb' }));
     app.use(express.urlencoded({ limit: '500mb', extended: true }));
     app.use(session);
@@ -113,12 +110,6 @@ export const setupServerApp = (app: Express, serverSetupFct?: (app: Express) => 
 
     app.get('/incompatible', (req: Request, res: Response) => {
         res.sendFile(path.join(publicDirectory, 'incompatible.html'));
-    });
-
-    app.get('/ping', (req: Request, res: Response) => {
-        return res.status(200).json({
-            status: 'online'
-        });
     });
 
     // Catch-all route: serves the frontend SPA for all unmatched routes (client-side routing)

--- a/packages/evolution-backend/src/apps/participant/__tests__/serverApp.test.ts
+++ b/packages/evolution-backend/src/apps/participant/__tests__/serverApp.test.ts
@@ -272,16 +272,6 @@ describe('serverApp index path routing', () => {
     });
 
     describe('special routes', () => {
-        beforeEach(() => {
-            jest.spyOn(surveyStatus, 'isSurveyEnded').mockReturnValue(false);
-        });
-
-        test('should return status for /ping endpoint', async () => {
-            const response = await request(app).get('/ping');
-
-            expect(response.status).toBe(200);
-            expect(response.body).toEqual({ status: 'online' });
-        });
 
         test('should return incompatible page for /incompatible endpoint', async () => {
             const response = await request(app).get('/incompatible');

--- a/packages/evolution-backend/src/apps/participant/serverApp.ts
+++ b/packages/evolution-backend/src/apps/participant/serverApp.ts
@@ -70,15 +70,8 @@ export const setupServerApp = (app: Express, serverSetupFct: (() => void) | unde
     });
     const passport = configurePassport(participantAuthModel);
 
-    app.use(
-        morgan('combined', {
-            // do not log if nolog=true is part of the url params:
-            // FIXME Why would we want to skip logging?
-            skip: function (req, _res) {
-                return req.url.indexOf('nolog=true') !== -1;
-            }
-        })
-    );
+    // Standard Apache combined log output
+    app.use(morgan('combined'));
     app.use(express.json({ limit: '500mb' }));
     app.use(express.urlencoded({ limit: '500mb', extended: true }));
     app.use(session);
@@ -125,12 +118,6 @@ export const setupServerApp = (app: Express, serverSetupFct: (() => void) | unde
 
     app.get('/incompatible', (req, res) => {
         res.sendFile(path.join(publicDirectory, 'incompatible.html'));
-    });
-
-    app.get('/ping', (req, res) => {
-        return res.status(200).json({
-            status: 'online'
-        });
     });
 
     // Catch-all route: serves the frontend SPA for all unmatched routes (client-side routing)

--- a/yarn.lock
+++ b/yarn.lock
@@ -11244,15 +11244,15 @@ moo@^0.5.1:
   integrity sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==
 
 morgan@^1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.10.0.tgz#091778abc1fc47cd3509824653dae1faab6b17d7"
-  integrity sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.10.1.tgz#4e02e6a4465a48e26af540191593955d17f61570"
+  integrity sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==
   dependencies:
     basic-auth "~2.0.1"
     debug "2.6.9"
     depd "~2.0.0"
     on-finished "~2.3.0"
-    on-headers "~1.0.2"
+    on-headers "~1.1.0"
 
 ms@2.0.0:
   version "2.0.0"
@@ -11521,14 +11521,9 @@ on-finished@^2.4.1:
 on-finished@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
-  integrity sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=
+  integrity sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==
   dependencies:
     ee-first "1.1.1"
-
-on-headers@~1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.2.tgz#772b0ae6aaa525c399e489adfad90c403eb3c28f"
-  integrity sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==
 
 on-headers@~1.1.0:
   version "1.1.0"


### PR DESCRIPTION
This prevented logging the requests in the infra, which is not desirable in production.

It was added 8 years ago to test a very specific thing, the `ping`, which is not necessary anyway, so we remove it too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the health check endpoint from both the admin and participant backend applications.
  * Updated request logging to consistently capture all incoming requests, removing previous conditional filtering that could selectively skip logs based on request parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->