### PR TITLE
demo_survey: fix the trip diary's section functions

### DIFF
--- a/example/demo_survey/src/survey/questionnaire.ts
+++ b/example/demo_survey/src/survey/questionnaire.ts
@@ -27,12 +27,18 @@ const segmentSectionConfigFromFactory = surveySections['segments'];
 // Add the segments section to the exported configuration
 const segmentConfig: SectionConfig = {
     ...segmentSectionConfigFromFactory,
-    isSectionVisible: function (interview) {
-        const person = odSurveyHelper.getPerson({ interview }) as any;
+    isSectionVisible: function (interview, iterationContext) {
+        const person = odSurveyHelper.getPerson({
+            interview,
+            personId: iterationContext[iterationContext.length - 1]
+        }) as any;
         return person && person.didTripsOnTripsDate === 'yes';
     },
-    isSectionCompleted: (interview) => {
-        const person = odSurveyHelper.getPerson({ interview });
+    isSectionCompleted: (interview, iterationContext) => {
+        const person = odSurveyHelper.getPerson({
+            interview,
+            personId: iterationContext[iterationContext.length - 1]
+        }) as any;
         return helper.tripsForPersonComplete(person, interview);
     }
 };

--- a/example/demo_survey/src/survey/sections.ts
+++ b/example/demo_survey/src/survey/sections.ts
@@ -329,13 +329,6 @@ const sections: { [sectionName: string]: SectionConfig } = {
             }
             return undefined;
         },
-        enableConditional: function (interview) {
-            const person = odSurveyHelper.getPerson({ interview });
-            return (
-                helper.householdMembersSectionComplete(interview) &&
-                helper.profileInfoForPersonComplete(person, interview)
-            );
-        },
         isSectionCompleted: function (interview, iterationContext) {
             const person = odSurveyHelper.getPerson({
                 interview,


### PR DESCRIPTION
fixes #1499

The segment section's functions need the iterationContext to get the person ID of the person to verify the section for, it may not be the same as the currently active person.

Also remove the `tripsIntro` enable conditional, as the section is not part of the navigation anyway and this function is for the interview as a whole, not a single person.