### PR TITLE
ci: add a backport to 0.5.0 workflow for merged PRs

### DIFF
--- a/.github/workflows/backport-generic.yml
+++ b/.github/workflows/backport-generic.yml
@@ -1,0 +1,171 @@
+# Reusable workflow to backport PRs to a specific target branch (e.g.
+# maintenance branch).
+#
+# Note that other repositories can re-use the generic backport workflow by
+# defining a workflow that uses
+# chairemobilite/evolution/.github/workflows/backport-generic.yml@main workflow.
+name: Backport To Specific Target Branch
+
+on:
+  workflow_call:
+    inputs:
+      target_branch:
+        required: true
+        type: string
+
+# CAUTION: Since this workflow is run on pull_request_target, it has access to
+# the full repository and can run any code in it with write permissions. It
+# should NEVER checkout code from the PR branch directly, as it could be
+# malicious. We should only cherry-pick merged code from the main branch. See
+# https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
+jobs:
+  backport:
+    # Run only when the PR was merged in main and labeled for backporting.
+    # Accepted labels: backport-<TARGET_BRANCH> or backport-all.
+    if: |
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
+      (
+        contains(github.event.pull_request.labels.*.name, format('backport-{0}', inputs.target_branch)) ||
+        contains(github.event.pull_request.labels.*.name, 'backport-all')
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to push the backport branch.
+      contents: write
+      # Needed to open the backport PR.
+      pull-requests: write
+    env:
+      TARGET_BRANCH: ${{ inputs.target_branch }}
+    steps:
+    - name: Checkout target branch
+      uses: actions/checkout@v4
+      with:
+        # Start from the maintenance branch we backport to. This is a trusted reference since only maintainers can merge PRs to main, and the workflow only runs on merged PRs.
+        ref: ${{ env.TARGET_BRANCH }}
+        # Full history is safer for cherry-pick operations.
+        fetch-depth: 0
+
+    - name: Cherry-pick PR commits to a backport branch
+      id: backport
+      env:
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        TARGET_BRANCH: ${{ env.TARGET_BRANCH }}
+        # This workflow assumes "Rebase and merge": merge_commit_sha is then the last rebased
+        # commit on the base branch, and the N previous commits (N = pull_request.commits) are
+        # exactly the PR's commits. We use MERGE_SHA~N..MERGE_SHA to cherry-pick them.
+        # NOTE: Does not work for squash merges (merge_commit_sha would be a single squashed
+        # commit, so MERGE_SHA~N..MERGE_SHA would reach into unrelated base-branch history).
+        MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        PR_COMMITS: ${{ github.event.pull_request.commits }}
+      run: |
+        set -euo pipefail
+
+        BRANCH="backport/pr-${PR_NUMBER}-to-${TARGET_BRANCH}"
+        echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+
+        # Standard bot identity recommended by GitHub Actions docs. 41898282 is the github-actions[bot] user id. (see https://github.com/actions/checkout#push-a-commit-to-a-pr-using-the-built-in-token)
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+        # Fetch the base branch (main) so MERGE_SHA is available locally.
+        git fetch origin main
+
+        git checkout -b "$BRANCH"
+
+        # Ensure the merge commit is a rebase merge (1 parent). Evolution never
+        # allows merge commits, but another repo using this workflow could and
+        # we don't support it.
+        PARENT_COUNT=$(git cat-file -p "$MERGE_SHA" | grep -c '^parent ')
+        if [ "$PARENT_COUNT" -ne 1 ]; then
+          echo "Expected rebase merge (1 parent), got $PARENT_COUNT parents. Squash/merge-commit not supported." >&2
+          exit 1
+        fi
+
+        if ! git cherry-pick -x "${MERGE_SHA}~${PR_COMMITS}..${MERGE_SHA}"; then
+          # Keep workflow green and handle conflicts in a follow-up notification step.
+          # Record which commit in the range caused the conflict.
+          CONFLICT_SHA=$(git log --format='%H' -1 CHERRY_PICK_HEAD 2>/dev/null || echo "$MERGE_SHA")
+          git cherry-pick --abort || true
+          echo "status=conflict" >> "$GITHUB_OUTPUT"
+          echo "conflict_sha=${CONFLICT_SHA}" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        echo "status=ok" >> "$GITHUB_OUTPUT"
+        git push --set-upstream origin "$BRANCH"
+
+    - name: Notify conflict on source PR
+      if: steps.backport.outputs.status == 'conflict'
+      uses: actions/github-script@v7
+      env:
+        CONFLICT_SHA: ${{ steps.backport.outputs.conflict_sha }}
+        TARGET_BRANCH: ${{ env.TARGET_BRANCH }}
+      with:
+        script: |
+          const number = context.payload.pull_request.number;
+          const conflictSha = process.env.CONFLICT_SHA;
+          const targetBranch = process.env.TARGET_BRANCH;
+          await github.rest.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: number,
+            body: [
+              `Backport to ${targetBranch} failed due to cherry-pick conflicts.`,
+              `Conflict occurred at commit: ${conflictSha}`,
+              '',
+              'Please backport this PR manually:',
+              `- \`git checkout ${targetBranch}\``,
+              `- \`git checkout -b backport/pr-${number}-to-${targetBranch}\``,
+              `- cherry-pick each commit of this PR in order`,
+              '- resolve conflicts',
+              `- open a PR to ${targetBranch}`
+            ].join('\n')
+          });
+
+    - name: Open backport PR to target branch
+      if: steps.backport.outputs.status == 'ok'
+      uses: actions/github-script@v7
+      env:
+        BACKPORT_BRANCH: ${{ steps.backport.outputs.branch }}
+        TARGET_BRANCH: ${{ env.TARGET_BRANCH }}
+      with:
+        # This is javascript code running in the action, not a shell script, so we can use the GitHub API client directly without worrying about escaping or formatting.
+        script: |
+          const owner = context.repo.owner;
+          const repo = context.repo.repo;
+          const base = process.env.TARGET_BRANCH;
+          // List query expects head as owner:branch format
+          const headForList = `${owner}:${process.env.BACKPORT_BRANCH}`;
+
+          const existing = await github.rest.pulls.list({
+            owner,
+            repo,
+            state: 'open',
+            base,
+            head: headForList
+          });
+
+          if (existing.data.length > 0) {
+            // Avoid duplicate backport PRs if a rerun happens.
+            core.info(`Backport PR already exists: #${existing.data[0].number}`);
+            return;
+          }
+
+          const sourcePr = context.payload.pull_request;
+          const title = `[Backport ${base}] ${sourcePr.title}`;
+          const body = [
+            `Backport of #${sourcePr.number} to ${base}.`,
+            '',
+            'This PR was created automatically by the backport workflow.'
+          ].join('\n');
+
+          // head is the branch in the current repo, where it has been created, so no need to include the owner
+          await github.rest.pulls.create({
+            owner,
+            repo,
+            base,
+            head: process.env.BACKPORT_BRANCH,
+            title,
+            body
+          });

--- a/.github/workflows/backport-to-branches.yml
+++ b/.github/workflows/backport-to-branches.yml
@@ -1,0 +1,23 @@
+name: Backport To Maintenance Branches
+
+on:
+  pull_request_target:
+    # Workflow will filter on merged branches only, we do not know at this point if the PR was merged or not, closed is the only option we have
+    types: [closed]
+
+jobs:
+  backport:
+    # Generic workflow will know when to backport based on the PR labels, but in
+    # case there are changes to that workflow, we guard here too to make sure we
+    # only handle merged PR for the main branch.
+    if: |
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main'
+    strategy:
+      matrix:
+        target_branch:
+          - v0.5.0
+    # Reusing the generic backport workflow for current maintenance branches. See https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows
+    uses: ./.github/workflows/backport-generic.yml
+    with:
+      target_branch: ${{ matrix.target_branch }}


### PR DESCRIPTION
This workflow automatically creates a PR against the v0.5.0 branch after merging a PR that is set to be backported.

PRs to backport are the ones labeled with `dependencies` (security updates by dependabot) and `backport-v0.5.0`, a label added manually to the PR.

The github-actions bot will automatically try to create a branch, based on the ref v0.5.0 and cherry-pick all the commits from the merged PR. This works only for PRs merged with the "rebase and merge" strategy, that we mostly use.

If a conflict is encountered while cherry-picking, it will add a comment in the merged PR to tell to do the backporting manually, otherwise, it will create a PR with the new branch, using the same title, prefixed with `[Backport v0.5.0]`.

Commit developed with the help of Copilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a reusable CI workflow that creates uniquely named branches, validates merge commits, attempts commit-range cherry-picks, captures conflicts (and posts manual-resolution instructions), pushes successful branches, and opens PRs while avoiding duplicates.
  * Added a triggering workflow that invokes the reusable workflow across configured maintenance branches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->