### PR TITLE
audits: backport audit checks from main to v0.5.0

### DIFF
--- a/locales/en/audits.json
+++ b/locales/en/audits.json
@@ -10,9 +10,10 @@
 
     "HH_I_Size": "Household size is out of range (should be between 1 and 20)",
     "HH_M_Size": "Household size is missing",
+    "HH_M_Home": "Home is missing",
+
     "HM_I_preGeographyAndHomeGeographyTooFarApartError": "Pre-filled and declared home geographies are far apart",
     "HM_I_preGeographyAndHomeGeographyTooFarApartWarning": "Pre-filled and declared home geographies are a bit far apart",
-
     "HM_M_Geography": "Home geography is missing",
     "HM_I_Geography": "Home geography is invalid",
     "HM_I_geographyNotInSurveyTerritory": "Home geography is outside the survey territory",

--- a/locales/en/audits.json
+++ b/locales/en/audits.json
@@ -8,8 +8,12 @@
     "I_I_ContactEmail": "Contact email is invalid",
     "I_I_HelpContactEmail": "Help contact email is invalid",
 
-    "HH_I_Size": "Household size is out of range (should be between 1 and 18)",
+    "HH_I_Size": "Household size is out of range (should be an integer between 1 and 18)",
     "HH_M_Size": "Household size is missing",
+    "HH_M_CarNumber": "Car number is missing",
+    "HH_I_CarNumber": "Car number is out of range (should be an integer between 0 and 13)",
+    "HH_L_SizeMembersCountMismatch": "Size and members count mismatch",
+    "HH_L_CarNumberVehiclesCountMismatch": "Car number and vehicles count mismatch",
     "HH_M_Home": "Home is missing",
 
     "HM_I_preGeographyAndHomeGeographyTooFarApartError": "Pre-filled and declared home geographies are far apart",

--- a/locales/en/audits.json
+++ b/locales/en/audits.json
@@ -8,7 +8,7 @@
     "I_I_ContactEmail": "Contact email is invalid",
     "I_I_HelpContactEmail": "Help contact email is invalid",
 
-    "HH_I_Size": "Household size is out of range (should be between 1 and 20)",
+    "HH_I_Size": "Household size is out of range (should be between 1 and 18)",
     "HH_M_Size": "Household size is missing",
     "HH_M_Home": "Home is missing",
 

--- a/locales/en/audits.json
+++ b/locales/en/audits.json
@@ -5,6 +5,8 @@
     "I_I_StartedAtAfterSurveyEndDate": "Interview start time is after survey end date",
     "I_M_AccessCode": "Access code is missing",
     "I_I_InvalidAccessCodeFormat": "Access code format is invalid",
+    "I_I_ContactEmail": "Contact email is invalid",
+    "I_I_HelpContactEmail": "Help contact email is invalid",
 
     "HH_I_Size": "Household size is out of range (should be between 1 and 20)",
     "HH_M_Size": "Household size is missing",

--- a/locales/fr/audits.json
+++ b/locales/fr/audits.json
@@ -10,9 +10,10 @@
 
     "HH_I_Size": "La taille du ménage est en dehors de la plage autorisée (devrait être entre 1 et 20)",
     "HH_M_Size": "La taille du ménage est manquante",
+    "HH_M_Home": "Le domicile est manquant",
+
     "HM_I_preGeographyAndHomeGeographyTooFarApartError": "Les géographies pré-remplie et déclarée du domicile sont éloignées",
     "HM_I_preGeographyAndHomeGeographyTooFarApartWarning": "Les géographies pré-remplie et déclarée du domicile sont un peu éloignées",
-
     "HM_M_Geography": "La géographie du domicile est manquante",
     "HM_I_Geography": "La géographie du domicile est invalide",
     "HM_I_geographyNotInSurveyTerritory": "La géographie du domicile est en dehors du territoire d'enquête",

--- a/locales/fr/audits.json
+++ b/locales/fr/audits.json
@@ -8,8 +8,12 @@
     "I_I_ContactEmail": "Le courriel de contact est invalide",
     "I_I_HelpContactEmail": "Le courriel de contact d'aide est invalide",
 
-    "HH_I_Size": "La taille du ménage est en dehors de la plage autorisée (devrait être entre 1 et 18)",
+    "HH_I_Size": "La taille du ménage est en dehors de la plage autorisée (devrait être un entier entre 1 et 18)",
     "HH_M_Size": "La taille du ménage est manquante",
+    "HH_M_CarNumber": "Le nombre de véhicules automobiles est manquant",
+    "HH_I_CarNumber": "Le nombre de véhicules automobiles est en dehors de la plage autorisée (devrait être un entier entre 0 et 13)",
+    "HH_L_SizeMembersCountMismatch": "La taille du ménage et le nombre de personnes ne correspondent pas",
+    "HH_L_CarNumberVehiclesCountMismatch": "Le nombre de véhicules automobiles et le nombre de véhicules déclarés ne correspondent pas",
     "HH_M_Home": "Le domicile est manquant",
 
     "HM_I_preGeographyAndHomeGeographyTooFarApartError": "Les géographies pré-remplie et déclarée du domicile sont éloignées",

--- a/locales/fr/audits.json
+++ b/locales/fr/audits.json
@@ -5,6 +5,8 @@
     "I_I_StartedAtAfterSurveyEndDate": "Le début de l'entrevue est après la date de fin de l'enquête",
     "I_M_AccessCode": "Le code d'accès est manquant",
     "I_I_InvalidAccessCodeFormat": "Le format du code d'accès est invalide",
+    "I_I_ContactEmail": "Le courriel de contact est invalide",
+    "I_I_HelpContactEmail": "Le courriel de contact d'aide est invalide",
 
     "HH_I_Size": "La taille du ménage est en dehors de la plage autorisée (devrait être entre 1 et 20)",
     "HH_M_Size": "La taille du ménage est manquante",

--- a/locales/fr/audits.json
+++ b/locales/fr/audits.json
@@ -8,7 +8,7 @@
     "I_I_ContactEmail": "Le courriel de contact est invalide",
     "I_I_HelpContactEmail": "Le courriel de contact d'aide est invalide",
 
-    "HH_I_Size": "La taille du ménage est en dehors de la plage autorisée (devrait être entre 1 et 20)",
+    "HH_I_Size": "La taille du ménage est en dehors de la plage autorisée (devrait être entre 1 et 18)",
     "HH_M_Size": "La taille du ménage est manquante",
     "HH_M_Home": "Le domicile est manquant",
 

--- a/packages/evolution-backend/src/services/audits/SurveyObjectAuditor.ts
+++ b/packages/evolution-backend/src/services/audits/SurveyObjectAuditor.ts
@@ -47,6 +47,7 @@ export class SurveyObjectAuditor {
         // Run household audit checks
         if (surveyObjectsWithAudits.household) {
             const householdContext: auditChecks.HouseholdAuditCheckContext = {
+                home: surveyObjectsWithAudits.home,
                 household: surveyObjectsWithAudits.household,
                 interview: surveyObjectsWithAudits.interview
             };

--- a/packages/evolution-backend/src/services/audits/__tests__/SurveyObjectAuditor.test.ts
+++ b/packages/evolution-backend/src/services/audits/__tests__/SurveyObjectAuditor.test.ts
@@ -179,6 +179,7 @@ describe('SurveyObjectAuditor', () => {
 
             expect(runHouseholdAuditChecks).toHaveBeenCalledWith(
                 {
+                    home: surveyObjects.home,
                     household: surveyObjects.household,
                     interview: surveyObjects.interview
                 },

--- a/packages/evolution-backend/src/services/audits/auditChecks/AuditCheckContexts.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/AuditCheckContexts.ts
@@ -27,6 +27,7 @@ export type InterviewAuditCheckContext = {
  * Context for household audit checks (includes parent objects)
  */
 export type HouseholdAuditCheckContext = {
+    home: Optional<Home>;
     household: Household;
     interview: Interview;
 };

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/HouseholdAuditChecks.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/HouseholdAuditChecks.ts
@@ -56,5 +56,28 @@ export const householdAuditChecks: { [errorCode: string]: HouseholdAuditCheckFun
         }
 
         return undefined; // No audit needed
+    },
+
+    /**
+     * Check if home is missing
+     * @param context - HouseholdAuditCheckContext
+     * @returns AuditForObject
+     */
+    HH_M_Home: (context: HouseholdAuditCheckContext): AuditForObject | undefined => {
+        const { home, household } = context;
+
+        if (!home) {
+            return {
+                objectType: 'household',
+                objectUuid: household._uuid!,
+                errorCode: 'HH_M_Home',
+                version: 1,
+                level: 'error',
+                message: 'Home is missing',
+                ignore: false
+            };
+        }
+
+        return undefined; // No audit needed
     }
 };

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/HouseholdAuditChecks.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/HouseholdAuditChecks.ts
@@ -34,8 +34,10 @@ export const householdAuditChecks: { [errorCode: string]: HouseholdAuditCheckFun
     },
 
     /**
-     * Check if household size is invalid
-     * validate size is between 1 and 20
+     * Check if household size is invalid.
+     * Validates an integer in [1, 18], consistent with the participant form rule.
+     *
+     * @see {@link import('evolution-common/lib/services/widgets/validations/validations').householdSizeValidation}
      * @param context - HouseholdAuditCheckContext
      * @returns AuditForObject
      */
@@ -43,14 +45,15 @@ export const householdAuditChecks: { [errorCode: string]: HouseholdAuditCheckFun
         const { household } = context;
         const size = household.size;
 
-        if (size !== undefined && (size < 1 || size > 20)) {
+        // Upper bound 18 must stay in sync with householdSizeValidation (same module as @see above).
+        if (size !== undefined && (size < 1 || size > 18)) {
             return {
                 objectType: 'household',
                 objectUuid: household._uuid!,
                 errorCode: 'HH_I_Size',
                 version: 1,
                 level: 'error',
-                message: 'Household size is out of range (should be between 1 and 20)',
+                message: 'Household size is out of range (should be between 1 and 18)',
                 ignore: false
             };
         }

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/HouseholdAuditChecks.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/HouseholdAuditChecks.ts
@@ -46,14 +46,14 @@ export const householdAuditChecks: { [errorCode: string]: HouseholdAuditCheckFun
         const size = household.size;
 
         // Upper bound 18 must stay in sync with householdSizeValidation (same module as @see above).
-        if (size !== undefined && (size < 1 || size > 18)) {
+        if (size !== undefined && (!Number.isInteger(size) || size < 1 || size > 18)) {
             return {
                 objectType: 'household',
                 objectUuid: household._uuid!,
                 errorCode: 'HH_I_Size',
                 version: 1,
                 level: 'error',
-                message: 'Household size is out of range (should be between 1 and 18)',
+                message: 'Household size is out of range (should be an integer between 1 and 18)',
                 ignore: false
             };
         }
@@ -77,6 +77,111 @@ export const householdAuditChecks: { [errorCode: string]: HouseholdAuditCheckFun
                 version: 1,
                 level: 'error',
                 message: 'Home is missing',
+                ignore: false
+            };
+        }
+
+        return undefined; // No audit needed
+    },
+
+    /**
+     * Check if size and members count mismatch
+     * validate size is equal to members count
+     * @param context - HouseholdAuditCheckContext
+     * @returns AuditForObject
+     */
+    HH_L_SizeMembersCountMismatch: (context: HouseholdAuditCheckContext): AuditForObject | undefined => {
+        const { household } = context;
+        const size = household.size;
+        const membersCount = household.members?.length;
+
+        if (size !== undefined && membersCount !== undefined && size !== membersCount) {
+            return {
+                objectType: 'household',
+                objectUuid: household._uuid!,
+                errorCode: 'HH_L_SizeMembersCountMismatch',
+                version: 1,
+                level: 'error',
+                message: 'Size and members count mismatch',
+                ignore: false
+            };
+        }
+
+        return undefined; // No audit needed
+    },
+
+    /**
+     * Check if car number is missing
+     * @param context - HouseholdAuditCheckContext
+     * @returns AuditForObject
+     */
+    HH_M_CarNumber: (context: HouseholdAuditCheckContext): AuditForObject | undefined => {
+        const { household } = context;
+        const carNumber = household.carNumber;
+
+        if (carNumber === undefined) {
+            return {
+                objectType: 'household',
+                objectUuid: household._uuid!,
+                errorCode: 'HH_M_CarNumber',
+                version: 1,
+                level: 'error',
+                message: 'Car number is missing',
+                ignore: false
+            };
+        }
+
+        return undefined; // No audit needed
+    },
+
+    /**
+     * Check if car number is invalid.
+     * Validates an integer in [0, 13] so audits stay consistent with the participant form rule.
+     * TODO: make max/min values configurable per survey with default values from project config.
+     *
+     * @see {@link import('evolution-common/lib/services/widgets/validations/validations').carNumberValidation}
+     * @param context - HouseholdAuditCheckContext
+     * @returns AuditForObject
+     */
+    HH_I_CarNumber: (context: HouseholdAuditCheckContext): AuditForObject | undefined => {
+        const { household } = context;
+        const carNumber = household.carNumber;
+
+        // Upper bound 13 must stay in sync with carNumberValidation (same module as @see above).
+        if (carNumber !== undefined && (!Number.isInteger(carNumber) || carNumber < 0 || carNumber > 13)) {
+            return {
+                objectType: 'household',
+                objectUuid: household._uuid!,
+                errorCode: 'HH_I_CarNumber',
+                version: 1,
+                level: 'error',
+                message: 'Car number is out of range (should be an integer between 0 and 13)',
+                ignore: false
+            };
+        }
+
+        return undefined; // No audit needed
+    },
+
+    /**
+     * Check if car number and vehicles count mismatch
+     * validate car number is equal to vehicles count
+     * @param context - HouseholdAuditCheckContext
+     * @returns AuditForObject
+     */
+    HH_L_CarNumberVehiclesCountMismatch: (context: HouseholdAuditCheckContext): AuditForObject | undefined => {
+        const { household } = context;
+        const carNumber = household.carNumber;
+        const vehiclesCount = household.vehicles?.length;
+
+        if (carNumber !== undefined && vehiclesCount !== undefined && carNumber !== vehiclesCount) {
+            return {
+                objectType: 'household',
+                objectUuid: household._uuid!,
+                errorCode: 'HH_L_CarNumberVehiclesCountMismatch',
+                version: 1,
+                level: 'error',
+                message: 'Car number and vehicles count mismatch',
                 ignore: false
             };
         }

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/InterviewAuditChecks.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/InterviewAuditChecks.ts
@@ -6,7 +6,7 @@
  */
 
 import type { AuditForObject } from 'evolution-common/lib/services/audits/types';
-import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
+import { _isBlank, _isEmail } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import type { InterviewAuditCheckContext, InterviewAuditCheckFunction } from '../AuditCheckContexts';
 import projectConfig from 'evolution-common/lib/config/project.config';
 import { secondsToMillisecondsTimestamp, parseISODateToTimestamp } from 'evolution-common/lib/utils/DateTimeUtils';
@@ -181,5 +181,51 @@ export const interviewAuditChecks: { [errorCode: string]: InterviewAuditCheckFun
             }
         }
         return undefined;
+    },
+
+    /**
+     * Check if interview contact email is invalid
+     * @param context - InterviewAuditCheckContext
+     * @returns {AuditForObject | undefined}
+     */
+    I_I_ContactEmail: (context: InterviewAuditCheckContext): AuditForObject | undefined => {
+        const { interview } = context;
+        const contactEmail = interview.contactEmail;
+        if (!_isBlank(contactEmail) && !_isEmail(contactEmail as string)) {
+            return {
+                objectType: 'interview',
+                objectUuid: interview.uuid!,
+                errorCode: 'I_I_ContactEmail',
+                version: 1,
+                level: 'error',
+                message: 'Contact email is invalid',
+                ignore: false
+            };
+        }
+        return undefined;
+    },
+
+    /**
+     * Check if interview help contact email is invalid
+     * @param context - InterviewAuditCheckContext
+     * @returns {AuditForObject | undefined}
+     */
+    I_I_HelpContactEmail: (context: InterviewAuditCheckContext): AuditForObject | undefined => {
+        const { interview } = context;
+        const helpContactEmail = interview.helpContactEmail;
+        if (!_isBlank(helpContactEmail) && !_isEmail(helpContactEmail as string)) {
+            return {
+                objectType: 'interview',
+                objectUuid: interview.uuid!,
+                errorCode: 'I_I_HelpContactEmail',
+                version: 1,
+                level: 'error',
+                message: 'Help contact email is invalid',
+                ignore: false
+            };
+        }
+        return undefined;
     }
+
+    // TODO: validate phone number formats and normalize. The format should be defined in the survey config (by country).
 };

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/HouseholdAuditChecks.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/HouseholdAuditChecks.test.ts
@@ -9,13 +9,14 @@ import { v4 as uuidV4 } from 'uuid';
 import { runHouseholdAuditChecks } from '../../AuditCheckRunners';
 import type { HouseholdAuditCheckFunction } from '../../AuditCheckContexts';
 import type { AuditForObject } from 'evolution-common/lib/services/audits/types';
-import { createContextWithHousehold } from './household/testHelper';
+import { createContextWithHouseholdAndHome } from './household/testHelper';
 
 describe('runHouseholdAuditChecks - Integration', () => {
-    const validUuid = uuidV4();
+    const validHouseholdUuid = uuidV4();
+    const validHomeUuid = uuidV4();
 
     it('should run all audit checks and return empty array when all checks pass', async () => {
-        const context = createContextWithHousehold();
+        const context = createContextWithHouseholdAndHome();
 
         // Mock audit checks that all pass (return undefined)
         const mockAuditChecks: { [errorCode: string]: HouseholdAuditCheckFunction } = {
@@ -30,14 +31,14 @@ describe('runHouseholdAuditChecks - Integration', () => {
     });
 
     it('should aggregate results from multiple failing checks', async () => {
-        const context = createContextWithHousehold(undefined, validUuid);
+        const context = createContextWithHouseholdAndHome(undefined, undefined, validHouseholdUuid, validHomeUuid);
 
         // Mock audit checks where some fail (return audit objects)
         const mockAuditChecks: { [errorCode: string]: HouseholdAuditCheckFunction } = {
             TEST_PASS: () => undefined,
             TEST_FAIL_1: (): AuditForObject => ({
                 objectType: 'household',
-                objectUuid: validUuid,
+                objectUuid: validHouseholdUuid,
                 errorCode: 'TEST_FAIL_1',
                 version: 1,
                 level: 'error',
@@ -46,7 +47,7 @@ describe('runHouseholdAuditChecks - Integration', () => {
             }),
             TEST_FAIL_2: (): AuditForObject => ({
                 objectType: 'household',
-                objectUuid: validUuid,
+                objectUuid: validHouseholdUuid,
                 errorCode: 'TEST_FAIL_2',
                 version: 1,
                 level: 'warning',
@@ -65,7 +66,7 @@ describe('runHouseholdAuditChecks - Integration', () => {
     });
 
     it('should handle empty audit checks object', async () => {
-        const context = createContextWithHousehold();
+        const context = createContextWithHouseholdAndHome();
 
         const mockAuditChecks: { [errorCode: string]: HouseholdAuditCheckFunction } = {};
 

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/household/HH_I_CarNumber.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/household/HH_I_CarNumber.test.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { v4 as uuidV4 } from 'uuid';
+import { householdAuditChecks } from '../../HouseholdAuditChecks';
+import { createContextWithHouseholdAndHome } from './testHelper';
+
+describe('HH_I_CarNumber audit check', () => {
+    const validHouseholdUuid = uuidV4();
+    const validHomeUuid = uuidV4();
+
+    it.each([0, 5, 13])('should pass when household car number is %p', (carNumber) => {
+        const context = createContextWithHouseholdAndHome({ carNumber }, undefined, validHouseholdUuid, validHomeUuid);
+        const result = householdAuditChecks.HH_I_CarNumber(context);
+
+        expect(result).toBeUndefined();
+    });
+
+    const invalidCases: ReadonlyArray<number> = [-1, 14, 1.5];
+
+    it.each(invalidCases)('should error when household car number is invalid (%p)', (carNumber) => {
+        const context = createContextWithHouseholdAndHome({ carNumber }, undefined, validHouseholdUuid, validHomeUuid);
+        const result = householdAuditChecks.HH_I_CarNumber(context);
+
+        expect(result).toMatchObject({
+            objectType: 'household',
+            objectUuid: validHouseholdUuid,
+            errorCode: 'HH_I_CarNumber',
+            version: 1,
+            level: 'error',
+            message: 'Car number is out of range (should be an integer between 0 and 13)',
+            ignore: false
+        });
+    });
+});

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/household/HH_I_Size.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/household/HH_I_Size.test.ts
@@ -32,7 +32,7 @@ describe('HH_I_Size audit check', () => {
             errorCode: 'HH_I_Size',
             version: 1,
             level: 'error',
-            message: 'Household size is out of range (should be between 1 and 18)',
+            message: 'Household size is out of range (should be an integer between 1 and 18)',
             ignore: false
         });
     });
@@ -48,7 +48,23 @@ describe('HH_I_Size audit check', () => {
             errorCode: 'HH_I_Size',
             version: 1,
             level: 'error',
-            message: 'Household size is out of range (should be between 1 and 18)',
+            message: 'Household size is out of range (should be an integer between 1 and 18)',
+            ignore: false
+        });
+    });
+
+    it('should error when household size is not an integer', () => {
+        const context = createContextWithHouseholdAndHome({ size: 2.5 }, undefined, validHouseholdUuid, validHomeUuid);
+
+        const result = householdAuditChecks.HH_I_Size(context);
+
+        expect(result).toMatchObject({
+            objectType: 'household',
+            objectUuid: validHouseholdUuid,
+            errorCode: 'HH_I_Size',
+            version: 1,
+            level: 'error',
+            message: 'Household size is out of range (should be an integer between 1 and 18)',
             ignore: false
         });
     });
@@ -74,7 +90,7 @@ describe('HH_I_Size audit check', () => {
             errorCode: 'HH_I_Size',
             version: 1,
             level: 'error',
-            message: 'Household size is out of range (should be between 1 and 18)',
+            message: 'Household size is out of range (should be an integer between 1 and 18)',
             ignore: false
         });
     });

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/household/HH_I_Size.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/household/HH_I_Size.test.ts
@@ -32,7 +32,7 @@ describe('HH_I_Size audit check', () => {
             errorCode: 'HH_I_Size',
             version: 1,
             level: 'error',
-            message: 'Household size is out of range (should be between 1 and 20)',
+            message: 'Household size is out of range (should be between 1 and 18)',
             ignore: false
         });
     });
@@ -48,7 +48,7 @@ describe('HH_I_Size audit check', () => {
             errorCode: 'HH_I_Size',
             version: 1,
             level: 'error',
-            message: 'Household size is out of range (should be between 1 and 20)',
+            message: 'Household size is out of range (should be between 1 and 18)',
             ignore: false
         });
     });
@@ -60,9 +60,23 @@ describe('HH_I_Size audit check', () => {
     });
 
     it('should pass when household size is at maximum boundary', () => {
-        const context = createContextWithHouseholdAndHome({ size: 20 }, undefined, validHouseholdUuid, validHomeUuid);
+        const context = createContextWithHouseholdAndHome({ size: 18 }, undefined, validHouseholdUuid, validHomeUuid);
         const result = householdAuditChecks.HH_I_Size(context);
         expect(result).toBeUndefined();
+    });
+
+    it('should error when household size is just above maximum', () => {
+        const context = createContextWithHouseholdAndHome({ size: 19 }, undefined, validHouseholdUuid, validHomeUuid);
+        const result = householdAuditChecks.HH_I_Size(context);
+        expect(result).toMatchObject({
+            objectType: 'household',
+            objectUuid: validHouseholdUuid,
+            errorCode: 'HH_I_Size',
+            version: 1,
+            level: 'error',
+            message: 'Household size is out of range (should be between 1 and 18)',
+            ignore: false
+        });
     });
 
 });

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/household/HH_I_Size.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/household/HH_I_Size.test.ts
@@ -7,13 +7,14 @@
 
 import { v4 as uuidV4 } from 'uuid';
 import { householdAuditChecks } from '../../HouseholdAuditChecks';
-import { createContextWithHousehold } from './testHelper';
+import { createContextWithHouseholdAndHome } from './testHelper';
 
 describe('HH_I_Size audit check', () => {
-    const validUuid = uuidV4();
+    const validHouseholdUuid = uuidV4();
+    const validHomeUuid = uuidV4();
 
     it('should pass when household has valid size', () => {
-        const context = createContextWithHousehold({ size: 3 }, validUuid);
+        const context = createContextWithHouseholdAndHome({ size: 3 }, undefined, validHouseholdUuid, validHomeUuid);
 
         const result = householdAuditChecks.HH_I_Size(context);
 
@@ -21,13 +22,13 @@ describe('HH_I_Size audit check', () => {
     });
 
     it('should error when household size is too small', () => {
-        const context = createContextWithHousehold({ size: 0 }, validUuid);
+        const context = createContextWithHouseholdAndHome({ size: 0 }, undefined, validHouseholdUuid, validHomeUuid);
 
         const result = householdAuditChecks.HH_I_Size(context);
 
         expect(result).toMatchObject({
             objectType: 'household',
-            objectUuid: validUuid,
+            objectUuid: validHouseholdUuid,
             errorCode: 'HH_I_Size',
             version: 1,
             level: 'error',
@@ -37,13 +38,13 @@ describe('HH_I_Size audit check', () => {
     });
 
     it('should error when household size is too large', () => {
-        const context = createContextWithHousehold({ size: 25 }, validUuid);
+        const context = createContextWithHouseholdAndHome({ size: 25 }, undefined, validHouseholdUuid, validHomeUuid);
 
         const result = householdAuditChecks.HH_I_Size(context);
 
         expect(result).toMatchObject({
             objectType: 'household',
-            objectUuid: validUuid,
+            objectUuid: validHouseholdUuid,
             errorCode: 'HH_I_Size',
             version: 1,
             level: 'error',
@@ -53,13 +54,13 @@ describe('HH_I_Size audit check', () => {
     });
 
     it('should pass when household size is at minimum boundary', () => {
-        const context = createContextWithHousehold({ size: 1 });
+        const context = createContextWithHouseholdAndHome({ size: 1 }, undefined, validHouseholdUuid, validHomeUuid);
         const result = householdAuditChecks.HH_I_Size(context);
         expect(result).toBeUndefined();
     });
 
     it('should pass when household size is at maximum boundary', () => {
-        const context = createContextWithHousehold({ size: 20 });
+        const context = createContextWithHouseholdAndHome({ size: 20 }, undefined, validHouseholdUuid, validHomeUuid);
         const result = householdAuditChecks.HH_I_Size(context);
         expect(result).toBeUndefined();
     });

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/household/HH_L_CarNumberVehiclesCountMismatch.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/household/HH_L_CarNumberVehiclesCountMismatch.test.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { v4 as uuidV4 } from 'uuid';
+import { householdAuditChecks } from '../../HouseholdAuditChecks';
+import { createContextWithHouseholdAndHome } from './testHelper';
+import { Vehicle } from 'evolution-common/lib/services/baseObjects/Vehicle';
+import { SurveyObjectsRegistry } from 'evolution-common/lib/services/baseObjects/SurveyObjectsRegistry';
+
+describe('HH_L_CarNumberVehiclesCountMismatch audit check', () => {
+    const validHouseholdUuid = uuidV4();
+    const validHomeUuid = uuidV4();
+    const surveyObjectsRegistry = new SurveyObjectsRegistry();
+
+    const makeVehicles = (count: number) =>
+        Array.from({ length: count }, () => new Vehicle({ _uuid: uuidV4() }, surveyObjectsRegistry));
+
+    it('should pass when household has valid car number and vehicles count', () => {
+        const context = createContextWithHouseholdAndHome({
+            carNumber: 3,
+            vehicles: makeVehicles(3)
+        }, undefined, validHouseholdUuid, validHomeUuid);
+
+        const result = householdAuditChecks.HH_L_CarNumberVehiclesCountMismatch(context);
+
+        expect(result).toBeUndefined();
+    });
+
+    const mismatchCases: ReadonlyArray<[carNumber: number, vehicleCount: number]> = [
+        [0, 1],
+        [1, 2],
+        [5, 1]
+    ];
+
+    it.each(mismatchCases)(
+        'should error when carNumber is %i but vehicles count is %i',
+        (carNumber, vehicleCount) => {
+            const context = createContextWithHouseholdAndHome(
+                { carNumber, vehicles: makeVehicles(vehicleCount) },
+                undefined,
+                validHouseholdUuid,
+                validHomeUuid
+            );
+
+            const result = householdAuditChecks.HH_L_CarNumberVehiclesCountMismatch(context);
+
+            expect(result).toMatchObject({
+                objectType: 'household',
+                objectUuid: validHouseholdUuid,
+                errorCode: 'HH_L_CarNumberVehiclesCountMismatch',
+                version: 1,
+                level: 'error',
+                message: 'Car number and vehicles count mismatch',
+                ignore: false
+            });
+        }
+    );
+
+    const skipWhenIncompleteCases: ReadonlyArray<[label: string, overrides: { carNumber?: number; vehicles?: Vehicle[] }]> =
+        [
+            ['carNumber undefined', { carNumber: undefined, vehicles: makeVehicles(1) }],
+            ['vehicles undefined', { carNumber: 1 }],
+            ['carNumber and vehicles undefined', { carNumber: undefined }]
+        ];
+
+    it.each(skipWhenIncompleteCases)(
+        'should return undefined when %s (mismatch check skipped)',
+        (_label, overrides) => {
+            const context = createContextWithHouseholdAndHome(
+                overrides,
+                undefined,
+                validHouseholdUuid,
+                validHomeUuid
+            );
+
+            expect(householdAuditChecks.HH_L_CarNumberVehiclesCountMismatch(context)).toBeUndefined();
+        }
+    );
+
+});
+

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/household/HH_L_SizeMembersCountMismatch.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/household/HH_L_SizeMembersCountMismatch.test.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { v4 as uuidV4 } from 'uuid';
+import { householdAuditChecks } from '../../HouseholdAuditChecks';
+import { createContextWithHouseholdAndHome } from './testHelper';
+import { Person } from 'evolution-common/lib/services/baseObjects/Person';
+import { SurveyObjectsRegistry } from 'evolution-common/lib/services/baseObjects/SurveyObjectsRegistry';
+
+describe('HH_L_SizeMembersCountMismatch audit check', () => {
+    const validHouseholdUuid = uuidV4();
+    const validHomeUuid = uuidV4();
+    const surveyObjectsRegistry = new SurveyObjectsRegistry();
+
+    const makeMembers = (count: number) =>
+        Array.from({ length: count }, () => new Person({ _uuid: uuidV4() }, surveyObjectsRegistry));
+
+    it('should pass when household size matches members count', () => {
+        const context = createContextWithHouseholdAndHome(
+            { size: 3, members: makeMembers(3) },
+            undefined,
+            validHouseholdUuid,
+            validHomeUuid
+        );
+
+        const result = householdAuditChecks.HH_L_SizeMembersCountMismatch(context);
+
+        expect(result).toBeUndefined();
+    });
+
+    const mismatchCases: ReadonlyArray<[size: number, memberCount: number]> = [
+        [1, 2],
+        [2, 1],
+        [5, 1]
+    ];
+
+    it.each(mismatchCases)(
+        'should error when size is %i but members count is %i',
+        (size, memberCount) => {
+            const context = createContextWithHouseholdAndHome(
+                { size, members: makeMembers(memberCount) },
+                undefined,
+                validHouseholdUuid,
+                validHomeUuid
+            );
+
+            const result = householdAuditChecks.HH_L_SizeMembersCountMismatch(context);
+
+            expect(result).toMatchObject({
+                objectType: 'household',
+                objectUuid: validHouseholdUuid,
+                errorCode: 'HH_L_SizeMembersCountMismatch',
+                version: 1,
+                level: 'error',
+                message: 'Size and members count mismatch',
+                ignore: false
+            });
+        }
+    );
+
+    it('should return undefined when size is undefined', () => {
+        const context = createContextWithHouseholdAndHome(
+            { size: undefined, members: makeMembers(2) },
+            undefined,
+            validHouseholdUuid,
+            validHomeUuid
+        );
+
+        expect(householdAuditChecks.HH_L_SizeMembersCountMismatch(context)).toBeUndefined();
+    });
+
+    it('should return undefined when members is undefined', () => {
+        const context = createContextWithHouseholdAndHome(
+            { size: 3, members: undefined },
+            undefined,
+            validHouseholdUuid,
+            validHomeUuid
+        );
+
+        expect(householdAuditChecks.HH_L_SizeMembersCountMismatch(context)).toBeUndefined();
+    });
+});

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/household/HH_M_CarNumber.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/household/HH_M_CarNumber.test.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { v4 as uuidV4 } from 'uuid';
+import { householdAuditChecks } from '../../HouseholdAuditChecks';
+import { createContextWithHouseholdAndHome } from './testHelper';
+
+describe('HH_M_CarNumber audit check', () => {
+    const validHouseholdUuid = uuidV4();
+    const validHomeUuid = uuidV4();
+
+    it('should pass when household has car number defined', () => {
+        const context = createContextWithHouseholdAndHome({ carNumber: 0 }, undefined, validHouseholdUuid, validHomeUuid);
+
+        const result = householdAuditChecks.HH_M_CarNumber(context);
+
+        expect(result).toBeUndefined();
+    });
+
+    it('should error when household car number is undefined', () => {
+        const context = createContextWithHouseholdAndHome(
+            { carNumber: undefined },
+            undefined,
+            validHouseholdUuid,
+            validHomeUuid
+        );
+
+        const result = householdAuditChecks.HH_M_CarNumber(context);
+
+        expect(result).toMatchObject({
+            objectType: 'household',
+            objectUuid: validHouseholdUuid,
+            errorCode: 'HH_M_CarNumber',
+            version: 1,
+            level: 'error',
+            message: 'Car number is missing',
+            ignore: false
+        });
+    });
+});

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/household/HH_M_Home.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/household/HH_M_Home.test.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { v4 as uuidV4 } from 'uuid';
+import { householdAuditChecks } from '../../HouseholdAuditChecks';
+import { createContextWithHouseholdAndHome } from './testHelper';
+
+describe('HH_M_Home audit check', () => {
+    const validHouseholdUuid = uuidV4();
+    const validHomeUuid = uuidV4();
+
+    it('should pass when household has valid home', () => {
+        const context = createContextWithHouseholdAndHome(undefined, {}, validHouseholdUuid, validHomeUuid);
+
+        const result = householdAuditChecks.HH_M_Home(context);
+
+        expect(result).toBeUndefined();
+    });
+
+    it('should error when home is undefined', () => {
+        const context = createContextWithHouseholdAndHome(undefined, undefined, validHouseholdUuid, validHomeUuid);
+
+        const result = householdAuditChecks.HH_M_Home(context);
+
+        expect(result).toMatchObject({
+            objectType: 'household',
+            objectUuid: validHouseholdUuid,
+            errorCode: 'HH_M_Home',
+            version: 1,
+            level: 'error',
+            message: 'Home is missing',
+            ignore: false
+        });
+    });
+});
+

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/household/HH_M_Size.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/household/HH_M_Size.test.ts
@@ -7,13 +7,14 @@
 
 import { v4 as uuidV4 } from 'uuid';
 import { householdAuditChecks } from '../../HouseholdAuditChecks';
-import { createContextWithHousehold } from './testHelper';
+import { createContextWithHouseholdAndHome } from './testHelper';
 
 describe('HH_M_Size audit check', () => {
-    const validUuid = uuidV4();
+    const validHouseholdUuid = uuidV4();
+    const validHomeUuid = uuidV4();
 
     it('should pass when household has valid size', () => {
-        const context = createContextWithHousehold({ size: 3 }, validUuid);
+        const context = createContextWithHouseholdAndHome({ size: 3 }, undefined, validHouseholdUuid, validHomeUuid);
 
         const result = householdAuditChecks.HH_M_Size(context);
 
@@ -21,13 +22,13 @@ describe('HH_M_Size audit check', () => {
     });
 
     it('should error when household size is undefined', () => {
-        const context = createContextWithHousehold({ size: undefined }, validUuid);
+        const context = createContextWithHouseholdAndHome({ size: undefined }, undefined, validHouseholdUuid, validHomeUuid);
 
         const result = householdAuditChecks.HH_M_Size(context);
 
         expect(result).toMatchObject({
             objectType: 'household',
-            objectUuid: validUuid,
+            objectUuid: validHouseholdUuid,
             errorCode: 'HH_M_Size',
             version: 1,
             level: 'error',

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/household/testHelper.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/household/testHelper.ts
@@ -6,9 +6,12 @@
  */
 
 import { v4 as uuidV4 } from 'uuid';
+import type { Optional } from 'evolution-common/lib/types/Optional.type';
 import type { Household } from 'evolution-common/lib/services/baseObjects/Household';
+import type { Home } from 'evolution-common/lib/services/baseObjects/Home';
 import type { Interview } from 'evolution-common/lib/services/baseObjects/interview/Interview';
 import type { HouseholdAuditCheckContext } from '../../../AuditCheckContexts';
+import { createMockHome } from '../home/testHelper';
 
 export const createMockHousehold = (overrides: Partial<Household> = {}, validUuid = uuidV4()) => {
     return {
@@ -18,9 +21,10 @@ export const createMockHousehold = (overrides: Partial<Household> = {}, validUui
     } as Household;
 };
 
-export const createContextWithHousehold = (householdOverrides: Partial<Household> = {}, validUuid = uuidV4()): HouseholdAuditCheckContext => {
+export const createContextWithHouseholdAndHome = (householdOverrides: Partial<Household> = {}, homeOverrides: Optional<Partial<Home>> = undefined, validHouseholdUuid = uuidV4(), validHomeUuid = uuidV4()): HouseholdAuditCheckContext => {
     return {
-        household: createMockHousehold(householdOverrides, validUuid),
+        household: createMockHousehold(householdOverrides, validHouseholdUuid),
+        home: homeOverrides ? createMockHome(homeOverrides, validHomeUuid) : undefined,
         interview: { _uuid: uuidV4() } as unknown as Interview
     };
 };

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/interview/I_I_ContactEmail.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/interview/I_I_ContactEmail.test.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2026, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { runEmailAuditCheckTests } from './testHelper';
+import { interviewAuditChecks } from '../../InterviewAuditChecks';
+
+describe('I_I_ContactEmail audit check', () => {
+    runEmailAuditCheckTests({
+        checkFn: interviewAuditChecks.I_I_ContactEmail,
+        checkName: 'I_I_ContactEmail',
+        emailField: 'contactEmail',
+        errorMessage: 'Contact email is invalid'
+    });
+});

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/interview/I_I_HelpContactEmail.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/interview/I_I_HelpContactEmail.test.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2026, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { runEmailAuditCheckTests } from './testHelper';
+import { interviewAuditChecks } from '../../InterviewAuditChecks';
+
+describe('I_I_HelpContactEmail audit check', () => {
+    runEmailAuditCheckTests({
+        checkFn: interviewAuditChecks.I_I_HelpContactEmail,
+        checkName: 'I_I_HelpContactEmail',
+        emailField: 'helpContactEmail',
+        errorMessage: 'Help contact email is invalid'
+    });
+});

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/interview/testHelper.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/interview/testHelper.ts
@@ -7,7 +7,7 @@
 
 import { v4 as uuidV4 } from 'uuid';
 import type { Interview } from 'evolution-common/lib/services/baseObjects/interview/Interview';
-import type { InterviewAuditCheckContext } from '../../../AuditCheckContexts';
+import type { InterviewAuditCheckContext, InterviewAuditCheckFunction } from '../../../AuditCheckContexts';
 import { InterviewParadata } from 'evolution-common/lib/services/baseObjects/interview/InterviewParadata';
 
 export const createMockInterview = (overrides: Partial<Interview> = {}, validUuid = uuidV4(), validId = 123) => {
@@ -24,4 +24,58 @@ export const createContextWithInterview = (interviewOverrides: Partial<Interview
     return {
         interview: createMockInterview(interviewOverrides, validUuid)
     };
+};
+
+/**
+ * Shared test suite for email audit checks that use the _isBlank + _isEmail pattern.
+ * Both valid and invalid scenarios are tested, including undefined and empty string.
+ */
+export const runEmailAuditCheckTests = (config: {
+    checkFn: InterviewAuditCheckFunction;
+    checkName: string;
+    emailField: keyof Interview;
+    errorMessage: string;
+}) => {
+    const validUuid = uuidV4();
+
+    // more valid email addresses (using _isEmail function) are already tested in the Lodash Extensions test file
+    describe('should pass in valid scenarios', () => {
+        it.each([
+            { description: 'valid email', email: 'contact@example.com' },
+            { description: 'email with plus sign', email: 'test+test@example.com' },
+            { description: 'undefined email', email: undefined },
+            { description: 'empty string email', email: '' }
+        ])('$description', ({ email }) => {
+            const interview = createMockInterview({ [config.emailField]: email }, validUuid);
+            const context: InterviewAuditCheckContext = { interview };
+
+            const result = config.checkFn(context);
+
+            expect(result).toBeUndefined();
+        });
+    });
+
+    describe('should fail when email is invalid', () => {
+        it.each([
+            { description: 'email with letters only', email: 'invalid-email' },
+            { description: 'email with special characters', email: '!@#$%^&*()' },
+            { description: 'email with digits only', email: '1234567' },
+            { description: 'email with multiple hyphens', email: '12-34-56-78@blue' }
+        ])('$description', ({ email }) => {
+            const interview = createMockInterview({ [config.emailField]: email }, validUuid);
+            const context: InterviewAuditCheckContext = { interview };
+
+            const result = config.checkFn(context);
+
+            expect(result).toEqual({
+                objectType: 'interview',
+                objectUuid: validUuid,
+                errorCode: config.checkName,
+                version: 1,
+                level: 'error',
+                message: config.errorMessage,
+                ignore: false
+            });
+        });
+    });
 };

--- a/packages/evolution-backend/src/services/audits/types.ts
+++ b/packages/evolution-backend/src/services/audits/types.ts
@@ -43,20 +43,3 @@ export type SurveyObjectParsers = {
     trip?: SurveyObjectParser<ExtendedTripAttributes, CorrectedResponse>;
     segment?: SurveyObjectParser<ExtendedSegmentAttributes, CorrectedResponse>;
 };
-
-/** Custom completeness configuration for survey objects.
- * This allows to define the completeness of the survey objects, customized for the survey.
- * Evolution does include default completeness configuration for the survey objects.
- * The main objective of these is to estimate the level of completeness of each section in
- * the questionnaire, by aggregating the completeness of each object.
- */
-/*export type SurveyObjectsCompleteness = {
-    interview?: ICompletable;
-    household?: ICompletable;
-    home?: ICompletable;
-    person?: ICompletable;
-    journey?: ICompletable;
-    visitedPlace?: ICompletable;
-    trip?: ICompletable;
-    segment?: ICompletable;
-};*/

--- a/packages/evolution-backend/src/services/audits/types.ts
+++ b/packages/evolution-backend/src/services/audits/types.ts
@@ -43,3 +43,20 @@ export type SurveyObjectParsers = {
     trip?: SurveyObjectParser<ExtendedTripAttributes, CorrectedResponse>;
     segment?: SurveyObjectParser<ExtendedSegmentAttributes, CorrectedResponse>;
 };
+
+/** Custom completeness configuration for survey objects.
+ * This allows to define the completeness of the survey objects, customized for the survey.
+ * Evolution does include default completeness configuration for the survey objects.
+ * The main objective of these is to estimate the level of completeness of each section in
+ * the questionnaire, by aggregating the completeness of each object.
+ */
+/*export type SurveyObjectsCompleteness = {
+    interview?: ICompletable;
+    household?: ICompletable;
+    home?: ICompletable;
+    person?: ICompletable;
+    journey?: ICompletable;
+    visitedPlace?: ICompletable;
+    trip?: ICompletable;
+    segment?: ICompletable;
+};*/


### PR DESCRIPTION
Those audit checks should be available for surveys based on the v0.5.0 branch, as they do not require any of Evolution's new features.