### PR TITLE
odsurvey: add get*ContextFromPath functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `addVisitedPlace` (commit [3b3be2d](https://github.com/chairemobilite/evolution/commit/3b3be2d7d0d79e5f5b4928f6784e892d67562687))
   - `getHomeAddressOneLine` (commit [3b28f45](https://github.com/chairemobilite/evolution/commit/3b28f454515445b4b438bfcb6cf00e1a8fffcde9))
   - `shouldShowTripsAndPlacesSections` (commit [852a240](https://github.com/chairemobilite/evolution/commit/852a240a98d3c3a92197fe9684102df1326545f4))
+  - `getJourneyContextFromPath`, `getTripContextFromPath`, `getVisitedPlaceContextFromPath`, `getSegmentContextFromPath` to get all objects in the interview from the path (fixes [#1538](https://github.com/chairemobilite/evolution/issues/1538))
 - Added a `visitedPlaces` section configuration, which includes activity, location and next place category questions, with the  `VisitedPlacesSectionFactory` class (fixes [#1437](https://github.com/chairemobilite/evolution/issues/1437))
 - Provide a `VisitedPlacesSection` template to be used in the UI to display visited places. The template can be used by the `visitedPlaces` name in the `template` property of a section's configuration (fixes [#1446](https://github.com/chairemobilite/evolution/issues/1446)).
 - The `getFormattedDate` widget factory option now takes an optional options parameter to fine-tune the desired format of the date (commit [8dbd493](https://github.com/chairemobilite/evolution/commit/8dbd4938c1dd4f5466a8c19b3b90f934e63b953f))

--- a/packages/evolution-common/src/services/odSurvey/__tests__/helpers.test.ts
+++ b/packages/evolution-common/src/services/odSurvey/__tests__/helpers.test.ts
@@ -1401,6 +1401,45 @@ describe('getJourneys', () => {
                   : null;
         expect(Helpers.getActiveJourney({ interview, person })).toEqual(expected);
     });
+
+    each([{
+        title: 'Path with existing person and journey',
+        path: 'household.persons.personId1.journeys.journeyId1',
+        expected: { 
+            person: interviewAttributesForTestCases.response!.household!.persons!.personId1,
+            journey: interviewAttributesForTestCases.response!.household!.persons!.personId1.journeys!.journeyId1
+        }
+    },
+    {
+        title: 'Path with existing person and journey and trailing data',
+        path: 'household.persons.personId1.journeys.journeyId1.visitedPlaces.visitedPlaceId1',
+        expected: { 
+            person: interviewAttributesForTestCases.response!.household!.persons!.personId1,
+            journey: interviewAttributesForTestCases.response!.household!.persons!.personId1.journeys!.journeyId1
+        }
+    },
+    {
+        title: 'Path with non-existing journey',
+        path: 'household.persons.personId1.journeys.nonExistingJourney',
+        expected: null
+    },
+    {
+        title: 'Path with non-existing person',
+        path: 'household.persons.nonExistingPerson.journeys.journeyId1',
+        expected: null
+    },
+    {
+        title: 'Path not matching expected format',
+        path: 'household.persons.personId1.otherData',
+        expected: null
+    }]).test('getJourneyContextFromPath: $title', ({ setup, path, expected }) => {
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        if (setup) {
+            setup(interview);
+        }
+        expect(Helpers.getJourneyContextFromPath({ interview, path })).toEqual(expected);
+    });
+
 });
 
 describe('shouldShowTripsAndPlacesSections', () => {
@@ -1641,6 +1680,51 @@ describe('getVisitedPlaces', () => {
             }
         }
     );
+
+    each([{
+        title: 'Path with existing person, journey and visited place',
+        path: 'household.persons.personId1.journeys.journeyId1.visitedPlaces.homePlace2P1',
+        expected: { 
+            person: interviewAttributesForTestCases.response!.household!.persons!.personId1,
+            journey: interviewAttributesForTestCases.response!.household!.persons!.personId1.journeys!.journeyId1,
+            visitedPlace: interviewAttributesForTestCases.response!.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!.homePlace2P1
+        }
+    },
+    {
+        title: 'Path with existing person and journey and trailing data',
+        path: 'household.persons.personId1.journeys.journeyId1.visitedPlaces.homePlace2P1.something',
+        expected: { 
+            person: interviewAttributesForTestCases.response!.household!.persons!.personId1,
+            journey: interviewAttributesForTestCases.response!.household!.persons!.personId1.journeys!.journeyId1,
+            visitedPlace: interviewAttributesForTestCases.response!.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!.homePlace2P1
+        }
+    },
+    {
+        title: 'Path with non-existing visited place',
+        path: 'household.persons.personId1.journeys.journeyId1.visitedPlaces.nonExistingVisitedPlace',
+        expected: null
+    },
+    {
+        title: 'Path with non-existing journey',
+        path: 'household.persons.personId1.journeys.nonExistingJourney',
+        expected: null
+    },
+    {
+        title: 'Path with non-existing person',
+        path: 'household.persons.nonExistingPerson.journeys.journeyId1',
+        expected: null
+    },
+    {
+        title: 'Path not matching expected format',
+        path: 'household.persons.personId1.otherData',
+        expected: null
+    }]).test('getVisitedPlaceContextFromPath: $title', ({ setup, path, expected }) => {
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        if (setup) {
+            setup(interview);
+        }
+        expect(Helpers.getVisitedPlaceContextFromPath({ interview, path })).toEqual(expected);
+    });
 });
 
 describe('getNext/PreviousVisitedPlace', () => {
@@ -2645,6 +2729,51 @@ describe('getTrips', () => {
         attributes.trips = trips;
         expect(Helpers.getPreviousTrip({ currentTrip, journey: attributes })).toEqual(previousTrip);
     });
+
+    each([{
+        title: 'Path with existing person, journey and trip',
+        path: 'household.persons.personId1.journeys.journeyId1.trips.tripId1P1',
+        expected: { 
+            person: interviewAttributesForTestCases.response!.household!.persons!.personId1,
+            journey: interviewAttributesForTestCases.response!.household!.persons!.personId1.journeys!.journeyId1,
+            trip: interviewAttributesForTestCases.response!.household!.persons!.personId1.journeys!.journeyId1.trips!.tripId1P1
+        }
+    },
+    {
+        title: 'Path with existing person, journey and trip with trailing data',
+        path: 'household.persons.personId1.journeys.journeyId1.trips.tripId1P1.segments.segmentId1',
+        expected: { 
+            person: interviewAttributesForTestCases.response!.household!.persons!.personId1,
+            journey: interviewAttributesForTestCases.response!.household!.persons!.personId1.journeys!.journeyId1,
+            trip: interviewAttributesForTestCases.response!.household!.persons!.personId1.journeys!.journeyId1.trips!.tripId1P1
+        }
+    },
+    {
+        title: 'Path with non-existing trip',
+        path: 'household.persons.personId1.journeys.journeyId1.trips.nonExistingTrip',
+        expected: null
+    },
+    {
+        title: 'Path with non-existing journey',
+        path: 'household.persons.personId1.journeys.nonExistingJourney',
+        expected: null
+    },
+    {
+        title: 'Path with non-existing person',
+        path: 'household.persons.nonExistingPerson.journeys.journeyId1',
+        expected: null
+    },
+    {
+        title: 'Path not matching expected format',
+        path: 'household.persons.personId1.otherData',
+        expected: null
+    }]).test('getTripContextFromPath: $title', ({ setup, path, expected }) => {
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        if (setup) {
+            setup(interview);
+        }
+        expect(Helpers.getTripContextFromPath({ interview, path })).toEqual(expected);
+    });
 });
 
 describe('selectNextIncompleteTrip', () => {
@@ -2949,5 +3078,57 @@ describe('getSegments', () => {
         const attributes = _cloneDeep(trip);
         attributes.segments = segments;
         expect(Helpers.getSegmentsArray({ trip: attributes })).toEqual([segments.segment2, segments.segment1]);
+    });
+
+    each([{
+        title: 'Path with existing person, journey and trip',
+        path: 'household.persons.personId2.journeys.journeyId2.trips.tripId1P2.segments.segmentId1P2T1',
+        expected: { 
+            person: interviewAttributesForTestCases.response!.household!.persons!.personId2,
+            journey: interviewAttributesForTestCases.response!.household!.persons!.personId2.journeys!.journeyId2,
+            trip: interviewAttributesForTestCases.response!.household!.persons!.personId2.journeys!.journeyId2.trips!.tripId1P2,
+            segment: interviewAttributesForTestCases.response!.household!.persons!.personId2.journeys!.journeyId2.trips!.tripId1P2.segments!.segmentId1P2T1
+        }
+    },
+    {
+        title: 'Path with existing person, journey and trip with trailing data',
+        path: 'household.persons.personId2.journeys.journeyId2.trips.tripId1P2.segments.segmentId1P2T1.someTrailingData',
+        expected: { 
+            person: interviewAttributesForTestCases.response!.household!.persons!.personId2,
+            journey: interviewAttributesForTestCases.response!.household!.persons!.personId2.journeys!.journeyId2,
+            trip: interviewAttributesForTestCases.response!.household!.persons!.personId2.journeys!.journeyId2.trips!.tripId1P2,
+            segment: interviewAttributesForTestCases.response!.household!.persons!.personId2.journeys!.journeyId2.trips!.tripId1P2.segments!.segmentId1P2T1
+        }
+    },
+    {
+        title: 'Path with non-existing segment',
+        path: 'household.persons.personId2.journeys.journeyId2.trips.tripId1P2.segments.nonExistingSegment',
+        expected: null
+    },
+    {
+        title: 'Path with non-existing trip',
+        path: 'household.persons.personId2.journeys.journeyId2.trips.nonExistingTrip',
+        expected: null
+    },
+    {
+        title: 'Path with non-existing journey',
+        path: 'household.persons.personId2.journeys.nonExistingJourney',
+        expected: null
+    },
+    {
+        title: 'Path with non-existing person',
+        path: 'household.persons.nonExistingPerson.journeys.journeyId2',
+        expected: null
+    },
+    {
+        title: 'Path not matching expected format',
+        path: 'household.persons.personId2.otherData',
+        expected: null
+    }]).test('getSegmentContextFromPath: $title', ({ setup, path, expected }) => {
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        if (setup) {
+            setup(interview);
+        }
+        expect(Helpers.getSegmentContextFromPath({ interview, path })).toEqual(expected);
     });
 });

--- a/packages/evolution-common/src/services/odSurvey/helpers.ts
+++ b/packages/evolution-common/src/services/odSurvey/helpers.ts
@@ -533,6 +533,46 @@ export const getJourneysArray = function ({ person }: { person: Person }): Journ
 };
 
 /**
+ * Get the person and journey from a path string if it matches the pattern
+ * `household.persons.{personId}.journeys.{journeyId}.`, otherwise return null.
+ * The person and journey IDs are extracted from the path and the corresponding
+ * person and journey objects are returned if they exist in the interview
+ * response.
+ *
+ * @param {Object} options - The options object.
+ * @param {UserInterviewAttributes} options.interview - The interview object.
+ * @param {string} [options.path] - Path string to extract the person and
+ * journey IDs from.
+ * @returns {{ person: Person, journey: Journey } | null} The current person and
+ * journey, or null if not found.
+ */
+export const getJourneyContextFromPath = ({
+    interview,
+    path
+}: {
+    interview: UserInterviewAttributes;
+    path: string;
+}): { person: Person; journey: Journey } | null => {
+    // Try to extract personId and journeyId from path if it matches
+    // household.persons.{personId}.journeys.{journeyId}. The path may either
+    // end at the journeyId or has a suffix after (non-capturing)
+    const match = path.match(/household\.persons\.([^.]+)\.journeys\.([^.]+)(?:\.|$)/);
+    if (match) {
+        const personId = match[1];
+        const journeyId = match[2];
+        const person = getPerson({ interview, personId });
+        if (person) {
+            const personJourneys = getJourneys({ person });
+            const journey = personJourneys[journeyId];
+            if (journey) {
+                return { person, journey };
+            }
+        }
+    }
+    return null;
+};
+
+/**
  * Determine whether the trips and visited places sections should exist for this
  * journey, based on the journey's data and prior answers.
  *
@@ -581,6 +621,51 @@ export const getActiveTrip = ({
     const trips = getTrips({ journey: activeJourney });
     const activeTripId = getResponse(interview, '_activeTripId', null) as string | null;
     return activeTripId ? trips[activeTripId] || null : null;
+};
+
+/**
+ * Get the person, journey and trip from a path string if it matches the pattern
+ * `household.persons.{personId}.journeys.{journeyId}.trips.{tripId}`, otherwise
+ * return null.  The person, journey and trip IDs are extracted from the path and the
+ * corresponding person, journey and trip objects are returned if they exist in the
+ * interview response.
+ *
+ * @param {Object} options - The options object.
+ * @param {UserInterviewAttributes} options.interview - The interview object.
+ * @param {string} [options.path] - Path string to extract the person, journey and
+ * trip IDs from.
+ * @returns {{ person: Person, journey: Journey, trip: Trip } | null} The current person, journey and
+ * trip, or null if not found.
+ */
+export const getTripContextFromPath = ({
+    interview,
+    path
+}: {
+    interview: UserInterviewAttributes;
+    path: string;
+}): { person: Person; journey: Journey; trip: Trip } | null => {
+    // Try to extract personId, journeyId and tripId from path if it matches
+    // household.persons.{personId}.journeys.{journeyId}.trips.{tripId}. The path may either
+    // end at the tripId or has a suffix after (non-capturing)
+    const match = path.match(/household\.persons\.([^.]+)\.journeys\.([^.]+)\.trips\.([^.]+)(?:\.|$)/);
+    if (match) {
+        const personId = match[1];
+        const journeyId = match[2];
+        const tripId = match[3];
+        const person = getPerson({ interview, personId });
+        if (person) {
+            const personJourneys = getJourneys({ person });
+            const journey = personJourneys[journeyId];
+            if (journey) {
+                const trips = getTrips({ journey });
+                const trip = trips[tripId];
+                if (trip) {
+                    return { person, journey, trip };
+                }
+            }
+        }
+    }
+    return null;
 };
 
 /**
@@ -761,6 +846,51 @@ export const getActiveVisitedPlace = ({
     const visitedPlaces = getVisitedPlaces({ journey: activeJourney });
     const activeTripId = getResponse(interview, '_activeVisitedPlaceId', null) as string | null;
     return activeTripId ? visitedPlaces[activeTripId] || null : null;
+};
+
+/**
+ * Get the person, journey and visited place from a path string if it matches the pattern
+ * `household.persons.{personId}.journeys.{journeyId}.visitedPlaces.{visitedPlaceId}`, otherwise
+ * return null.  The person, journey and visited place IDs are extracted from the path and the
+ * corresponding person, journey and visited place objects are returned if they exist in the
+ * interview response.
+ *
+ * @param {Object} options - The options object.
+ * @param {UserInterviewAttributes} options.interview - The interview object.
+ * @param {string} [options.path] - Path string to extract the person, journey and
+ * visited place IDs from.
+ * @returns {{ person: Person, journey: Journey, visitedPlace: VisitedPlace } | null} The current person, journey and
+ * visited place, or null if not found.
+ */
+export const getVisitedPlaceContextFromPath = ({
+    interview,
+    path
+}: {
+    interview: UserInterviewAttributes;
+    path: string;
+}): { person: Person; journey: Journey; visitedPlace: VisitedPlace } | null => {
+    // Try to extract personId, journeyId and visitedPlaceId from path if it matches
+    // household.persons.{personId}.journeys.{journeyId}.visitedPlaces.{visitedPlaceId}. The path may either
+    // end at the visitedPlaceId or has a suffix after (non-capturing)
+    const match = path.match(/household\.persons\.([^.]+)\.journeys\.([^.]+)\.visitedPlaces\.([^.]+)(?:\.|$)/);
+    if (match) {
+        const personId = match[1];
+        const journeyId = match[2];
+        const visitedPlaceId = match[3];
+        const person = getPerson({ interview, personId });
+        if (person) {
+            const personJourneys = getJourneys({ person });
+            const journey = personJourneys[journeyId];
+            if (journey) {
+                const visitedPlaces = getVisitedPlaces({ journey });
+                const visitedPlace = visitedPlaces[visitedPlaceId];
+                if (visitedPlace) {
+                    return { person, journey, visitedPlace };
+                }
+            }
+        }
+    }
+    return null;
 };
 
 /**
@@ -1304,4 +1434,57 @@ export const getSegments = ({ trip }: { trip: Trip }): { [segmentId: string]: Se
 export const getSegmentsArray = ({ trip }: { trip: Trip }): Segment[] => {
     const segments = getSegments({ trip });
     return Object.values(segments).sort((segmentA, segmentB) => segmentA._sequence - segmentB._sequence);
+};
+
+/**
+ * Get the person, journey, trip and segment from a path string if it matches
+ * the pattern
+ * `household.persons.{personId}.journeys.{journeyId}.trips.{tripId}.segments.{segmentId}`,
+ * otherwise return null.  The person, journey, trip and segment IDs are
+ * extracted from the path and the corresponding person, journey, trip and
+ * segment objects are returned if they exist in the interview response.
+ *
+ * @param {Object} options - The options object.
+ * @param {UserInterviewAttributes} options.interview - The interview object.
+ * @param {string} [options.path] - Path string to extract the person, journey,
+ * trip and segment IDs from.
+ * @returns {{ person: Person, journey: Journey, trip: Trip, segment: Segment }
+ * | null} The current person, journey, trip and segment, or null if not found.
+ */
+export const getSegmentContextFromPath = ({
+    interview,
+    path
+}: {
+    interview: UserInterviewAttributes;
+    path: string;
+}): { person: Person; journey: Journey; trip: Trip; segment: Segment } | null => {
+    // Try to extract personId, journeyId and tripId from path if it matches
+    // household.persons.{personId}.journeys.{journeyId}.trips.{tripId}.segments.{segmentId}. The path may either
+    // end at the segmentId or has a suffix after (non-capturing)
+    const match = path.match(
+        /household\.persons\.([^.]+)\.journeys\.([^.]+)\.trips\.([^.]+)\.segments\.([^.]+)(?:\.|$)/
+    );
+    if (match) {
+        const personId = match[1];
+        const journeyId = match[2];
+        const tripId = match[3];
+        const segmentId = match[4];
+        const person = getPerson({ interview, personId });
+        if (person) {
+            const personJourneys = getJourneys({ person });
+            const journey = personJourneys[journeyId];
+            if (journey) {
+                const trips = getTrips({ journey });
+                const trip = trips[tripId];
+                if (trip) {
+                    const segments = getSegments({ trip });
+                    const segment = segments[segmentId];
+                    if (segment) {
+                        return { person, journey, trip, segment };
+                    }
+                }
+            }
+        }
+    }
+    return null;
 };

--- a/packages/evolution-common/src/services/questionnaire/sections/common/__tests__/widgetPersonVisitedPlacesMap.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/common/__tests__/widgetPersonVisitedPlacesMap.test.ts
@@ -12,15 +12,19 @@ import projectConfig from '../../../../../config/project.config';
 import { pointsToBezierCurve } from '../../../../geodata/SurveyGeographyUtils';
 import { VisitedPlace } from '../../../types';
 
-jest.mock('../../../../odSurvey/helpers', () => ({
-    getActivePerson: jest.fn().mockReturnValue({}),
-    getActiveJourney: jest.fn().mockReturnValue({}),
-    getCountOrSelfDeclared: jest.fn().mockReturnValue(1),
-    getVisitedPlacesArray: jest.fn().mockReturnValue([]),
-    getVisitedPlaceGeography: jest.fn().mockReturnValue(null)
-}));
-const mockedGetActivePerson = odHelpers.getActivePerson as jest.MockedFunction<typeof odHelpers.getActivePerson>;
-const mockedGetActiveJourney = odHelpers.getActiveJourney as jest.MockedFunction<typeof odHelpers.getActiveJourney>;
+jest.mock('../../../../odSurvey/helpers', () => {
+    // Require the original module to not be mocked...
+    // FIXME Refactor to use the actual functions instead of mocking them
+    const originalModule = jest.requireActual('../../../../odSurvey/helpers');
+    return {
+        ...originalModule,
+        getJourneyContextFromPath: jest.fn().mockReturnValue(null),
+        getCountOrSelfDeclared: jest.fn().mockReturnValue(1),
+        getVisitedPlacesArray: jest.fn().mockReturnValue([]),
+        getVisitedPlaceGeography: jest.fn().mockReturnValue(null)
+    };
+});
+const mockedGetJourneyContextFromPath = odHelpers.getJourneyContextFromPath as jest.MockedFunction<typeof odHelpers.getJourneyContextFromPath>;
 const mockedGetCountOrSelfDeclared = odHelpers.getCountOrSelfDeclared as jest.MockedFunction<typeof odHelpers.getCountOrSelfDeclared>;
 const mockedGetVisitedPlacesArray = odHelpers.getVisitedPlacesArray as jest.MockedFunction<typeof odHelpers.getVisitedPlacesArray>;
 const mockedGetVisitedPlaceGeography = odHelpers.getVisitedPlaceGeography as jest.MockedFunction<typeof odHelpers.getVisitedPlaceGeography>;
@@ -69,41 +73,19 @@ describe('personVisitedPlacesMapConfig title', () => {
     const widgetTitle = getPersonVisitedPlacesMapConfig(options).title as any;
     const mockedT = jest.fn().mockReturnValue('translatedString');
    
-    test('should call translation with correct parameters if no active person', () => {
-        mockedGetActivePerson.mockReturnValueOnce(null);
-        mockedGetActiveJourney.mockReturnValueOnce(null);
-        expect(widgetTitle(mockedT, interviewAttributesForTestCases, 'path')).toEqual('translatedString');
-        expect(mockedT).toHaveBeenCalledWith(['customSurvey:survey:TripsMap', 'survey:TripsMap'], {
-            context: 'undated',
-            count: 1,
-            nickname: '',
-            journeyDates: null
-        });
-        expect(options.context).toHaveBeenCalledWith('undated');
-    });
-
-    test('should call translation with correct parameters if no active journey', () => {
-        const nickname = 'Jane'
-        mockedGetActivePerson.mockReturnValueOnce({ _uuid: 'person1', _sequence: 1, nickname });
-        mockedGetActiveJourney.mockReturnValueOnce(null);
-        expect(widgetTitle(mockedT, interviewAttributesForTestCases, 'path')).toEqual('translatedString');
-        expect(mockedT).toHaveBeenCalledWith(['customSurvey:survey:TripsMap', 'survey:TripsMap'], {
-            context: 'undated',
-            count: 1,
-            nickname,
-            journeyDates: null
-        });
-        expect(options.context).toHaveBeenCalledWith('undated');
+    test('should call translation with correct parameters if no active person or journey', () => {
+        mockedGetJourneyContextFromPath.mockReturnValueOnce(null);
+        expect(widgetTitle(mockedT, interviewAttributesForTestCases, 'path')).toEqual('');
+        expect(mockedT).not.toHaveBeenCalled();
     });
 
     test('should call translation with correct parameters if one person household and no journey dates', () => {
-        mockedGetActivePerson.mockReturnValueOnce({ _uuid: 'person1', _sequence: 1 });
-        mockedGetActiveJourney.mockReturnValueOnce({ _uuid: 'journey1', _sequence: 1 });
+        mockedGetJourneyContextFromPath.mockReturnValueOnce({ person: { _uuid: 'person1', _sequence: 1 }, journey: { _uuid: 'journey1', _sequence: 1 } });
         expect(widgetTitle(mockedT, interviewAttributesForTestCases, 'path')).toEqual('translatedString');
         expect(mockedT).toHaveBeenCalledWith(['customSurvey:survey:TripsMap', 'survey:TripsMap'], {
             context: 'undated',
             count: 1,
-            nickname: '',
+            nickname: 'translatedString', // Should have called the getPersonIdentificationString function and translated the name
             journeyDates: null
         });
         expect(options.context).toHaveBeenCalledWith('undated');
@@ -111,8 +93,7 @@ describe('personVisitedPlacesMapConfig title', () => {
 
     test('should call translation with correct parameters if multiple person household and journey with start date', () => {
         const nickname = 'Jane'
-        mockedGetActivePerson.mockReturnValueOnce({ _uuid: 'person1', _sequence: 1, nickname });
-        mockedGetActiveJourney.mockReturnValueOnce({ _uuid: 'journey1', _sequence: 1, startDate: '2024-11-18' });
+        mockedGetJourneyContextFromPath.mockReturnValueOnce({ person: { _uuid: 'person1', _sequence: 1, nickname }, journey: { _uuid: 'journey1', _sequence: 1, startDate: '2024-11-18' } });
         mockedGetCountOrSelfDeclared.mockReturnValueOnce(2);
         expect(widgetTitle(mockedT, interviewAttributesForTestCases, 'path')).toEqual('translatedString');
         expect(mockedT).toHaveBeenCalledWith(['customSurvey:survey:TripsMap', 'survey:TripsMap'], {
@@ -138,26 +119,8 @@ describe('personVisitedPlacesMapConfig geojsons', () => {
     const person = { _uuid: 'person1', _sequence: 1 };
     const journey = { _uuid: 'journeyId1', _sequence: 1 };
    
-    test('should return empty features collections when no person', () => {
-        mockedGetActivePerson.mockReturnValueOnce(null);
-        mockedGetActiveJourney.mockReturnValueOnce(journey);
-        expect(widgetGeojsons(interviewAttributesForTestCases)).toEqual({
-            points: {
-                type: 'FeatureCollection',
-                features: []
-            },
-            linestrings: {
-                type: 'FeatureCollection',
-                features: []
-            }
-        });
-        expect(mockedGetVisitedPlacesArray).not.toHaveBeenCalled();
-        expect(mockedGetVisitedPlaceGeography).not.toHaveBeenCalled();
-    });
-
-    test('should return empty features collections if no active journey', () => {
-        mockedGetActivePerson.mockReturnValueOnce(person);
-        mockedGetActiveJourney.mockReturnValueOnce(null);
+    test('should return empty features collections when no person/journey context', () => {
+        mockedGetJourneyContextFromPath.mockReturnValueOnce(null);
         expect(widgetGeojsons(interviewAttributesForTestCases)).toEqual({
             points: {
                 type: 'FeatureCollection',
@@ -173,8 +136,7 @@ describe('personVisitedPlacesMapConfig geojsons', () => {
     });
 
     test('should return empty features collections if no active visitedPlaces', () => {
-        mockedGetActivePerson.mockReturnValueOnce(person);
-        mockedGetActiveJourney.mockReturnValueOnce(journey);
+        mockedGetJourneyContextFromPath.mockReturnValueOnce({ person, journey });
         mockedGetVisitedPlacesArray.mockReturnValueOnce([]);
         expect(widgetGeojsons(interviewAttributesForTestCases)).toEqual({
             points: {
@@ -216,8 +178,7 @@ describe('personVisitedPlacesMapConfig geojsons', () => {
             activity: 'home',
             geography: { type: 'Feature', properties: { lastAction: 'mapClicked' }, geometry: { type: 'Point', coordinates: [0, 0] } }
         }]
-        mockedGetActivePerson.mockReturnValueOnce(person);
-        mockedGetActiveJourney.mockReturnValueOnce(journey);
+        mockedGetJourneyContextFromPath.mockReturnValueOnce({ person, journey });
         mockedGetVisitedPlacesArray.mockReturnValueOnce(visitedPlaces);
         // Mock geographies for each visited place
         mockedGetVisitedPlaceGeography.mockReturnValueOnce(visitedPlaces[0].geography!);
@@ -290,8 +251,7 @@ describe('personVisitedPlacesMapConfig geojsons', () => {
             activity: 'workUsual',
             geography: { type: 'Feature', geometry: { type: 'Point', coordinates: [0.5, 0.2] } } as any
         }]
-        mockedGetActivePerson.mockReturnValueOnce(person);
-        mockedGetActiveJourney.mockReturnValueOnce(journey);
+        mockedGetJourneyContextFromPath.mockReturnValueOnce({ person, journey });
         mockedGetVisitedPlacesArray.mockReturnValueOnce(visitedPlaces);
         // Mock geographies for each visited place
         mockedGetVisitedPlaceGeography.mockReturnValueOnce(null);

--- a/packages/evolution-common/src/services/questionnaire/sections/common/widgetPersonVisitedPlacesMap.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/common/widgetPersonVisitedPlacesMap.ts
@@ -24,33 +24,37 @@ export const getPersonVisitedPlacesMapConfig = (
         type: 'infoMap',
         path: 'household.persons.{_activePersonId}.journeys.{_activeJourneyId}.visitedPlacesMap',
         defaultCenter: projectConfig.mapDefaultCenter,
-        title: (t: TFunction, interview: UserInterviewAttributes) => {
+        title: (t: TFunction, interview: UserInterviewAttributes, path: string) => {
             // FIXME This differs from the widgetPersonTripsTitle text only in
             // the translated string array. We could add a helper to get a
             // dated/nicknamed string of the current journey
-            const person = odHelpers.getActivePerson({ interview });
-            const journey = odHelpers.getActiveJourney({ interview });
+            const journeyContext = odHelpers.getJourneyContextFromPath({ interview, path });
+            if (!journeyContext) {
+                console.error('Journey context not found for path', path);
+                return '';
+            }
             // FIXME Write a function somewhere to get the journey's or dateToString function, once we move to objects
             // FIXME2 Plan for a translation string that has a period (undated, dated, period)
-            const journeyDates = journey && journey.startDate ? options.getFormattedDate(journey.startDate) : null;
+            const journeyDates = journeyContext.journey.startDate
+                ? options.getFormattedDate(journeyContext.journey.startDate)
+                : null;
             return t(['customSurvey:survey:TripsMap', 'survey:TripsMap'], {
                 context: getContext(journeyDates === null ? 'undated' : undefined),
-                nickname: person !== null && person.nickname ? person.nickname : '',
+                nickname: odHelpers.getPersonIdentificationString({ person: journeyContext.person, t }),
                 journeyDates,
-                count: person === null ? 1 : odHelpers.getCountOrSelfDeclared({ interview, person })
+                count: odHelpers.getCountOrSelfDeclared({ interview, person: journeyContext.person })
             });
         },
         linestringColor: '#0000ff',
-        geojsons: (interview) => {
+        geojsons: (interview, path) => {
             // FIXME This has a lot in common with
             // `generateMapFeatureFromInterview` from the odSurveyAdminHelper.ts
             // file, which displays the visited places and trips for all persons
             // in the household. Probably parts of these function can be
             // extracted and re-used here, once there is more stability and we
             // know exactly what to display
-            const person = odHelpers.getActivePerson({ interview });
-            const journey = odHelpers.getActiveJourney({ interview });
-            if (journey === null || person === null) {
+            const journeyContext = odHelpers.getJourneyContextFromPath({ interview, path });
+            if (journeyContext === null) {
                 return {
                     points: {
                         type: 'FeatureCollection',
@@ -62,6 +66,7 @@ export const getPersonVisitedPlacesMapConfig = (
                     }
                 };
             }
+            const { journey, person } = journeyContext;
             const visitedPlaces = odHelpers.getVisitedPlacesArray({ journey });
 
             const tripsGeojsonFeatures: GeoJSON.Feature<GeoJSON.LineString, SurveyMapObjectProperty>[] = [];

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/buttonSaveTripSegments.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/buttonSaveTripSegments.test.ts
@@ -7,19 +7,23 @@
 import _cloneDeep from 'lodash/cloneDeep';
 
 import { getButtonSaveTripSegmentsConfig } from '../buttonSaveTripSegments';
-import { interviewAttributesForTestCases, widgetFactoryOptions } from '../../../../../tests/surveys';
+import { interviewAttributesForTestCases, setActiveSurveyObjects, widgetFactoryOptions } from '../../../../../tests/surveys';
 import * as utilHelpers from '../../../../../utils/helpers';
 import * as odHelpers from '../../../../odSurvey/helpers';
 
-jest.mock('../../../../odSurvey/helpers', () => ({
-    getPerson: jest.fn().mockReturnValue({}),
-    getActiveJourney: jest.fn().mockReturnValue({}),
-    selectNextIncompleteTrip: jest.fn().mockReturnValue(null)
-}));
-const mockedGetPerson = odHelpers.getPerson as jest.MockedFunction<typeof odHelpers.getPerson>;
-const mockedGetActiveJourney = odHelpers.getActiveJourney as jest.MockedFunction<typeof odHelpers.getActiveJourney>;
+jest.mock('../../../../odSurvey/helpers', () => {
+    // Require the original module to not be mocked...
+    // FIXME Refactor to use the actual functions instead of mocking them
+    const originalModule = jest.requireActual('../../../../odSurvey/helpers');
+    return {
+        ...originalModule,
+        getCountOrSelfDeclared: jest.fn().mockReturnValue(1),
+        getVisitedPlacesArray: jest.fn().mockReturnValue([]),
+        getVisitedPlaceGeography: jest.fn().mockReturnValue(null),
+        selectNextIncompleteTrip: jest.fn()
+    };
+});
 const mockedSelectNextIncompleteTrip = odHelpers.selectNextIncompleteTrip as jest.MockedFunction<typeof odHelpers.selectNextIncompleteTrip>;
-
 
 beforeEach(() => {
     jest.clearAllMocks();
@@ -61,8 +65,12 @@ describe('getButtonSaveTripSegmentsConfig labels', () => {
 describe('getButtonSaveTripSegmentsConfig conditional', () => {
     const widgetConfig = getButtonSaveTripSegmentsConfig(widgetFactoryOptions);
 
-    jest.spyOn(utilHelpers, 'getResponse').mockReturnValue({});
+    const getResponseSpy = jest.spyOn(utilHelpers, 'getResponse').mockReturnValue({});
     const mockedGetResponse = utilHelpers.getResponse as jest.MockedFunction<typeof utilHelpers.getResponse>;
+
+    afterAll(() => {
+        getResponseSpy.mockRestore();
+    });
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -116,10 +124,9 @@ describe('getButtonSaveTripSegmentsConfig button action', () => {
 describe('getButtonSaveTripSegmentsConfig save callback', () => {
     const widgetConfig = getButtonSaveTripSegmentsConfig(widgetFactoryOptions);
 
-    jest.spyOn(utilHelpers, 'getResponse').mockReturnValue({});
-    const mockedGetResponse = utilHelpers.getResponse as jest.MockedFunction<typeof utilHelpers.getResponse>;
-
-    const buttonPath = 'path.to.trip.buttonAction';
+    // Person2 trip2 has 2 segments
+    const buttonPathPrefix = 'household.persons.personId2.journeys.journeyId2.trips.tripId2P2';
+    const buttonPath = `${buttonPathPrefix}.buttonSaveTrip`;
     const saveCallback = widgetConfig.saveCallback;
     const updateCallbacks =
         { startUpdateInterview: jest.fn(), startAddGroupedObjects: jest.fn(), startRemoveGroupedObjects: jest.fn(), startNavigate: jest.fn() };
@@ -129,91 +136,102 @@ describe('getButtonSaveTripSegmentsConfig save callback', () => {
     });
 
     test('should set all _isNew to `false` and select next incomplete trip', () => {
-        // Mock function response: 2 segments, active journey and incomplete trip
-        const journey = { _uuid: 'journey', _sequence: 1 };
+        // Set active trip ID for next incomplete trip selection
+        const testInterview = _cloneDeep(interviewAttributesForTestCases);
+        setActiveSurveyObjects(testInterview, {
+            personId: 'personId2',
+            journeyId: 'journeyId2',
+            activeTripId: 'tripId2P2'
+        });
+        // Mock function response for incomplete trip
         const incompleteTrip = { _uuid: 'trip1', _sequence: 1 };
-        mockedGetResponse.mockReturnValueOnce({ segment1: { _uuid: 'segment1', _sequence: 1 }, segment2: { _uuid: 'segment2', _sequence: 2 } });
-        mockedGetActiveJourney.mockReturnValueOnce(journey);
         mockedSelectNextIncompleteTrip.mockReturnValueOnce(incompleteTrip);
 
         // Call the save callback
-        saveCallback!(updateCallbacks, interviewAttributesForTestCases, buttonPath);
+        saveCallback!(updateCallbacks, testInterview, buttonPath);
 
         // Test function calls
-        expect(mockedGetResponse).toHaveBeenCalledWith(interviewAttributesForTestCases, 'path.to.trip.segments', {});
-        expect(mockedGetActiveJourney).toHaveBeenCalledWith({ interview: interviewAttributesForTestCases });
-        expect(mockedSelectNextIncompleteTrip).toHaveBeenCalledWith({ journey });
+        expect(mockedSelectNextIncompleteTrip).toHaveBeenCalledWith({ journey: testInterview.response.household!.persons!.personId2!.journeys!.journeyId2 });
         expect(updateCallbacks.startUpdateInterview).toHaveBeenCalledWith({
             sectionShortname: 'segments',
             valuesByPath: {
-                'response.path.to.trip.segments.segment1._isNew': false,
-                'response.path.to.trip.segments.segment2._isNew': false,
+                'response.household.persons.personId2.journeys.journeyId2.trips.tripId2P2.segments.segmentId1P2T2._isNew': false,
+                'response.household.persons.personId2.journeys.journeyId2.trips.tripId2P2.segments.segmentId2P2T2._isNew': false,
                 'response._activeTripId': 'trip1'
             }
         });
     });
 
     test('should set all _isNew to `false` and select no trip if no active journey', () => {
-        // Mock function response: 2 segments no active journey
-        mockedGetResponse.mockReturnValueOnce({ segment1: { _uuid: 'segment1', _sequence: 1 }, segment2: { _uuid: 'segment2', _sequence: 2 } });
-        mockedGetActiveJourney.mockReturnValueOnce(null);
-
+        // Set active trip ID for next incomplete trip selection
+        const testInterview = _cloneDeep(interviewAttributesForTestCases);
+        setActiveSurveyObjects(testInterview, {
+            personId: undefined,
+            journeyId: undefined,
+            activeTripId: undefined
+        });
+        
         // Call the save callback
-        saveCallback!(updateCallbacks, interviewAttributesForTestCases, buttonPath);
+        saveCallback!(updateCallbacks, testInterview, buttonPath);
 
         // Test function calls
-        expect(mockedGetResponse).toHaveBeenCalledWith(interviewAttributesForTestCases, 'path.to.trip.segments', {});
-        expect(mockedGetActiveJourney).toHaveBeenCalledWith({ interview: interviewAttributesForTestCases });
         expect(mockedSelectNextIncompleteTrip).not.toHaveBeenCalled();
         expect(updateCallbacks.startUpdateInterview).toHaveBeenCalledWith({
             sectionShortname: 'segments',
             valuesByPath: {
-                'response.path.to.trip.segments.segment1._isNew': false,
-                'response.path.to.trip.segments.segment2._isNew': false,
+                'response.household.persons.personId2.journeys.journeyId2.trips.tripId2P2.segments.segmentId1P2T2._isNew': false,
+                'response.household.persons.personId2.journeys.journeyId2.trips.tripId2P2.segments.segmentId2P2T2._isNew': false,
                 'response._activeTripId': null
             }
         });
     });
 
     test('should set all _isNew to `false` and select no trip if no incomplete trip', () => {
-        // Mock function response: 2 segments, active journey and incomplete trip
-        const journey = { _uuid: 'journey', _sequence: 1 };
-        mockedGetResponse.mockReturnValueOnce({ segment1: { _uuid: 'segment1', _sequence: 1 }, segment2: { _uuid: 'segment2', _sequence: 2 } });
-        mockedGetActiveJourney.mockReturnValueOnce(journey);
+        // Set active trip ID for next incomplete trip selection
+        const testInterview = _cloneDeep(interviewAttributesForTestCases);
+        setActiveSurveyObjects(testInterview, {
+            personId: 'personId2',
+            journeyId: 'journeyId2',
+            activeTripId: 'tripId2P2'
+        });
+        // Mock function response for incomplete trip
         mockedSelectNextIncompleteTrip.mockReturnValueOnce(null);
 
         // Call the save callback
-        saveCallback!(updateCallbacks, interviewAttributesForTestCases, buttonPath);
+        saveCallback!(updateCallbacks, testInterview, buttonPath);
 
         // Test function calls
-        expect(mockedGetResponse).toHaveBeenCalledWith(interviewAttributesForTestCases, 'path.to.trip.segments', {});
-        expect(mockedGetActiveJourney).toHaveBeenCalledWith({ interview: interviewAttributesForTestCases });
-        expect(mockedSelectNextIncompleteTrip).toHaveBeenCalledWith({ journey });
+        expect(mockedSelectNextIncompleteTrip).toHaveBeenCalledWith({ journey: testInterview.response.household!.persons!.personId2!.journeys!.journeyId2 });
         expect(updateCallbacks.startUpdateInterview).toHaveBeenCalledWith({
             sectionShortname: 'segments',
             valuesByPath: {
-                'response.path.to.trip.segments.segment1._isNew': false,
-                'response.path.to.trip.segments.segment2._isNew': false,
+                'response.household.persons.personId2.journeys.journeyId2.trips.tripId2P2.segments.segmentId1P2T2._isNew': false,
+                'response.household.persons.personId2.journeys.journeyId2.trips.tripId2P2.segments.segmentId2P2T2._isNew': false,
                 'response._activeTripId': null
             }
         });
     });
 
-    test('should just set next incomplete trip is no segments', () => {
+    test('should just set next incomplete trip if no segments', () => {
+        // Use a path to a trip with no segments
+        const testButtonPathPrefix = 'household.persons.personId1.journeys.journeyId1.trips.tripId1P1';
+        const testButtonPath = `${testButtonPathPrefix}.buttonSaveTrip`;
+        // Set active trip ID for next incomplete trip selection
+        const testInterview = _cloneDeep(interviewAttributesForTestCases);
+        setActiveSurveyObjects(testInterview, {
+            personId: 'personId1',
+            journeyId: 'journeyId1',
+            activeTripId: 'tripId1P1'
+        });
         // Mock function response: 2 segments, active journey and incomplete trip
-        const journey = { _uuid: 'journey', _sequence: 1 };
         const incompleteTrip = { _uuid: 'trip1', _sequence: 1 };
-        mockedGetResponse.mockReturnValueOnce({ });
-        mockedGetActiveJourney.mockReturnValueOnce(journey);
         mockedSelectNextIncompleteTrip.mockReturnValueOnce(incompleteTrip);
 
         // Call the save callback
-        saveCallback!(updateCallbacks, interviewAttributesForTestCases, buttonPath);
+        saveCallback!(updateCallbacks, testInterview, testButtonPath);
 
         // Test function calls
-        expect(mockedGetResponse).toHaveBeenCalledWith(interviewAttributesForTestCases, 'path.to.trip.segments', {});
-        expect(mockedGetActiveJourney).toHaveBeenCalledWith({ interview: interviewAttributesForTestCases });
-        expect(mockedSelectNextIncompleteTrip).toHaveBeenCalledWith({ journey });
+        expect(mockedSelectNextIncompleteTrip).toHaveBeenCalledWith({ journey: testInterview.response.household!.persons!.personId1!.journeys!.journeyId1 });
         expect(updateCallbacks.startUpdateInterview).toHaveBeenCalledWith({
             sectionShortname: 'segments',
             valuesByPath: { 'response._activeTripId': 'trip1' }

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/helpers.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/helpers.test.ts
@@ -7,84 +7,52 @@
 import _cloneDeep from 'lodash/cloneDeep';
 import each from 'jest-each';
 import * as odHelpers from '../../../../odSurvey/helpers';
-import { interviewAttributesForTestCases } from '../../../../../tests/surveys';
+import { interviewAttributesForTestCases, setActiveSurveyObjects } from '../../../../../tests/surveys';
 import { getResponse, setResponse } from '../../../../../utils/helpers';
 import * as helpers from '../helpers';
 import { Journey, Person } from '../../../types';
-import { modeValues, modePreValues, Mode } from '../../../../odSurvey/types';
+import { modeValues, Mode } from '../../../../odSurvey/types';
 
 describe('getPreviousTripSingleSegment', () => {
-
-    test('No active trip', () => {
-        // Prepare test data
-        const interview = _cloneDeep(interviewAttributesForTestCases);
-        interview.response._activePersonId = 'personId1';
-        interview.response._activeJourneyId = 'journeyId1';
-        interview.response._activeTripId = undefined;
-
-        // Get person and test the function
-        const person = odHelpers.getPerson({ interview }) as Person;
-        expect(helpers.getPreviousTripSingleSegment({ interview, person })).toBeUndefined();
-    });
-
-    test('No active journey', () => {
-        // Prepare test data
-        const interview = _cloneDeep(interviewAttributesForTestCases);
-        interview.response._activePersonId = 'personId1';
-        interview.response._activeJourneyId = undefined;
-        interview.response._activeTripId = 'tripId1P1';
-
-        // Get person and test the function
-        const person = odHelpers.getPerson({ interview }) as Person;
-        expect(helpers.getPreviousTripSingleSegment({ interview, person })).toBeUndefined();
-    });
 
     test('No previous trips', () => {
         // Prepare test data
         const interview = _cloneDeep(interviewAttributesForTestCases);
-        interview.response._activePersonId = 'personId1';
-        interview.response._activeJourneyId = 'journeyId1';
-        interview.response._activeTripId = 'tripId1P1';
+        const journey = interview.response.household!.persons!.personId1.journeys!.journeyId1;
+        const trip = journey.trips!.tripId1P1;
 
-        // Get person and test the function
-        const person = odHelpers.getPerson({ interview }) as Person;
-        expect(helpers.getPreviousTripSingleSegment({ interview, person })).toBeUndefined();
+        // Test the function
+        expect(helpers.getPreviousTripSingleSegment({ journey, trip })).toBeUndefined();
     });
 
     test('Previous trip, but no segments', () => {
         // Prepare test data
         const interview = _cloneDeep(interviewAttributesForTestCases);
-        interview.response._activePersonId = 'personId1';
-        interview.response._activeJourneyId = 'journeyId1';
-        interview.response._activeTripId = 'tripId2P1';
+        const journey = interview.response.household!.persons!.personId1.journeys!.journeyId1;
+        const trip = journey.trips!.tripId2P1;
 
-        // Get person and test the function
-        const person = odHelpers.getPerson({ interview }) as Person;
-        expect(helpers.getPreviousTripSingleSegment({ interview, person })).toBeUndefined();
+        // Test the function
+        expect(helpers.getPreviousTripSingleSegment({ journey, trip })).toBeUndefined();
     });
 
     test('Previous trip, one segment', () => {
         // Prepare test data, trip 2 of person 2 as trip 1 has a single mode
         const interview = _cloneDeep(interviewAttributesForTestCases);
-        interview.response._activePersonId = 'personId2';
-        interview.response._activeJourneyId = 'journeyId2';
-        interview.response._activeTripId = 'tripId2P2';
+        const journey = interview.response.household!.persons!.personId2.journeys!.journeyId2;
+        const trip = journey.trips!.tripId2P2;
 
-        // Get person and test the function
-        const person = odHelpers.getPerson({ interview }) as Person;
-        expect(helpers.getPreviousTripSingleSegment({ interview, person })).toEqual(interview.response.household!.persons!.personId2.journeys!.journeyId2.trips!.tripId1P2.segments!.segmentId1P2T1);
+        // Test the function
+        expect(helpers.getPreviousTripSingleSegment({ journey, trip })).toEqual(journey.trips!.tripId1P2.segments!.segmentId1P2T1);
     });
 
     test('Previous trip, multiple segments', () => {
         // Prepare test data, trip 3 of person 2 as trip 2 has 2 modes
         const interview = _cloneDeep(interviewAttributesForTestCases);
-        interview.response._activePersonId = 'personId2';
-        interview.response._activeJourneyId = 'journeyId2';
-        interview.response._activeTripId = 'tripId3P2';
+        const journey = interview.response.household!.persons!.personId2.journeys!.journeyId2;
+        const trip = journey.trips!.tripId3P2;
 
-        // Get person and test the function
-        const person = odHelpers.getPerson({ interview }) as Person;
-        expect(helpers.getPreviousTripSingleSegment({ interview, person })).toBeUndefined();
+        // Test the function
+        expect(helpers.getPreviousTripSingleSegment({ journey, trip })).toBeUndefined();
     });
 });
 
@@ -324,56 +292,50 @@ describe('shouldShowSameAsReverseTripQuestion', () => {
         segmentId1P1T2: baseTestSegment
     };
 
+    const path = 'household.persons.personId1.journeys.journeyId1.trips.tripId2P1.segments.segmentId1P1T2';
+
     test('Segment is not new, but simple chain', () => {
         // Prepare interview data, setting segment as not new
-        const testSegment = _cloneDeep(baseTestSegment);
-        testSegment._isNew = false;
+        const testInterview = _cloneDeep(baseTestInterview);
+        setResponse(testInterview, path + '._isNew', false);
 
         // Test conditional
-        const result = helpers.shouldShowSameAsReverseTripQuestion!({ interview: baseTestInterview, segment: testSegment });
+        const result = helpers.shouldShowSameAsReverseTripQuestion!({ interview: testInterview, path });
         expect(result).toEqual(false);
     });
 
-    test('Segment is new, trip is null, previousTrip is null', () => {
-        // Unset active trip
-        const interview = _cloneDeep(baseTestInterview);
-        delete interview.response._activeTripId;
-
-        // Test conditional
-        const result = helpers.shouldShowSameAsReverseTripQuestion!({ interview, segment: baseTestSegment });
-        expect(result).toEqual(false);
+    test('Segment is new, trip context does not resolve context', () => {
+        // Test conditional, use an invalid path
+        expect(() => helpers.shouldShowSameAsReverseTripQuestion!({ interview: baseTestInterview, path: 'invalid.path' })).toThrow('shouldShowSameAsReverseTripQuestion: segment context not found for path invalid.path');
     });
 
     test('Segment is new, trip not null, previousTrip is null', () => {
         // Prepare interview data, use the segment from the first trip of P1
         const interview = _cloneDeep(baseTestInterview);
-        // Unset active trip
-        interview.response._activeTripId = 'tripId1P1';
-        setResponse(interview, 'household.persons.personId1.journeys.journeyId1.trips.tripId1P1.segments.segmentId1P1T1._isNew', true);
-        const segment = getResponse(interview, 'household.persons.personId1.journeys.journeyId1.trips.tripId1P1.segments.segmentId1P1T1') as any;
+        const path = 'household.persons.personId1.journeys.journeyId1.trips.tripId1P1.segments.segmentId1P1T1';
+        setResponse(interview, path + '._isNew', true);
 
         // Test conditional
-        const result = helpers.shouldShowSameAsReverseTripQuestion!({ interview, segment });
+        const result = helpers.shouldShowSameAsReverseTripQuestion!({ interview, path });
         expect(result).toEqual(false);
     });
 
     test('Segment is new, with previous trip, not simple chain', () => {
         // Prepare interview data, take tripId2P2, it is not a simple chain
         const interview = _cloneDeep(baseTestInterview);
-        interview.response._activePersonId = 'personId2';
-        interview.response._activeJourneyId = 'journeyId2';
-        interview.response._activeTripId = 'tripId2P2';
-        setResponse(interview, 'household.persons.personId2.journeys.journeyId2.trips.tripId2P2.segments.segmentId1P2T2._isNew', true);
-        const segment = getResponse(interview, 'household.persons.personId2.journeys.journeyId2.trips.tripId2P2.segments.segmentId1P2T2') as any;
+        const path = 'household.persons.personId2.journeys.journeyId2.trips.tripId2P2.segments.segmentId1P2T2';
+        setActiveSurveyObjects(interview, { personId: 'personId2', journeyId: 'journeyId2', activeTripId: 'tripId2P2' });
+        
+        setResponse(interview, path + '._isNew', true);
 
         // Test conditional
-        const result = helpers.shouldShowSameAsReverseTripQuestion!({ interview, segment });
+        const result = helpers.shouldShowSameAsReverseTripQuestion!({ interview, path });
         expect(result).toEqual(false);
     });
 
     test('Segment is new, simple chain', () => {
         // Test conditional
-        const result = helpers.shouldShowSameAsReverseTripQuestion!({ interview: baseTestInterview, segment: baseTestSegment });
+        const result = helpers.shouldShowSameAsReverseTripQuestion!({ interview: baseTestInterview, path });
         expect(result).toEqual(true);
     });
 

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetDriver.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetDriver.test.ts
@@ -12,91 +12,88 @@ import { setResponse, translateString } from '../../../../../utils/helpers';
 import * as odHelpers from '../../../../odSurvey/helpers';
 
 const segmentSectionConfig = {
-	type: 'segments' as const,
-	enabled: true
+    type: 'segments' as const,
+    enabled: true
 };
 
 describe('widgetDriver config', () => {
-	test('should return the expected base widget configuration', () => {
-		const widgetConfig = getSegmentDriverWidgetConfig(segmentSectionConfig, widgetFactoryOptions);
-		expect(widgetConfig).toEqual({
-			type: 'question',
-			path: 'driver',
-			inputType: 'select',
-			datatype: 'string',
-			twoColumns: false,
-			label: expect.any(Function),
-			choices: expect.any(Function),
-			conditional: expect.any(Function),
-			validations: expect.any(Function)
-		});
-	});
+    test('should return the expected base widget configuration', () => {
+        const widgetConfig = getSegmentDriverWidgetConfig(segmentSectionConfig, widgetFactoryOptions);
+        expect(widgetConfig).toEqual({
+            type: 'question',
+            path: 'driver',
+            inputType: 'select',
+            datatype: 'string',
+            twoColumns: false,
+            label: expect.any(Function),
+            choices: expect.any(Function),
+            conditional: expect.any(Function),
+            validations: expect.any(Function)
+        });
+    });
 });
 
 describe('widgetDriver label', () => {
-	test('should use active person context and count in label', () => {
-		const mockedGetActivePerson = jest.spyOn(odHelpers, 'getActivePerson').mockReturnValue({
-			_uuid: 'personId1',
-			_sequence: 1,
-			gender: 'female'
-		} as any);
-		const mockedGetCountOrSelfDeclared = jest.spyOn(odHelpers, 'getCountOrSelfDeclared').mockReturnValue(2);
-		const mockedT = jest.fn();
+    test('should use active person context and count in label', () => {
+        const path = 'household.persons.personId2.journeys.journeyId2.trips.tripId1P2.segments.segmentId1P2T1.driver';
+        const mockedGetCountOrSelfDeclared = jest.spyOn(odHelpers, 'getCountOrSelfDeclared').mockReturnValue(2);
+        const mockedT = jest.fn();
 
-		const interview = _cloneDeep(interviewAttributesForTestCases);
-		const widgetConfig = getSegmentDriverWidgetConfig(
-			segmentSectionConfig,
-			widgetFactoryOptions
-		) as QuestionWidgetConfig;
-		translateString(widgetConfig.label, { t: mockedT } as any, interview, 'some.path.driver');
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        // Set gender of person
+        interview.response.household!.persons!.personId2.gender = 'female';
+        const widgetConfig = getSegmentDriverWidgetConfig(
+            segmentSectionConfig,
+            widgetFactoryOptions
+        ) as QuestionWidgetConfig;
+        translateString(widgetConfig.label, { t: mockedT } as any, interview, path);
 
-		expect(mockedT).toHaveBeenCalledWith('segments:Driver', { context: 'female', count: 2 });
-		expect(mockedGetActivePerson).toHaveBeenCalledWith({ interview });
-		expect(mockedGetCountOrSelfDeclared).toHaveBeenCalledWith({
-			interview,
-			person: { _uuid: 'personId1', _sequence: 1, gender: 'female' }
-		});
-	});
+        expect(mockedT).toHaveBeenCalledWith('segments:Driver', { context: 'female', count: 2 });
+        expect(mockedGetCountOrSelfDeclared).toHaveBeenCalledWith({
+            interview,
+            person: interview.response.household!.persons!.personId2
+        });
+    });
 });
 
 describe('widgetDriver choices', () => {
-	beforeEach(() => {
-		jest.restoreAllMocks();
-	});
+    beforeEach(() => {
+        jest.restoreAllMocks();
+    });
 
-	test('should return empty choices if there is no active person', () => {
-		jest.spyOn(odHelpers, 'getActivePerson').mockReturnValue(null);
+    test('should return empty choices if there is no active person', () => {
+        jest.spyOn(odHelpers, 'getActivePerson').mockReturnValue(null);
 
-		const interview = _cloneDeep(interviewAttributesForTestCases);
-		const widgetConfig = getSegmentDriverWidgetConfig(
-			segmentSectionConfig,
-			widgetFactoryOptions
-		) as any;
-		const choices = (widgetConfig.choices as any)(interview, 'some.path.driver');
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        const widgetConfig = getSegmentDriverWidgetConfig(
+            segmentSectionConfig,
+            widgetFactoryOptions
+        ) as any;
+        const choices = (widgetConfig.choices as any)(interview, 'some.path.driver');
 
-		expect(choices).toEqual([]);
-	});
+        expect(choices).toEqual([]);
+    });
 
-	test('should prepend household drivers and exclude active person', () => {
-		const activePerson = { _uuid: 'personId1', _sequence: 1 } as any;
-		jest.spyOn(odHelpers, 'getActivePerson').mockReturnValue(activePerson);
+    test('should prepend household drivers and exclude active person', () => {
+        const activePerson = { _uuid: 'personId1', _sequence: 1 } as any;
+        jest.spyOn(odHelpers, 'getActivePerson').mockReturnValue(activePerson);
         // Return the active person as one of the drivers to test that they are
         // properly excluded from the choices, and that the other drivers are
         // included
-		jest.spyOn(odHelpers, 'getPotentialDrivers').mockReturnValue([
-			activePerson,
-			{ _uuid: 'personId2', _sequence: 2, nickname: 'The Dude' } as any,
-			{ _uuid: 'personId3', _sequence: 3 } as any
-		]);
+        jest.spyOn(odHelpers, 'getPotentialDrivers').mockReturnValue([
+            activePerson,
+            { _uuid: 'personId2', _sequence: 2, nickname: 'The Dude' } as any,
+            { _uuid: 'personId3', _sequence: 3 } as any
+        ]);
 
-		const interview = _cloneDeep(interviewAttributesForTestCases);
-		const widgetConfig = getSegmentDriverWidgetConfig(
-			segmentSectionConfig,
-			widgetFactoryOptions
-		) as any;
-		const choices = (widgetConfig.choices as any)(interview, 'some.path.driver');
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        const widgetConfig = getSegmentDriverWidgetConfig(
+            segmentSectionConfig,
+            widgetFactoryOptions
+        ) as any;
+        const choices = (widgetConfig.choices as any)(interview, 'some.path.driver');
 
-		expect(choices).toHaveLength(3);
+        expect(choices).toHaveLength(3);
         expect(choices).toEqual([{
             groupShortname: '',
             groupLabel: '',
@@ -134,24 +131,24 @@ describe('widgetDriver choices', () => {
         const personId3Choice = choices[0].choices.find((choice: any) => choice.value === 'personId3');
         translateString(personId3Choice.label, { t: mockedT } as any, interview, 'some.path.driver');
         expect(mockedT).toHaveBeenCalledWith('survey:personWithSequence', { sequence: 3, context: undefined });
-	});
+    });
 
     test('should not contain household members if the person is the only driver in the household', () => {
-		const activePerson = { _uuid: 'personId1', _sequence: 1 } as any;
-		jest.spyOn(odHelpers, 'getActivePerson').mockReturnValue(activePerson);
+        const activePerson = { _uuid: 'personId1', _sequence: 1 } as any;
+        jest.spyOn(odHelpers, 'getActivePerson').mockReturnValue(activePerson);
         // Return the active person as the only driver
-		jest.spyOn(odHelpers, 'getPotentialDrivers').mockReturnValue([
-			activePerson
+        jest.spyOn(odHelpers, 'getPotentialDrivers').mockReturnValue([
+            activePerson
         ]);
 
-		const interview = _cloneDeep(interviewAttributesForTestCases);
-		const widgetConfig = getSegmentDriverWidgetConfig(
-			segmentSectionConfig,
-			widgetFactoryOptions
-		) as any;
-		const choices = (widgetConfig.choices as any)(interview, 'some.path.driver');
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        const widgetConfig = getSegmentDriverWidgetConfig(
+            segmentSectionConfig,
+            widgetFactoryOptions
+        ) as any;
+        const choices = (widgetConfig.choices as any)(interview, 'some.path.driver');
 
-		expect(choices).toHaveLength(2);
+        expect(choices).toHaveLength(2);
         expect(choices).toEqual([{
             groupShortname: '',
             groupLabel: '',
@@ -171,22 +168,22 @@ describe('widgetDriver choices', () => {
                 { value: 'dontKnow', label: expect.any(Function), conditional: expect.any(Function) }
             ]
         }]);
-	});
+    });
 
     test('should not contain household members if there are no drivers in the household', () => {
-		const activePerson = { _uuid: 'personId1', _sequence: 1 } as any;
-		jest.spyOn(odHelpers, 'getActivePerson').mockReturnValue(activePerson);
+        const activePerson = { _uuid: 'personId1', _sequence: 1 } as any;
+        jest.spyOn(odHelpers, 'getActivePerson').mockReturnValue(activePerson);
         // Return no drivers
-		jest.spyOn(odHelpers, 'getPotentialDrivers').mockReturnValue([]);
+        jest.spyOn(odHelpers, 'getPotentialDrivers').mockReturnValue([]);
 
-		const interview = _cloneDeep(interviewAttributesForTestCases);
-		const widgetConfig = getSegmentDriverWidgetConfig(
-			segmentSectionConfig,
-			widgetFactoryOptions
-		) as any;
-		const choices = (widgetConfig.choices as any)(interview, 'some.path.driver');
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        const widgetConfig = getSegmentDriverWidgetConfig(
+            segmentSectionConfig,
+            widgetFactoryOptions
+        ) as any;
+        const choices = (widgetConfig.choices as any)(interview, 'some.path.driver');
 
-		expect(choices).toHaveLength(2);
+        expect(choices).toHaveLength(2);
         expect(choices).toEqual([{
             groupShortname: '',
             groupLabel: '',
@@ -206,89 +203,89 @@ describe('widgetDriver choices', () => {
                 { value: 'dontKnow', label: expect.any(Function), conditional: expect.any(Function) }
             ]
         }]);
-	});
+    });
 
-	test('paratransit conditional should depend on disability helpers', () => {
-		const activePerson = { _uuid: 'personId1', _sequence: 1 } as any;
-		jest.spyOn(odHelpers, 'getActivePerson').mockReturnValue(activePerson);
-		jest.spyOn(odHelpers, 'getPotentialDrivers').mockReturnValue([]);
-		const mockedPersonMayHaveDisability = jest.spyOn(odHelpers, 'personMayHaveDisability');
-		const mockedHouseholdMayHaveDisability = jest.spyOn(odHelpers, 'householdMayHaveDisability');
+    test('paratransit conditional should depend on disability helpers', () => {
+        const activePerson = { _uuid: 'personId1', _sequence: 1 } as any;
+        jest.spyOn(odHelpers, 'getActivePerson').mockReturnValue(activePerson);
+        jest.spyOn(odHelpers, 'getPotentialDrivers').mockReturnValue([]);
+        const mockedPersonMayHaveDisability = jest.spyOn(odHelpers, 'personMayHaveDisability');
+        const mockedHouseholdMayHaveDisability = jest.spyOn(odHelpers, 'householdMayHaveDisability');
 
-		const interview = _cloneDeep(interviewAttributesForTestCases);
-		const widgetConfig = getSegmentDriverWidgetConfig(
-			segmentSectionConfig,
-			widgetFactoryOptions
-		) as any;
-		const choices = (widgetConfig.choices as any)(interview, 'some.path.driver');
-		const groupedChoices = choices.flatMap((group: any) => group.choices);
-		const paratransit = groupedChoices.find((choice: any) => choice.value === 'paratransit');
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        const widgetConfig = getSegmentDriverWidgetConfig(
+            segmentSectionConfig,
+            widgetFactoryOptions
+        ) as any;
+        const choices = (widgetConfig.choices as any)(interview, 'some.path.driver');
+        const groupedChoices = choices.flatMap((group: any) => group.choices);
+        const paratransit = groupedChoices.find((choice: any) => choice.value === 'paratransit');
 
-		mockedPersonMayHaveDisability.mockReturnValueOnce(false);
-		mockedHouseholdMayHaveDisability.mockReturnValueOnce(true);
-		expect(paratransit.conditional(interview, 'some.path.driver')).toEqual(true);
+        mockedPersonMayHaveDisability.mockReturnValueOnce(false);
+        mockedHouseholdMayHaveDisability.mockReturnValueOnce(true);
+        expect(paratransit.conditional(interview, 'some.path.driver')).toEqual(true);
         expect(mockedPersonMayHaveDisability).toHaveBeenCalledWith({ person: activePerson });
         expect(mockedHouseholdMayHaveDisability).toHaveBeenCalledWith({ interview });
         expect(mockedPersonMayHaveDisability).toHaveBeenCalledTimes(1);
         expect(mockedHouseholdMayHaveDisability).toHaveBeenCalledTimes(1);
 
-		mockedPersonMayHaveDisability.mockReturnValueOnce(false);
-		mockedHouseholdMayHaveDisability.mockReturnValueOnce(false);
-		expect(paratransit.conditional(interview, 'some.path.driver')).toEqual(false);
+        mockedPersonMayHaveDisability.mockReturnValueOnce(false);
+        mockedHouseholdMayHaveDisability.mockReturnValueOnce(false);
+        expect(paratransit.conditional(interview, 'some.path.driver')).toEqual(false);
         expect(mockedPersonMayHaveDisability).toHaveBeenCalledTimes(2);
         expect(mockedHouseholdMayHaveDisability).toHaveBeenCalledTimes(2);
-	});
+    });
 
-	test('dontKnow conditional should depend on household count/self-declared', () => {
-		const activePerson = { _uuid: 'personId1', _sequence: 1 } as any;
-		jest.spyOn(odHelpers, 'getActivePerson').mockReturnValue(activePerson);
-		jest.spyOn(odHelpers, 'getPotentialDrivers').mockReturnValue([]);
-		const mockedGetCountOrSelfDeclared = jest.spyOn(odHelpers, 'getCountOrSelfDeclared');
+    test('dontKnow conditional should depend on household count/self-declared', () => {
+        const activePerson = { _uuid: 'personId1', _sequence: 1 } as any;
+        jest.spyOn(odHelpers, 'getActivePerson').mockReturnValue(activePerson);
+        jest.spyOn(odHelpers, 'getPotentialDrivers').mockReturnValue([]);
+        const mockedGetCountOrSelfDeclared = jest.spyOn(odHelpers, 'getCountOrSelfDeclared');
 
-		const interview = _cloneDeep(interviewAttributesForTestCases);
-		const widgetConfig = getSegmentDriverWidgetConfig(
-			segmentSectionConfig,
-			widgetFactoryOptions
-		) as any;
-		const choices = (widgetConfig.choices as any)(interview, 'some.path.driver');
-		const groupedChoices = choices.flatMap((group: any) => group.choices);
-		const dontKnow = groupedChoices.find((choice: any) => choice.value === 'dontKnow');
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        const widgetConfig = getSegmentDriverWidgetConfig(
+            segmentSectionConfig,
+            widgetFactoryOptions
+        ) as any;
+        const choices = (widgetConfig.choices as any)(interview, 'some.path.driver');
+        const groupedChoices = choices.flatMap((group: any) => group.choices);
+        const dontKnow = groupedChoices.find((choice: any) => choice.value === 'dontKnow');
 
-		mockedGetCountOrSelfDeclared.mockReturnValueOnce(1);
-		expect(dontKnow.conditional(interview, 'some.path.driver')).toEqual(false);
+        mockedGetCountOrSelfDeclared.mockReturnValueOnce(1);
+        expect(dontKnow.conditional(interview, 'some.path.driver')).toEqual(false);
 
-		mockedGetCountOrSelfDeclared.mockReturnValueOnce(3);
-		expect(dontKnow.conditional(interview, 'some.path.driver')).toEqual(true);
-	});
+        mockedGetCountOrSelfDeclared.mockReturnValueOnce(3);
+        expect(dontKnow.conditional(interview, 'some.path.driver')).toEqual(true);
+    });
 
-	test.each([
-		['familyMember', 'segments:DriverFamily'],
-		['colleague', 'segments:DriverColleague'],
-		['taxiDriver', 'segments:DriverTaxi'],
-		['transitTaxiDriver', 'segments:DriverTransitTaxi'],
-		['paratransit', 'segments:DriverParaTransit'],
-		['carpool', 'segments:DriverCarpool'],
-		['other', 'segments:DriverOther'],
-		['dontKnow', 'segments:DriverDontKnow']
-	])('builtin choice label should translate %s with key %s', (choiceValue, expectedLabelKey) => {
-		const activePerson = { _uuid: 'personId1', _sequence: 1 } as any;
-		jest.spyOn(odHelpers, 'getActivePerson').mockReturnValue(activePerson);
-		jest.spyOn(odHelpers, 'getPotentialDrivers').mockReturnValue([]);
+    test.each([
+        ['familyMember', 'segments:DriverFamily'],
+        ['colleague', 'segments:DriverColleague'],
+        ['taxiDriver', 'segments:DriverTaxi'],
+        ['transitTaxiDriver', 'segments:DriverTransitTaxi'],
+        ['paratransit', 'segments:DriverParaTransit'],
+        ['carpool', 'segments:DriverCarpool'],
+        ['other', 'segments:DriverOther'],
+        ['dontKnow', 'segments:DriverDontKnow']
+    ])('builtin choice label should translate %s with key %s', (choiceValue, expectedLabelKey) => {
+        const activePerson = { _uuid: 'personId1', _sequence: 1 } as any;
+        jest.spyOn(odHelpers, 'getActivePerson').mockReturnValue(activePerson);
+        jest.spyOn(odHelpers, 'getPotentialDrivers').mockReturnValue([]);
 
-		const interview = _cloneDeep(interviewAttributesForTestCases);
-		const widgetConfig = getSegmentDriverWidgetConfig(
-			segmentSectionConfig,
-			widgetFactoryOptions
-		) as any;
-		const choices = (widgetConfig.choices as any)(interview, 'some.path.driver');
-		const groupedChoices = choices.flatMap((choiceGroup: any) => choiceGroup.choices);
-		const choice = groupedChoices.find((choice: any) => choice.value === choiceValue);
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        const widgetConfig = getSegmentDriverWidgetConfig(
+            segmentSectionConfig,
+            widgetFactoryOptions
+        ) as any;
+        const choices = (widgetConfig.choices as any)(interview, 'some.path.driver');
+        const groupedChoices = choices.flatMap((choiceGroup: any) => choiceGroup.choices);
+        const choice = groupedChoices.find((choice: any) => choice.value === choiceValue);
 
-		expect(choice).toBeDefined();
-		const mockedT = jest.fn();
-		translateString(choice.label, { t: mockedT } as any, interview, 'some.path.driver');
-		expect(mockedT).toHaveBeenCalledWith(expectedLabelKey);
-	});
+        expect(choice).toBeDefined();
+        const mockedT = jest.fn();
+        translateString(choice.label, { t: mockedT } as any, interview, 'some.path.driver');
+        expect(mockedT).toHaveBeenCalledWith(expectedLabelKey);
+    });
 
     test.each([
         ['undefined', undefined],
@@ -296,98 +293,95 @@ describe('widgetDriver choices', () => {
         ['empty string', ''],
         ['string with only spaces', '   ']
     ])('Test person with invalid nickname %s', (_description, nickname) => {
-		const activePerson = { _uuid: 'personId1', _sequence: 1 } as any;
-		jest.spyOn(odHelpers, 'getActivePerson').mockReturnValue(activePerson);
+        const activePerson = { _uuid: 'personId1', _sequence: 1 } as any;
+        jest.spyOn(odHelpers, 'getActivePerson').mockReturnValue(activePerson);
         // Include a driver without a nickname to test the label of that choice
-		jest.spyOn(odHelpers, 'getPotentialDrivers').mockReturnValue([
-			{ _uuid: 'personId3', _sequence: 3, nickname, age: 34, gender: 'male' } as any
-		]);
+        jest.spyOn(odHelpers, 'getPotentialDrivers').mockReturnValue([
+            { _uuid: 'personId3', _sequence: 3, nickname, age: 34, gender: 'male' } as any
+        ]);
 
-		const interview = _cloneDeep(interviewAttributesForTestCases);
-		const widgetConfig = getSegmentDriverWidgetConfig(
-			segmentSectionConfig,
-			widgetFactoryOptions
-		) as any;
-		const choices = (widgetConfig.choices as any)(interview, 'some.path.driver');
-		const groupedChoices = choices.flatMap((choiceGroup: any) => choiceGroup.choices);
-		const choice = groupedChoices.find((choice: any) => choice.value === 'personId3');
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        const widgetConfig = getSegmentDriverWidgetConfig(
+            segmentSectionConfig,
+            widgetFactoryOptions
+        ) as any;
+        const choices = (widgetConfig.choices as any)(interview, 'some.path.driver');
+        const groupedChoices = choices.flatMap((choiceGroup: any) => choiceGroup.choices);
+        const choice = groupedChoices.find((choice: any) => choice.value === 'personId3');
 
-		expect(choice).toBeDefined();
-		const mockedT = jest.fn();
-		translateString(choice.label, { t: mockedT } as any, interview, 'some.path.driver');
-		expect(mockedT).toHaveBeenCalledWith('survey:personWithSequenceAndAge', { sequence: 3, age: 34, context: 'male' });
-	});
+        expect(choice).toBeDefined();
+        const mockedT = jest.fn();
+        translateString(choice.label, { t: mockedT } as any, interview, 'some.path.driver');
+        expect(mockedT).toHaveBeenCalledWith('survey:personWithSequenceAndAge', { sequence: 3, age: 34, context: 'male' });
+    });
 });
 
 describe('widgetDriver conditional', () => {
-	const segmentPath =
-		'household.persons.personId2.journeys.journeyId2.trips.tripId1P2.segments.segmentId1P2T1';
+    const segmentPath =
+        'household.persons.personId2.journeys.journeyId2.trips.tripId1P2.segments.segmentId1P2T1';
 
-	beforeEach(() => {
-		jest.restoreAllMocks();
-	});
+    beforeEach(() => {
+        jest.restoreAllMocks();
+    });
 
-	test('should be hidden if mode is not carPassenger', () => {
-		const interview = _cloneDeep(interviewAttributesForTestCases);
-		setResponse(interview, `${segmentPath}.mode`, 'walk');
+    test('should be hidden if mode is not carPassenger', () => {
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        setResponse(interview, `${segmentPath}.mode`, 'walk');
 
-		const widgetConfig = getSegmentDriverWidgetConfig(
-			segmentSectionConfig,
-			widgetFactoryOptions
-		) as QuestionWidgetConfig;
-		const conditionalResult = widgetConfig.conditional?.(interview, `${segmentPath}.driver`);
+        const widgetConfig = getSegmentDriverWidgetConfig(
+            segmentSectionConfig,
+            widgetFactoryOptions
+        ) as QuestionWidgetConfig;
+        const conditionalResult = widgetConfig.conditional?.(interview, `${segmentPath}.driver`);
 
-		expect(conditionalResult).toEqual([false, null]);
-	});
+        expect(conditionalResult).toEqual([false, null]);
+    });
 
-	test('should be hidden and log an error if trip or journey is missing', () => {
-		const interview = _cloneDeep(interviewAttributesForTestCases);
-		setResponse(interview, `${segmentPath}.mode`, 'carPassenger');
-		jest.spyOn(odHelpers, 'getActiveTrip').mockReturnValue(null);
-		jest.spyOn(odHelpers, 'getActiveJourney').mockReturnValue(null);
-		const mockedConsoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+    test('should be hidden and log an error if trip or journey is missing', () => {
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        setResponse(interview, `${segmentPath}.mode`, 'carPassenger');
+        jest.spyOn(odHelpers, 'getTripContextFromPath').mockReturnValue(null);
+        const mockedConsoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
 
-		const widgetConfig = getSegmentDriverWidgetConfig(
-			segmentSectionConfig,
-			widgetFactoryOptions
-		) as QuestionWidgetConfig;
-		const conditionalResult = widgetConfig.conditional?.(interview, `${segmentPath}.driver`);
+        const widgetConfig = getSegmentDriverWidgetConfig(
+            segmentSectionConfig,
+            widgetFactoryOptions
+        ) as QuestionWidgetConfig;
+        const conditionalResult = widgetConfig.conditional?.(interview, `${segmentPath}.driver`);
 
-		expect(conditionalResult).toEqual([false, null]);
-		expect(mockedConsoleError).toHaveBeenCalledTimes(1);
-	});
+        expect(conditionalResult).toEqual([false, null]);
+        expect(mockedConsoleError).toHaveBeenCalledTimes(1);
+    });
 
-	test('should be shown when activity is not workOnTheRoad', () => {
-		const interview = _cloneDeep(interviewAttributesForTestCases);
-		setResponse(interview, `${segmentPath}.mode`, 'carPassenger');
-		jest.spyOn(odHelpers, 'getActiveTrip').mockReturnValue({ _uuid: 'tripId1P2', _sequence: 1});
-		jest.spyOn(odHelpers, 'getActiveJourney').mockReturnValue({ _uuid: 'journeyId2', _sequence: 1 });
-		jest.spyOn(odHelpers, 'getVisitedPlaces').mockReturnValue({});
-		jest.spyOn(odHelpers, 'getDestination').mockReturnValue({ _uuid: 'dest', _sequence: 1, activity: 'workUsual' });
+    test('should be shown when activity is not workOnTheRoad', () => {
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        setResponse(interview, `${segmentPath}.mode`, 'carPassenger');
+        jest.spyOn(odHelpers, 'getVisitedPlaces').mockReturnValue({});
+        jest.spyOn(odHelpers, 'getDestination').mockReturnValue({ _uuid: 'dest', _sequence: 1, activity: 'workUsual' });
 
-		const widgetConfig = getSegmentDriverWidgetConfig(
-			segmentSectionConfig,
-			widgetFactoryOptions
-		) as QuestionWidgetConfig;
-		const conditionalResult = widgetConfig.conditional?.(interview, `${segmentPath}.driver`);
+        const widgetConfig = getSegmentDriverWidgetConfig(
+            segmentSectionConfig,
+            widgetFactoryOptions
+        ) as QuestionWidgetConfig;
+        const conditionalResult = widgetConfig.conditional?.(interview, `${segmentPath}.driver`);
 
-		expect(conditionalResult).toEqual([true, null]);
-	});
+        expect(conditionalResult).toEqual([true, null]);
+    });
 
-	test('should be hidden when activity is workOnTheRoad', () => {
-		const interview = _cloneDeep(interviewAttributesForTestCases);
-		setResponse(interview, `${segmentPath}.mode`, 'carPassenger');
-		jest.spyOn(odHelpers, 'getActiveTrip').mockReturnValue({ _uuid: 'tripId1P2', _sequence: 1 });
-		jest.spyOn(odHelpers, 'getActiveJourney').mockReturnValue({ _uuid: 'journeyId2', _sequence: 1 });
-		jest.spyOn(odHelpers, 'getVisitedPlaces').mockReturnValue({});
-		jest.spyOn(odHelpers, 'getDestination').mockReturnValue({ _uuid: 'dest', _sequence: 1, activity: 'workOnTheRoad' });
+    test('should be hidden when activity is workOnTheRoad', () => {
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        setResponse(interview, `${segmentPath}.mode`, 'carPassenger');
+        jest.spyOn(odHelpers, 'getActiveTrip').mockReturnValue({ _uuid: 'tripId1P2', _sequence: 1 });
+        jest.spyOn(odHelpers, 'getActiveJourney').mockReturnValue({ _uuid: 'journeyId2', _sequence: 1 });
+        jest.spyOn(odHelpers, 'getVisitedPlaces').mockReturnValue({});
+        jest.spyOn(odHelpers, 'getDestination').mockReturnValue({ _uuid: 'dest', _sequence: 1, activity: 'workOnTheRoad' });
 
-		const widgetConfig = getSegmentDriverWidgetConfig(
-			segmentSectionConfig,
-			widgetFactoryOptions
-		) as QuestionWidgetConfig;
-		const conditionalResult = widgetConfig.conditional?.(interview, `${segmentPath}.driver`);
+        const widgetConfig = getSegmentDriverWidgetConfig(
+            segmentSectionConfig,
+            widgetFactoryOptions
+        ) as QuestionWidgetConfig;
+        const conditionalResult = widgetConfig.conditional?.(interview, `${segmentPath}.driver`);
 
-		expect(conditionalResult).toEqual([false, null]);
-	});
+        expect(conditionalResult).toEqual([false, null]);
+    });
 });

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetPersonTripsTitle.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetPersonTripsTitle.test.ts
@@ -6,17 +6,7 @@
  */
 import _cloneDeep from 'lodash/cloneDeep';
 import { getPersonsTripsTitleWidgetConfig } from '../widgetPersonTripsTitle';
-import { interviewAttributesForTestCases, widgetFactoryOptions } from '../../../../../tests/surveys';
-import * as odHelpers from '../../../../odSurvey/helpers';
-
-jest.mock('../../../../odSurvey/helpers', () => ({
-    getActivePerson: jest.fn().mockReturnValue({}),
-    getActiveJourney: jest.fn().mockReturnValue({}),
-    getCountOrSelfDeclared: jest.fn().mockReturnValue(1)
-}));
-const mockedGetActivePerson = odHelpers.getActivePerson as jest.MockedFunction<typeof odHelpers.getActivePerson>;
-const mockedGetActiveJourney = odHelpers.getActiveJourney as jest.MockedFunction<typeof odHelpers.getActiveJourney>;
-const mockedGetCountOrSelfDeclared = odHelpers.getCountOrSelfDeclared as jest.MockedFunction<typeof odHelpers.getCountOrSelfDeclared>;
+import { interviewAttributesForTestCases, setActiveSurveyObjects, widgetFactoryOptions } from '../../../../../tests/surveys';
 
 const mockGetFormattedDate = widgetFactoryOptions.getFormattedDate as jest.MockedFunction<typeof widgetFactoryOptions.getFormattedDate>;
 mockGetFormattedDate.mockReturnValue('formattedDate');
@@ -48,37 +38,26 @@ describe('personsTripsTitleWidgetConfig text', () => {
     const widgetText = getPersonsTripsTitleWidgetConfig(options).text as any;
     const mockedT = jest.fn().mockReturnValue('translatedString');
    
-    test('should call translation with correct parameters if no active person', () => {
-        mockedGetActivePerson.mockReturnValueOnce(null);
-        mockedGetActiveJourney.mockReturnValueOnce(null);
-        expect(widgetText(mockedT, interviewAttributesForTestCases, 'path')).toEqual('translatedString');
-        expect(mockedT).toHaveBeenCalledWith(['customSurvey:segments:Description', 'segments:Description'], {
-            context: 'undated',
-            count: 1,
-            nickname: '',
-            journeyDates: null
-        });
-        expect(options.context).toHaveBeenCalledWith('undated');
-    });
-
-    test('should call translation with correct parameters if no active journey', () => {
-        const nickname = 'Jane'
-        mockedGetActivePerson.mockReturnValueOnce({ _uuid: 'person1', _sequence: 1, nickname });
-        mockedGetActiveJourney.mockReturnValueOnce(null);
-        expect(widgetText(mockedT, interviewAttributesForTestCases, 'path')).toEqual('translatedString');
-        expect(mockedT).toHaveBeenCalledWith(['customSurvey:segments:Description', 'segments:Description'], {
-            context: 'undated',
-            count: 1,
-            nickname,
-            journeyDates: null
-        });
-        expect(options.context).toHaveBeenCalledWith('undated');
+    test('should call translation with correct parameters if no person/journey context', () => {
+        const testInterview = _cloneDeep(interviewAttributesForTestCases);
+        setActiveSurveyObjects(testInterview, { personId: undefined, journeyId: undefined });
+        // Path that does not correspond to any journey context
+        expect(() => widgetText(mockedT, testInterview)).toThrow('personTripsTitle: Person or Journey not found');
+        expect(mockedT).not.toHaveBeenCalled();
     });
 
     test('should call translation with correct parameters if one person household and no journey dates', () => {
-        mockedGetActivePerson.mockReturnValueOnce({ _uuid: 'person1', _sequence: 1 });
-        mockedGetActiveJourney.mockReturnValueOnce({ _uuid: 'journey1', _sequence: 1 });
-        expect(widgetText(mockedT, interviewAttributesForTestCases, 'path')).toEqual('translatedString');
+        const testInterview = _cloneDeep(interviewAttributesForTestCases);
+        setActiveSurveyObjects(testInterview, { personId: 'personId1', journeyId: 'journeyId1' });
+        // Correct path and delete other persons and date
+        const personIds = Object.keys(testInterview.response.household!.persons!);
+        for (const personId of personIds) {
+            if (personId !== 'personId1') {
+                delete testInterview.response.household!.persons![personId];
+            }
+        }
+        delete testInterview.response.household!.persons!.personId1.journeys!.journeyId1.startDate;
+        expect(widgetText(mockedT, testInterview)).toEqual('translatedString');
         expect(mockedT).toHaveBeenCalledWith(['customSurvey:segments:Description', 'segments:Description'], {
             context: 'undated',
             count: 1,
@@ -89,14 +68,17 @@ describe('personsTripsTitleWidgetConfig text', () => {
     });
 
     test('should call translation with correct parameters if multiple person household and journey with start date', () => {
-        const nickname = 'Jane'
-        mockedGetActivePerson.mockReturnValueOnce({ _uuid: 'person1', _sequence: 1, nickname });
-        mockedGetActiveJourney.mockReturnValueOnce({ _uuid: 'journey1', _sequence: 1, startDate: '2024-11-18' });
-        mockedGetCountOrSelfDeclared.mockReturnValueOnce(2);
-        expect(widgetText(mockedT, interviewAttributesForTestCases, 'path')).toEqual('translatedString');
+        const testInterview = _cloneDeep(interviewAttributesForTestCases);
+        setActiveSurveyObjects(testInterview, { personId: 'personId1', journeyId: 'journeyId1' });
+        // Add a nickname to person and start date to the journey
+        const nickname = 'Jane';
+        testInterview.response.household!.persons!.personId1.nickname = nickname;
+        testInterview.response.household!.persons!.personId1.journeys!.journeyId1.startDate = '2024-01-01';
+
+        expect(widgetText(mockedT, testInterview)).toEqual('translatedString');
         expect(mockedT).toHaveBeenCalledWith(['customSurvey:segments:Description', 'segments:Description'], {
             context: undefined,
-            count: 2,
+            count: 3,
             nickname,
             journeyDates: 'formattedDate'
         });

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetSameAsReverseTrip.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetSameAsReverseTrip.test.ts
@@ -151,7 +151,7 @@ describe('sameAsReverseTripWidget label', () => {
         const context = 'currentContext';
         mockedGetContext.mockReturnValueOnce(context);
 
-        translateString(label, { t: mockedT } as any, baseTestInterview, 'path');
+        translateString(label, { t: mockedT } as any, baseTestInterview, 'household.persons.personId1.journeys.journeyId1.trips.tripId2P1.segments.segmentId1P1T1.sameModeAsReverseTrip');
         expect(mockedT).toHaveBeenCalledTimes(2);
         expect(mockedT).toHaveBeenCalledWith(['customSurvey:segments:SegmentSameModeReturnHome', 'segments:SegmentSameModeReturnHome'], {
             context,
@@ -171,7 +171,7 @@ describe('sameAsReverseTripWidget label', () => {
         // No previous segment
         mockedGetPreviousTripSingleSegment.mockReturnValueOnce(undefined);
 
-        translateString(label, { t: mockedT } as any, baseTestInterview, 'path');
+        translateString(label, { t: mockedT } as any, baseTestInterview, 'household.persons.personId1.journeys.journeyId1.trips.tripId3P1.segments.segmentId1P1T1.sameModeAsReverseTrip');
         expect(mockedT).toHaveBeenCalledTimes(1);
         expect(mockedT).toHaveBeenCalledWith(['customSurvey:segments:SegmentSameModeReturn', 'segments:SegmentSameModeReturn'], {
             context: undefined,

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetSegmentHasNextMode.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetSegmentHasNextMode.test.ts
@@ -104,7 +104,7 @@ describe('segmentHasNextMode conditional', () => {
         // Test conditional
         const result = conditional!(interview, `${segmentPath}.hasNextMode`);
         expect(result).toEqual([true, null]);
-        expect(mockedShouldShowSameAsReverseTripQuestion).toHaveBeenCalledWith({ interview, segment: getResponse(interview, segmentPath) });
+        expect(mockedShouldShowSameAsReverseTripQuestion).toHaveBeenCalledWith({ interview, path: `${segmentPath}.hasNextMode` });
         expect(mockedGetPreviousTripSingleSegment).not.toHaveBeenCalled();
     });
 
@@ -119,8 +119,11 @@ describe('segmentHasNextMode conditional', () => {
         // Test conditional
         const result = conditional!(interview, `${segmentPath}.hasNextMode`);
         expect(result).toEqual([false, false]);
-        expect(mockedShouldShowSameAsReverseTripQuestion).toHaveBeenCalledWith({ interview, segment: getResponse(interview, segmentPath) });
-        expect(mockedGetPreviousTripSingleSegment).toHaveBeenCalledWith({ interview, person: getResponse(interview, 'household.persons.personId2') });
+        expect(mockedShouldShowSameAsReverseTripQuestion).toHaveBeenCalledWith({ interview, path: `${segmentPath}.hasNextMode` });
+        expect(mockedGetPreviousTripSingleSegment).toHaveBeenCalledWith({ 
+            journey: interview.response.household!.persons!.personId2.journeys!.journeyId2, 
+            trip: interview.response.household!.persons!.personId2.journeys!.journeyId2.trips!.tripId1P2, 
+        });
     });
 
     test('should not be displayed, but un-initialized, if the same mode as reverse trip question is presented and unanswered', () => {
@@ -133,7 +136,7 @@ describe('segmentHasNextMode conditional', () => {
         // Test conditional
         const result = conditional!(interview, `${segmentPath}.hasNextMode`);
         expect(result).toEqual([false, null]);
-        expect(mockedShouldShowSameAsReverseTripQuestion).toHaveBeenCalledWith({ interview, segment: getResponse(interview, segmentPath) });
+        expect(mockedShouldShowSameAsReverseTripQuestion).toHaveBeenCalledWith({ interview, path: `${segmentPath}.hasNextMode` });
         expect(mockedGetPreviousTripSingleSegment).not.toHaveBeenCalled();
     });
 

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetSegmentMode.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetSegmentMode.test.ts
@@ -260,7 +260,7 @@ describe('Mode conditional', () => {
         // Test conditional
         const result = conditional!(interview, `${segmentPath}.mode`);
         expect(result).toEqual([true, null]);
-        expect(mockedShouldShowSameAsReverseTripQuestion).toHaveBeenCalledWith({ interview, segment: getResponse(interview, segmentPath) });
+        expect(mockedShouldShowSameAsReverseTripQuestion).toHaveBeenCalledWith({ interview, path: `${segmentPath}.mode` });
         expect(mockedGetPreviousTripSingleSegment).not.toHaveBeenCalled();
     });
 
@@ -276,8 +276,11 @@ describe('Mode conditional', () => {
         // Test conditional
         const result = conditional!(interview, `${segmentPath}.mode`);
         expect(result).toEqual([false, mode]);
-        expect(mockedShouldShowSameAsReverseTripQuestion).toHaveBeenCalledWith({ interview, segment: getResponse(interview, segmentPath) });
-        expect(mockedGetPreviousTripSingleSegment).toHaveBeenCalledWith({ interview, person: getResponse(interview, 'household.persons.personId2') });
+        expect(mockedShouldShowSameAsReverseTripQuestion).toHaveBeenCalledWith({ interview, path: `${segmentPath}.mode` });
+        expect(mockedGetPreviousTripSingleSegment).toHaveBeenCalledWith({ 
+            journey: interview.response.household!.persons!.personId2.journeys!.journeyId2,
+            trip: interview.response.household!.persons!.personId2.journeys!.journeyId2.trips!.tripId1P2, 
+        });
     });
 
     test('should not be displayed, but un-initialized, if the same mode as reverse trip question is presented and unanswered', () => {
@@ -290,7 +293,7 @@ describe('Mode conditional', () => {
         // Test conditional
         const result = conditional!(interview, `${segmentPath}.mode`);
         expect(result).toEqual([false, null]);
-        expect(mockedShouldShowSameAsReverseTripQuestion).toHaveBeenCalledWith({ interview, segment: getResponse(interview, segmentPath) });
+        expect(mockedShouldShowSameAsReverseTripQuestion).toHaveBeenCalledWith({ interview, path: `${segmentPath}.mode` });
         expect(mockedGetPreviousTripSingleSegment).not.toHaveBeenCalled();
     });
 });

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetSegmentModePre.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetSegmentModePre.test.ts
@@ -303,7 +303,7 @@ describe('ModePre conditional', () => {
         // Test conditional
         const result = conditional!(testInterview, `${segmentPath}.modePre`);
         expect(result).toEqual([true, null]);
-        expect(mockedShouldShowSameAsReverseTripQuestion).toHaveBeenCalledWith({ interview: testInterview, segment: currentSegment });
+        expect(mockedShouldShowSameAsReverseTripQuestion).toHaveBeenCalledWith({ interview: testInterview, path: `${segmentPath}.modePre` });
         expect(mockedGetPreviousTripSingleSegment).not.toHaveBeenCalled();
     });
 
@@ -317,7 +317,7 @@ describe('ModePre conditional', () => {
         // Test conditional
         const result = conditional!(interview, `${segmentPath}.modePre`);
         expect(result).toEqual([true, null]);
-        expect(mockedShouldShowSameAsReverseTripQuestion).toHaveBeenCalledWith({ interview, segment: getResponse(interview, segmentPath) });
+        expect(mockedShouldShowSameAsReverseTripQuestion).toHaveBeenCalledWith({ interview, path: `${segmentPath}.modePre` });
         expect(mockedGetPreviousTripSingleSegment).not.toHaveBeenCalled();
     });
 
@@ -333,8 +333,11 @@ describe('ModePre conditional', () => {
         // Test conditional
         const result = conditional!(interview, `${segmentPath}.modePre`);
         expect(result).toEqual([false, previousModePre]);
-        expect(mockedShouldShowSameAsReverseTripQuestion).toHaveBeenCalledWith({ interview, segment: getResponse(interview, segmentPath) });
-        expect(mockedGetPreviousTripSingleSegment).toHaveBeenCalledWith({ interview, person: getResponse(interview, 'household.persons.personId2') });
+        expect(mockedShouldShowSameAsReverseTripQuestion).toHaveBeenCalledWith({ interview, path: `${segmentPath}.modePre` });
+        expect(mockedGetPreviousTripSingleSegment).toHaveBeenCalledWith({
+            journey: interview.response.household!.persons!.personId2!.journeys!.journeyId2,
+            trip: interview.response.household!.persons!.personId2!.journeys!.journeyId2!.trips!.tripId1P2,
+        });
     });
 
     test('should not be displayed, but un-initialized, if the same mode as reverse trip question is presented and unanswered', () => {
@@ -347,7 +350,7 @@ describe('ModePre conditional', () => {
         // Test conditional
         const result = conditional!(interview, `${segmentPath}.modePre`);
         expect(result).toEqual([false, null]);
-        expect(mockedShouldShowSameAsReverseTripQuestion).toHaveBeenCalledWith({ interview, segment: getResponse(interview, segmentPath) });
+        expect(mockedShouldShowSameAsReverseTripQuestion).toHaveBeenCalledWith({ interview, path: `${segmentPath}.modePre` });
         expect(mockedGetPreviousTripSingleSegment).not.toHaveBeenCalled();
     });
 });
@@ -443,10 +446,12 @@ describe('ModePre label', () => {
         // Prepare interview
         const interview = _cloneDeep(interviewAttributesForTestCases);
 
+        // Use a path that won't resolve current context
+        const invalidPath = 'invalid.path';
+
         // Test label function
-        const modeLabel = translateString(label, { t: mockedT } as any, interview, `${p2t2segmentsPath}.segmentId1P2T2.modePre`);
+        expect(() => translateString(label, { t: mockedT } as any, interview, invalidPath)).toThrow('Error: trip, journey or person is null in getModePreWidgetConfig, they should all be defined');
         expect(mockedT).not.toHaveBeenCalled();
-        expect(modeLabel).toEqual('');
     });
 
     test('should return another label if segment is not the first', () => {

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetTripSegmentsIntro.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetTripSegmentsIntro.test.ts
@@ -6,34 +6,7 @@
  */
 import _cloneDeep from 'lodash/cloneDeep';
 import { getTripSegmentsIntro } from '../widgetTripSegmentsIntro';
-import { interviewAttributesForTestCases } from '../../../../../tests/surveys';
-import * as odHelpers from '../../../../odSurvey/helpers';
-
-jest.mock('../../../../odSurvey/helpers', () => {
-    // Do not mock what does not need to be mocked, to avoid mocking everything.
-    const originalModule = jest.requireActual('../../../../odSurvey/helpers');
-
-    // FIXME Initially, we mocked everything that was called, it may not be necessary to mock them all
-    return {
-        ...originalModule,
-        getPerson: jest.fn().mockReturnValue({}),
-        getActiveJourney: jest.fn().mockReturnValue({}),
-        getActiveTrip: jest.fn().mockReturnValue({}),
-        getVisitedPlaces: jest.fn().mockReturnValue({}),
-        getOrigin: jest.fn().mockReturnValue({ activity: 'home', _uuid: 'originuuid', _sequence: 1 }),
-        getDestination: jest.fn().mockReturnValue({ activity: 'work', _uuid: 'originuuid', _sequence: 2 }),
-        getVisitedPlaceName: jest.fn().mockReturnValue('visitedPlaceName'),
-        getCountOrSelfDeclared: jest.fn().mockReturnValue(1),
-    };
-});
-const mockedGetPerson = odHelpers.getPerson as jest.MockedFunction<typeof odHelpers.getPerson>;
-const mockedGetActiveJourney = odHelpers.getActiveJourney as jest.MockedFunction<typeof odHelpers.getActiveJourney>;
-const mockedGetActiveTrip = odHelpers.getActiveTrip as jest.MockedFunction<typeof odHelpers.getActiveTrip>;
-const mockedGetVisitedPlaces = odHelpers.getVisitedPlaces as jest.MockedFunction<typeof odHelpers.getVisitedPlaces>;
-const mockedGetOrigin = odHelpers.getOrigin as jest.MockedFunction<typeof odHelpers.getOrigin>;
-const mockedGetDestination = odHelpers.getDestination as jest.MockedFunction<typeof odHelpers.getDestination>;
-const mockedGetVisitedPlaceName = odHelpers.getVisitedPlaceName as jest.MockedFunction<typeof odHelpers.getVisitedPlaceName>;
-const mockedGetCountOrSelfDeclared = odHelpers.getCountOrSelfDeclared as jest.MockedFunction<typeof odHelpers.getCountOrSelfDeclared>;
+import { interviewAttributesForTestCases, setActiveSurveyObjects } from '../../../../../tests/surveys';
 
 beforeEach(() => {
     jest.clearAllMocks();
@@ -63,108 +36,81 @@ describe('tripSegmentsIntro text', () => {
 
     const widgetText = getTripSegmentsIntro(options).text as any;
     const mockedT = jest.fn().mockReturnValue('translatedString');
+    const p2t2segmentsPath = 'household.persons.personId2.journeys.journeyId2.trips.tripId2P2.segments';
    
-    test('should return empty if no person', () => {
-        mockedGetPerson.mockReturnValueOnce(null);
-        expect(widgetText(mockedT, interviewAttributesForTestCases, 'path')).toEqual('');
-        expect(mockedGetVisitedPlaceName).not.toHaveBeenCalled();
-        expect(mockedGetVisitedPlaces).not.toHaveBeenCalled();
-        expect(mockedT).not.toHaveBeenCalled();
-    });
-
-    test('should return empty if no active journey', () => {
-        mockedGetActiveJourney.mockReturnValueOnce(null);
-        expect(widgetText(mockedT, interviewAttributesForTestCases, 'path')).toEqual('');
-        expect(mockedGetVisitedPlaceName).not.toHaveBeenCalled();
-        expect(mockedGetVisitedPlaces).not.toHaveBeenCalled();
-        expect(mockedT).not.toHaveBeenCalled();
-    });
-
-    test('should return empty if no active trip', () => {
-        mockedGetActiveTrip.mockReturnValueOnce(null);
-        expect(widgetText(mockedT, interviewAttributesForTestCases, 'path')).toEqual('');
-        expect(mockedGetVisitedPlaceName).not.toHaveBeenCalled();
-        expect(mockedGetVisitedPlaces).not.toHaveBeenCalled();
+    test('should throw an error if no person/journey/trip context', () => {
+        // Use a path that does not resolve to anything
+        const invalidPath = 'invalid.path';
+        expect(() => widgetText(mockedT, interviewAttributesForTestCases, invalidPath)).toThrow('trip segments intro: trip, journey or person not found');
         expect(mockedT).not.toHaveBeenCalled();
     });
 
     test('should return empty if no origin', () => {
-        mockedGetOrigin.mockReturnValueOnce(null);
-        expect(widgetText(mockedT, interviewAttributesForTestCases, 'path')).toEqual('');
-        expect(mockedGetVisitedPlaceName).not.toHaveBeenCalled();
-        expect(mockedGetVisitedPlaces).toHaveBeenCalled();
+        // Set the origin to an unexisting place
+        const testInterview = _cloneDeep(interviewAttributesForTestCases);
+        setActiveSurveyObjects(testInterview, { personId: 'personId2', journeyId: 'journeyId2', activeTripId: 'tripId2P2' });
+        testInterview.response.household!.persons!.personId2.journeys!.journeyId2.trips!.tripId2P2._originVisitedPlaceUuid = 'unexisting';
+
+        expect(widgetText(mockedT, testInterview, p2t2segmentsPath)).toEqual('');
         expect(mockedT).not.toHaveBeenCalled();
     });
 
     test('should return empty if no destination', () => {
-        mockedGetDestination.mockReturnValueOnce(null);
-        expect(widgetText(mockedT, interviewAttributesForTestCases, 'path')).toEqual('');
-        expect(mockedGetVisitedPlaceName).not.toHaveBeenCalled();
-        expect(mockedGetVisitedPlaces).toHaveBeenCalled();
+        const testInterview = _cloneDeep(interviewAttributesForTestCases);
+        setActiveSurveyObjects(testInterview, { personId: 'personId2', journeyId: 'journeyId2', activeTripId: 'tripId2P2' });
+        testInterview.response.household!.persons!.personId2.journeys!.journeyId2.trips!.tripId2P2._destinationVisitedPlaceUuid = 'unexisting';
+
+        expect(widgetText(mockedT, testInterview, p2t2segmentsPath)).toEqual('');
         expect(mockedT).not.toHaveBeenCalled();
     });
 
     test('should return correct string with normal activities', () => {
-        mockedGetVisitedPlaceName.mockReturnValueOnce('originName').mockReturnValueOnce('destinationName');
-        expect(widgetText(mockedT, interviewAttributesForTestCases, 'path')).toEqual('translatedString');
-        expect(mockedGetVisitedPlaceName).toHaveBeenCalledTimes(2);
-        expect(mockedGetVisitedPlaces).toHaveBeenCalled();
+        // Set the origin to an unexisting place
+        const testInterview = _cloneDeep(interviewAttributesForTestCases);
+        setActiveSurveyObjects(testInterview, { personId: 'personId2', journeyId: 'journeyId2', activeTripId: 'tripId2P2' });
+        
+        expect(widgetText(mockedT, testInterview)).toEqual('translatedString');
         expect(mockedT).toHaveBeenCalledWith(['customSurvey:segments:CurrentTripSegmentsIntro', 'segments:CurrentTripSegmentsIntro'], {
-            context: 'work',
-            count: 1,
-            originName: 'originName',
-            destinationName: 'destinationName'
+            context: 'other',
+            count: 3,
+            destinationName: testInterview.response.household!.persons!.personId2.journeys!.journeyId2.visitedPlaces!.otherWorkPlace1P2.name,
+            // leads to shortcut
+            originName: testInterview.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!.otherPlace2P1.name
         });
-        expect(options.context).toHaveBeenCalledWith('work');
+        expect(options.context).toHaveBeenCalledWith('other');
     });
 
     test('should return correct string with loop activity at origin', () => {
-        mockedGetOrigin.mockReturnValueOnce({ activity: 'leisureStroll', _uuid: 'originuuid', _sequence: 1 });
-        mockedGetVisitedPlaceName.mockReturnValueOnce('originName').mockReturnValueOnce('destinationName');
-        expect(widgetText(mockedT, interviewAttributesForTestCases, 'path')).toEqual('translatedString');
-        expect(mockedGetVisitedPlaceName).toHaveBeenCalledTimes(2);
-        expect(mockedGetVisitedPlaces).toHaveBeenCalled();
+        // Set the origin place's activity to a loop activity, taking the first trip instead of second, as it is not a shortcut
+        const testInterview = _cloneDeep(interviewAttributesForTestCases);
+        setActiveSurveyObjects(testInterview, { personId: 'personId2', journeyId: 'journeyId2', activeTripId: 'tripId1P2' });
+        testInterview.response.household!.persons!.personId2.journeys!.journeyId2.visitedPlaces!.homePlace1P2.activity = 'leisureStroll';
+        expect(widgetText(mockedT, testInterview)).toEqual('translatedString');
         expect(mockedT).toHaveBeenCalledWith(['customSurvey:segments:CurrentTripSegmentsIntro', 'segments:CurrentTripSegmentsIntro'], {
             context: 'leisureStroll',
-            count: 1,
-            originName: 'originName',
-            destinationName: 'destinationName'
+            count: 3,
+            originName: 'translatedString', // origin has no name
+            // leads to shortcut
+            destinationName: testInterview.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!.otherPlace2P1.name
         });
+        expect(mockedT).toHaveBeenCalledWith('survey:placeWithSequenceGeneric', { sequence: 1 });
         expect(options.context).toHaveBeenCalledWith('leisureStroll');
     });
 
     test('should return correct string with normal activities and no context function', () => {
+        // No context sent as options
         const widgetText = getTripSegmentsIntro().text as any;
-        mockedGetOrigin.mockReturnValueOnce({ activity: 'leisureStroll', _uuid: 'originuuid', _sequence: 1 });
-        mockedGetVisitedPlaceName.mockReturnValueOnce('originName').mockReturnValueOnce('destinationName');
-        expect(widgetText(mockedT, interviewAttributesForTestCases, 'path')).toEqual('translatedString');
-        expect(mockedGetVisitedPlaceName).toHaveBeenCalledTimes(2);
-        expect(mockedGetVisitedPlaces).toHaveBeenCalled();
+        const testInterview = _cloneDeep(interviewAttributesForTestCases);
+        setActiveSurveyObjects(testInterview, { personId: 'personId2', journeyId: 'journeyId2', activeTripId: 'tripId2P2' });
+        
+        expect(widgetText(mockedT, testInterview)).toEqual('translatedString');
         expect(mockedT).toHaveBeenCalledWith(['customSurvey:segments:CurrentTripSegmentsIntro', 'segments:CurrentTripSegmentsIntro'], {
-            context: 'leisureStroll',
-            count: 1,
-            originName: 'originName',
-            destinationName: 'destinationName'
+            context: 'other',
+            count: 3,
+            destinationName: testInterview.response.household!.persons!.personId2.journeys!.journeyId2.visitedPlaces!.otherWorkPlace1P2.name,
+            // leads to shortcut
+            originName: testInterview.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!.otherPlace2P1.name
         });
-    });
-
-    test('should return correct string with normal activities, context and person count', () => {
-        const context = 'context';
-        const count = 3;
-        options.context.mockReturnValueOnce('context');
-        mockedGetCountOrSelfDeclared.mockReturnValueOnce(count);
-
-        mockedGetVisitedPlaceName.mockReturnValueOnce('originName').mockReturnValueOnce('destinationName');
-        expect(widgetText(mockedT, interviewAttributesForTestCases, 'path')).toEqual('translatedString');
-        expect(mockedGetVisitedPlaceName).toHaveBeenCalledTimes(2);
-        expect(mockedGetVisitedPlaces).toHaveBeenCalled();
-        expect(mockedT).toHaveBeenCalledWith(['customSurvey:segments:CurrentTripSegmentsIntro', 'segments:CurrentTripSegmentsIntro'], {
-            context,
-            count,
-            originName: 'originName',
-            destinationName: 'destinationName'
-        });
-        expect(options.context).toHaveBeenCalledWith('work');
     });
 
 });

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/buttonSaveTripSegments.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/buttonSaveTripSegments.ts
@@ -34,8 +34,15 @@ export const getButtonSaveTripSegmentsConfig = (options: WidgetFactoryOptions): 
                 const segmentPath = `${segmentsPath}.${segmentUuid}`;
                 updateValuesbyPath[`response.${segmentPath}._isNew`] = false;
             }
-            const journey = odHelpers.getActiveJourney({ interview });
-            const nextTrip = journey !== null ? odHelpers.selectNextIncompleteTrip({ journey }) : null;
+            const journeyContext = odHelpers.getJourneyContextFromPath({ interview, path });
+            const activeJourney = odHelpers.getActiveJourney({ interview });
+            // Select next active trip if journey is the active one
+            const nextTrip =
+                journeyContext !== null &&
+                activeJourney !== null &&
+                journeyContext.journey._uuid === activeJourney?._uuid
+                    ? odHelpers.selectNextIncompleteTrip({ journey: journeyContext.journey })
+                    : null;
             updateValuesbyPath['response._activeTripId'] = nextTrip ? nextTrip._uuid : null;
             callbacks.startUpdateInterview({ sectionShortname: 'segments', valuesByPath: updateValuesbyPath });
         },

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/helpers.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/helpers.ts
@@ -20,24 +20,22 @@ import type {
 } from '../../types';
 
 /**
- * Get the mode used in the single segment of the previous trip of the active
+ * Get the mode used in the single segment of the previous trip of the current
  * one
  *
  * @param {Object} options - The options object.
- * @param {Object} options.interview The interview object
- * @param {Object} options.person The person these trips belong to
+ * @param {Object} options.journey The journey object that these trips are part of
+ * @param {Object} options.trip The current trip object
  * @returns If there is a single mode in the previous trip, return it, otherwise
  * undefined
  */
 export const getPreviousTripSingleSegment = ({
-    interview,
-    person
+    journey,
+    trip
 }: {
-    interview: UserInterviewAttributes;
-    person: Person;
+    journey: Journey;
+    trip: Trip;
 }): Optional<Segment> => {
-    const journey = odHelpers.getActiveJourney({ interview, person });
-    const trip = odHelpers.getActiveTrip({ interview, journey });
     if (!journey || !trip) {
         return undefined;
     }
@@ -135,25 +133,25 @@ export const isSimpleChainSingleModeReturnTrip = ({
 
 export const shouldShowSameAsReverseTripQuestion = ({
     interview,
-    segment
+    path
 }: {
     interview: UserInterviewAttributes;
-    segment: Segment;
+    path: string;
 }): boolean => {
+    const segmentContext = odHelpers.getSegmentContextFromPath({ interview, path });
+    if (!segmentContext) {
+        throw new Error('shouldShowSameAsReverseTripQuestion: segment context not found for path ' + path);
+    }
+    const { person, journey, trip, segment } = segmentContext;
     // Do not display if segment is not new
     if (segment._isNew === false) {
         return false;
     }
     // Display this question if the segment is new and the previous and current
     // trips form a simple chain with a single mode
-    const person = odHelpers.getPerson({ interview }) as Person;
-    const journey = odHelpers.getActiveJourney({ interview, person }) as Journey;
-    const trip = odHelpers.getActiveTrip({ interview, journey });
-    const previousTrip = trip !== null ? odHelpers.getPreviousTrip({ currentTrip: trip, journey }) : null;
+    const previousTrip = odHelpers.getPreviousTrip({ currentTrip: trip, journey });
     return (
-        trip !== null &&
-        previousTrip !== null &&
-        isSimpleChainSingleModeReturnTrip({ interview, journey, person, trip, previousTrip })
+        previousTrip !== null && isSimpleChainSingleModeReturnTrip({ interview, journey, person, trip, previousTrip })
     );
 };
 

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/widgetDriver.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/widgetDriver.ts
@@ -116,8 +116,8 @@ export const getSegmentDriverWidgetConfig = (
         inputType: 'select',
         datatype: 'string',
         twoColumns: false,
-        label: (t: TFunction, interview) => {
-            const person = odHelpers.getActivePerson({ interview });
+        label: (t: TFunction, interview, path) => {
+            const person = odHelpers.getPerson({ interview, path });
             return t('segments:Driver', {
                 context: person?.gender || person?.sexAssignedAtBirth,
                 count: person ? odHelpers.getCountOrSelfDeclared({ interview, person }) : 1
@@ -129,14 +129,14 @@ export const getSegmentDriverWidgetConfig = (
             if (mode !== 'carPassenger') {
                 return [false, null];
             }
-            const trip = odHelpers.getActiveTrip({ interview });
-            const journey = odHelpers.getActiveJourney({ interview });
-            if (!trip || !journey) {
+            const tripContext = odHelpers.getTripContextFromPath({ interview, path });
+            if (!tripContext) {
                 console.error(
                     'Error: trip or journey is null in getSegmentHasNextModeWidgetConfig, they should both be defined'
                 );
                 return [false, null];
             }
+            const { journey, trip } = tripContext;
             const visitedPlaces = odHelpers.getVisitedPlaces({ journey });
             const destination = odHelpers.getDestination({ visitedPlaces, trip });
             const activity = destination ? destination.activity : null;

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/widgetPersonTripsTitle.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/widgetPersonTripsTitle.ts
@@ -20,17 +20,20 @@ export const getPersonsTripsTitleWidgetConfig = (
     return {
         type: 'text',
         align: 'left',
-        text: (t: TFunction, interview: UserInterviewAttributes, _path: string) => {
+        text: (t: TFunction, interview: UserInterviewAttributes) => {
             const person = odHelpers.getActivePerson({ interview });
             const journey = odHelpers.getActiveJourney({ interview });
+            if (!person || !journey) {
+                throw new Error('personTripsTitle: Person or Journey not found');
+            }
             // FIXME Write a function somewhere to get the journey's or dateToString function, once we move to objects
             // FIXME2 Plan for a translation string that has a period (undated, dated, period)
-            const journeyDates = journey && journey.startDate ? options.getFormattedDate(journey.startDate) : null;
+            const journeyDates = journey.startDate ? options.getFormattedDate(journey.startDate) : null;
             return t(['customSurvey:segments:Description', 'segments:Description'], {
                 context: getContext(journeyDates === null ? 'undated' : undefined),
-                nickname: person !== null && person.nickname ? person.nickname : '',
+                nickname: person.nickname ? person.nickname : '',
                 journeyDates,
-                count: person === null ? 1 : odHelpers.getCountOrSelfDeclared({ interview, person })
+                count: odHelpers.getCountOrSelfDeclared({ interview, person })
             });
         }
     };

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/widgetSameAsReverseTrip.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/widgetSameAsReverseTrip.ts
@@ -6,11 +6,9 @@
  */
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { WidgetConfig } from '../../../questionnaire/types';
-import { getResponse } from '../../../../utils/helpers';
 import { TFunction } from 'i18next';
 import * as odHelpers from '../../../odSurvey/helpers';
 import { getPreviousTripSingleSegment, shouldShowSameAsReverseTripQuestion } from './helpers';
-import { Journey, Person } from '../../types';
 import { yesNoChoices } from '../common/choices';
 
 export const getSameAsReverseTripWidgetConfig = (
@@ -23,11 +21,13 @@ export const getSameAsReverseTripWidgetConfig = (
         inputType: 'radio',
         twoColumns: false,
         datatype: 'boolean',
-        label: (t: TFunction, interview, _path) => {
-            const person = odHelpers.getPerson({ interview }) as Person;
-            const previousSegment = getPreviousTripSingleSegment({ interview, person });
-            const journey = odHelpers.getActiveJourney({ interview, person }) as Journey;
-            const trip = odHelpers.getActiveTrip({ interview, journey });
+        label: (t: TFunction, interview, path) => {
+            const tripContext = odHelpers.getTripContextFromPath({ interview, path });
+            if (!tripContext) {
+                throw new Error('Trip context not found for path ' + path);
+            }
+            const { person, journey, trip } = tripContext;
+            const previousSegment = getPreviousTripSingleSegment({ journey, trip });
             const visitedPlaces = odHelpers.getVisitedPlaces({ journey });
             const destination = trip ? odHelpers.getDestination({ trip, visitedPlaces }) : undefined;
             const labelWithDestination = `segments:SegmentSameModeReturn${destination && destination.activity === 'home' ? 'Home' : ''}`;
@@ -52,9 +52,6 @@ export const getSameAsReverseTripWidgetConfig = (
                 }
             ];
         },
-        conditional: (interview, path) => {
-            const segment: any = getResponse(interview, path, null, '../');
-            return [shouldShowSameAsReverseTripQuestion({ interview, segment }), null];
-        }
+        conditional: (interview, path) => [shouldShowSameAsReverseTripQuestion({ interview, path }), null]
     };
 };

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/widgetSegmentHasNextMode.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/widgetSegmentHasNextMode.ts
@@ -6,11 +6,9 @@
  */
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { WidgetConfig } from '../../../questionnaire/types';
-import { getResponse } from '../../../../utils/helpers';
 import { TFunction } from 'i18next';
 import * as odHelpers from '../../../odSurvey/helpers';
 import { getPreviousTripSingleSegment, shouldShowSameAsReverseTripQuestion } from './helpers';
-import { Journey, Person } from '../../types';
 import { yesNoChoices } from '../common/choices';
 
 export const getSegmentHasNextModeWidgetConfig = (
@@ -23,10 +21,12 @@ export const getSegmentHasNextModeWidgetConfig = (
         inputType: 'radio',
         twoColumns: false,
         datatype: 'boolean',
-        label: (t: TFunction, interview) => {
-            const person = odHelpers.getPerson({ interview }) as Person;
-            const journey = odHelpers.getActiveJourney({ interview, person }) as Journey;
-            const trip = odHelpers.getActiveTrip({ interview, journey });
+        label: (t: TFunction, interview, path) => {
+            const tripContext = odHelpers.getTripContextFromPath({ interview, path });
+            if (!tripContext) {
+                throw new Error('Trip context not found for path ' + path);
+            }
+            const { person, journey, trip } = tripContext;
             const visitedPlaces = odHelpers.getVisitedPlaces({ journey });
             const origin = trip ? odHelpers.getOrigin({ trip, visitedPlaces }) : undefined;
             const destination = trip ? odHelpers.getDestination({ trip, visitedPlaces }) : undefined;
@@ -66,15 +66,19 @@ export const getSegmentHasNextModeWidgetConfig = (
             ];
         },
         conditional: (interview, path) => {
-            const segment: any = getResponse(interview, path, null, '../');
-            const shouldShowSameAsReverseTrip = shouldShowSameAsReverseTripQuestion({ interview, segment });
+            const segmentContext = odHelpers.getSegmentContextFromPath({ interview, path });
+            if (!segmentContext) {
+                throw new Error('Segment context not found for path ' + path);
+            }
+            const { journey, trip, segment } = segmentContext;
+            const shouldShowSameAsReverseTrip = shouldShowSameAsReverseTripQuestion({ interview, path });
             // Do not show if the question of the same mode as previous trip is shown and the answer is not 'no'
             if (shouldShowSameAsReverseTrip && segment.sameModeAsReverseTrip !== false) {
                 if (segment.sameModeAsReverseTrip === true) {
                     // If the question of the same mode as previous trip is shown and the answer is yes, then there is no next mode
                     const previousTripSegment = getPreviousTripSingleSegment({
-                        interview,
-                        person: odHelpers.getActivePerson({ interview }) as Person
+                        journey,
+                        trip
                     });
                     if (previousTripSegment && previousTripSegment.modePre !== undefined) {
                         return [false, false];
@@ -84,11 +88,7 @@ export const getSegmentHasNextModeWidgetConfig = (
                 return [false, null];
             }
             // Otherwise, get the segments of the current trip and show only for the last segment
-            const trip = odHelpers.getActiveTrip({ interview });
-            const segments = trip?.segments ? trip.segments : {};
-            const segmentsArray = Object.values(segments).sort((segmentA, segmentB) => {
-                return segmentA['_sequence'] - segmentB['_sequence'];
-            });
+            const segmentsArray = odHelpers.getSegmentsArray({ trip });
             const lastSegment: any = segmentsArray[segmentsArray.length - 1];
             if (!lastSegment || segmentsArray.length === 1 || segment._sequence === lastSegment._sequence) {
                 return [true, null];

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/widgetSegmentMode.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/widgetSegmentMode.ts
@@ -12,7 +12,7 @@ import { TFunction } from 'i18next';
 import * as odHelpers from '../../../odSurvey/helpers';
 import * as segmentHelpers from './helpers';
 import { Mode, modePreToModeMap } from '../../../odSurvey/types';
-import type { Person, Segment } from '../../types';
+import type { Segment } from '../../types';
 import { getModeIcon } from './modeIconMapping';
 import { WidgetFactoryOptions } from '../types';
 
@@ -76,18 +76,22 @@ export const getModeWidgetConfig = (
             ];
         },
         conditional: function (interview, path) {
-            const segment = getResponse(interview, path, null, '../') as Segment;
+            const segmentContext = odHelpers.getSegmentContextFromPath({ interview, path });
+            if (!segmentContext) {
+                throw new Error('Segment context not found for path ' + path);
+            }
+            const { journey, trip, segment } = segmentContext;
             const shouldShowSameAsReverseTrip = segmentHelpers.shouldShowSameAsReverseTripQuestion({
                 interview,
-                segment
+                path
             });
             // Do not show if the question of the same mode as previous trip is shown and the answer is not 'no'
             if (shouldShowSameAsReverseTrip && segment.sameModeAsReverseTrip !== false) {
                 if (segment.sameModeAsReverseTrip === true) {
                     // If the question of the same mode as previous trip is shown and the answer is yes, the mode is the same as the previous trip
                     const previousTripSegment = segmentHelpers.getPreviousTripSingleSegment({
-                        interview,
-                        person: odHelpers.getActivePerson({ interview }) as Person
+                        journey,
+                        trip
                     });
                     if (previousTripSegment && previousTripSegment.mode !== undefined) {
                         return [false, previousTripSegment.mode];

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/widgetSegmentModePre.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/widgetSegmentModePre.ts
@@ -13,7 +13,7 @@ import * as odHelpers from '../../../odSurvey/helpers';
 import config from '../../../../config/project.config';
 import * as segmentHelpers from './helpers';
 import type { ModePre } from '../../../odSurvey/types';
-import type { Person, Segment } from '../../types';
+import type { Person } from '../../types';
 import { getModePreIcon } from './modeIconMapping';
 import { WidgetFactoryOptions } from '../types';
 
@@ -84,18 +84,17 @@ export const getModePreWidgetConfig = (
         columns: 2,
         choices,
         label: (t: TFunction, interview, path) => {
-            const person = odHelpers.getPerson({ interview });
-            const journey = odHelpers.getActiveJourney({ interview, person });
-            const sequence = getResponse(interview, path, null, '../_sequence');
-            const trip = odHelpers.getActiveTrip({ interview, journey });
-            const visitedPlaces = journey ? odHelpers.getVisitedPlaces({ journey }) : {};
-            // This should never happen, but just in case
-            if (!trip || !journey || !person) {
-                console.log(
+            const tripContext = odHelpers.getTripContextFromPath({ interview, path });
+            if (!tripContext) {
+                // This should not happen
+                throw new Error(
                     'Error: trip, journey or person is null in getModePreWidgetConfig, they should all be defined'
                 );
-                return '';
             }
+            const { person, journey, trip } = tripContext;
+
+            const sequence = getResponse(interview, path, null, '../_sequence');
+            const visitedPlaces = journey ? odHelpers.getVisitedPlaces({ journey }) : {};
             const origin = odHelpers.getOrigin({ trip: trip!, visitedPlaces });
             const originName = origin
                 ? odHelpers.getVisitedPlaceName({ t, visitedPlace: origin, interview })
@@ -127,18 +126,22 @@ export const getModePreWidgetConfig = (
             ];
         },
         conditional: function (interview, path) {
-            const segment = getResponse(interview, path, null, '../') as Segment;
+            const segmentContext = odHelpers.getSegmentContextFromPath({ interview, path });
+            if (!segmentContext) {
+                throw new Error('Segment context not found for path ' + path);
+            }
+            const { journey, trip, segment } = segmentContext;
             const shouldShowSameAsReverseTrip = segmentHelpers.shouldShowSameAsReverseTripQuestion({
                 interview,
-                segment
+                path
             });
             // Do not show if the question of the same mode as previous trip is shown and the answer is not 'no'
             if (shouldShowSameAsReverseTrip && segment.sameModeAsReverseTrip !== false) {
                 if (segment.sameModeAsReverseTrip === true) {
                     // If the question of the same mode as previous trip is shown and the answer is yes, the mode is the same as the previous trip
                     const previousTripSegment = segmentHelpers.getPreviousTripSingleSegment({
-                        interview,
-                        person: odHelpers.getActivePerson({ interview }) as Person
+                        journey,
+                        trip
                     });
                     if (previousTripSegment && previousTripSegment.modePre !== undefined) {
                         return [false, previousTripSegment.modePre];

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/widgetTripSegmentsIntro.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/widgetTripSegmentsIntro.ts
@@ -14,13 +14,13 @@ export const getTripSegmentsIntro = (
     options: { context?: (additionalContext?: string) => string } = {}
 ): TextWidgetConfig => ({
     type: 'text',
-    text: (t: TFunction, interview, _path) => {
+    text: (t: TFunction, interview) => {
         const person = odHelpers.getPerson({ interview });
         const journey = odHelpers.getActiveJourney({ interview, person });
         const trip = odHelpers.getActiveTrip({ interview, journey });
         if (!trip || !journey || !person) {
-            console.error('trip segments intro: trip, journey or person not found');
-            return '';
+            // This should not happen
+            throw new Error('trip segments intro: trip, journey or person not found');
         }
         const visitedPlaces = odHelpers.getVisitedPlaces({ journey });
         const origin = odHelpers.getOrigin({ trip, visitedPlaces });
@@ -29,10 +29,8 @@ export const getTripSegmentsIntro = (
             console.error('trip segments intro: origin or destination not found, trip is invalid');
             return '';
         }
-        const originName = origin ? odHelpers.getVisitedPlaceName({ visitedPlace: origin, t, interview }) : '';
-        const destinationName = destination
-            ? odHelpers.getVisitedPlaceName({ visitedPlace: destination, t, interview })
-            : '';
+        const originName = odHelpers.getVisitedPlaceName({ visitedPlace: origin, t, interview });
+        const destinationName = odHelpers.getVisitedPlaceName({ visitedPlace: destination, t, interview });
         // If origin or destination is a loopActivity, use this activity as context, otherwise, it's the destination
         const activityContext = odHelpers.isLoopActivity({ visitedPlace: origin })
             ? origin.activity

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/helpers.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/helpers.test.ts
@@ -117,13 +117,13 @@ describe('Visited places helpers - validatePreviousNextPlaceIsNotActivities', ()
     test('should warn and return true when there is no active journey', () => {
         const interview = _cloneDeep(interviewAttributesForTestCases);
         const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
-        const visitedPlace = interview.response.household!.persons!.personId1!.journeys!.journeyId1!.visitedPlaces!
-            .workPlace1P1;
+        // use a path that won't resolve to existing context
+        const path = 'household.persons.personId1.journeys.journeyId2.visitedPlaces.workPlace1P1';
 
         expect(
             helpers.validatePreviousNextPlaceIsCompatibleActivities({
                 interview,
-                visitedPlace,
+                path,
                 incompatibleConsecutiveActivities: ['home']
             })
         ).toEqual(true);
@@ -133,67 +133,61 @@ describe('Visited places helpers - validatePreviousNextPlaceIsNotActivities', ()
     });
 
     test.each([
-        [
-            'previous place activity is incompatible',
-            (interview: typeof interviewAttributesForTestCases) => {
+        {
+            title: 'previous place activity is incompatible',
+            setupTest: (interview: typeof interviewAttributesForTestCases) => {
                 setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
                 return {
-                    visitedPlace:
-                        interview.response.household!.persons!.personId1!.journeys!.journeyId1!.visitedPlaces!
-                            .workPlace1P1,
+                    path: 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.someField',
                     incompatibleConsecutiveActivities: ['home'] as Activity[]
                 };
             },
-            false
-        ],
-        [
-            'next place activity is incompatible',
-            (interview: typeof interviewAttributesForTestCases) => {
+            expected: false
+        },
+        {
+            title: 'next place activity is incompatible',
+            setupTest: (interview: typeof interviewAttributesForTestCases) => {
                 setActiveSurveyObjects(interview, { personId: 'personId2', journeyId: 'journeyId2', visitedPlaceId: 'otherWorkPlace1P2' });
                 return {
-                    visitedPlace:
-                        interview.response.household!.persons!.personId2!.journeys!.journeyId2!.visitedPlaces!
-                            .otherWorkPlace1P2,
+                    path: 'household.persons.personId2.journeys.journeyId2.visitedPlaces.otherWorkPlace1P2.someField',
                     incompatibleConsecutiveActivities: ['home'] as Activity[]
                 };
             },
-            false
-        ],
-        [
-            'previous and next activities are not incompatible',
-            (interview: typeof interviewAttributesForTestCases) => {
+            expected: false
+        },
+        {
+            title: 'previous and next activities are not incompatible',
+            setupTest: (interview: typeof interviewAttributesForTestCases) => {
                 setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
                 return {
-                    visitedPlace:
-                        interview.response.household!.persons!.personId1!.journeys!.journeyId1!.visitedPlaces!
-                            .workPlace1P1,
+                    path: 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.someField',
                     incompatibleConsecutiveActivities: ['shopping'] as Activity[]
                 };
             },
-            true
-        ],
-        [
-            'adjacent places have blank activities',
-            (interview: typeof interviewAttributesForTestCases) => {
+            expected: true
+        },
+        {
+            title: 'adjacent places have blank activities',
+            setupTest: (interview: typeof interviewAttributesForTestCases) => {
                 setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
                 const journey = interview.response.household!.persons!.personId1!.journeys!.journeyId1!;
                 journey.visitedPlaces!.homePlace1P1.activity = undefined;
                 journey.visitedPlaces!.homePlace2P1.activity = undefined;
                 return {
-                    visitedPlace: journey.visitedPlaces!.workPlace1P1,
+                    path: 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.someField',
                     incompatibleConsecutiveActivities: ['home'] as Activity[]
                 };
             },
-            true
-        ]
-    ])('should return %s: %s', (_title, setupTest, expected) => {
+            expected: true
+        }
+    ])('should return $title: $expected', ({ setupTest, expected}) => {
         const interview = _cloneDeep(interviewAttributesForTestCases);
-        const { visitedPlace, incompatibleConsecutiveActivities } = setupTest(interview);
+        const { path, incompatibleConsecutiveActivities } = setupTest(interview);
 
         expect(
             helpers.validatePreviousNextPlaceIsCompatibleActivities({
                 interview,
-                visitedPlace,
+                path,
                 incompatibleConsecutiveActivities
             })
         ).toEqual(expected);

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetActivity.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetActivity.test.ts
@@ -17,6 +17,7 @@ import {
 } from '../../../../odSurvey/types';
 import * as odHelpers from '../../../../odSurvey/helpers';
 import { getActivityWidgetConfig } from '../widgetActivity';
+import * as visitedPlacesHelpers from '../helpers';
 
 const visitedPlacesSectionConfig = {
     type: 'visitedPlaces' as const,
@@ -75,26 +76,34 @@ describe('Activity choices conditionals', () => {
         'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.activity';
     const activityCategoryPath =
         'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.activityCategory';
+    // Make sure we have carsharing members for the carsharingStation conditional
+    interview.response.household!.persons!.personId1!.carsharingMember = 'yes';
 
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
     each(
         activityValues.flatMap((activity) =>
-            activityCategoryValues.map((activityCategory) => [
+            activityCategoryValues.map((activityCategory) => ({
                 activity,
                 activityCategory,
-                activityToDisplayCategory[activity].includes(activityCategory)
-            ])
+                expected: activityToDisplayCategory[activity].includes(activityCategory)
+            }))
         )
     ).test(
-        'activity %s should be shown for activityCategory %s: %s',
-        (activityValue, activityCategoryValue, expected) => {
-            const activityChoice = choices.find((choice) => choice.value === activityValue);
+        'activity $activity should be shown for activityCategory $activityCategory: $expected',
+        ({ activity, activityCategory, expected }) => {
+            // Make sure this function returns true as we do not setup the whole interview for this test, we just want to test the presence of the category.
+            jest.spyOn(visitedPlacesHelpers, 'validatePreviousNextPlaceIsCompatibleActivities').mockReturnValue(true);
+            const activityChoice = choices.find((choice) => choice.value === activity);
             expect(activityChoice).toBeDefined();
 
-            setResponse(interview, activityCategoryPath, activityCategoryValue);
+            setResponse(interview, activityCategoryPath, activityCategory);
             const result = activityChoice?.conditional?.(interview, activityPath);
             expect(result).toEqual(expected);
         }

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetActivityCategory.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetActivityCategory.test.ts
@@ -13,207 +13,207 @@ import * as odHelpers from '../../../../odSurvey/helpers';
 import { getActivityCategoryWidgetConfig } from '../widgetActivityCategory';
 
 const visitedPlacesSectionConfig = {
-	type: 'visitedPlaces' as const,
-	enabled: true,
+    type: 'visitedPlaces' as const,
+    enabled: true,
     tripDiaryMinTimeOfDay: 4 * 60 * 60, // 4h in seconds
     tripDiaryMaxTimeOfDay: 28 * 60 * 60 // 28h in seconds (i.e. 4h the next day)
 };
 
 describe('getActivityCategoryWidgetConfig', () => {
-	test('should return the correct widget config', () => {
-		const widgetConfig = getActivityCategoryWidgetConfig(
-			visitedPlacesSectionConfig,
-			widgetFactoryOptions
-		) as QuestionWidgetConfig & InputRadioType;
+    test('should return the correct widget config', () => {
+        const widgetConfig = getActivityCategoryWidgetConfig(
+            visitedPlacesSectionConfig,
+            widgetFactoryOptions
+        ) as QuestionWidgetConfig & InputRadioType;
 
-		expect(widgetConfig).toEqual({
-			type: 'question',
-			path: 'activityCategory',
-			inputType: 'radio',
-			twoColumns: false,
-			datatype: 'string',
-			columns: 2,
-			containsHtml: true,
-			useAssignedValueOnHide: true,
-			choices: expect.arrayContaining([
-				expect.objectContaining({ value: 'home', label: expect.any(Function), conditional: expect.any(Function) }),
-				expect.objectContaining({ value: 'work', label: expect.any(Function), conditional: expect.any(Function) }),
-				expect.objectContaining({ value: 'school', label: expect.any(Function), conditional: expect.any(Function) }),
-				expect.objectContaining({ value: 'shoppingServiceRestaurant', label: expect.any(Function) }),
-				expect.objectContaining({ value: 'dropFetchSomeone', label: expect.any(Function) }),
-				expect.objectContaining({ value: 'leisure', label: expect.any(Function) }),
-				expect.objectContaining({ value: 'otherParentHome', label: expect.any(Function), conditional: expect.any(Function) }),
-				expect.objectContaining({ value: 'other', label: expect.any(Function) })
-			]),
-			label: expect.any(Function),
-			validations: expect.any(Function),
-			conditional: expect.any(Function)
-		});
-	});
+        expect(widgetConfig).toEqual({
+            type: 'question',
+            path: 'activityCategory',
+            inputType: 'radio',
+            twoColumns: false,
+            datatype: 'string',
+            columns: 2,
+            containsHtml: true,
+            useAssignedValueOnHide: true,
+            choices: expect.arrayContaining([
+                expect.objectContaining({ value: 'home', label: expect.any(Function), conditional: expect.any(Function) }),
+                expect.objectContaining({ value: 'work', label: expect.any(Function), conditional: expect.any(Function) }),
+                expect.objectContaining({ value: 'school', label: expect.any(Function), conditional: expect.any(Function) }),
+                expect.objectContaining({ value: 'shoppingServiceRestaurant', label: expect.any(Function) }),
+                expect.objectContaining({ value: 'dropFetchSomeone', label: expect.any(Function) }),
+                expect.objectContaining({ value: 'leisure', label: expect.any(Function) }),
+                expect.objectContaining({ value: 'otherParentHome', label: expect.any(Function), conditional: expect.any(Function) }),
+                expect.objectContaining({ value: 'other', label: expect.any(Function) })
+            ]),
+            label: expect.any(Function),
+            validations: expect.any(Function),
+            conditional: expect.any(Function)
+        });
+    });
 });
 
 describe('Activity category choices labels', () => {
-	const widgetConfig = getActivityCategoryWidgetConfig(
-		visitedPlacesSectionConfig,
-		widgetFactoryOptions
-	) as QuestionWidgetConfig & InputRadioType;
-	const choices = widgetConfig.choices as RadioChoiceType[];
-	const interview = _cloneDeep(interviewAttributesForTestCases);
+    const widgetConfig = getActivityCategoryWidgetConfig(
+        visitedPlacesSectionConfig,
+        widgetFactoryOptions
+    ) as QuestionWidgetConfig & InputRadioType;
+    const choices = widgetConfig.choices as RadioChoiceType[];
+    const interview = _cloneDeep(interviewAttributesForTestCases);
 
-	each([
-		['home', 'visitedPlaces:activityCategories.home'],
-		['work', 'visitedPlaces:activityCategories.work'],
-		['shoppingServiceRestaurant', 'visitedPlaces:activityCategories.shoppingServiceRestaurant'],
-		['dropFetchSomeone', 'visitedPlaces:activityCategories.dropFetchSomeone'],
-		['leisure', 'visitedPlaces:activityCategories.leisure'],
-		['otherParentHome', 'visitedPlaces:activityCategories.otherParentHome'],
-		['other', 'visitedPlaces:activityCategories.other']
-	]).test('should return the right label for %s choice', (choiceValue, expectedLabel) => {
-		const mockedT = jest.fn();
-		const choice = choices.find((c) => c.value === choiceValue);
-		expect(choice).toBeDefined();
-		translateString(choice?.label, { t: mockedT } as any, interview, 'path');
-		expect(mockedT).toHaveBeenCalledWith(expectedLabel);
-	});
+    each([
+        ['home', 'visitedPlaces:activityCategories.home'],
+        ['work', 'visitedPlaces:activityCategories.work'],
+        ['shoppingServiceRestaurant', 'visitedPlaces:activityCategories.shoppingServiceRestaurant'],
+        ['dropFetchSomeone', 'visitedPlaces:activityCategories.dropFetchSomeone'],
+        ['leisure', 'visitedPlaces:activityCategories.leisure'],
+        ['otherParentHome', 'visitedPlaces:activityCategories.otherParentHome'],
+        ['other', 'visitedPlaces:activityCategories.other']
+    ]).test('should return the right label for %s choice', (choiceValue, expectedLabel) => {
+        const mockedT = jest.fn();
+        const choice = choices.find((c) => c.value === choiceValue);
+        expect(choice).toBeDefined();
+        translateString(choice?.label, { t: mockedT } as any, interview, 'path');
+        expect(mockedT).toHaveBeenCalledWith(expectedLabel);
+    });
 
-	each([
-		['childcare', 'visitedPlaces:activityCategories.childcare'],
-		['kindergarten', 'visitedPlaces:activityCategories.kindergarten'],
-		['kindergartenFor4YearsOld', 'visitedPlaces:activityCategories.school'],
-		['primarySchool', 'visitedPlaces:activityCategories.school'],
-		['secondarySchool', 'visitedPlaces:activityCategories.school'],
-		['university', 'visitedPlaces:activityCategories.schoolStudies']
-	]).test('school label should use right translation key for schoolType %s', (schoolType, expectedLabel) => {
-		const mockedT = jest.fn();
-		const schoolChoice = choices.find((c) => c.value === 'school');
-		expect(schoolChoice).toBeDefined();
-		setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
-		interview.response.household!.persons!.personId1!.schoolType = schoolType as any;
-		translateString(schoolChoice?.label, { t: mockedT } as any, interview, 'path');
-		expect(mockedT).toHaveBeenCalledWith(expectedLabel);
-	});
+    each([
+        ['childcare', 'visitedPlaces:activityCategories.childcare'],
+        ['kindergarten', 'visitedPlaces:activityCategories.kindergarten'],
+        ['kindergartenFor4YearsOld', 'visitedPlaces:activityCategories.school'],
+        ['primarySchool', 'visitedPlaces:activityCategories.school'],
+        ['secondarySchool', 'visitedPlaces:activityCategories.school'],
+        ['university', 'visitedPlaces:activityCategories.schoolStudies']
+    ]).test('school label should use right translation key for schoolType %s', (schoolType, expectedLabel) => {
+        const mockedT = jest.fn();
+        const schoolChoice = choices.find((c) => c.value === 'school');
+        expect(schoolChoice).toBeDefined();
+        setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
+        interview.response.household!.persons!.personId1!.schoolType = schoolType as any;
+        translateString(schoolChoice?.label, { t: mockedT } as any, interview, 'path');
+        expect(mockedT).toHaveBeenCalledWith(expectedLabel);
+    });
 });
 
 describe('Activity category choices conditionals', () => {
-	const widgetConfig = getActivityCategoryWidgetConfig(
-		visitedPlacesSectionConfig,
-		widgetFactoryOptions
-	) as QuestionWidgetConfig & InputRadioType;
-	const choices = widgetConfig.choices as RadioChoiceType[];
+    const widgetConfig = getActivityCategoryWidgetConfig(
+        visitedPlacesSectionConfig,
+        widgetFactoryOptions
+    ) as QuestionWidgetConfig & InputRadioType;
+    const choices = widgetConfig.choices as RadioChoiceType[];
 
-	const mockedIsStudentFromSchoolType = jest.spyOn(odHelpers, 'isStudentFromSchoolType');
+    const mockedIsStudentFromSchoolType = jest.spyOn(odHelpers, 'isStudentFromSchoolType');
 
-	beforeEach(() => {
-		jest.clearAllMocks();
-	});
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
 
-	test('home conditional should return false when active person/journey/place is missing', () => {
-		const interview = _cloneDeep(interviewAttributesForTestCases);
-		const homeChoice = choices.find((c) => c.value === 'home');
-		expect(homeChoice).toBeDefined();
-		expect(homeChoice?.conditional?.(interview, 'path')).toEqual(false);
-	});
+    test('home conditional should return false when active person/journey/place is missing', () => {
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        const homeChoice = choices.find((c) => c.value === 'home');
+        expect(homeChoice).toBeDefined();
+        expect(homeChoice?.conditional?.(interview, 'path')).toEqual(false);
+    });
 
-	test('home conditional should return true when previous and next places are not home', () => {
-		const interview = _cloneDeep(interviewAttributesForTestCases);
-		interview.response.household!.persons!.personId1!.journeys!.journeyId1!.visitedPlaces = {
-			firstPlace: { _uuid: 'firstPlace', _sequence: 1, activity: 'shopping', activityCategory: 'shoppingServiceRestaurant' },
-			middlePlace: { _uuid: 'middlePlace', _sequence: 2, activity: 'other', activityCategory: 'leisure' },
-			lastPlace: { _uuid: 'lastPlace', _sequence: 3, activity: 'workUsual', activityCategory: 'work' }
-		};
-		setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'middlePlace' });
-		const homeChoice = choices.find((c) => c.value === 'home');
-		expect(homeChoice).toBeDefined();
-		expect(homeChoice?.conditional?.(interview, 'path')).toEqual(true);
-	});
+    test('home conditional should return true when previous and next places are not home', () => {
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        interview.response.household!.persons!.personId1!.journeys!.journeyId1!.visitedPlaces = {
+            firstPlace: { _uuid: 'firstPlace', _sequence: 1, activity: 'shopping', activityCategory: 'shoppingServiceRestaurant' },
+            middlePlace: { _uuid: 'middlePlace', _sequence: 2, activity: 'other', activityCategory: 'leisure' },
+            lastPlace: { _uuid: 'lastPlace', _sequence: 3, activity: 'workUsual', activityCategory: 'work' }
+        };
+        setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'middlePlace' });
+        const homeChoice = choices.find((c) => c.value === 'home');
+        expect(homeChoice).toBeDefined();
+        expect(homeChoice?.conditional?.(interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.middlePlace.activityCategory')).toEqual(true);
+    });
 
-	test('home conditional should return false when previous place activityCategory is home', () => {
-		const interview = _cloneDeep(interviewAttributesForTestCases);
-		setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
-		const homeChoice = choices.find((c) => c.value === 'home');
-		expect(homeChoice).toBeDefined();
-		expect(homeChoice?.conditional?.(interview, 'path')).toEqual(false);
-	});
+    test('home conditional should return false when previous place activityCategory is home', () => {
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
+        const homeChoice = choices.find((c) => c.value === 'home');
+        expect(homeChoice).toBeDefined();
+        expect(homeChoice?.conditional?.(interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.activityCategory')).toEqual(false);
+    });
 
     test('home conditional should return false when next place activityCategory is home', () => {
-		const interview = _cloneDeep(interviewAttributesForTestCases);
-		setActiveSurveyObjects(interview, { personId: 'personId2', journeyId: 'journeyId2', visitedPlaceId: 'otherWorkPlace1P2' });
-		const homeChoice = choices.find((c) => c.value === 'home');
-		expect(homeChoice).toBeDefined();
-		expect(homeChoice?.conditional?.(interview, 'path')).toEqual(false);
-	});
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        setActiveSurveyObjects(interview, { personId: 'personId2', journeyId: 'journeyId2', visitedPlaceId: 'otherWorkPlace1P2' });
+        const homeChoice = choices.find((c) => c.value === 'home');
+        expect(homeChoice).toBeDefined();
+        expect(homeChoice?.conditional?.(interview, 'household.persons.personId2.journeys.journeyId2.visitedPlaces.otherWorkPlace1P2.activityCategory')).toEqual(false);
+    });
 
-	each([
-		['No person', null, false],
-		['Age undefined', undefined, true],
-		['Age below working age', 14, false],
-		['Age at working age', 15, true]
-	]).test('work conditional: %s', (_title, age, expected) => {
-		const interview = _cloneDeep(interviewAttributesForTestCases);
-		const workChoice = choices.find((c) => c.value === 'work');
-		expect(workChoice).toBeDefined();
+    each([
+        ['No person', null, false],
+        ['Age undefined', undefined, true],
+        ['Age below working age', 14, false],
+        ['Age at working age', 15, true]
+    ]).test('work conditional: %s', (_title, age, expected) => {
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        const workChoice = choices.find((c) => c.value === 'work');
+        expect(workChoice).toBeDefined();
 
-		if (age === null) {
-			setResponse(interview, '_activePersonId', null);
-		} else {
-			setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
-			interview.response.household!.persons!.personId1!.age = age;
-		}
+        if (age === null) {
+            setResponse(interview, '_activePersonId', null);
+        } else {
+            setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
+            interview.response.household!.persons!.personId1!.age = age;
+        }
 
-		expect(workChoice?.conditional?.(interview, 'path')).toEqual(expected);
-	});
+        expect(workChoice?.conditional?.(interview, 'path')).toEqual(expected);
+    });
 
     // FIXME Review this one
-	each([
-		['No person', false, null, undefined, undefined],
+    each([
+        ['No person', false, null, undefined, undefined],
         ['Person with no age and occupation', true, undefined, undefined, undefined],
-		['Full time student occupation', true, 45, 'fullTimeStudent', undefined],
+        ['Full time student occupation', true, 45, 'fullTimeStudent', undefined],
         ['Part time student occupation', true, 10, 'partTimeStudent', undefined],
         ['Full time Worker occupation', true, 25, 'fullTimeWorker', undefined],
-		['Part time Worker occupation', true, 18, 'partTimeWorker', undefined],
+        ['Part time Worker occupation', true, 18, 'partTimeWorker', undefined],
         ['Worker and student occupation', true, 60, 'workerAndStudent', undefined],
-		['No occupation, isStudentFromEnrolled true', true, 4, undefined, true],
+        ['No occupation, isStudentFromEnrolled true', true, 4, undefined, true],
         ['No occupation, isStudentFromEnrolled true', false, 4, undefined, false],
-		['Non-student/worker occupation, isStudentFromEnrolled true', true, 10, 'other', true],
-		['Non-student/worker occupation, isStudentFromEnrolled false', false, 10, 'other', false]
-	]).test(
-		'school conditional: %s => %s',
-		(_title, expected, age, occupation, isStudentFromEnrolledValue: boolean | undefined) => {
-			const interview = _cloneDeep(interviewAttributesForTestCases);
-			const schoolChoice = choices.find((c) => c.value === 'school');
-			expect(schoolChoice).toBeDefined();
+        ['Non-student/worker occupation, isStudentFromEnrolled true', true, 10, 'other', true],
+        ['Non-student/worker occupation, isStudentFromEnrolled false', false, 10, 'other', false]
+    ]).test(
+        'school conditional: %s => %s',
+        (_title, expected, age, occupation, isStudentFromEnrolledValue: boolean | undefined) => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const schoolChoice = choices.find((c) => c.value === 'school');
+            expect(schoolChoice).toBeDefined();
 
-			if (age === null) {
-				setResponse(interview, '_activePersonId', null);
-			} else {
-				setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
-				interview.response.household!.persons!.personId1!.age = age;
-				interview.response.household!.persons!.personId1!.occupation = occupation as any;
-				if (isStudentFromEnrolledValue !== undefined) {
-					mockedIsStudentFromSchoolType.mockReturnValueOnce(isStudentFromEnrolledValue);
-				}
-			}
+            if (age === null) {
+                setResponse(interview, '_activePersonId', null);
+            } else {
+                setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
+                interview.response.household!.persons!.personId1!.age = age;
+                interview.response.household!.persons!.personId1!.occupation = occupation as any;
+                if (isStudentFromEnrolledValue !== undefined) {
+                    mockedIsStudentFromSchoolType.mockReturnValueOnce(isStudentFromEnrolledValue);
+                }
+            }
 
             // Test the conditional and verify the call to isStudentFromSchoolType
-			expect(schoolChoice?.conditional?.(interview, 'path')).toEqual(expected);
-			if (isStudentFromEnrolledValue !== undefined) {
-				expect(mockedIsStudentFromSchoolType).toHaveBeenCalledWith({
-					person: interview.response.household!.persons!.personId1!
-				});
-			} else {
+            expect(schoolChoice?.conditional?.(interview, 'path')).toEqual(expected);
+            if (isStudentFromEnrolledValue !== undefined) {
+                expect(mockedIsStudentFromSchoolType).toHaveBeenCalledWith({
+                    person: interview.response.household!.persons!.personId1!
+                });
+            } else {
                 expect(mockedIsStudentFromSchoolType).not.toHaveBeenCalled();
             }
-		}
-	);
+        }
+    );
 
     each([
         ['No person', false, null],
         ['No age', false, undefined],
         ['Person below adult age', true, 10],
         ['Person below adult age, previous place is otherParentHome', false, 10, {
-			firstPlace: { _uuid: 'firstPlace', _sequence: 1, activity: 'shopping', activityCategory: 'otherParentHome' },
-			workPlace1P1: { _uuid: 'workPlace1P1', _sequence: 2, activity: 'other', activityCategory: 'leisure' }
-		}],
+            firstPlace: { _uuid: 'firstPlace', _sequence: 1, activity: 'shopping', activityCategory: 'otherParentHome' },
+            workPlace1P1: { _uuid: 'workPlace1P1', _sequence: 2, activity: 'other', activityCategory: 'leisure' }
+        }],
         ['Person below adult age, next place is otherParentHome', false, 10, {
             workPlace1P1: { _uuid: 'workPlace1P1', _sequence: 1, activity: 'other', activityCategory: 'leisure' },
             middlePlace: { _uuid: 'middlePlace', _sequence: 2, activity: 'other', activityCategory: 'otherParentHome' },
@@ -222,7 +222,7 @@ describe('Activity category choices conditionals', () => {
         ['Person of adult age', false, 20]
     ]).test('otherParentHome conditional: %s => %s', (_title, expected, age, visitedPlaces = false) => {
         // Prepare interview data
-		const interview = _cloneDeep(interviewAttributesForTestCases);
+        const interview = _cloneDeep(interviewAttributesForTestCases);
         if (age === null) {
             setResponse(interview, '_activePersonId', null);
         } else {
@@ -235,112 +235,129 @@ describe('Activity category choices conditionals', () => {
         }
 
         // Test the conditional
-		const otherParentHomeChoice = choices.find((c) => c.value === 'otherParentHome');
-		expect(otherParentHomeChoice).toBeDefined();
-		expect(otherParentHomeChoice?.conditional?.(interview, 'path')).toEqual(expected);
-	});
+        const otherParentHomeChoice = choices.find((c) => c.value === 'otherParentHome');
+        expect(otherParentHomeChoice).toBeDefined();
+        const path = 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.activityCategory';
+        expect(otherParentHomeChoice?.conditional?.(interview, path)).toEqual(expected);
+    });
+
+    test('otherParentHome conditional with unexisting place context', () => {
+        // Prepare interview data
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        const age = 10;
+        interview.response.household!.persons!.personId1!.age = age;
+
+        // Test the conditional
+        const otherParentHomeChoice = choices.find((c) => c.value === 'otherParentHome');
+        expect(otherParentHomeChoice).toBeDefined();
+        const path = 'household.persons.personId1.journeys.journeyId1.visitedPlaces.unexisting place.activityCategory';
+        expect(otherParentHomeChoice?.conditional?.(interview, path)).toEqual(false);
+    });
 
 });
 
 describe('Activity category widget label', () => {
-	const widgetConfig = getActivityCategoryWidgetConfig(
-		visitedPlacesSectionConfig,
-		widgetFactoryOptions
-	) as QuestionWidgetConfig & InputRadioType;
-	const label = widgetConfig.label;
+    const widgetConfig = getActivityCategoryWidgetConfig(
+        visitedPlacesSectionConfig,
+        widgetFactoryOptions
+    ) as QuestionWidgetConfig & InputRadioType;
+    const label = widgetConfig.label;
 
-	beforeEach(() => {
-		jest.clearAllMocks();
-	});
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
 
-	test('should return empty string when person/journey/active place is missing', () => {
-		const interview = _cloneDeep(interviewAttributesForTestCases);
-		const mockedT = jest.fn();
-		const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
-		expect(translateString(label, { t: mockedT } as any, interview, 'path')).toEqual('');
-		expect(consoleSpy).toHaveBeenCalled();
-		consoleSpy.mockRestore();
-	});
+    test('should return empty string when person/journey/active place is missing', () => {
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        const mockedT = jest.fn();
+        const invalidPath = 'household.persons.invalidPerson.journeys.invalidJourney.visitedPlaces.invalidPlace.activityCategory';
+        expect(() => translateString(label, { t: mockedT } as any, interview, invalidPath)).toThrow('Visited place context not found for path ' + invalidPath);
+    });
 
-	test('should use first location label for first visited place', () => {
-		const interview = _cloneDeep(interviewAttributesForTestCases);
-		const mockedT = jest.fn().mockReturnValue('translatedLabel');
-		setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'homePlace1P1' });
-		expect(translateString(label, { t: mockedT } as any, interview, 'path')).toEqual('translatedLabel');
-		expect(mockedT).toHaveBeenCalledWith('visitedPlaces:ActivityCategoryFirstLocation');
-	});
+    test('should use first location label for first visited place', () => {
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        const mockedT = jest.fn().mockReturnValue('translatedLabel');
+        const path = 'household.persons.personId1.journeys.journeyId1.visitedPlaces.homePlace1P1.activityCategory';
+        expect(translateString(label, { t: mockedT } as any, interview, path)).toEqual('translatedLabel');
+        expect(mockedT).toHaveBeenCalledWith('visitedPlaces:ActivityCategoryFirstLocation');
+    });
 
-	test('should use after home label for second place when first place activity is home', () => {
-		const interview = _cloneDeep(interviewAttributesForTestCases);
-		const mockedT = jest.fn().mockReturnValue('translatedLabel');
-		setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
-		expect(translateString(label, { t: mockedT } as any, interview, 'path')).toEqual('translatedLabel');
-		expect(mockedT).toHaveBeenCalledWith('visitedPlaces:ActivityCategoryAfterHome');
-	});
+    test('should use after home label for second place when first place activity is home', () => {
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        const mockedT = jest.fn().mockReturnValue('translatedLabel');
+        const path = 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.activityCategory';
+        expect(translateString(label, { t: mockedT } as any, interview, path)).toEqual('translatedLabel');
+        expect(mockedT).toHaveBeenCalledWith('visitedPlaces:ActivityCategoryAfterHome');
+    });
 
-	test('should use default activity category label for other places', () => {
-		const interview = _cloneDeep(interviewAttributesForTestCases);
-		const mockedT = jest.fn().mockReturnValue('translatedLabel');
-		setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'homePlace2P1' });
-		expect(translateString(label, { t: mockedT } as any, interview, 'path')).toEqual('translatedLabel');
-		expect(mockedT).toHaveBeenCalledWith('visitedPlaces:ActivityCategory');
-	});
+    test('should use default activity category label for other places', () => {
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        const mockedT = jest.fn().mockReturnValue('translatedLabel');
+        const path = 'household.persons.personId1.journeys.journeyId1.visitedPlaces.homePlace2P1.activityCategory';
+        expect(translateString(label, { t: mockedT } as any, interview, path)).toEqual('translatedLabel');
+        expect(mockedT).toHaveBeenCalledWith('visitedPlaces:ActivityCategory');
+    });
 });
 
 describe('Activity category validations', () => {
-	const interview = _cloneDeep(interviewAttributesForTestCases);
-	const widgetConfig = getActivityCategoryWidgetConfig(
-		visitedPlacesSectionConfig,
-		widgetFactoryOptions
-	) as QuestionWidgetConfig & InputRadioType;
-	const validations = widgetConfig.validations;
+    const interview = _cloneDeep(interviewAttributesForTestCases);
+    const widgetConfig = getActivityCategoryWidgetConfig(
+        visitedPlacesSectionConfig,
+        widgetFactoryOptions
+    ) as QuestionWidgetConfig & InputRadioType;
+    const validations = widgetConfig.validations;
 
-	test('should return error when value is blank', () => {
-		expect(validations!(undefined, null, interview, 'path')).toEqual([
-			{
-				validation: true,
-				errorMessage: expect.any(Function)
-			}
-		]);
-	});
+    test('should return error when value is blank', () => {
+        expect(validations!(undefined, null, interview, 'path')).toEqual([
+            {
+                validation: true,
+                errorMessage: expect.any(Function)
+            }
+        ]);
+    });
 
-	test('should return no error when value is set', () => {
+    test('should return no error when value is set', () => {
         const validation = validations!('home', null, interview, 'path');
         expect(validation).toEqual([
-			{
-				validation: false,
-				errorMessage: expect.any(Function)
-			}
-		]);
+            {
+                validation: false,
+                errorMessage: expect.any(Function)
+            }
+        ]);
 
         // Verify the error message
-		const mockedT = jest.fn();
-		translateString(validation[0].errorMessage, { t: mockedT } as any, interview, 'path');
-		expect(mockedT).toHaveBeenCalledWith('visitedPlaces:activityIsRequiredError');
-	});
+        const mockedT = jest.fn();
+        translateString(validation[0].errorMessage, { t: mockedT } as any, interview, 'path');
+        expect(mockedT).toHaveBeenCalledWith('visitedPlaces:activityIsRequiredError');
+    });
 });
 
 describe('Activity category widget conditional', () => {
-	const widgetConfig = getActivityCategoryWidgetConfig(
-		visitedPlacesSectionConfig,
-		widgetFactoryOptions
-	) as QuestionWidgetConfig & InputRadioType;
-	const conditional = widgetConfig.conditional;
+    const widgetConfig = getActivityCategoryWidgetConfig(
+        visitedPlacesSectionConfig,
+        widgetFactoryOptions
+    ) as QuestionWidgetConfig & InputRadioType;
+    const conditional = widgetConfig.conditional;
 
-	test('should hide widget and assign home when active visited place is a new home place', () => {
-		const interview = _cloneDeep(interviewAttributesForTestCases);
-		setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'homePlace2P1' });
-		const activeVisitedPlace = interview.response.household!.persons!.personId1!.journeys!.journeyId1!.visitedPlaces!
-			.homePlace2P1!;
-		(activeVisitedPlace as any)._isNew = true;
-		activeVisitedPlace.activityCategory = 'home' as any;
+    test('should hide widget and assign home when active visited place is a new home place', () => {
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'homePlace2P1' });
+        const activeVisitedPlace = interview.response.household!.persons!.personId1!.journeys!.journeyId1!.visitedPlaces!
+            .homePlace2P1!;
+        (activeVisitedPlace as any)._isNew = true;
+        activeVisitedPlace.activityCategory = 'home' as any;
 
-		expect(conditional!(interview, 'path')).toEqual([false, 'home']);
-	});
+        expect(conditional!(interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.homePlace2P1.activityCategory')).toEqual([false, 'home']);
+    });
 
-	test('should show widget in regular case', () => {
-		const interview = _cloneDeep(interviewAttributesForTestCases);
-		setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
-		expect(conditional!(interview, 'path')).toEqual([true]);
-	});
+    test('should show widget in regular case', () => {
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        expect(conditional!(interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.activityCategory')).toEqual([true]);
+    });
+
+    test('should show widget if context not set', () => {
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        // Use a path that won't resolve a context
+        expect(conditional!(interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.nonExistentPlace.activityCategory')).toEqual([true]);
+    });
 });

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetPersonVisitedPlaceTitle.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetPersonVisitedPlaceTitle.test.ts
@@ -66,7 +66,7 @@ describe('personsTripsTitleWidgetConfig text', () => {
         // Delete other persons
         delete testInterview.response.household!.persons!.personId2;
         delete testInterview.response.household!.persons!.personId3;
-        expect(widgetText(mockedT, testInterview, 'path')).toEqual('visitedPlaces:personVisitedPlacesTitle');
+        expect(widgetText(mockedT, testInterview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces')).toEqual('visitedPlaces:personVisitedPlacesTitle');
         expect(mockedT).toHaveBeenCalledWith('visitedPlaces:personVisitedPlacesTitle', {
             context: undefined,
             count: 1,
@@ -85,7 +85,7 @@ describe('personsTripsTitleWidgetConfig text', () => {
         // Set a nickname for the person
         testInterview.response.household!.persons!.personId1.nickname = 'Jane';
 
-        expect(widgetText(mockedT, testInterview, 'path')).toEqual('visitedPlaces:personVisitedPlacesTitle');
+        expect(widgetText(mockedT, testInterview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces')).toEqual('visitedPlaces:personVisitedPlacesTitle');
         expect(mockedT).toHaveBeenCalledWith('visitedPlaces:personVisitedPlacesTitle', {
             context: undefined,
             count: 3,

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetsGeography.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetsGeography.test.ts
@@ -337,7 +337,7 @@ describe('visitedPlaceGeography widget', () => {
             const expectedCoordinates = shoppingPlace1P2Coordinates;
             setActiveSurveyObjects(interview, { personId: 'personId2', journeyId: 'journeyId2', visitedPlaceId: 'otherWorkPlace1P2' });
 
-            expect(defaultCenter(interview, 'path')).toEqual({ lat: expectedCoordinates[1], lon: expectedCoordinates[0] });
+            expect(defaultCenter(interview, 'household.persons.personId2.journeys.journeyId2.visitedPlaces.otherWorkPlace1P2.geography')).toEqual({ lat: expectedCoordinates[1], lon: expectedCoordinates[0] });
         });
 
         test('should use home geography when active place has no previous visited place', () => {
@@ -348,7 +348,7 @@ describe('visitedPlaceGeography widget', () => {
             const expectedCoordinates = homeGeographyCoordinates;
             setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'homePlace1P1' });
 
-            expect(defaultCenter(interview, 'path')).toEqual({ lat: expectedCoordinates[1], lon: expectedCoordinates[0] });
+            expect(defaultCenter(interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.homePlace1P1.geography')).toEqual({ lat: expectedCoordinates[1], lon: expectedCoordinates[0] });
         });
 
         test('should fallback to default map center when no home geography is available', () => {
@@ -358,7 +358,7 @@ describe('visitedPlaceGeography widget', () => {
             setResponse(interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.homePlace1P1.geography', undefined);
             setResponse(interview, 'home.geography.geometry.coordinates', undefined);
 
-            expect(defaultCenter(interview, 'path')).toEqual(config.mapDefaultCenter);
+            expect(defaultCenter(interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.homePlace1P1.geography')).toEqual(config.mapDefaultCenter);
         });
     });
 

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/helpers.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/helpers.ts
@@ -12,7 +12,7 @@ import {
     activityValues,
     activityToDisplayCategory
 } from '../../../odSurvey/types';
-import type { UserInterviewAttributes, VisitedPlace, VisitedPlacesSectionConfiguration } from '../../types';
+import type { UserInterviewAttributes, VisitedPlacesSectionConfiguration } from '../../types';
 import * as odSurveyHelpers from '../../../odSurvey/helpers';
 
 /**
@@ -21,6 +21,8 @@ import * as odSurveyHelpers from '../../../odSurvey/helpers';
  * @param arg
  * @param arg.interview The interview to get the previous and next visited
  * places from
+ * @param arg.path The path of the current visited place widget, used to get the
+ * visited place context and the previous and next visited places
  * @param arg.incompatibleActivities The list of incompatible activities for the
  * current activity choice
  * @returns True if the previous and next visited places have an activity that
@@ -28,21 +30,22 @@ import * as odSurveyHelpers from '../../../odSurvey/helpers';
  */
 export const validatePreviousNextPlaceIsCompatibleActivities = ({
     interview,
-    visitedPlace,
+    path,
     incompatibleConsecutiveActivities
 }: {
     interview: UserInterviewAttributes;
-    visitedPlace: VisitedPlace;
+    path: string;
     incompatibleConsecutiveActivities: Activity[];
 }) => {
-    const journey = odSurveyHelpers.getActiveJourney({ interview });
-    if (!journey) {
+    const visitedPlaceContext = odSurveyHelpers.getVisitedPlaceContextFromPath({ interview, path });
+    console.log('Visited place context for path', path, ':', visitedPlaceContext);
+    if (!visitedPlaceContext) {
         console.warn(
             'Warning: validatePreviousNextPlaceIsCompatibleActivities called but no active journey found in the interview. This conditional will return true, but this may indicate a problem with the interview data or the order of conditionals.'
         );
         return true;
     }
-
+    const { journey, visitedPlace } = visitedPlaceContext;
     const previousVisitedPlace = odSurveyHelpers.getPreviousVisitedPlace({
         journey,
         visitedPlaceId: visitedPlace._uuid
@@ -51,6 +54,13 @@ export const validatePreviousNextPlaceIsCompatibleActivities = ({
         journey,
         visitedPlaceId: visitedPlace._uuid
     });
+    console.log(
+        'previous/next visited places for visited place with id',
+        visitedPlace._uuid,
+        ':',
+        previousVisitedPlace,
+        nextVisitedPlace
+    );
     return (
         (!previousVisitedPlace ||
             !previousVisitedPlace.activity ||

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetActivity.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetActivity.ts
@@ -28,17 +28,13 @@ const isInActivityCategoryConditional = (visitedPlace: VisitedPlace, activity: A
     return activityToDisplayCategory[activity].includes(visitedPlace.activityCategory as ActivityCategory);
 };
 
-const validateActivityOfNextPrevious = (
-    visitedPlace: VisitedPlace,
-    interview: UserInterviewAttributes,
-    activity: Activity
-) => {
+const validateActivityOfNextPrevious = (path: string, interview: UserInterviewAttributes, activity: Activity) => {
     if (!incompatibleConsecutiveActivities[activity]) {
         return true;
     }
     return visitedPlacesHelpers.validatePreviousNextPlaceIsCompatibleActivities({
         interview,
-        visitedPlace,
+        path,
         incompatibleConsecutiveActivities: incompatibleConsecutiveActivities[activity]
     });
 };
@@ -102,7 +98,7 @@ const getActivityChoices = (filteredActivities: Activity[]): RadioChoiceType[] =
             if (!isInActivityCategoryConditional(visitedPlace, activity)) {
                 return false;
             }
-            if (!validateActivityOfNextPrevious(visitedPlace, interview, activity)) {
+            if (!validateActivityOfNextPrevious(path, interview, activity)) {
                 return false;
             }
             // Run the perActivity conditional if it exists

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetActivityCategory.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetActivityCategory.ts
@@ -41,14 +41,13 @@ const perActivityCategoryLabels: Partial<{ [category in ActivityCategory]: I18nD
 };
 
 const perActivityCategoryConditionals: Partial<{ [category in ActivityCategory]: WidgetConditional }> = {
-    home: function (interview) {
+    home: function (interview, path) {
         // Only show the home activity category if the previous and next visited places are not home
-        const person = odHelpers.getPerson({ interview });
-        const journey = odHelpers.getActiveJourney({ interview, person });
-        const activeVisitedPlace = odHelpers.getActiveVisitedPlace({ interview, journey });
-        if (!person || !journey || !activeVisitedPlace) {
+        const visitedPlaceContext = odHelpers.getVisitedPlaceContextFromPath({ interview, path });
+        if (!visitedPlaceContext) {
             return false;
         }
+        const { journey, visitedPlace: activeVisitedPlace } = visitedPlaceContext;
         const nextVisitedPlace = odHelpers.getNextVisitedPlace({
             journey,
             visitedPlaceId: activeVisitedPlace._uuid
@@ -96,13 +95,12 @@ const perActivityCategoryConditionals: Partial<{ [category in ActivityCategory]:
             odHelpers.isStudentFromSchoolType({ person })
         );
     },
-    otherParentHome: function (interview) {
-        const person = odHelpers.getPerson({ interview });
-        const journey = odHelpers.getActiveJourney({ interview, person });
-        const activeVisitedPlace = odHelpers.getActiveVisitedPlace({ interview, journey });
-        if (!person || !journey || !activeVisitedPlace) {
+    otherParentHome: function (interview, path) {
+        const visitedPlaceContext = odHelpers.getVisitedPlaceContextFromPath({ interview, path });
+        if (!visitedPlaceContext) {
             return false;
         }
+        const { person, journey, visitedPlace: activeVisitedPlace } = visitedPlaceContext;
         const nextVisitedPlace = odHelpers.getNextVisitedPlace({
             journey,
             visitedPlaceId: activeVisitedPlace._uuid
@@ -163,16 +161,12 @@ export const getActivityCategoryWidgetConfig = (
         containsHtml: true,
         useAssignedValueOnHide: true,
         choices,
-        label: (t: TFunction, interview) => {
-            const person = odHelpers.getPerson({ interview });
-            const journey = odHelpers.getActiveJourney({ interview, person });
-            const activeVisitedPlace = odHelpers.getActiveVisitedPlace({ interview, journey });
-            if (!person || !journey || !activeVisitedPlace) {
-                console.error(
-                    'Error: activeVisitedPlace, journey or person is null in getActivityCategoryWidgetConfig, they should all be defined'
-                );
-                return '';
+        label: (t: TFunction, interview, path) => {
+            const visitedPlaceContext = odHelpers.getVisitedPlaceContextFromPath({ interview, path });
+            if (!visitedPlaceContext) {
+                throw new Error('Visited place context not found for path ' + path);
             }
+            const { journey, visitedPlace: activeVisitedPlace } = visitedPlaceContext;
             const visitedPlacesArray = odHelpers.getVisitedPlacesArray({ journey });
             const firstVisitedPlace = visitedPlacesArray[0];
             const secondVisitedPlace = visitedPlacesArray[1];
@@ -197,14 +191,15 @@ export const getActivityCategoryWidgetConfig = (
                 }
             ];
         },
-        conditional: function (interview) {
-            const journey = odHelpers.getActiveJourney({ interview });
-            const activeVisitedPlace = odHelpers.getActiveVisitedPlace({ interview, journey });
+        conditional: function (interview, path) {
+            const visitedPlaceContext = odHelpers.getVisitedPlaceContextFromPath({ interview, path });
+            if (!visitedPlaceContext) {
+                return [true];
+            }
+            const { visitedPlace: activeVisitedPlace } = visitedPlaceContext;
             // Do not show for the a new place that is home
             // FIXME This is copy pasted from od_nationale_quebec. Is this right? Do we want to hide the activity category question for a new visited place that is home? What if the user wants to change the activity category of a new visited place that is home?
-            return activeVisitedPlace !== null &&
-                (activeVisitedPlace as any)._isNew === true &&
-                activeVisitedPlace.activityCategory === 'home'
+            return (activeVisitedPlace as any)._isNew === true && activeVisitedPlace.activityCategory === 'home'
                 ? [false, activeVisitedPlace.activityCategory]
                 : [true];
         }

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetNextPlaceCategory.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetNextPlaceCategory.ts
@@ -7,7 +7,6 @@
 import _escape from 'lodash/escape';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import type {
-    Journey,
     RadioChoiceType,
     VisitedPlace,
     VisitedPlacesSectionConfiguration,
@@ -62,11 +61,11 @@ const nextPlaceCategoryChoices: RadioChoiceType[] = [
             }
         },
         conditional: function (interview, path) {
-            const journey = odHelpers.getActiveJourney({ interview });
-            if (!journey) {
+            const visitedPlaceContext = odHelpers.getVisitedPlaceContextFromPath({ interview, path });
+            if (!visitedPlaceContext) {
                 throw new Error('Active journey not found in interview response');
             }
-            const activeVisitedPlace = getResponse(interview, path, undefined, '../') as VisitedPlace;
+            const { journey, visitedPlace: activeVisitedPlace } = visitedPlaceContext;
             const visitedPlacesArray = odHelpers.getVisitedPlacesArray({ journey });
             // Display only if the current visited place is the last one in the
             // list and there is more than one visited place (otherwise, the
@@ -127,8 +126,12 @@ export const getNextPlaceCategoryWidgetConfig = (
     choices: nextPlaceCategoryChoices,
     validations: requiredValidation,
     conditional: function (interview, path) {
-        const journey = odHelpers.getActiveJourney({ interview }) as Journey;
-        const activeVisitedPlace = getResponse(interview, path, undefined, '../') as VisitedPlace;
+        const visitedPlaceContext = odHelpers.getVisitedPlaceContextFromPath({ interview, path });
+        if (!visitedPlaceContext) {
+            console.warn('widgetNextPlaceCategory: Visited place context not found for path ' + path);
+            return false;
+        }
+        const { journey, visitedPlace: activeVisitedPlace } = visitedPlaceContext;
         const visitedPlacesArray = odHelpers.getVisitedPlacesArray({ journey });
         // If the arrival time of the visited place is exactly at the max time
         // of day for the trip diary, we can assume that the person stayed there

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetPersonVisitedPlacesTitle.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetPersonVisitedPlacesTitle.ts
@@ -20,12 +20,13 @@ export const getPersonVisitedPlacesTitleWidgetConfig = (
         type: 'text',
         align: 'left',
         containsHtml: true,
-        text: (t: TFunction, interview: UserInterviewAttributes, _path: string) => {
-            const person = odHelpers.getActivePerson({ interview });
-            const journey = odHelpers.getActiveJourney({ interview });
-            if (!person || !journey) {
+        text: (t: TFunction, interview: UserInterviewAttributes, path: string) => {
+            const journeyContext = odHelpers.getJourneyContextFromPath({ interview, path });
+            if (!journeyContext) {
                 throw new Error('Active person or journey not found in interview response');
             }
+            const { person, journey } = journeyContext;
+
             // Format the journey start date for context in the title
             // FIXME Update to support multiple days journeys when we support them in builtin questionnaire
             const assignedDay = journey.startDate;

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetsGeography.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetsGeography.ts
@@ -105,14 +105,15 @@ export class VisitedPlaceGeographyWidgetFactory implements WidgetConfigFactory {
             },
             size: [70, 70]
         },
-        defaultCenter: function (interview) {
+        defaultCenter: function (interview, path) {
             // Center on the previous visited place geography if it exists, otherwise center on home geography, otherwise use the default center
-            const journey = odHelpers.getActiveJourney({ interview });
-            const visitedPlace = odHelpers.getActiveVisitedPlace({ interview, journey });
-            const previousVisitedPlace =
-                visitedPlace && journey
-                    ? odHelpers.getPreviousVisitedPlace({ journey, visitedPlaceId: visitedPlace._uuid })
-                    : undefined;
+            const visitedPlaceContext = odHelpers.getVisitedPlaceContextFromPath({ interview, path });
+            const previousVisitedPlace = visitedPlaceContext
+                ? odHelpers.getPreviousVisitedPlace({
+                    journey: visitedPlaceContext.journey,
+                    visitedPlaceId: visitedPlaceContext.visitedPlace._uuid
+                })
+                : undefined;
             if (previousVisitedPlace) {
                 const person = odHelpers.getActivePerson({ interview });
                 const geography = person


### PR DESCRIPTION
See individual commits for details.

Refactor the current builtin question widgets to use those new helper functions. Also refactor some unit tests to not mock the helpers, but instead use actual customized test data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added helper functions for improved context retrieval from survey paths, enabling more reliable journey, trip, visited place, and segment data extraction.

* **Bug Fixes**
  * Enhanced error handling and validation throughout questionnaire sections with stricter context checking and explicit error reporting.

* **Refactor**
  * Refactored context resolution to use path-based lookups instead of global active state, improving code robustness and testability across survey sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->