### PR TITLE
questionnaire: extract a `yesNoChoices` array

### DIFF
--- a/packages/evolution-common/src/services/questionnaire/sections/common/choices.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/common/choices.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { TFunction } from 'i18next';
+
+/**
+ * Common yes/no choices for radio buttons in the questionnaire. The label is
+ * translated using the "survey:Yes" and "survey:No" keys.
+ */
+export const yesNoChoices = [
+    {
+        value: true,
+        label: (t: TFunction) => t('survey:Yes')
+    },
+    {
+        value: false,
+        label: (t: TFunction) => t('survey:No')
+    }
+];

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/widgetSameAsReverseTrip.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/widgetSameAsReverseTrip.ts
@@ -11,6 +11,7 @@ import { TFunction } from 'i18next';
 import * as odHelpers from '../../../odSurvey/helpers';
 import { getPreviousTripSingleSegment, shouldShowSameAsReverseTripQuestion } from './helpers';
 import { Journey, Person } from '../../types';
+import { yesNoChoices } from '../common/choices';
 
 export const getSameAsReverseTripWidgetConfig = (
     // FIXME: Type this when there is a few more widgets implemented
@@ -42,16 +43,7 @@ export const getSameAsReverseTripWidgetConfig = (
                         : ''
             });
         },
-        choices: [
-            {
-                value: true,
-                label: (t: TFunction) => t('survey:Yes')
-            },
-            {
-                value: false,
-                label: (t: TFunction) => t('survey:No')
-            }
-        ],
+        choices: yesNoChoices,
         validations: function (value) {
             return [
                 {

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/widgetSegmentHasNextMode.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/widgetSegmentHasNextMode.ts
@@ -11,6 +11,7 @@ import { TFunction } from 'i18next';
 import * as odHelpers from '../../../odSurvey/helpers';
 import { getPreviousTripSingleSegment, shouldShowSameAsReverseTripQuestion } from './helpers';
 import { Journey, Person } from '../../types';
+import { yesNoChoices } from '../common/choices';
 
 export const getSegmentHasNextModeWidgetConfig = (
     // FIXME: Type this when there is a few more widgets implemented
@@ -55,16 +56,7 @@ export const getSegmentHasNextModeWidgetConfig = (
                 count: odHelpers.getCountOrSelfDeclared({ interview, person })
             });
         },
-        choices: [
-            {
-                value: true,
-                label: (t: TFunction) => t('survey:Yes')
-            },
-            {
-                value: false,
-                label: (t: TFunction) => t('survey:No')
-            }
-        ],
+        choices: yesNoChoices,
         validations: function (value) {
             return [
                 {


### PR DESCRIPTION
This is a simple 2 values array of choices for a yes/no question. The resulting value type is a boolean, `true` for `yes` and `false` for `no`. The current widgets using a yes/no choice are updated to use this choices array.