### PR TITLE
odSurvey: add a few more helper functions, used in the shortcut migration to Evolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `shouldShowTripsAndPlacesSections` (commit [852a240](https://github.com/chairemobilite/evolution/commit/852a240a98d3c3a92197fe9684102df1326545f4))
   - `getJourneyContextFromPath`, `getTripContextFromPath`, `getVisitedPlaceContextFromPath`, `getSegmentContextFromPath` to get all objects in the interview from the path (fixes [#1538](https://github.com/chairemobilite/evolution/issues/1538))
   - `getVisitedPlaceDescription`
+  - `isUsualActivity`
 - Added a `visitedPlaces` section configuration, which includes activity, location and next place category questions, with the  `VisitedPlacesSectionFactory` class (fixes [#1437](https://github.com/chairemobilite/evolution/issues/1437))
 - Provide a `VisitedPlacesSection` template to be used in the UI to display visited places. The template can be used by the `visitedPlaces` name in the `template` property of a section's configuration (fixes [#1446](https://github.com/chairemobilite/evolution/issues/1446)).
 - The `getFormattedDate` widget factory option now takes an optional options parameter to fine-tune the desired format of the date (commit [8dbd493](https://github.com/chairemobilite/evolution/commit/8dbd4938c1dd4f5466a8c19b3b90f934e63b953f))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `getHomeAddressOneLine` (commit [3b28f45](https://github.com/chairemobilite/evolution/commit/3b28f454515445b4b438bfcb6cf00e1a8fffcde9))
   - `shouldShowTripsAndPlacesSections` (commit [852a240](https://github.com/chairemobilite/evolution/commit/852a240a98d3c3a92197fe9684102df1326545f4))
   - `getJourneyContextFromPath`, `getTripContextFromPath`, `getVisitedPlaceContextFromPath`, `getSegmentContextFromPath` to get all objects in the interview from the path (fixes [#1538](https://github.com/chairemobilite/evolution/issues/1538))
+  - `getVisitedPlaceDescription`
 - Added a `visitedPlaces` section configuration, which includes activity, location and next place category questions, with the  `VisitedPlacesSectionFactory` class (fixes [#1437](https://github.com/chairemobilite/evolution/issues/1437))
 - Provide a `VisitedPlacesSection` template to be used in the UI to display visited places. The template can be used by the `visitedPlaces` name in the `template` property of a section's configuration (fixes [#1446](https://github.com/chairemobilite/evolution/issues/1446)).
 - The `getFormattedDate` widget factory option now takes an optional options parameter to fine-tune the desired format of the date (commit [8dbd493](https://github.com/chairemobilite/evolution/commit/8dbd4938c1dd4f5466a8c19b3b90f934e63b953f))
@@ -50,6 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Deprecated
+
+- The evolution-frontend's `frontendHelper#getVisitedPlaceDescription` has been deprecated. Use the `getVisitedPlaceDescription` OD survey helper function from `evolution-common/lib/services/odSurvey/helpers`
 
 ### Removed
 

--- a/packages/evolution-common/src/services/odSurvey/__tests__/helpers.test.ts
+++ b/packages/evolution-common/src/services/odSurvey/__tests__/helpers.test.ts
@@ -7,7 +7,7 @@
 import each from 'jest-each';
 import _cloneDeep from 'lodash/cloneDeep';
 import { TFunction } from 'i18next';
-import { interviewAttributesForTestCases } from '../../../tests/surveys';
+import { interviewAttributesForTestCases, setActiveSurveyObjects } from '../../../tests/surveys';
 import * as Helpers from '../helpers';
 import projectConfig from '../../../config/project.config';
 import { Journey, Person, Trip, UserInterviewAttributes, VisitedPlace } from '../../questionnaire/types';
@@ -3026,6 +3026,170 @@ describe('getVisitedPlaceGeography', () => {
         } else {
             expect(geography).toBeNull();
         }
+    });
+});
+
+describe('getVisitedPlaceDescription', () => {
+    const interview = _cloneDeep(interviewAttributesForTestCases);
+    const visitedPlacesP1 = interview.response.household!.persons!.personId1!.journeys!.journeyId1!.visitedPlaces!;
+    const visitedPlacesP2 = interview.response.household!.persons!.personId2!.journeys!.journeyId2!.visitedPlaces!;
+    const person1 = interview.response.household!.persons!.personId1! as Person;
+    const person2 = interview.response.household!.persons!.personId2! as Person;
+    const mockedT = jest.fn().mockImplementation((key: string) => key);
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockedT.mockImplementation((key: string) => key);
+    });
+
+    // Content parts: name • nickname • activity, varying options
+    each([
+        {
+            title: 'home place, no nickname, defaults (html)',
+            visitedPlace: visitedPlacesP1.homePlace1P1,
+            person: person1,
+            options: {},
+            expected: '<em>visitedPlaces:activities:home</em>'
+        },
+        {
+            title: 'named place, no nickname, defaults (html)',
+            visitedPlace: visitedPlacesP1.workPlace1P1,
+            person: person1,
+            options: {},
+            expected: '<em>This is my work</em> • visitedPlaces:activities:workUsual'
+        },
+        {
+            title: 'named place, no nickname, allowHtml=false',
+            visitedPlace: visitedPlacesP1.workPlace1P1,
+            person: person1,
+            options: { allowHtml: false },
+            expected: 'This is my work • visitedPlaces:activities:workUsual'
+        },
+        {
+            title: 'named place, person with nickname, withNickname=true (default)',
+            visitedPlace: visitedPlacesP1.workPlace1P1,
+            person: person2,
+            options: {},
+            expected: '<em>This is my work</em> • p2 • visitedPlaces:activities:workUsual'
+        },
+        {
+            title: 'home place, person with nickname, withPersonIdentification=true (default)',
+            visitedPlace: visitedPlacesP1.homePlace1P1,
+            person: person2,
+            options: {},
+            expected: '<em>visitedPlaces:activities:home</em> • p2'
+        },
+        {
+            title: 'named place, person with nickname, withPersonIdentification=false',
+            visitedPlace: visitedPlacesP1.workPlace1P1,
+            person: person2,
+            options: { withPersonIdentification: false },
+            expected: '<em>This is my work</em> • visitedPlaces:activities:workUsual'
+        },
+        {
+            title: 'named place, withActivity=false',
+            visitedPlace: visitedPlacesP1.workPlace1P1,
+            person: person1,
+            options: { withActivity: false },
+            expected: '<em>This is my work</em>'
+        },
+        {
+            title: 'home place, withActivity=false, only home name shown',
+            visitedPlace: visitedPlacesP1.homePlace1P1,
+            person: person1,
+            options: { withActivity: false },
+            expected: '<em>visitedPlaces:activities:home</em>'
+        },
+        {
+            title: 'shortcut place resolves to original place name',
+            visitedPlace: visitedPlacesP2.shoppingPlace1P2,
+            person: person2,
+            options: {},
+            expected: '<em>This is a shopping place</em> • p2 • visitedPlaces:activities:shopping'
+        }
+    ]).test('content: $title', ({ visitedPlace, person, options, expected }) => {
+        expect(
+            Helpers.getVisitedPlaceDescription({ visitedPlace, interview, person, t: mockedT as any, options })
+        ).toEqual(expected);
+    });
+
+    // Content parts: name • nickname • activity, varying options
+    test('no nickname with 1-person household: $title', () => {
+        const interviewCopy = _cloneDeep(interview);
+        // Keep only personId1 in the household to simulate a 1-person household
+        interviewCopy.response.household!.persons = { personId1: interviewCopy.response.household!.persons!.personId1 };
+        expect(
+            Helpers.getVisitedPlaceDescription({ 
+                visitedPlace: visitedPlacesP1.workPlace1P1,
+                interview: interviewCopy,
+                person: person1,
+                t: mockedT as any,
+                options: { withPersonIdentification: true, withActivity: true } 
+            })
+        ).toEqual('<em>This is my work</em> • visitedPlaces:activities:workUsual');
+    });
+
+    // Content parts: name • nickname • activity, varying options
+    test('no nickname for the active person', () => {
+        const interviewCopy = _cloneDeep(interview);
+        setActiveSurveyObjects(interviewCopy, { personId: 'personId1' });
+        // No nickname for person 1, because it's the active one
+        expect(
+            Helpers.getVisitedPlaceDescription({ 
+                visitedPlace: visitedPlacesP1.workPlace1P1,
+                interview: interviewCopy,
+                person: person1,
+                t: mockedT as any,
+                options: { withPersonIdentification: true, withActivity: true } 
+            })
+        ).toEqual('<em>This is my work</em> • visitedPlaces:activities:workUsual');
+
+        // nickname for person 2
+        expect(
+            Helpers.getVisitedPlaceDescription({ 
+                visitedPlace: visitedPlacesP1.workPlace1P1,
+                interview: interviewCopy,
+                person: person2,
+                t: mockedT as any,
+                options: { withPersonIdentification: true, withActivity: true } 
+            })
+        ).toEqual('<em>This is my work</em> • p2 • visitedPlaces:activities:workUsual');
+    });
+
+    // Times formatting: suffix format is ` (arrival -> departure)`
+    each([
+        {
+            title: 'both arrival and departure',
+            visitedPlace: visitedPlacesP1.workPlace1P1, // arrivalTime=8:10, departureTime=9:00
+            expected: '<em>This is my work</em> • visitedPlaces:activities:workUsual (8:10 -> 9:00)'
+        },
+        {
+            title: 'only departure time',
+            visitedPlace: visitedPlacesP1.homePlace1P1, // no arrival, departureTime=8:00
+            expected: '<em>visitedPlaces:activities:home</em> (-> 8:00)'
+        },
+        {
+            title: 'only arrival time',
+            visitedPlace: visitedPlacesP1.otherPlace2P1, // arrivalTime=15:15, no departure
+            expected: '<em>This is a shopping place</em> • visitedPlaces:activities:shopping (15:15 ->)'
+        },
+        {
+            title: 'no times defined, no times suffix',
+            visitedPlace: visitedPlacesP2.homePlace1P2, // no times at all
+            expected: '<em>visitedPlaces:activities:home</em>'
+        }
+    ]).test('times: $title', ({ visitedPlace, expected }) => {
+        expect(
+            Helpers.getVisitedPlaceDescription({ visitedPlace, interview, person: person1, t: mockedT as any, options: { withTimes: true } })
+        ).toEqual(expected);
+    });
+
+    test('arrivalTime=0 (midnight) should be included in times, not treated as absent', () => {
+        const visitedPlace = _cloneDeep(visitedPlacesP1.homePlace1P1);
+        visitedPlace.arrivalTime = 0;
+        expect(
+            Helpers.getVisitedPlaceDescription({ visitedPlace, interview, person: person1, t: mockedT as any, options: { withTimes: true } })
+        ).toEqual('<em>visitedPlaces:activities:home</em> (0:00 -> 8:00)');
     });
 });
 

--- a/packages/evolution-common/src/services/odSurvey/__tests__/helpers.test.ts
+++ b/packages/evolution-common/src/services/odSurvey/__tests__/helpers.test.ts
@@ -12,7 +12,7 @@ import * as Helpers from '../helpers';
 import projectConfig from '../../../config/project.config';
 import { Journey, Person, Trip, UserInterviewAttributes, VisitedPlace } from '../../questionnaire/types';
 import { setProjectConfiguration } from 'chaire-lib-common/lib/config/shared/project.config';
-import { loopActivities } from '../types';
+import { loopActivities, usualActivities } from '../types';
 import { otherPlace2P1Coordinates } from '../../../tests/surveys/testCasesInterview';
 
 const baseInterviewAttributes: Pick<
@@ -1788,6 +1788,22 @@ describe('isLoopActivity', () => {
             activity: activity
         };
         expect(Helpers.isLoopActivity({ visitedPlace })).toEqual(expected);
+    });
+});
+
+describe('isUsualActivity', () => {
+    test.each([
+        ...usualActivities.map((activity) => [`Usual activity ${activity}`, activity, true] as any),
+        ['Non-usual activity', 'workNotUsual', false],
+        ['Undefined activity', undefined, false],
+        ['Null activity', null as any, false]
+    ])('isUsualActivity: %s', (_title, activity, expected) => {
+        const visitedPlace = {
+            _uuid: 'visitedPlace1',
+            _sequence: 1,
+            activity: activity
+        };
+        expect(Helpers.isUsualActivity({ visitedPlace })).toEqual(expected);
     });
 });
 

--- a/packages/evolution-common/src/services/odSurvey/__tests__/helpers.test.ts
+++ b/packages/evolution-common/src/services/odSurvey/__tests__/helpers.test.ts
@@ -2880,7 +2880,7 @@ describe('getVisitedPlaceNames', () => {
             interview: interviewAttributesForTestCases,
             visitedPlace: interviewAttributesForTestCases.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!
                 .homePlace1P1,
-            expectedTVal: 'survey:visitedPlace:activityCategories:home',
+            expectedTVal: 'visitedPlaces:activities:home',
             expected: 'mocked'
         },
         {

--- a/packages/evolution-common/src/services/odSurvey/helpers.ts
+++ b/packages/evolution-common/src/services/odSurvey/helpers.ts
@@ -24,7 +24,7 @@ import {
 } from '../questionnaire/types';
 import { TFunction } from 'i18next';
 import config from '../../config/project.config';
-import { loopActivities } from './types';
+import { loopActivities, usualActivities } from './types';
 import { SchoolType } from '../baseObjects/attributeTypes/PersonAttributes';
 import { secondsSinceMidnightToTimeStr } from 'chaire-lib-common/lib/utils/DateTimeUtils';
 
@@ -1188,6 +1188,16 @@ export const getPreviousVisitedPlace = function ({
  */
 export const isLoopActivity = ({ visitedPlace }: { visitedPlace: VisitedPlace }): boolean =>
     visitedPlace.activity !== undefined && loopActivities.includes(visitedPlace.activity);
+
+/**
+ * Determine whether the visited place has a usual activity.
+ *
+ * @param {Object} options - The options object.
+ * @param {VisitedPlace} options.visitedPlace The visited place to check
+ * @returns {boolean} `true` if the visited place has a usual activity, `false` otherwise
+ */
+export const isUsualActivity = ({ visitedPlace }: { visitedPlace: VisitedPlace }): boolean =>
+    visitedPlace.activity !== undefined && usualActivities.includes(visitedPlace.activity);
 
 /**
  * Get the next incomplete visited place, or return `null` if all visited places

--- a/packages/evolution-common/src/services/odSurvey/helpers.ts
+++ b/packages/evolution-common/src/services/odSurvey/helpers.ts
@@ -976,7 +976,7 @@ export const getVisitedPlaceName = function ({
     interview: UserInterviewAttributes;
 }): string {
     if (visitedPlace && visitedPlace.activity === 'home') {
-        return t(`survey:visitedPlace:activityCategories:${visitedPlace.activity}`);
+        return t('visitedPlaces:activities:home');
     }
 
     // Resolve any shortcut, then return the name if available

--- a/packages/evolution-common/src/services/odSurvey/helpers.ts
+++ b/packages/evolution-common/src/services/odSurvey/helpers.ts
@@ -26,6 +26,7 @@ import { TFunction } from 'i18next';
 import config from '../../config/project.config';
 import { loopActivities } from './types';
 import { SchoolType } from '../baseObjects/attributeTypes/PersonAttributes';
+import { secondsSinceMidnightToTimeStr } from 'chaire-lib-common/lib/utils/DateTimeUtils';
 
 // This file contains helper function that retrieves various data from the
 // response field of the interview
@@ -1029,6 +1030,103 @@ export const getVisitedPlaceGeography = function ({
         }
     }
     return geojson;
+};
+
+/**
+ * Get the visited place one-line description, including the place name (if
+ * available), the activity name (if requested and available), the person's
+ * nickname (if requested and available) and the arrival and departure times (if
+ * requested and available).
+ *
+ * @param args The arguments object
+ * @param args.visitedPlace The visited place for which to get the description
+ * @param args.interview The interview object
+ * @param args.person The person who went to this visited place
+ * @param args.t The translation function
+ * @param args.options Configuration options for the description
+ * @param args.options.withTimes Whether to add the times to the description
+ * (default: false)
+ * @param args.options.withActivity Whether to add the activity name to the
+ * description (default: true) If place name is empty, it will show activity
+ * name, even if this flag is false.  If place name is not empty, it will only
+ * be shown if this flag is true.
+ * @param args.options.withPersonIdentification Whether to include the person's
+ * identification string. It won't be shown for the active person or if there is
+ * only one person in the household (default: true)
+ * @param args.options.allowHtml Whether the description can contain HTML
+ * characters (default: true)
+ * @returns The formatted description string
+ */
+export const getVisitedPlaceDescription = ({
+    visitedPlace,
+    interview,
+    person,
+    t,
+    options
+}: {
+    interview: UserInterviewAttributes;
+    visitedPlace: VisitedPlace;
+    person: Person;
+    t: TFunction;
+    options: {
+        withTimes?: boolean;
+        withActivity?: boolean;
+        withPersonIdentification?: boolean;
+        allowHtml?: boolean;
+    };
+}): string => {
+    const { withTimes = false, withActivity = true, withPersonIdentification = true, allowHtml = true } = options;
+    const contentParts: string[] = [];
+
+    // Add place name (if available).
+    const visitedPlaceName = getVisitedPlaceName({ visitedPlace, interview, t });
+    if (visitedPlaceName) {
+        contentParts.push(allowHtml ? `<em>${visitedPlaceName}</em>` : visitedPlaceName);
+    }
+
+    // Add the person's identification string if withPersonIdentification is true requested and the person is not the active or only person
+    if (withPersonIdentification) {
+        const activePerson = getActivePerson({ interview });
+        if (activePerson === null || activePerson._uuid !== person._uuid) {
+            contentParts.push(getPersonIdentificationString({ person, t }));
+        }
+    }
+
+    // Add activity (always last before times)
+    // Show activity only if withActivity is true and it is different from the place name (which may be the activity in some cases, like 'home')
+    if (withActivity) {
+        const activityText = t(`visitedPlaces:activities:${visitedPlace.activity}`);
+        if (activityText && activityText !== visitedPlaceName) {
+            contentParts.push(activityText);
+        }
+    }
+
+    // Add times if requested and available
+    let timesPart = '';
+    if (withTimes) {
+        const arrivalTime =
+            visitedPlace.arrivalTime !== undefined && visitedPlace.arrivalTime !== null
+                ? secondsSinceMidnightToTimeStr(visitedPlace.arrivalTime)
+                : undefined;
+        const departureTime =
+            visitedPlace.departureTime !== undefined && visitedPlace.departureTime !== null
+                ? secondsSinceMidnightToTimeStr(visitedPlace.departureTime)
+                : undefined;
+
+        if (arrivalTime || departureTime) {
+            let timeString = '';
+            if (arrivalTime && departureTime) {
+                timeString = `${arrivalTime} -> ${departureTime}`;
+            } else if (arrivalTime) {
+                timeString = `${arrivalTime} ->`;
+            } else if (departureTime) {
+                timeString = `-> ${departureTime}`;
+            }
+            timesPart = ` (${timeString})`;
+        }
+    }
+
+    return contentParts.join(' • ') + timesPart;
 };
 
 /**

--- a/packages/evolution-common/src/services/odSurvey/types.ts
+++ b/packages/evolution-common/src/services/odSurvey/types.ts
@@ -13,6 +13,12 @@
 export const loopActivities: Activity[] = ['workOnTheRoad', 'leisureStroll'];
 
 /**
+ * Activities that are considered to be done at a single explicit location, and
+ * that are often repeated at the same location.
+ */
+export const usualActivities: Activity[] = ['workUsual', 'schoolUsual'];
+
+/**
  * Simple modes, ie individual modes that involve no or private vehicles and are
  * often used multiple times in a journey
  */

--- a/packages/evolution-common/src/services/questionnaire/types/Data.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/Data.ts
@@ -110,6 +110,11 @@ export type QuestionnaireObjectWithUuidAndSequence = {
     _sequence: number;
 };
 
+type NamedPlace = {
+    name?: string;
+    geography?: GeoJSON.Feature<GeoJSON.Point, SurveyPointProperties>;
+};
+
 /**
  * @typedef {Object} Person
  * @property {number} _sequence The sequence number of the person.
@@ -120,6 +125,8 @@ export type Person = PersonAttributes &
     QuestionnaireObjectWithUuidAndSequence & {
         /** uuid of the person who responds for this person (for household where more than 1 person have more than the minimum self response age) */
         whoWillAnswerForThisPerson?: string;
+        usualSchoolPlace?: NamedPlace;
+        usualWorkPlace?: NamedPlace;
         journeys?: {
             [journeyId: string]: Journey;
         };
@@ -166,19 +173,23 @@ export type Journey = JourneyAttributes &
     };
 
 // FIXME We are not using the VisitedPlaceAttributes type here because during survey, most of the data from that type is rather as a property of the geography feature and not as fields of the object
-export type VisitedPlace = QuestionnaireObjectWithUuidAndSequence & {
-    activity?: Optional<Activity>;
-    activityCategory?: Optional<ActivityCategory>;
-    geography?: GeoJSON.Feature<GeoJSON.Point, SurveyPointProperties>;
-    departureTime?: number;
-    arrivalTime?: number;
-    /**
-     * The category of the next place. The 'wentToUsualWorkPlace' category is
-     * used for workOnTheRoad trips. It is imputed by values entered by
-     * participant
-     */
-    nextPlaceCategory?: 'wentBackHome' | 'visitedAnotherPlace' | 'stayedThereUntilTheNextDay' | 'wentToUsualWorkPlace';
-} & (
+export type VisitedPlace = QuestionnaireObjectWithUuidAndSequence &
+    NamedPlace & {
+        activity?: Optional<Activity>;
+        activityCategory?: Optional<ActivityCategory>;
+        departureTime?: number;
+        arrivalTime?: number;
+        /**
+         * The category of the next place. The 'wentToUsualWorkPlace' category is
+         * used for workOnTheRoad trips. It is imputed by values entered by
+         * participant
+         */
+        nextPlaceCategory?:
+            | 'wentBackHome'
+            | 'visitedAnotherPlace'
+            | 'stayedThereUntilTheNextDay'
+            | 'wentToUsualWorkPlace';
+    } & (
         | { alreadyVisitedBySelfOrAnotherHouseholdMember?: false; name?: string; shortcut?: never }
         | { alreadyVisitedBySelfOrAnotherHouseholdMember: true; name?: never; shortcut?: string }
     );

--- a/packages/evolution-frontend/src/components/survey/sectionTemplates/VisitedPlacesSection.tsx
+++ b/packages/evolution-frontend/src/components/survey/sectionTemplates/VisitedPlacesSection.tsx
@@ -25,10 +25,7 @@ import ConfirmModal from 'chaire-lib-frontend/lib/components/modal/ConfirmModal'
 import LoadingPage from 'chaire-lib-frontend/lib/components/pages/LoadingPage';
 import { type SectionProps, useSectionTemplate } from '../../hooks/useSectionTemplate';
 import { SurveyContext } from '../../../contexts/SurveyContext';
-import {
-    getVisitedPlaceDescription,
-    secondsSinceMidnightToTimeStrWithSuffix
-} from '../../../services/display/frontendHelper';
+import { secondsSinceMidnightToTimeStrWithSuffix } from '../../../services/display/frontendHelper';
 import type { GroupConfig, VisitedPlace } from 'evolution-common/lib/services/questionnaire/types';
 import { getResponse } from 'evolution-common/lib/utils/helpers';
 import { getActivityIcon } from 'evolution-common/lib/services/questionnaire/sections/visitedPlaces/activityIconMapping';
@@ -133,7 +130,13 @@ export const VisitedPlacesSection: React.FC<SectionProps> = (props: SectionProps
         const personVisitedPlacesSchedules: ReactNode[] = [];
         for (let i = 0, count = visitedPlacesForSchedule.length; i < count; i++) {
             const visitedPlace = visitedPlacesForSchedule[i];
-            const visitedPlaceDescription = getVisitedPlaceDescription(visitedPlace, true, false);
+            const visitedPlaceDescription = odHelpers.getVisitedPlaceDescription({
+                visitedPlace,
+                person: personForSchedule,
+                interview: props.interview,
+                t,
+                options: { withTimes: true, allowHtml: false, withPersonIdentification: false }
+            });
             let departureTime = i === count - 1 ? 28 * 3600 : null;
             let arrivalTime = i === 0 ? 0 : null;
             if (visitedPlace.departureTime) {

--- a/packages/evolution-frontend/src/components/survey/sectionTemplates/__tests__/VisitedPlacesSection.test.tsx
+++ b/packages/evolution-frontend/src/components/survey/sectionTemplates/__tests__/VisitedPlacesSection.test.tsx
@@ -51,7 +51,6 @@ jest.mock('react-i18next', () => ({
     })
 }));
 jest.mock('../../../../services/display/frontendHelper', () => ({
-    getVisitedPlaceDescription: jest.fn().mockReturnValue('visitedPlaceDescription'),
     secondsSinceMidnightToTimeStrWithSuffix: jest.fn((seconds: number) => `time-${seconds}`)
 }));
 

--- a/packages/evolution-frontend/src/components/survey/sectionTemplates/__tests__/__snapshots__/VisitedPlacesSection.test.tsx.snap
+++ b/packages/evolution-frontend/src/components/survey/sectionTemplates/__tests__/__snapshots__/VisitedPlacesSection.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`VisitedPlacesSection UI display should render the default visited place
             <div
               class="survey-visited-places-schedule-visited-place hand-cursor-on-hover"
               style="left: 0%; width: 28.5714%;"
-              title="visitedPlaceDescription"
+              title="visitedPlaces:activities:home (-> 8:00)"
             >
               <div
                 class="survey-visited-places-schedule-visited-place-icon"
@@ -89,7 +89,7 @@ exports[`VisitedPlacesSection UI display should render the default visited place
             <div
               class="survey-visited-places-schedule-visited-place hand-cursor-on-hover"
               style="left: 29.1667%; width: 2.9762%;"
-              title="visitedPlaceDescription"
+              title="This is my work • visitedPlaces:activities:workUsual (8:10 -> 9:00)"
             >
               <div
                 class="survey-visited-places-schedule-visited-place-icon"
@@ -136,7 +136,7 @@ exports[`VisitedPlacesSection UI display should render the default visited place
             <div
               class="survey-visited-places-schedule-visited-place hand-cursor-on-hover"
               style="left: 32.7381%; width: 17.2619%;"
-              title="visitedPlaceDescription"
+              title="visitedPlaces:activities:home (9:10 -> 14:00)"
             >
               <div
                 class="survey-visited-places-schedule-visited-place-icon"
@@ -183,7 +183,7 @@ exports[`VisitedPlacesSection UI display should render the default visited place
             <div
               class="survey-visited-places-schedule-visited-place hand-cursor-on-hover"
               style="left: 50.8929%; width: 2.6785%;"
-              title="visitedPlaceDescription"
+              title="survey:placeWithSequenceGeneric • visitedPlaces:activities:shopping (14:15 -> 15:00)"
             >
               <div
                 class="survey-visited-places-schedule-visited-place-icon"
@@ -230,7 +230,7 @@ exports[`VisitedPlacesSection UI display should render the default visited place
             <div
               class="survey-visited-places-schedule-visited-place hand-cursor-on-hover"
               style="left: 54.4643%; width: 45.5357%;"
-              title="visitedPlaceDescription"
+              title="This is a shopping place • visitedPlaces:activities:shopping (15:15 ->)"
             >
               <div
                 class="survey-visited-places-schedule-visited-place-icon"
@@ -957,7 +957,7 @@ exports[`VisitedPlacesSection UI display should render the selected visited plac
             <div
               class="survey-visited-places-schedule-visited-place"
               style="left: 0%; width: 28.5714%;"
-              title="visitedPlaceDescription"
+              title="visitedPlaces:activities:home (-> 8:00)"
             >
               <div
                 class="survey-visited-places-schedule-visited-place-icon"
@@ -1003,7 +1003,7 @@ exports[`VisitedPlacesSection UI display should render the selected visited plac
             <div
               class="survey-visited-places-schedule-visited-place"
               style="left: 29.1667%; width: 2.9762%;"
-              title="visitedPlaceDescription"
+              title="This is my work • visitedPlaces:activities:workUsual (8:10 -> 9:00)"
             >
               <div
                 class="survey-visited-places-schedule-visited-place-icon"
@@ -1050,7 +1050,7 @@ exports[`VisitedPlacesSection UI display should render the selected visited plac
             <div
               class="survey-visited-places-schedule-visited-place"
               style="left: 32.7381%; width: 17.2619%;"
-              title="visitedPlaceDescription"
+              title="visitedPlaces:activities:home (9:10 -> 14:00)"
             >
               <div
                 class="survey-visited-places-schedule-visited-place-icon"
@@ -1097,7 +1097,7 @@ exports[`VisitedPlacesSection UI display should render the selected visited plac
             <div
               class="survey-visited-places-schedule-visited-place"
               style="left: 50.8929%; width: 2.6785%;"
-              title="visitedPlaceDescription"
+              title="survey:placeWithSequenceGeneric • visitedPlaces:activities:shopping (14:15 -> 15:00)"
             >
               <div
                 class="survey-visited-places-schedule-visited-place-icon"
@@ -1144,7 +1144,7 @@ exports[`VisitedPlacesSection UI display should render the selected visited plac
             <div
               class="survey-visited-places-schedule-visited-place"
               style="left: 54.4643%; width: 45.5357%;"
-              title="visitedPlaceDescription"
+              title="This is a shopping place • visitedPlaces:activities:shopping (15:15 ->)"
             >
               <div
                 class="survey-visited-places-schedule-visited-place-icon"

--- a/packages/evolution-frontend/src/services/display/frontendHelper.ts
+++ b/packages/evolution-frontend/src/services/display/frontendHelper.ts
@@ -179,6 +179,8 @@ export const validateButtonActionWithCompleteSection: ButtonAction = (
  * @param withTimes Whether to add the times to the description
  * @param allowHtml Whether the description can contain HTML characters
  * @returns
+ * @deprecated This function has been moved and more options have been added in
+ * evolution-common/lib/services/odSurvey/helpers.
  */
 export const getVisitedPlaceDescription = function (
     visitedPlace: VisitedPlace,


### PR DESCRIPTION
See individual commits for details

- Add a `NamedPlace` type in the questionnaire, for the `name` and `geography` properties, used for usual and visited places
- Add the `getVisitedPlaceDescription` helper function, in replacement to the frontend's function (now deprecated), that is now in common, as it does not depend on any UI specific elements and is used by the widget configuration
- Add the `isUsualActivity` helper function, to denote another special kind of activity that has a unique place geography associated with it, that may not be defined in the visited places