### PR TITLE
Generator: Update widget generation to handle inactive state

### DIFF
--- a/packages/evolution-generator/src/scripts/generate_widgets.py
+++ b/packages/evolution-generator/src/scripts/generate_widgets.py
@@ -227,6 +227,7 @@ def generate_widget_statement(row, gender_fields: GenderFields = None) -> Widget
     # Initialize gender_fields to a default class if none is provided
     gender_fields = gender_fields or GenderFields()
     question_name = row["questionName"]
+    active = row.get("active", True)  # Default to True if not present
     input_type = row["inputType"]
     section = row["section"]
     path = row["path"]
@@ -241,6 +242,13 @@ def generate_widget_statement(row, gender_fields: GenderFields = None) -> Widget
 
     # Initialize result with default values
     result: WidgetResult = {"statement": "", "has_helper_import": False}
+
+    # If the widget is not active, generate a comment and return
+    if active is False:
+        result["statement"] = (
+            f"// Note: {question_name} widget is not active. This widget will not be displayed in the survey."
+        )
+        return result
 
     # Generate the widgets statement based on the input type
     if input_type == "Custom":
@@ -353,7 +361,7 @@ def generate_widget_statement(row, gender_fields: GenderFields = None) -> Widget
 # Define a function to generate the widget name for a given row and group
 def generate_widget_name(row, group, is_last):
     question_name = row["questionName"]
-    active = row["active"]
+    active = row.get("active", True)  # Default to True if not present
     rowGroup = row.get("group") if row.get("group") else ""
 
     # Return the question_name commented if not active

--- a/packages/evolution-generator/src/tests/test_generate_widgets.py
+++ b/packages/evolution-generator/src/tests/test_generate_widgets.py
@@ -1097,6 +1097,31 @@ class TestGenerateWidgetStatementComments:
         )
 
 
+class TestGenerateWidgetStatementActiveFlag:
+    def test_inactive_widget_generates_not_active_comment_only(self):
+        row = {
+            "questionName": "acceptToBeContactedForHelp",
+            "active": False,
+            "inputType": "Radio",
+            "section": "home",
+            "path": "acceptToBeContactedForHelp",
+            "conditional": "",
+            "validation": "",
+            "inputRange": "",
+            "help_popup": "",
+            "choices": "yesNo",
+            "label::fr": "Acceptez-vous d'être contacté pour de l'aide?",
+            "label::en": "Do you agree to be contacted for help?",
+        }
+
+        result = generate_widget_statement(row, GenderFields())
+        assert (
+            result["statement"]
+            == "// Note: acceptToBeContactedForHelp widget is not active. This widget will not be displayed in the survey."
+        )
+        assert "export const acceptToBeContactedForHelp" not in result["statement"]
+
+
 # TODO: Test generate_select_widget
 # TODO: Test generate_number_widget
 # TODO: Test generate_range_widget


### PR DESCRIPTION
# PR

## Description
Fix: #436
Added functionality to the `generate_widget_statement` function to check the 'active' status of widgets. If a widget is inactive, a comment is generated indicating that it will not be displayed in the survey.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Widgets can now be marked as inactive and will be skipped during generation with an explanatory note comment.

* **Tests**
  * Added test coverage for inactive widget handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->