### PR TITLE
personVisitedPlacesTitle: fix getting active journey in label

### DIFF
--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetPersonVisitedPlaceTitle.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetPersonVisitedPlaceTitle.test.ts
@@ -8,8 +8,6 @@ import _cloneDeep from 'lodash/cloneDeep';
 import { getPersonVisitedPlacesTitleWidgetConfig } from '../widgetPersonVisitedPlacesTitle';
 import { interviewAttributesForTestCases, widgetFactoryOptions } from '../../../../../tests/surveys';
 
-const mockGetFormattedDate = widgetFactoryOptions.getFormattedDate as jest.MockedFunction<typeof widgetFactoryOptions.getFormattedDate>;
-
 const visitedPlacesSectionConfig = {
     type: 'visitedPlaces' as const,
     enabled: true,
@@ -52,10 +50,18 @@ describe('personsTripsTitleWidgetConfig text', () => {
     // Extract the journey date for use in expected parameters in tests
     const journeyDate = interviewAttributesForTestCases.response.household!.persons!.personId1.journeys!.journeyId1.startDate;
    
-    test('should call translation with correct parameters if no active journey', () => {
+    test('should throw an error if no active person', () => {
+        const testInterview = _cloneDeep(interviewAttributesForTestCases);
+        setActiveJourney(testInterview, undefined, undefined);
+        expect(() => widgetText(mockedT, testInterview, 'path')).toThrow('Active person not found in interview response');
+        expect(mockedT).not.toHaveBeenCalled();
+        expect(widgetFactoryOptions.getFormattedDate).not.toHaveBeenCalled();
+    });
+
+    test('should throw an error if no active journey', () => {
         const testInterview = _cloneDeep(interviewAttributesForTestCases);
         setActiveJourney(testInterview, 'personId1', undefined);
-        expect(() => widgetText(mockedT, testInterview, 'path')).toThrow('Active person or journey not found in interview response');
+        expect(() => widgetText(mockedT, testInterview, 'path')).toThrow('Active journey for person not found in interview response');
         expect(mockedT).not.toHaveBeenCalled();
         expect(widgetFactoryOptions.getFormattedDate).not.toHaveBeenCalled();
     });
@@ -66,7 +72,7 @@ describe('personsTripsTitleWidgetConfig text', () => {
         // Delete other persons
         delete testInterview.response.household!.persons!.personId2;
         delete testInterview.response.household!.persons!.personId3;
-        expect(widgetText(mockedT, testInterview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces')).toEqual('visitedPlaces:personVisitedPlacesTitle');
+        expect(widgetText(mockedT, testInterview, 'path')).toEqual('visitedPlaces:personVisitedPlacesTitle');
         expect(mockedT).toHaveBeenCalledWith('visitedPlaces:personVisitedPlacesTitle', {
             context: undefined,
             count: 1,
@@ -85,7 +91,7 @@ describe('personsTripsTitleWidgetConfig text', () => {
         // Set a nickname for the person
         testInterview.response.household!.persons!.personId1.nickname = 'Jane';
 
-        expect(widgetText(mockedT, testInterview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces')).toEqual('visitedPlaces:personVisitedPlacesTitle');
+        expect(widgetText(mockedT, testInterview, 'path')).toEqual('visitedPlaces:personVisitedPlacesTitle');
         expect(mockedT).toHaveBeenCalledWith('visitedPlaces:personVisitedPlacesTitle', {
             context: undefined,
             count: 3,

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetPersonVisitedPlacesTitle.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetPersonVisitedPlacesTitle.ts
@@ -20,12 +20,16 @@ export const getPersonVisitedPlacesTitleWidgetConfig = (
         type: 'text',
         align: 'left',
         containsHtml: true,
-        text: (t: TFunction, interview: UserInterviewAttributes, path: string) => {
-            const journeyContext = odHelpers.getJourneyContextFromPath({ interview, path });
-            if (!journeyContext) {
-                throw new Error('Active person or journey not found in interview response');
+        text: (t: TFunction, interview: UserInterviewAttributes) => {
+            // Get the active person and journey from interview data, there is no path necessary for text widgets
+            const person = odHelpers.getPerson({ interview }) as any;
+            if (!person) {
+                throw new Error('Active person not found in interview response');
             }
-            const { person, journey } = journeyContext;
+            const journey = odHelpers.getActiveJourney({ interview, person });
+            if (!journey) {
+                throw new Error('Active journey for person not found in interview response');
+            }
 
             // Format the journey start date for context in the title
             // FIXME Update to support multiple days journeys when we support them in builtin questionnaire


### PR DESCRIPTION
fixes #1565

The widget does not receive a path with the complete context in it. It actually has no path defined, so we need to get the active journey from the interview data.