### PR TITLE
ui tests: support collecting trip diary data during tests

### DIFF
--- a/packages/evolution-frontend/tests/ui-testing/SurveyObjectDetectors.ts
+++ b/packages/evolution-frontend/tests/ui-testing/SurveyObjectDetectors.ts
@@ -37,6 +37,7 @@ export class SurveyObjectDetector {
     private activeJourneyId: string | undefined = undefined;
     private activeVisitedPlaceId: string | undefined = undefined;
     private activeTripId: string | undefined = undefined;
+    private tripDiaries: { personId: string; journeyId: string }[] = [];
 
     // Replace ${personId[n]} with the actual personId
     private replaceWithPersonId(str: string): string {
@@ -83,6 +84,46 @@ export class SurveyObjectDetector {
         return newString;
     }
 
+    // Replace ${tripDiary[n]} with the actual trip diary ID, or optional fields like ${tripDiary[n].personId}, ${tripDiary[n].journeyId}, ${tripDiary[n].visitedPlace[index]}
+    private replaceWithTripDiaryData(str: string): string {
+        let newString = str;
+        // Match patterns like: ${tripDiary[0]}, ${tripDiary[0].personId}, ${tripDiary[0].journeyId}, ${tripDiary[0].visitedPlaces[0]}
+        const tripDiaryRegex = /\$\{tripDiary\[(\d+)\](?:\.(\w+)(?:\[(\d+)\])?)?\}/g;
+
+        newString = str.replace(tripDiaryRegex, (match, diaryIndexStr, fieldName, arrayIndexStr) => {
+            const diaryIndex = Number(diaryIndexStr);
+
+            // Check if the diary index is valid
+            if (diaryIndex >= this.tripDiaries.length) {
+                return match; // Return original if index out of bounds
+            }
+
+            const tripDiary = this.tripDiaries[diaryIndex];
+
+            // If no field specified, the complete path of the trip diary
+            if (!fieldName) {
+                return `household.persons.${tripDiary.personId}.journeys.${tripDiary.journeyId}`;
+            }
+
+            // Handle specific field accesses
+            if (fieldName === 'personId') {
+                return tripDiary.personId;
+            } else if (fieldName === 'journeyId') {
+                return tripDiary.journeyId;
+            } else if (fieldName === 'visitedPlaces' && arrayIndexStr !== undefined) {
+                const arrayIndex = Number(arrayIndexStr);
+                const visitedPlacesForJourney = this.visitedPlaces[tripDiary.journeyId];
+                if (visitedPlacesForJourney && arrayIndex < visitedPlacesForJourney.length) {
+                    return visitedPlacesForJourney[arrayIndex];
+                }
+            }
+
+            return match; // Return original if field not found
+        });
+
+        return newString;
+    }
+
     private activeVehicleStr = '${activeVehicleId}';
     private activePersonStr = '${activePersonId}';
     private activeJourneyStr = '${activeJourneyId}';
@@ -105,6 +146,7 @@ export class SurveyObjectDetector {
         newString = this.replaceWithActiveObjectId(newString, this.activeVisitedPlaceStr, this.activeVisitedPlaceId);
         newString = this.replaceWithActiveObjectId(newString, this.activeTripStr, this.activeTripId);
         newString = this.replaceWithSegmentId(newString);
+        newString = this.replaceWithTripDiaryData(newString);
         return newString;
     }
 
@@ -234,6 +276,28 @@ export class SurveyObjectDetector {
         }
     }
 
+    private detectTripDiary(data: any) {
+        // Order of trip diaries may not be the same as the order of the persons and journeys, so we need to detect the start of a trip diary and save the order
+        let activePersonId: string | undefined = undefined;
+        let activeJourneyId: string | undefined = undefined;
+        // Get the active person, journey and visited place ids, we are in a trip diary if the first 2 are defined
+        this.detectActiveObject(data, activePersonKeyRegex, (activeId) => (activePersonId = activeId));
+        this.detectActiveObject(data, activeJourneyKeyRegex, (activeId) => (activeJourneyId = activeId));
+
+        if (activeJourneyId && activePersonId) {
+            // We are in a trip diary, we can save the order of the visited places for this journey
+            const tripDiary = this.tripDiaries.find(
+                (diary) => diary.personId === activePersonId && diary.journeyId === activeJourneyId
+            );
+            if (!tripDiary) {
+                this.tripDiaries.push({
+                    personId: activePersonId,
+                    journeyId: activeJourneyId
+                });
+            }
+        }
+    }
+
     /**
      * Detect survey objects and active objects from the survey update data
      *
@@ -251,5 +315,6 @@ export class SurveyObjectDetector {
         this.detectActiveObject(data, activeVisitedPlaceKeyRegex, (activeId) => (this.activeVisitedPlaceId = activeId));
         this.detectActiveObject(data, activeTripKeyRegex, (activeId) => (this.activeTripId = activeId));
         this.detectActiveObject(data, activeVehicleKeyRegex, (activeId) => (this.activeVehicleId = activeId));
+        this.detectTripDiary(data);
     }
 }

--- a/packages/evolution-frontend/tests/ui-testing/testHelpers.ts
+++ b/packages/evolution-frontend/tests/ui-testing/testHelpers.ts
@@ -448,10 +448,11 @@ export const expectInputRadioOptionsTest = ({
 export const inputSelectTest: InputSelectTest = ({ context, path, value }) => {
     test(`Select ${value} for ${path} - ${getTestCounter(context, `${path} - ${value}`)}`, async () => {
         const newPath = context.objectDetector.replaceWithIds(path);
-        const option = context.page.locator(`id=survey-question__${newPath}`);
-        await option.scrollIntoViewIfNeeded();
-        await option.selectOption(value);
-        await expect(option).toHaveValue(value);
+        const resolvedOption = typeof value === 'string' ? context.objectDetector.replaceWithIds(value) : value;
+        const selectWidget = context.page.locator(`id=survey-question__${newPath}`);
+        await selectWidget.scrollIntoViewIfNeeded();
+        await selectWidget.selectOption(resolvedOption);
+        await expect(selectWidget).toHaveValue(resolvedOption);
         await focusOut(context.page);
     });
 };


### PR DESCRIPTION
fixes #1569

A new trip diary is entered whenever a new personId/journeyId is set as active. Then using placeholder strings like `${tripDiary[n]}`, `${tripDiary[n].personId|journeyId|visitedPlaces[i]}` will return respectively the path of the trip diary's journey or the requested ID of the person, journey or visited place for the trip diary at index `n`.

Update the select test to also resolve the options with placeholder, like the radio options already do.

This is a necessary step to support multiple trip diaries tests, where the person/journey sort order may be random.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced UI test infrastructure with improved template token resolution for test selectors.
  * Strengthened test utility functions for more reliable test execution and assertion validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chairemobilite/evolution/pull/1570)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->