### PR TITLE
Bug: change default active state to False

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING**: Rename the map widget's `updateDefaultValueWhenResponded` to `resetToDefaultUnlessUserInteracted` for clarity. The property applies to all map types, not just 'findPlace'.
 - **BREAKING**: The generator's `Labels` sheet in the Excel file should rename the "section" and "path" columns to "namespace" and "key", which better represents where we want the key to be (fixes [#1530](https://github.com/chairemobilite/evolution/issues/1530)).
 - **BREAKING**: The generator now use the question name as translation label key instead of the path. Surveys using the generator will automatically update all label fields, but if additional label with context had been added in the "Labels" sheet to match the question's original label, these might need to be updated (fixes [#1530](https://github.com/chairemobilite/evolution/issues/1530)).
-
+- **BREAKING**: Generator inactive widgets: `active` now behaves like a real boolean (Excel `0`/`1` included), defaults to inactive when omitted, and inactive rows stay commented-out in generated widget files instead of emitting broken code (fixes [#1597](https://github.com/chairemobilite/evolution/issues/1597)).
 
 ### Deprecated
 

--- a/packages/evolution-generator/src/scripts/generate_widgets.py
+++ b/packages/evolution-generator/src/scripts/generate_widgets.py
@@ -239,7 +239,7 @@ def generate_widget_statement(row, gender_fields: GenderFields = None) -> Widget
     # Initialize gender_fields to a default class if none is provided
     gender_fields = gender_fields or GenderFields()
     question_name = row["questionName"]
-    active = row.get("active", True)  # Default to True if not present
+    active = row.get("active", False)  # Default to False if not present
     input_type = row["inputType"]
     section = row["section"]
     path = row["path"]
@@ -258,7 +258,7 @@ def generate_widget_statement(row, gender_fields: GenderFields = None) -> Widget
     result: WidgetResult = {"statement": "", "has_helper_import": False}
 
     # If the widget is not active, generate a comment and return
-    if active is False:
+    if not active:
         result["statement"] = (
             f"// Note: {question_name} widget is not active. This widget will not be displayed in the survey."
         )
@@ -375,7 +375,7 @@ def generate_widget_statement(row, gender_fields: GenderFields = None) -> Widget
 # Define a function to generate the widget name for a given row and group
 def generate_widget_name(row, group, is_last):
     question_name = row["questionName"]
-    active = row.get("active", True)  # Default to True if not present
+    active = row.get("active", False)  # Default to False if not present
     rowGroup = row.get("group") if row.get("group") else ""
 
     # Return the question_name commented if not active

--- a/packages/evolution-generator/src/tests/test_generate_widgets.py
+++ b/packages/evolution-generator/src/tests/test_generate_widgets.py
@@ -12,6 +12,7 @@ from scripts.generate_widgets import (
     generate_radio_number_widget,
     generate_next_button_widget,
     generate_string_widget,
+    generate_widget_name,
     generate_widget_statement,
     generate_suffix_label_code,
     generate_label,
@@ -28,7 +29,6 @@ from scripts.generate_widgets import (
 # TODO: Test generate_widgets
 # TODO: Test generate_widget_statement
 # TODO: Test generate_built_in_widget when we are ready to support them
-# TODO: Test generate_widget_name
 # TODO: Test generate_widgets_names_statements
 
 
@@ -1056,6 +1056,7 @@ class TestGenerateWidgetStatementComments:
     def test_single_line_comment_is_preserved(self):
         row = {
             "questionName": "acceptToBeContactedForHelp",
+            "active": True,
             "inputType": "Radio",
             "section": "home",
             "path": "acceptToBeContactedForHelp",
@@ -1079,6 +1080,7 @@ class TestGenerateWidgetStatementComments:
     def test_multi_line_comment_is_preserved(self):
         row = {
             "questionName": "acceptToBeContactedForHelp",
+            "active": True,
             "inputType": "Radio",
             "section": "home",
             "path": "acceptToBeContactedForHelp",
@@ -1102,6 +1104,7 @@ class TestGenerateWidgetStatementComments:
     def test_no_comments_column_does_not_add_comment(self):
         row = {
             "questionName": "acceptToBeContactedForHelp",
+            "active": True,
             "inputType": "Radio",
             "section": "home",
             "path": "acceptToBeContactedForHelp",
@@ -1145,6 +1148,134 @@ class TestGenerateWidgetStatementActiveFlag:
             == "// Note: acceptToBeContactedForHelp widget is not active. This widget will not be displayed in the survey."
         )
         assert "export const acceptToBeContactedForHelp" not in result["statement"]
+
+    def test_inactive_widget_with_active_zero_generates_not_active_comment_only(self):
+        """Test that active=0 (e.g. from Excel) is treated as inactive"""
+        row = {
+            "questionName": "acceptToBeContactedForHelp",
+            "active": 0,
+            "inputType": "Radio",
+            "section": "home",
+            "path": "acceptToBeContactedForHelp",
+            "conditional": "",
+            "validation": "",
+            "inputRange": "",
+            "help_popup": "",
+            "choices": "yesNo",
+            "label::fr": "Acceptez-vous d'être contacté pour de l'aide?",
+            "label::en": "Do you agree to be contacted for help?",
+        }
+
+        result = generate_widget_statement(row, GenderFields())
+        assert (
+            result["statement"]
+            == "// Note: acceptToBeContactedForHelp widget is not active. This widget will not be displayed in the survey."
+        )
+        assert "export const acceptToBeContactedForHelp" not in result["statement"]
+
+    def test_inactive_widget_with_empty_active_defaults_to_inactive(self):
+        """Test that an empty active cell (e.g. from Excel) defaults to inactive"""
+        row = {
+            "questionName": "acceptToBeContactedForHelp",
+            "active": "",
+            "inputType": "Radio",
+            "section": "home",
+            "path": "acceptToBeContactedForHelp",
+            "conditional": "",
+            "validation": "",
+            "inputRange": "",
+            "help_popup": "",
+            "choices": "yesNo",
+            "label::fr": "Acceptez-vous d'être contacté pour de l'aide?",
+            "label::en": "Do you agree to be contacted for help?",
+        }
+
+        result = generate_widget_statement(row, GenderFields())
+        assert (
+            result["statement"]
+            == "// Note: acceptToBeContactedForHelp widget is not active. This widget will not be displayed in the survey."
+        )
+        assert "export const acceptToBeContactedForHelp" not in result["statement"]
+
+    def test_active_widget_with_active_one_generates_widget_statement(self):
+        """Test that active=1 (e.g. from Excel) is treated as active and generates the widget"""
+        row = {
+            "questionName": "acceptToBeContactedForHelp",
+            "active": 1,
+            "inputType": "Radio",
+            "section": "home",
+            "path": "acceptToBeContactedForHelp",
+            "conditional": "",
+            "validation": "",
+            "inputRange": "",
+            "help_popup": "",
+            "choices": "yesNo",
+            "label::fr": "Acceptez-vous d'être contacté pour de l'aide?",
+            "label::en": "Do you agree to be contacted for help?",
+        }
+
+        result = generate_widget_statement(row, GenderFields())
+        assert (
+            "export const acceptToBeContactedForHelp: WidgetConfig.InputRadioType = {"
+            in result["statement"]
+        )
+        assert "path: 'acceptToBeContactedForHelp'," in result["statement"]
+        assert "choices: choices.yesNo" in result["statement"]
+        assert "widget is not active" not in result["statement"]
+        assert result["statement"].strip().endswith("};")
+
+    def test_active_widget_with_active_true_generates_widget_statement(self):
+        """Test that active=True is treated as active and generates the widget"""
+        row = {
+            "questionName": "acceptToBeContactedForHelp",
+            "active": True,
+            "inputType": "Radio",
+            "section": "home",
+            "path": "acceptToBeContactedForHelp",
+            "conditional": "",
+            "validation": "",
+            "inputRange": "",
+            "help_popup": "",
+            "choices": "yesNo",
+            "label::fr": "Acceptez-vous d'être contacté pour de l'aide?",
+            "label::en": "Do you agree to be contacted for help?",
+        }
+
+        result = generate_widget_statement(row, GenderFields())
+        assert (
+            "export const acceptToBeContactedForHelp: WidgetConfig.InputRadioType = {"
+            in result["statement"]
+        )
+        assert "widget is not active" not in result["statement"]
+        assert result["statement"].strip().endswith("};")
+
+
+class TestGenerateWidgetName:
+    """Tests for generate_widget_name function"""
+
+    INDENT = "    "
+
+    def test_active_one_emits_uncommented_name(self):
+        """active=1 (e.g. from Excel) should be treated as active"""
+        row = {"questionName": "homeAddress", "active": 1, "group": ""}
+        result = generate_widget_name(row, group="", is_last=False)
+        assert result == f"{self.INDENT}'homeAddress',"
+
+    def test_active_zero_emits_commented_name(self):
+        """active=0 (e.g. from Excel) should be treated as inactive"""
+        row = {"questionName": "homeAddress", "active": 0, "group": ""}
+        result = generate_widget_name(row, group="", is_last=False)
+        assert result == f"{self.INDENT}// 'homeAddress',"
+
+    def test_last_row_omits_trailing_comma(self):
+        row = {"questionName": "homeAddress", "active": 1, "group": ""}
+        result = generate_widget_name(row, group="", is_last=True)
+        assert result == f"{self.INDENT}'homeAddress'"
+
+    def test_returns_none_when_group_does_not_match_row_group(self):
+        row = {"questionName": "homeAddress", "active": True, "group": "personGroup"}
+        result = generate_widget_name(row, group="", is_last=False)
+        assert result is None
 
 
 # TODO: Test generate_select_widget


### PR DESCRIPTION
# PR
fix: #1597

## Description
Bug: change default active state to False
Updated the default value of the 'active' field in the generate_widget_statement and generate_widget_name functions to False.
- Adjusted the logic to handle inactive widgets correctly in the generated statements.
- Added tests to ensure proper handling of active states represented as 0, 1, and True.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Widgets now default to inactive when the active flag is missing; inactive rows are emitted as commented placeholders unless explicitly active.

* **Tests**
  * Expanded coverage for widget name/statement generation, Excel-style active values, formatting, trailing commas, and group-matching behavior.

* **Documentation**
  * Changelog updated to document the inactive-widget generation change.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chairemobilite/evolution/pull/1585?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->