### PR TITLE
CI and backport: update workflow to explain how to run CI on backported PRs

### DIFF
--- a/.github/workflows/backport-generic.yml
+++ b/.github/workflows/backport-generic.yml
@@ -161,7 +161,7 @@ jobs:
           ].join('\n');
 
           // head is the branch in the current repo, where it has been created, so no need to include the owner
-          await github.rest.pulls.create({
+          const pr = await github.rest.pulls.create({
             owner,
             repo,
             base,
@@ -169,3 +169,29 @@ jobs:
             title,
             body
           });
+
+          const prNumber = pr.data.number;
+
+          // Post a comment with instructions to trigger the CI workflow
+          await github.rest.issues.createComment({
+            owner,
+            repo,
+            issue_number: prNumber,
+            body: [
+              '## :robot: Automated Backport Created',
+              '',
+              'CI workflows are not automatically triggered for backport PRs.',
+              '',
+              '### To run the CI checks:',
+              '',
+              `1. Go to the [Actions tab](${context.payload.repository.html_url}/actions) in the repository`,
+              '2. Find and select the **CI** workflow from the list on the left',
+              `3. Click the **"Run workflow"** dropdown button`,
+              `4. Select branch: **${process.env.BACKPORT_BRANCH}**`,
+              '5. Click **"Run workflow"** to trigger the checks',
+              '',
+              '_The build status is required before merging this backport._'
+            ].join('\n')
+          });
+
+          core.info(`Backport PR #${prNumber} created with CI instructions comment`);

--- a/.github/workflows/evolution.yml
+++ b/.github/workflows/evolution.yml
@@ -5,9 +5,9 @@ name: CI
 
 on:
   push:
-    branches: [ main, od_2023, v0.3.0 ]
+    branches: [ main, od_2023, v0.3.0, v0.5.0 ]
   pull_request:
-    branches: [ main, od_2023, v0.3.0 ]
+    branches: [ main, od_2023, v0.3.0, v0.5.0 ]
   # This event allows to manually trigger the workflow from the Actions tab in GitHub UI, used to manually trigger this workflow on backported branches
   workflow_dispatch:
 

--- a/.github/workflows/evolution.yml
+++ b/.github/workflows/evolution.yml
@@ -8,6 +8,8 @@ on:
     branches: [ main, od_2023, v0.3.0 ]
   pull_request:
     branches: [ main, od_2023, v0.3.0 ]
+  # This event allows to manually trigger the workflow from the Actions tab in GitHub UI, used to manually trigger this workflow on backported branches
+  workflow_dispatch:
 
 jobs:
   build-and-test:


### PR DESCRIPTION
backport workflow: add comment explaining how to trigger CI

Once the PR is created, a comment will be posted to indicate how to
trigger the workflow run for this PR manually from the Actions tab. This
is preferable go granting the github actions bot additional permissions
on the actions. And since the branche is created in the repo itself, the
trigger button that appears for external contributor is not shown, so it
need to be triggered manually instead.

CI: add the `workflow_dispatch` option to workflows

This allows to manually trigger the workflow runs from the Actions menu.
This will be useful for backported PRs, which do not automatically run
the workflows (that would required write permissions to actions, which
may be a security risk) and instead will need to be manually triggered.

Developed with the help of copilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Enhanced backport workflow to include manual CI instructions on newly created backport pull requests.
* Extended continuous integration workflow support to version 0.5.0 branch alongside existing release branches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chairemobilite/evolution/pull/1588)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->