### PR TITLE
generator: let the csv generation use the `get_data_from_excel`

### DIFF
--- a/example/demo_generator/references/Household_Travel_Generate_Survey_csv/Labels.csv
+++ b/example/demo_generator/references/Household_Travel_Generate_Survey_csv/Labels.csv
@@ -1,3 +1,3 @@
-namespace,key,label::fr,label::en,label_one::fr,label_one::en,
-household,personSchoolTypeYoungChild,**Type d’école / garderie**,**School type / daycare**,,,
-household,personSchoolTypeOlderPerson,**Établissement d'enseignement / type d'école**,**School type**,,,
+namespace,key,label::fr,label::en,label_one::fr,label_one::en
+household,personSchoolTypeYoungChild,**Type d’école / garderie**,**School type / daycare**,,
+household,personSchoolTypeOlderPerson,**Établissement d'enseignement / type d'école**,**School type**,,

--- a/packages/evolution-generator/src/scripts/excel_to_csv_generator.py
+++ b/packages/evolution-generator/src/scripts/excel_to_csv_generator.py
@@ -11,7 +11,7 @@ import re
 
 import openpyxl
 
-from helpers.generator_helpers import is_excel_file
+from helpers.generator_helpers import is_excel_file, get_data_from_excel
 
 
 class ExcelToCsvGenerator:
@@ -73,10 +73,29 @@ class ExcelToCsvGenerator:
         """Write a single sheet to "<SheetName>.csv" and return its path."""
         csv_file_name = f"{self.sanitize_sheet_title(worksheet.title)}.csv"
         csv_file_path = os.path.join(self.output_folder_path, csv_file_name)
+
         with open(csv_file_path, mode="w", encoding="utf-8", newline="") as csv_file:
             writer = csv.writer(csv_file)
-            for row in worksheet.iter_rows(values_only=True):
-                writer.writerow(["" if value is None else value for value in row])
+
+            # Use get_data_from_excel to properly bound rows and headers
+            try:
+                rows, headers = get_data_from_excel(
+                    self.excel_file_path, worksheet.title
+                )
+
+                # Write headers
+                writer.writerow(headers)
+
+                # Write data rows (skip header row at index 0)
+                for row in rows[1:]:
+                    values = ["" if cell.value is None else cell.value for cell in row]
+                    # Trim trailing None/empty values to match header count
+                    values = values[: len(headers)]
+                    writer.writerow(values)
+
+            except Exception as e:
+                print(f"Error processing sheet '{worksheet.title}': {e}")
+                raise
 
         print(f"Generated {csv_file_path} successfully")
         return csv_file_path


### PR DESCRIPTION
fixes #1590

The csv generation could trigger an infinite when the workbook iterator did not stop at the last line, but just kept producing more lines. The `get_data_from_excel` already solves this issue, so the csv generation will use that also

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSV export error handling to include worksheet-specific error messages for easier diagnosis.
  * Ensured CSV rows align with headers, trimming excess values and converting missing cells to empty values.
  * Updated sheet processing to more reliably extract and write header plus row data, reducing malformed CSV output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chairemobilite/evolution/pull/1591)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->