### PR TITLE
auth: make the `verify` route available only to admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Require admin access to verify new user accounts
+
 ### Dependency updates
 
 - style-loader: 4.0.0

--- a/packages/evolution-frontend/src/components/admin/routers/AdminSurveyRouter.tsx
+++ b/packages/evolution-frontend/src/components/admin/routers/AdminSurveyRouter.tsx
@@ -78,7 +78,7 @@ const getAdminSurveyRoutes = (): RouteObject[] => [
             },
             {
                 path: '/verify/:token',
-                element: <PublicRoute component={VerifyPage} path="/verify/:token" />
+                element: <AdminRoute component={VerifyPage} path="/verify/:token" />
             },
             {
                 path: '/reset/:token',

--- a/packages/evolution-frontend/src/components/admin/routers/__tests__/AdminSurveyRouter.test.ts
+++ b/packages/evolution-frontend/src/components/admin/routers/__tests__/AdminSurveyRouter.test.ts
@@ -175,7 +175,7 @@ describe('getAdminSurveyRoutes', () => {
         { path: '/register', wrapperType: 'PublicRoute' },
         { path: '/forgot', wrapperType: 'PublicRoute' },
         { path: '/unconfirmed', wrapperType: 'PublicRoute' },
-        { path: '/verify/:token', wrapperType: 'PublicRoute' },
+        { path: '/verify/:token', wrapperType: 'AdminRoute' },
         { path: '/reset/:token', wrapperType: 'PublicRoute' },
         { path: '/unauthorized', wrapperType: 'PublicRoute' },
         { path: '/maintenance', wrapperType: 'PublicRoute' },


### PR DESCRIPTION
The verify page currently automatically verifies the account, without requiring login. Since some email clients automatically click on links sent to emails, that means that without requiring authentication, this automatically validates the account without an admin explicitly approving it. While by default the permissions are minimal, it still means the user has a valid account on the system, opening possible security risk.

This makes sure the `verify` page requires login. This also makes the `confirmByUser` method non-functional, but it is habitually not used in surveys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * User account verification now requires admin access instead of being publicly accessible.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chairemobilite/evolution/pull/1592)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->