### PR TITLE
Cherry-pick commits from main

### DIFF
--- a/.github/workflows/evolution.yml
+++ b/.github/workflows/evolution.yml
@@ -8,6 +8,8 @@ on:
     branches: [ main, od_2023, v0.3.0, v0.5.0 ]
   pull_request:
     branches: [ main, od_2023, v0.3.0, v0.5.0 ]
+  # This event allows to manually trigger the workflow from the Actions tab in GitHub UI, used to manually trigger this workflow on backported branches
+  workflow_dispatch:
 
 jobs:
   build-and-test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Require admin access to verify new user accounts
+
 ### Dependency updates
 
 

--- a/packages/evolution-frontend/src/components/admin/routers/AdminSurveyRouter.tsx
+++ b/packages/evolution-frontend/src/components/admin/routers/AdminSurveyRouter.tsx
@@ -77,7 +77,7 @@ const getAdminSurveyRoutes = (): RouteObject[] => [
             },
             {
                 path: '/verify/:token',
-                element: <PublicRoute component={VerifyPage} path="/verify/:token" />
+                element: <AdminRoute component={VerifyPage} path="/verify/:token" />
             },
             {
                 path: '/reset/:token',

--- a/packages/evolution-frontend/src/components/admin/routers/__tests__/AdminSurveyRouter.test.ts
+++ b/packages/evolution-frontend/src/components/admin/routers/__tests__/AdminSurveyRouter.test.ts
@@ -170,7 +170,7 @@ describe('getAdminSurveyRoutes', () => {
         { path: '/register', wrapperType: 'PublicRoute' },
         { path: '/forgot', wrapperType: 'PublicRoute' },
         { path: '/unconfirmed', wrapperType: 'PublicRoute' },
-        { path: '/verify/:token', wrapperType: 'PublicRoute' },
+        { path: '/verify/:token', wrapperType: 'AdminRoute' },
         { path: '/reset/:token', wrapperType: 'PublicRoute' },
         { path: '/unauthorized', wrapperType: 'PublicRoute' },
         { path: '/maintenance', wrapperType: 'PublicRoute' },


### PR DESCRIPTION
Add the workflow_dispatch action to allow to trigger workflow on backported PRs

Backport the fix to require logged in users to verify accounts