### PR TITLE
fix(frontend): collapse duplicate URL path slashes before React Router

### DIFF
--- a/example/demo_survey/tests/test-pathname-double-slash.UI.spec.ts
+++ b/example/demo_survey/tests/test-pathname-double-slash.UI.spec.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { expect, test } from '@playwright/test';
+
+/**
+ * Origin for building absolute URLs with intentional `//` in the path (Playwright resolves
+ * `page.goto('//home')` as a scheme-relative URL, so we cannot use a path-only goto here).
+ * Falls back if `project.use.baseURL` is unset (regression guard).
+ */
+const getOrigin = (): string => {
+    const baseUrl = test.info().project.use.baseURL;
+    const resolved = typeof baseUrl === 'string' && baseUrl.length > 0 ? baseUrl : 'http://localhost:8080';
+    return new URL(resolved).origin;
+};
+
+/**
+ * Regression for packages/evolution-frontend/src/utils/normalizeBrowserLocationPathname.ts:
+ * duplicate slashes in the path must normalize so React Router matches routes.
+ */
+test.describe('pathname duplicate slashes', () => {
+    test('leading // before a public route collapses to a single slash', async ({ page }) => {
+        const origin = getOrigin();
+        await page.goto(`${origin}//home`);
+        await expect(page).toHaveURL(`${origin}/home`);
+        expect(new URL(page.url()).pathname).toBe('/home');
+    });
+
+    test('keeps query string and hash after normalization', async ({ page }) => {
+        const origin = getOrigin();
+        await page.goto(`${origin}//home?x=1#frag`);
+        const u = new URL(page.url());
+        expect(u.pathname).toBe('/home');
+        expect(u.search).toBe('?x=1');
+        expect(u.hash).toBe('#frag');
+        await expect(page).toHaveURL(`${origin}/home?x=1#frag`);
+    });
+
+    test('duplicate slashes on root path normalize to /', async ({ page }) => {
+        const origin = getOrigin();
+        await page.goto(`${origin}//`);
+        expect(new URL(page.url()).pathname).toBe('/');
+    });
+});

--- a/packages/evolution-frontend/src/apps/admin/index.tsx
+++ b/packages/evolution-frontend/src/apps/admin/index.tsx
@@ -25,6 +25,8 @@ import VisitedPlacesSection from '../../components/survey/sectionTemplates/Visit
 import { UserPermissions } from 'chaire-lib-common/lib/services/user/userType';
 import { Toaster } from 'sonner';
 
+import { replaceBrowserPathnameIfNeeded } from '../../utils/normalizeBrowserLocationPathname';
+
 // TODO This is a workaround to get the links to the user, until some more complete solution is implemented (see https://github.com/chairemobilite/transition/issues/1516)
 const pages: { path: string; permissions: UserPermissions; title: string }[] = [
     { path: '/admin/validation', permissions: { Interviews: ['validate'] }, title: 'admin:validationPageTitle' },
@@ -39,6 +41,7 @@ setApplicationConfiguration({
 
 export default () => {
     document.title = config.title[i18n.language];
+    replaceBrowserPathnameIfNeeded();
 
     const store = configureStore();
     const Jsx = () => {

--- a/packages/evolution-frontend/src/apps/participant/index.tsx
+++ b/packages/evolution-frontend/src/apps/participant/index.tsx
@@ -23,6 +23,7 @@ import '../../styles/survey/styles-participant-survey.scss';
 import verifyAuthentication from 'chaire-lib-frontend/lib/services/auth/verifyAuthentication';
 import SegmentsSection from '../../components/survey/sectionTemplates/TripsAndSegmentsSection';
 import VisitedPlacesSection from '../../components/survey/sectionTemplates/VisitedPlacesSection';
+import { replaceBrowserPathnameIfNeeded } from '../../utils/normalizeBrowserLocationPathname';
 
 setApplicationConfiguration({
     homePage: '/survey',
@@ -36,6 +37,7 @@ type AppSettings = {
 
 const App = (settings?: AppSettings) => {
     document.title = config.title[i18n.language];
+    replaceBrowserPathnameIfNeeded();
 
     const store = configureStore();
     const Jsx: React.FC = () => {

--- a/packages/evolution-frontend/src/utils/__tests__/normalizeBrowserLocationPathname.test.ts
+++ b/packages/evolution-frontend/src/utils/__tests__/normalizeBrowserLocationPathname.test.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2026, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import each from 'jest-each';
+import { collapseConsecutiveSlashesInPathname } from '../normalizeBrowserLocationPathname';
+
+each([
+    ['/', '/'],
+    ['/interviews/byCode/ABC123', '/interviews/byCode/ABC123'],
+    ['//interviews/byCode/ABC123', '/interviews/byCode/ABC123'],
+    ['///interviews/byCode/ABC123', '/interviews/byCode/ABC123'],
+    ['/interviews//byCode/ABC123', '/interviews/byCode/ABC123'],
+    ['', '/']
+]).test('collapseConsecutiveSlashesInPathname(%s) => %s', (input, expected) => {
+    expect(collapseConsecutiveSlashesInPathname(input)).toBe(expected);
+});

--- a/packages/evolution-frontend/src/utils/normalizeBrowserLocationPathname.ts
+++ b/packages/evolution-frontend/src/utils/normalizeBrowserLocationPathname.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+/**
+ * Collapses consecutive `/` in a URL pathname to a single `/`.
+ * React Router matches the literal `location.pathname`, so `//segment/...` must be normalized
+ * (see https://github.com/chairemobilite/evolution/issues/2).
+ *
+ * @param pathname - `window.location.pathname` (may include duplicate slashes)
+ * @returns Canonical pathname starting with `/` when non-empty
+ */
+export const collapseConsecutiveSlashesInPathname = (pathname: string): string => {
+    const collapsed = pathname.replace(/\/+/g, '/');
+    return collapsed === '' ? '/' : collapsed;
+};
+
+/**
+ * If the current pathname contains duplicate slashes, replaces the browser URL in-place
+ * (same origin, search, hash, history state) so React Router sees a path it can match.
+ *
+ * Call only from browser entry bundles (e.g. admin/participant `index.tsx`). Do not import
+ * into Node-only code: `window` is assumed to exist.
+ */
+export const replaceBrowserPathnameIfNeeded = (): void => {
+    const { pathname, search, hash } = window.location;
+    const normalized = collapseConsecutiveSlashesInPathname(pathname);
+    if (normalized === pathname) {
+        return;
+    }
+    window.history.replaceState(window.history.state, '', `${normalized}${search}${hash}`);
+};


### PR DESCRIPTION
Add replaceBrowserPathnameIfNeeded on admin and participant entrypoints, with a small pathname helper and Jest coverage. Add a Playwright spec in demo_survey for //home and related cases.

closes #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic URL pathname normalization across the admin and participant apps.
  * Duplicate slashes are collapsed while preserving query parameters and URL fragments.
  * Root and empty paths are normalized to `/`.

* **Bug Fixes**
  * Prevented malformed URLs with repeated slashes from affecting navigation or displayed routes.

* **Tests**
  * Added coverage for pathname normalization, query strings, hashes, and public route navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->