### PR TITLE
widgetActivityCategory: fix conditional and label for school

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - @turf/turf: 7.3.1 => 7.3.5
 - @casl/ability: 6.7.3 => 6.8.1
 - In the root `package.json` add a resolution of `kdbush` to 3.0.0 to avoid compilation errors with some packages depending on a more recent version. This requirement comes from Transition, who does the same (see https://github.com/chairemobilite/transition/issues/921 to track issue to upgrade/remove `kdbush`).
+- Added dependency to `i18next-intervalplural-postprocessor` 3.0.0 to support i18next [interval pluralization](https://www.i18next.com/translation-function/plurals#interval-plurals)
 
 ## [Unreleased (0.5.1)] - YYYY-MM-DD
 

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetActivityCategory.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetActivityCategory.test.ts
@@ -72,7 +72,7 @@ describe('Activity category choices labels', () => {
         const mockedT = jest.fn();
         const choice = choices.find((c) => c.value === choiceValue);
         expect(choice).toBeDefined();
-        translateString(choice?.label, { t: mockedT } as any, interview, 'path');
+        translateString(choice?.label, { t: mockedT } as any, interview, 'interview.response.household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.activityCategory');
         expect(mockedT).toHaveBeenCalledWith(expectedLabel);
     });
 
@@ -89,9 +89,33 @@ describe('Activity category choices labels', () => {
         expect(schoolChoice).toBeDefined();
         setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
         interview.response.household!.persons!.personId1!.schoolType = schoolType as any;
-        translateString(schoolChoice?.label, { t: mockedT } as any, interview, 'path');
+        translateString(schoolChoice?.label, { t: mockedT } as any, interview, 'interview.response.household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.activityCategory');
         expect(mockedT).toHaveBeenCalledWith(expectedLabel);
     });
+
+    test('school label when no schoolType nor age should use generic label', () => {
+        const mockedT = jest.fn();
+        const schoolChoice = choices.find((c) => c.value === 'school');
+        expect(schoolChoice).toBeDefined();
+        setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
+        interview.response.household!.persons!.personId1!.schoolType = undefined;
+        interview.response.household!.persons!.personId1!.age = undefined;
+        translateString(schoolChoice?.label, { t: mockedT } as any, interview, 'interview.response.household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.activityCategory');
+        expect(mockedT).toHaveBeenCalledWith('visitedPlaces:activityCategories.schoolStudies');
+    });
+
+    test('school label when no schoolType should use age as count', () => {
+        const mockedT = jest.fn();
+        const schoolChoice = choices.find((c) => c.value === 'school');
+        expect(schoolChoice).toBeDefined();
+        const age = 34;
+        setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
+        interview.response.household!.persons!.personId1!.schoolType = undefined;
+        interview.response.household!.persons!.personId1!.age = age;
+        translateString(schoolChoice?.label, { t: mockedT } as any, interview, 'interview.response.household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.activityCategory');
+        expect(mockedT).toHaveBeenCalledWith('visitedPlaces:activityCategories.schoolStudies_interval', { postProcess: 'interval', count: age });
+    });
+
 });
 
 describe('Activity category choices conditionals', () => {

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetActivityCategory.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetActivityCategory.test.ts
@@ -169,11 +169,11 @@ describe('Activity category choices conditionals', () => {
         ['Person with no age and occupation', true, undefined, undefined, undefined],
         ['Full time student occupation', true, 45, 'fullTimeStudent', undefined],
         ['Part time student occupation', true, 10, 'partTimeStudent', undefined],
-        ['Full time Worker occupation', true, 25, 'fullTimeWorker', undefined],
-        ['Part time Worker occupation', true, 18, 'partTimeWorker', undefined],
+        ['Full time Worker occupation', false, 25, 'fullTimeWorker', false],
+        ['Part time Worker occupation', false, 18, 'partTimeWorker', false],
         ['Worker and student occupation', true, 60, 'workerAndStudent', undefined],
         ['No occupation, isStudentFromEnrolled true', true, 4, undefined, true],
-        ['No occupation, isStudentFromEnrolled true', false, 4, undefined, false],
+        ['No occupation, isStudentFromEnrolled false', false, 4, undefined, false],
         ['Non-student/worker occupation, isStudentFromEnrolled true', true, 10, 'other', true],
         ['Non-student/worker occupation, isStudentFromEnrolled false', false, 10, 'other', false]
     ]).test(

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetActivityCategory.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetActivityCategory.ts
@@ -84,14 +84,11 @@ const perActivityCategoryConditionals: Partial<{ [category in ActivityCategory]:
         if (_isBlank(person.age) && _isBlank(occupation)) {
             return true;
         }
-        // Return true if an occupation is set and it is one of the student or
-        // worker occupations, or if isStudentFromEnrolled is true.
+        // Return true if an occupation is set and it is one of the student occupations, or if isStudentFromEnrolled is true.
         // FIXME Should this condition actually be a single `isStudent` helper function to replace the `isStudentFromEnrolled`? Current condition comes from od_nationale_quebec. See how to implement in Evolution
         return (
             (!_isBlank(occupation) &&
-                ['fullTimeWorker', 'partTimeWorker', 'fullTimeStudent', 'partTimeStudent', 'workerAndStudent'].includes(
-                    occupation!
-                )) ||
+                ['fullTimeStudent', 'partTimeStudent', 'workerAndStudent'].includes(occupation!)) ||
             odHelpers.isStudentFromSchoolType({ person })
         );
     },

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetActivityCategory.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetActivityCategory.ts
@@ -21,17 +21,27 @@ import config from '../../../../config/project.config';
 import * as visitedPlacesHelpers from './helpers';
 
 const perActivityCategoryLabels: Partial<{ [category in ActivityCategory]: I18nData }> = {
-    school: (t: TFunction, interview) => {
-        const person = odHelpers.getPerson({ interview });
-        if (person?.schoolType === 'childcare') {
+    school: (t: TFunction, interview, path) => {
+        const person = odHelpers.getPerson({ interview, path });
+        // If no person or school type and age are unknown, return the generic label for school studies
+        if (!person || (person.schoolType === undefined && person.age === undefined)) {
+            return t('visitedPlaces:activityCategories.schoolStudies');
+        }
+        // If school type is not known, return a label specific to the age if available
+        if (person.schoolType === undefined && person.age !== undefined) {
+            return t('visitedPlaces:activityCategories.schoolStudies_interval', {
+                postProcess: 'interval',
+                count: person.age
+            });
+        }
+        if (person.schoolType === 'childcare') {
             return t('visitedPlaces:activityCategories.childcare');
-        } else if (person?.schoolType === 'kindergarten') {
+        } else if (person.schoolType === 'kindergarten') {
             return t('visitedPlaces:activityCategories.kindergarten');
         } else if (
-            person?.schoolType &&
-            (person.schoolType === 'kindergartenFor4YearsOld' ||
-                person.schoolType === 'primarySchool' ||
-                person.schoolType === 'secondarySchool')
+            person.schoolType === 'kindergartenFor4YearsOld' ||
+            person.schoolType === 'primarySchool' ||
+            person.schoolType === 'secondarySchool'
         ) {
             return t('visitedPlaces:activityCategories.school');
         } else {
@@ -133,6 +143,22 @@ const getActivityCategoryChoices = (filteredCategories: ActivityCategory[]): Rad
 
 /**
  * Get the activity category widget configuration for the visited place section.
+ *
+ * Activity category labels can be overriden by providing translation keys for
+ * `visitedPlaces:activityCategories.${category}`. The school activity category
+ * label can also be customized based on the person's `schoolType` field by
+ * providing translation keys for
+ * `visitedPlaces:activityCategories.schoolStudies`,
+ * `visitedPlaces:activityCategories.childcare`,
+ * `visitedPlaces:activityCategories.kindergarten`,
+ * `visitedPlaces:activityCategories.school`, and
+ * `visitedPlaces:activityCategories.schoolStudies_interval`. If no `schoolType`
+ * is set, the label can be customized based on the person's age by providing a
+ * translation key for `visitedPlaces:activityCategories.schoolStudies_interval`
+ * with i18next interval pluralization, where the count is the person's age and
+ * the intervals are defined based on the age groups relevant for school types
+ * (for example `(0-15)[École];(15-inf)[École / Études];`).
+ *
  * @param sectionConfig The configuration of the section
  * @param options The widget factory options
  * @returns The widget configuration for the activity category question, which

--- a/packages/evolution-frontend/package.json
+++ b/packages/evolution-frontend/package.json
@@ -53,6 +53,7 @@
     "highcharts-react-official": "^3.2.1",
     "i18next": "^26.0.6",
     "i18next-browser-languagedetector": "^8.2.1",
+    "i18next-intervalplural-postprocessor": "^3.0.0",
     "lodash": "^4.18.1",
     "maplibre-gl": "^5.7.1",
     "moment": "^2.30.1",

--- a/packages/evolution-frontend/src/config/i18n.config.ts
+++ b/packages/evolution-frontend/src/config/i18n.config.ts
@@ -9,6 +9,7 @@ import { initReactI18next } from 'react-i18next';
 import moment from 'moment';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import config from 'chaire-lib-frontend/lib/config/project.config';
+import intervalPlural from 'i18next-intervalplural-postprocessor';
 
 // Declare custom locales path from webpack
 declare const __CUSTOM_LOCALES_PATH__: string | undefined;
@@ -39,6 +40,7 @@ const detectorOrder = config.detectLanguageFromUrl
 
 i18n.use(LanguageDetector)
     .use(initReactI18next)
+    .use(intervalPlural)
     .init(
         {
             detection: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9102,6 +9102,11 @@ i18next-http-backend@^3.0.5:
   dependencies:
     cross-fetch "4.1.0"
 
+i18next-intervalplural-postprocessor@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/i18next-intervalplural-postprocessor/-/i18next-intervalplural-postprocessor-3.0.0.tgz#35580abdaff5e838c44c22740a7178063b7bdd0b"
+  integrity sha512-ZJWg2Gcb0kQqVI7kygLj9wVwQHK3mzRAg94uLsdoHqss0M9n0HSPr1pThd2AttkBsJFWR26G18hnKCqcTB8shQ==
+
 i18next@^26.0.6:
   version "26.0.6"
   resolved "https://registry.yarnpkg.com/i18next/-/i18next-26.0.6.tgz#558b5e3170249d7d338d7732edb662a4108082a0"


### PR DESCRIPTION
fixes #1583 See individual commits for details:

* Support interval plurals in translation strings (https://www.i18next.com/translation-function/plurals#interval-plurals)
* Do not show school activity category for worker occupation
* If the survey does not contain a schoolType, fallback to a string that uses the age for interval, surveys can define these values. If not set, it falls back to the default translation strings, ie schoolStudies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interval pluralization support for improved translation accuracy in questionnaire labels.

* **Bug Fixes**
  * Enhanced school activity category label logic to correctly handle various school type and age scenarios.
  * Improved translation path resolution for more accurate widget label localization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->