### PR TITLE
tripDiary: support inlining usual places in trip diary

### DIFF
--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/helpers.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/helpers.test.ts
@@ -778,6 +778,440 @@ describe('formatTripDuration', () => {
     });
 });
 
+describe('Visited places helpers - getPersonUsualWorkPlace', () => {
+    type GetPersonUsualWorkPlaceCase = {
+        title: string;
+        setup: (interview: UserRuntimeInterviewAttributes) => {
+            path: string;
+            expectedMayHaveUsualWorkPlace: boolean;
+            expectedWorkPlaceUuid?: string;
+            expectedWorkPlaceName?: string;
+            expectedWorkPlaceHasGeography?: boolean;
+            expectedWorkPlaceShouldBeNull: boolean;
+        };
+    };
+
+    test.each<GetPersonUsualWorkPlaceCase>([
+        {
+            title: 'returns null work place even if person work place has geography',
+            setup: (interview: UserRuntimeInterviewAttributes) => {
+                // From the config, that place is not expected to exist, do not return it here even if it does
+                interview.response.household!.persons!.personId3!.usualWorkPlace = {
+                    geography: {
+                        type: 'Feature' as const,
+                        geometry: { type: 'Point' as const, coordinates: [-74.1, 46.1] },
+                        properties: { lastAction: 'findPlace' as const }
+                    },
+                    name: 'Configured usual work'
+                };
+                return {
+                    path: 'household.persons.personId3.journeys.journeyId3.visitedPlaces.schoolPlace1P3.activity',
+                    expectedMayHaveUsualWorkPlace: true,
+                    expectedWorkPlaceUuid: undefined,
+                    expectedWorkPlaceHasGeography: false,
+                    expectedWorkPlaceShouldBeNull: true
+                }
+            }
+        },
+        {
+            title: 'Use the work usual place from journey',
+            setup: (interview: UserRuntimeInterviewAttributes) => {
+                // person1 has a usual work place configure in the journey
+                return {
+                    path: 'household.persons.personId1.journeys.journeyId1.visitedPlaces.homePlace1P1.activity',
+                    expectedMayHaveUsualWorkPlace: true,
+                    expectedWorkPlaceUuid: 'workPlace1P1',
+                    expectedWorkPlaceHasGeography: true,
+                    expectedWorkPlaceShouldBeNull: false
+                }
+            }
+        },
+        {
+            title: 'returns false when occupation indicates the person is not a worker',
+            setup: (interview: UserRuntimeInterviewAttributes) => {
+                interview.response.household!.persons!.personId1!.occupation = 'fullTimeStudent' as any;
+                return {
+                    path: 'household.persons.personId1.journeys.journeyId1.visitedPlaces.homePlace1P1.activity',
+                    expectedMayHaveUsualWorkPlace: false,
+                    expectedWorkPlaceHasGeography: false,
+                    expectedWorkPlaceShouldBeNull: true
+                };
+            }
+        },
+        {
+            title: 'returns false when workPlaceType does not imply a usual place',
+            setup: (interview: UserRuntimeInterviewAttributes) => {
+                interview.response.household!.persons!.personId1!.workPlaceType = 'onTheRoadWithoutUsualPlace' as any;
+                return {
+                    path: 'household.persons.personId1.journeys.journeyId1.visitedPlaces.homePlace1P1.activity',
+                    expectedMayHaveUsualWorkPlace: false,
+                    expectedWorkPlaceHasGeography: false,
+                    expectedWorkPlaceShouldBeNull: true
+                };
+            }
+        }
+    ])('getPersonUsualWorkPlace with inlineUsualPlacesEntry true: $title', ({ setup }) => {
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        const {
+            path,
+            expectedMayHaveUsualWorkPlace,
+            expectedWorkPlaceUuid,
+            expectedWorkPlaceName,
+            expectedWorkPlaceHasGeography,
+            expectedWorkPlaceShouldBeNull
+        } = setup(interview);
+
+        helpers.initializeVisitedPlaceSectionHelpers({ ...defaultVisitedPlaceConfig, inlineUsualPlacesEntry: true })
+        const result = helpers.getPersonUsualWorkPlace(interview, path);
+
+        expect(result.mayHaveUsualPlace).toBe(expectedMayHaveUsualWorkPlace);
+
+        if (expectedWorkPlaceShouldBeNull) {
+            expect(result.usualPlace).toBeNull();
+        } else {
+            expect(result.usualPlace).not.toBeNull();
+        }
+
+        if (expectedWorkPlaceUuid) {
+            expect((result.usualPlace as any)?._uuid).toBe(expectedWorkPlaceUuid);
+        }
+        if (expectedWorkPlaceName) {
+            expect((result.usualPlace as any)?.name).toBe(expectedWorkPlaceName);
+        }
+
+        if (expectedWorkPlaceHasGeography) {
+            expect(result.usualPlace?.geography).toBeDefined();
+        }
+    });
+
+    test.each<GetPersonUsualWorkPlaceCase>([
+        {
+            title: 'returns the usual work place when it has geography',
+            setup: (interview: UserRuntimeInterviewAttributes) => {
+                interview.response.household!.persons!.personId1!.usualWorkPlace = {
+                    geography: {
+                        type: 'Feature' as const,
+                        geometry: { type: 'Point' as const, coordinates: [-74, 46] },
+                        properties: { lastAction: 'findPlace' as const }
+                    },
+                    name: 'Configured usual work'
+                };
+                return {
+                    path: 'household.persons.personId1.journeys.journeyId1.visitedPlaces.homePlace1P1.activity',
+                    expectedMayHaveUsualWorkPlace: true,
+                    expectedWorkPlaceUuid: undefined,
+                    expectedWorkPlaceName: 'Configured usual work',
+                    expectedWorkPlaceHasGeography: true,
+                    expectedWorkPlaceShouldBeNull: false
+                };
+            }
+        },
+        {
+            title: 'returns null when the person has no usual work place geography',
+            // personId1 has a usual work place in the journey, but it should not be returned
+            setup: (_interview: UserRuntimeInterviewAttributes) => ({
+                path: 'household.persons.personId1.journeys.journeyId1.visitedPlaces.homePlace1P1.activity',
+                expectedMayHaveUsualWorkPlace: true,
+                expectedWorkPlaceShouldBeNull: true
+            })
+        },
+        {
+            title: 'returns false when occupation indicates the person is not a worker',
+            setup: (interview: UserRuntimeInterviewAttributes) => {
+                interview.response.household!.persons!.personId1!.occupation = 'fullTimeStudent' as any;
+                return {
+                    path: 'household.persons.personId1.journeys.journeyId1.visitedPlaces.homePlace1P1.activity',
+                    expectedMayHaveUsualWorkPlace: false,
+                    expectedWorkPlaceHasGeography: false,
+                    expectedWorkPlaceShouldBeNull: true
+                };
+            }
+        },
+        {
+            title: 'returns false when workPlaceType does not imply a usual place',
+            setup: (interview: UserRuntimeInterviewAttributes) => {
+                interview.response.household!.persons!.personId1!.workPlaceType = 'onTheRoad' as any;
+                return {
+                    path: 'household.persons.personId1.journeys.journeyId1.visitedPlaces.homePlace1P1.activity',
+                    expectedMayHaveUsualWorkPlace: false,
+                    expectedWorkPlaceHasGeography: false,
+                    expectedWorkPlaceShouldBeNull: true
+                };
+            }
+        }
+    ])('getPersonUsualWorkPlace with inlineUsualPlacesEntry false: $title', ({ setup }) => {
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        const {
+            path,
+            expectedMayHaveUsualWorkPlace,
+            expectedWorkPlaceUuid,
+            expectedWorkPlaceName,
+            expectedWorkPlaceHasGeography,
+            expectedWorkPlaceShouldBeNull
+        } = setup(interview);
+
+        helpers.initializeVisitedPlaceSectionHelpers({ ...defaultVisitedPlaceConfig, inlineUsualPlacesEntry: false })
+        const result = helpers.getPersonUsualWorkPlace(interview, path);
+
+        expect(result.mayHaveUsualPlace).toBe(expectedMayHaveUsualWorkPlace);
+
+        if (expectedWorkPlaceShouldBeNull) {
+            expect(result.usualPlace).toBeNull();
+        } else {
+            expect(result.usualPlace).not.toBeNull();
+        }
+
+        if (expectedWorkPlaceUuid) {
+            expect((result.usualPlace as any)?._uuid).toBe(expectedWorkPlaceUuid);
+        }
+        if (expectedWorkPlaceName) {
+            expect((result.usualPlace as any)?.name).toBe(expectedWorkPlaceName);
+        }
+
+        if (expectedWorkPlaceHasGeography) {
+            expect(result.usualPlace?.geography).toBeDefined();
+        }
+    });
+
+    test('getPersonUsualWorkPlace throws if the person cannot be resolved', () => {
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        helpers.initializeVisitedPlaceSectionHelpers({ ...defaultVisitedPlaceConfig, inlineUsualPlacesEntry: false })
+
+        expect(() =>
+            helpers.getPersonUsualWorkPlace(
+                interview,
+                'household.persons.invalidPerson.journeys.journeyId1.visitedPlaces.homePlace1P1.activity'
+            )
+        ).toThrow('Journey context not found in interview response');
+    });
+});
+
+describe('Visited places helpers - getPersonUsualSchoolPlace', () => {
+    type GetPersonUsualSchoolPlaceCase = {
+        title: string;
+        setup: (interview: UserRuntimeInterviewAttributes) => {
+            path: string;
+            expectedMayHaveUsualSchoolPlace: boolean;
+            expectedSchoolPlaceUuid?: string;
+            expectedSchoolPlaceName?: string;
+            expectedSchoolPlaceHasGeography?: boolean;
+            expectedSchoolPlaceShouldBeNull: boolean;
+        };
+    };
+
+    test.each<GetPersonUsualSchoolPlaceCase>([
+        {
+            title: 'returns null school place even if school place has geography, and no occupation or schoolPlaceType set',
+            setup: (interview: UserRuntimeInterviewAttributes) => {
+                // From the config, that place is not expected to exist, do not return it here even if it does
+                interview.response.household!.persons!.personId1!.usualSchoolPlace = {
+                    geography: {
+                        type: 'Feature' as const,
+                        geometry: { type: 'Point' as const, coordinates: [-74.1, 46.1] },
+                        properties: { lastAction: 'findPlace' as const }
+                    },
+                    name: 'Configured usual school'
+                };
+                return {
+                    path: 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.activity',
+                    expectedMayHaveUsualSchoolPlace: true,
+                    expectedSchoolPlaceUuid: undefined,
+                    expectedSchoolPlaceName: undefined,
+                    expectedSchoolPlaceHasGeography: false,
+                    expectedSchoolPlaceShouldBeNull: true
+                };
+            }
+        },
+        {
+            title: 'Use the school usual place from journey',
+            setup: (_interview: UserRuntimeInterviewAttributes) => ({
+                path: 'household.persons.personId3.journeys.journeyId3.visitedPlaces.homePlace1P3.activity',
+                expectedMayHaveUsualSchoolPlace: true,
+                expectedSchoolPlaceUuid: 'schoolPlace1P3',
+                expectedSchoolPlaceHasGeography: true,
+                expectedSchoolPlaceShouldBeNull: false
+            })
+        },
+        {
+            title: 'returns true when person is under mandatory school age even if occupation is not student',
+            setup: (interview: UserRuntimeInterviewAttributes) => {
+                interview.response.household!.persons!.personId1!.occupation = 'fullTimeWorker' as any;
+                interview.response.household!.persons!.personId1!.age = 6;
+                return {
+                    path: 'household.persons.personId1.journeys.journeyId1.visitedPlaces.homePlace1P1.activity',
+                    expectedMayHaveUsualSchoolPlace: true,
+                    expectedSchoolPlaceShouldBeNull: true
+                };
+            }
+        },
+        {
+            title: 'returns false when schoolPlaceType does not imply a usual place',
+            setup: (interview: UserRuntimeInterviewAttributes) => {
+                interview.response.household!.persons!.personId1!.schoolPlaceType = 'remote' as any;
+                return {
+                    path: 'household.persons.personId1.journeys.journeyId1.visitedPlaces.homePlace1P1.activity',
+                    expectedMayHaveUsualSchoolPlace: false,
+                    expectedSchoolPlaceShouldBeNull: true
+                };
+            }
+        },
+        {
+            title: 'returns true when no occupation set',
+            setup: (interview: UserRuntimeInterviewAttributes) => {
+                return {
+                    path: 'household.persons.personId1.journeys.journeyId1.visitedPlaces.homePlace1P1.activity',
+                    expectedMayHaveUsualSchoolPlace: true,
+                    expectedSchoolPlaceShouldBeNull: true
+                };
+            }
+        },
+        {
+            title: 'returns false when no occupation is not a student type',
+            setup: (interview: UserRuntimeInterviewAttributes) => {
+                interview.response.household!.persons!.personId1!.occupation = 'retired' as any;
+                return {
+                    path: 'household.persons.personId1.journeys.journeyId1.visitedPlaces.homePlace1P1.activity',
+                    expectedMayHaveUsualSchoolPlace: false,
+                    expectedSchoolPlaceShouldBeNull: true
+                };
+            }
+        }
+    ])('getPersonUsualSchoolPlace when inlineUsualPlacesEntry is true: $title', ({ setup }) => {
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        const {
+            path,
+            expectedMayHaveUsualSchoolPlace,
+            expectedSchoolPlaceUuid,
+            expectedSchoolPlaceName,
+            expectedSchoolPlaceHasGeography,
+            expectedSchoolPlaceShouldBeNull
+        } = setup(interview);
+
+        helpers.initializeVisitedPlaceSectionHelpers({ ...defaultVisitedPlaceConfig, inlineUsualPlacesEntry: true })
+        const result = helpers.getPersonUsualSchoolPlace(interview, path);
+
+        expect(result.mayHaveUsualPlace).toBe(expectedMayHaveUsualSchoolPlace);
+
+        if (expectedSchoolPlaceShouldBeNull) {
+            expect(result.usualPlace).toBeNull();
+        } else {
+            expect(result.usualPlace).not.toBeNull();
+        }
+
+        if (expectedSchoolPlaceUuid) {
+            expect((result.usualPlace as any)?._uuid).toBe(expectedSchoolPlaceUuid);
+        }
+        if (expectedSchoolPlaceName) {
+            expect((result.usualPlace as any)?.name).toBe(expectedSchoolPlaceName);
+        }
+
+        if (expectedSchoolPlaceHasGeography) {
+            expect(result.usualPlace?.geography).toBeDefined();
+        }
+    });
+
+    test.each<GetPersonUsualSchoolPlaceCase>([
+        {
+            title: 'returns the usual school place when it has geography',
+            setup: (interview: UserRuntimeInterviewAttributes) => {
+                interview.response.household!.persons!.personId3!.usualSchoolPlace = {
+                    geography: {
+                        type: 'Feature' as const,
+                        geometry: { type: 'Point' as const, coordinates: [-74.1, 46.1] },
+                        properties: { lastAction: 'findPlace' as const }
+                    },
+                    name: 'Configured usual school'
+                };
+                return {
+                    path: 'household.persons.personId3.journeys.journeyId3.visitedPlaces.schoolPlace1P3.activity',
+                    expectedMayHaveUsualSchoolPlace: true,
+                    expectedSchoolPlaceUuid: undefined,
+                    expectedSchoolPlaceName: 'Configured usual school',
+                    expectedSchoolPlaceHasGeography: true,
+                    expectedSchoolPlaceShouldBeNull: false
+                };
+            }
+        },
+        {
+            title: 'Do not look at schoolUsual place from journey when no usual school place geography exists',
+            setup: (_interview: UserRuntimeInterviewAttributes) => ({
+                path: 'household.persons.personId3.journeys.journeyId3.visitedPlaces.homePlace1P3.activity',
+                expectedMayHaveUsualSchoolPlace: true,
+                expectedSchoolPlaceUuid: undefined,
+                expectedSchoolPlaceHasGeography: false,
+                expectedSchoolPlaceShouldBeNull: true
+            })
+        },
+        {
+            title: 'returns true when person is under mandatory school age even if occupation is not student',
+            setup: (interview: UserRuntimeInterviewAttributes) => {
+                interview.response.household!.persons!.personId1!.occupation = 'fullTimeWorker';
+                interview.response.household!.persons!.personId1!.age = 6;
+                return {
+                    path: 'household.persons.personId1.journeys.journeyId1.visitedPlaces.homePlace1P1.activity',
+                    expectedMayHaveUsualSchoolPlace: true,
+                    expectedSchoolPlaceShouldBeNull: true
+                };
+            }
+        },
+        {
+            title: 'returns false when schoolPlaceType does not imply a usual place',
+            setup: (interview: UserRuntimeInterviewAttributes) => {
+                interview.response.household!.persons!.personId1!.schoolPlaceType = 'remote';
+                return {
+                    path: 'household.persons.personId1.journeys.journeyId1.visitedPlaces.homePlace1P1.activity',
+                    expectedMayHaveUsualSchoolPlace: false,
+                    expectedSchoolPlaceShouldBeNull: true
+                };
+            }
+        }
+    ])('getPersonUsualSchoolPlace when inlineUsualPlacesEntry is false: $title', ({ setup }) => {
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        const {
+            path,
+            expectedMayHaveUsualSchoolPlace,
+            expectedSchoolPlaceUuid,
+            expectedSchoolPlaceName,
+            expectedSchoolPlaceHasGeography,
+            expectedSchoolPlaceShouldBeNull
+        } = setup(interview);
+
+        helpers.initializeVisitedPlaceSectionHelpers({ ...defaultVisitedPlaceConfig, inlineUsualPlacesEntry: false })
+        const result = helpers.getPersonUsualSchoolPlace(interview, path);
+
+        expect(result.mayHaveUsualPlace).toBe(expectedMayHaveUsualSchoolPlace);
+
+        if (expectedSchoolPlaceShouldBeNull) {
+            expect(result.usualPlace).toBeNull();
+        } else {
+            expect(result.usualPlace).not.toBeNull();
+        }
+
+        if (expectedSchoolPlaceUuid) {
+            expect((result.usualPlace as any)?._uuid).toBe(expectedSchoolPlaceUuid);
+        }
+        if (expectedSchoolPlaceName) {
+            expect((result.usualPlace as any)?.name).toBe(expectedSchoolPlaceName);
+        }
+
+        if (expectedSchoolPlaceHasGeography) {
+            expect(result.usualPlace?.geography).toBeDefined();
+        }
+    });
+
+    test('getPersonUsualSchoolPlace throws if the person cannot be resolved', () => {
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        helpers.initializeVisitedPlaceSectionHelpers({ ...defaultVisitedPlaceConfig, inlineUsualPlacesEntry: true })
+
+        expect(() =>
+            helpers.getPersonUsualSchoolPlace(
+                interview,
+                'household.persons.invalidPerson.journeys.journeyId3.visitedPlaces.homePlace1P3.activity'
+            )
+        ).toThrow('Journey context not found in interview response');
+    });
+});
+
 describe('isLastVisitedPlaceConditional', () => {
     test.each([
         ['not last place', false, 'homePlace1P1'],

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetActivity.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetActivity.test.ts
@@ -65,7 +65,9 @@ describe('getActivityWidgetConfig', () => {
 });
 
 describe('Activity choices conditionals', () => {
-    const widgetConfig = getActivityWidgetConfig(visitedPlacesSectionConfig, widgetFactoryOptions) as QuestionWidgetConfig &
+    const visitedPlaceConfig = { ...visitedPlacesSectionConfig, inlineUsualPlacesEntry: true };
+    visitedPlacesHelpers.initializeVisitedPlaceSectionHelpers(visitedPlaceConfig);
+    const widgetConfig = getActivityWidgetConfig(visitedPlaceConfig, widgetFactoryOptions) as QuestionWidgetConfig &
         InputRadioType;
     const choices = widgetConfig.choices as RadioChoiceType[];
 
@@ -81,6 +83,8 @@ describe('Activity choices conditionals', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
+        // Reset helpers to the default
+        visitedPlacesHelpers.initializeVisitedPlaceSectionHelpers(visitedPlacesSectionConfig);
     });
 
     afterEach(() => {
@@ -127,9 +131,57 @@ describe('Activity choices labels', () => {
         const mockedT = jest.fn();
         const choice = choices.find((c) => c.value === choiceValue);
         expect(choice).toBeDefined();
-        translateString(choice?.label, { t: mockedT } as any, interview, 'path');
+        translateString(choice?.label, { t: mockedT } as any, interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.activity');
         expect(mockedT).toHaveBeenCalledWith(`visitedPlaces:activities.${choiceValue}`);
     });
+
+    test('schoolUsual choice label should include the school name if available', () => {
+        const mockedT = jest.fn();
+        const choice = choices.find((c) => c.value === 'schoolUsual');
+        expect(choice).toBeDefined();
+
+        // Setup the interview with a usual school place with a name
+        interview.response.household!.persons!.personId1!.usualSchoolPlace = {
+            name: 'My usual school',
+            geography: {
+                type: 'Feature',
+                geometry: { type: 'Point', coordinates: [-73, 45] },
+                properties: { lastAction: 'mapClicked' }
+            }
+        };
+
+        translateString(choice?.label, { t: mockedT } as any, interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.activity');
+        expect(mockedT).toHaveBeenCalledWith(
+            ['visitedPlaces:activities.schoolUsual_withPlace', 'visitedPlaces:activities.schoolUsual'],
+            {
+                placeName: 'My usual school'
+            }
+        );
+    });
+
+    test('workUsual choice label should include the work place name if available', () => {
+        const mockedT = jest.fn();
+        const choice = choices.find((c) => c.value === 'workUsual');
+        expect(choice).toBeDefined();
+
+        // Setup the interview with a usual work place with a name
+        interview.response.household!.persons!.personId1!.usualWorkPlace = {
+            name: 'My usual work',
+            geography: {
+                type: 'Feature',
+                geometry: { type: 'Point', coordinates: [-73, 45] },
+                properties: { lastAction: 'mapClicked' }
+            }
+        };
+
+        translateString(choice?.label, { t: mockedT } as any, interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.activity');
+        expect(mockedT).toHaveBeenCalledWith(
+            ['visitedPlaces:activities.workUsual_withPlace', 'visitedPlaces:activities.workUsual'],
+            {
+                placeName: 'My usual work'
+            }
+        );
+    })
 });
 
 describe('Activity per-choice conditionals', () => {
@@ -141,91 +193,295 @@ describe('Activity per-choice conditionals', () => {
         jest.clearAllMocks();
     });
 
-    test('workUsual conditional should return false for non-worker occupation without usual work place', () => {
-        const interview = _cloneDeep(interviewAttributesForTestCases);
-        const workUsualChoice = choices.find((c) => c.value === 'workUsual');
-        expect(workUsualChoice).toBeDefined();
+    describe('workUsual/schoolUsual conditionals, with pre-defined usual places', () => {
+        const widgetConfig = getActivityWidgetConfig(visitedPlacesSectionConfig, widgetFactoryOptions) as QuestionWidgetConfig &
+            InputRadioType;
+        const choices = widgetConfig.choices as RadioChoiceType[];
 
-        setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
-        interview.response.household!.persons!.personId1!.occupation = 'fullTimeStudent';
-        (interview.response.household!.persons!.personId1! as any).usualWorkPlace = undefined;
+        beforeEach(() => {
+            // Reset helpers to the default
+            visitedPlacesHelpers.initializeVisitedPlaceSectionHelpers(visitedPlacesSectionConfig);
+        });
 
-        expect(workUsualChoice?.conditional?.(interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.activity')).toEqual(false);
+        test('workUsual conditional should return false for non-worker occupation without usual work place', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const workUsualChoice = choices.find((c) => c.value === 'workUsual');
+            expect(workUsualChoice).toBeDefined();
+
+            setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
+            interview.response.household!.persons!.personId1!.occupation = 'fullTimeStudent';
+            interview.response.household!.persons!.personId1!.usualWorkPlace = undefined;
+
+            expect(workUsualChoice?.conditional?.(interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.activity')).toEqual(false);
+        });
+
+        test('workUsual conditional should return true for worker with usual work place', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const workUsualChoice = choices.find((c) => c.value === 'workUsual');
+            expect(workUsualChoice).toBeDefined();
+
+            setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
+            interview.response.household!.persons!.personId1!.occupation = 'fullTimeWorker';
+            interview.response.household!.persons!.personId1!.usualWorkPlace = {
+                geography: {
+                    type: 'Feature',
+                    geometry: { type: 'Point', coordinates: [-73, 45] },
+                    properties: { lastAction: 'mapClicked' }
+                }
+            };
+
+            expect(workUsualChoice?.conditional?.(interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.activity')).toEqual(true);
+        });
+
+        test('workUsual conditional should return false for worker with usual work place, but when it is not set', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const workUsualChoice = choices.find((c) => c.value === 'workUsual');
+            expect(workUsualChoice).toBeDefined();
+
+            setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
+            interview.response.household!.persons!.personId1!.occupation = 'fullTimeWorker';
+            interview.response.household!.persons!.personId1!.usualWorkPlace = undefined;
+
+            expect(workUsualChoice?.conditional?.(interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.activity')).toEqual(false);
+        });
+
+        test('workUsual conditional should return true if occupation is not set, but work place set', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const workUsualChoice = choices.find((c) => c.value === 'workUsual');
+            expect(workUsualChoice).toBeDefined();
+
+            setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
+            interview.response.household!.persons!.personId1!.occupation = undefined;
+            interview.response.household!.persons!.personId1!.usualWorkPlace = {
+                geography: {
+                    type: 'Feature',
+                    geometry: { type: 'Point', coordinates: [-73, 45] },
+                    properties: { lastAction: 'mapClicked' }
+                }
+            };
+
+            expect(workUsualChoice?.conditional?.(interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.activity')).toEqual(true);
+        });
+
+        test('schoolUsual conditional should throw an error when active person is missing', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            // Set wrong active person to trigger invalid person condition in the conditional function
+            setActiveSurveyObjects(interview, { personId: 'personId4', journeyId: 'journeyId4', visitedPlaceId: 'schoolPlace1P4' });
+            const schoolUsualChoice = choices.find((c) => c.value === 'schoolUsual');
+            expect(schoolUsualChoice).toBeDefined();
+
+            expect(() => schoolUsualChoice?.conditional?.(interview, 'household.persons.personId4.journeys.journeyId4.visitedPlaces.schoolPlace1P4.activity')).toThrow(Error);
+        });
+
+        test('schoolUsual conditional should return true for person aged 10', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const schoolUsualChoice = choices.find((c) => c.value === 'schoolUsual');
+            expect(schoolUsualChoice).toBeDefined();
+
+            setActiveSurveyObjects(interview, { personId: 'personId3', journeyId: 'journeyId3', visitedPlaceId: 'schoolPlace1P3' });
+            interview.response.household!.persons!.personId3!.age = 10;
+            interview.response.household!.persons!.personId3!.usualSchoolPlace = {
+                geography: {
+                    type: 'Feature',
+                    geometry: { type: 'Point', coordinates: [-73, 45] },
+                    properties: { lastAction: 'mapClicked' }
+                }
+            };
+
+            expect(schoolUsualChoice?.conditional?.(interview, 'household.persons.personId3.journeys.journeyId3.visitedPlaces.schoolPlace1P3.activity')).toEqual(true);
+        });
+
+        test('schoolUsual conditional should return true if occupation is not set, but usual school place is set', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const schoolUsualChoice = choices.find((c) => c.value === 'schoolUsual');
+            expect(schoolUsualChoice).toBeDefined();
+
+            setActiveSurveyObjects(interview, { personId: 'personId3', journeyId: 'journeyId3', visitedPlaceId: 'schoolPlace1P3' });
+            interview.response.household!.persons!.personId3!.occupation = undefined;
+            interview.response.household!.persons!.personId3!.usualSchoolPlace = {
+                geography: {
+                    type: 'Feature',
+                    geometry: { type: 'Point', coordinates: [-73, 45] },
+                    properties: { lastAction: 'mapClicked' }
+                }
+            };
+
+            expect(schoolUsualChoice?.conditional?.(interview, 'household.persons.personId3.journeys.journeyId3.visitedPlaces.schoolPlace1P3.activity')).toEqual(true);
+        });
+
+        test('schoolUsual conditional should return false for non-student without usual school place', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const schoolUsualChoice = choices.find((c) => c.value === 'schoolUsual');
+            expect(schoolUsualChoice).toBeDefined();
+
+            setActiveSurveyObjects(interview, { personId: 'personId3', journeyId: 'journeyId3', visitedPlaceId: 'schoolPlace1P3' });
+            interview.response.household!.persons!.personId3!.occupation = 'fullTimeWorker';
+            interview.response.household!.persons!.personId3!.age = 30;
+            interview.response.household!.persons!.personId3!.usualSchoolPlace = undefined;
+
+            expect(schoolUsualChoice?.conditional?.(interview, 'household.persons.personId3.journeys.journeyId3.visitedPlaces.schoolPlace1P3.activity')).toEqual(false);
+        });
+
+        test('schoolUsual conditional should return false for student with no usual school place set', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const schoolUsualChoice = choices.find((c) => c.value === 'schoolUsual');
+            expect(schoolUsualChoice).toBeDefined();
+
+            setActiveSurveyObjects(interview, { personId: 'personId3', journeyId: 'journeyId3', visitedPlaceId: 'schoolPlace1P3' });
+            interview.response.household!.persons!.personId3!.occupation = 'fullTimeStudent';
+            interview.response.household!.persons!.personId3!.age = 30;
+            interview.response.household!.persons!.personId3!.usualSchoolPlace = undefined;
+
+            expect(schoolUsualChoice?.conditional?.(interview, 'household.persons.personId3.journeys.journeyId3.visitedPlaces.schoolPlace1P3.activity')).toEqual(false);
+        });
     });
 
-    test('workUsual conditional should return true for worker with usual work place', () => {
-        const interview = _cloneDeep(interviewAttributesForTestCases);
-        const workUsualChoice = choices.find((c) => c.value === 'workUsual');
-        expect(workUsualChoice).toBeDefined();
+    describe('workUsual/schoolUsual conditionals, with inline usual places', () => {
+        const visitedPlaceConfig = { ...visitedPlacesSectionConfig, inlineUsualPlacesEntry: true };
+        visitedPlacesHelpers.initializeVisitedPlaceSectionHelpers(visitedPlaceConfig);
+        const widgetConfig = getActivityWidgetConfig(visitedPlaceConfig, widgetFactoryOptions) as QuestionWidgetConfig &
+            InputRadioType;
+        const choices = widgetConfig.choices as RadioChoiceType[];
 
-        setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
-        interview.response.household!.persons!.personId1!.occupation = 'fullTimeWorker';
-        (interview.response.household!.persons!.personId1! as any).usualWorkPlace = {
-            geography: {
-                type: 'Feature',
-                geometry: { type: 'Point', coordinates: [-73, 45] },
-                properties: { lastAction: 'mapClicked' }
-            }
-        };
+        beforeEach(() => {
+            // Set helpers with inline
+            visitedPlacesHelpers.initializeVisitedPlaceSectionHelpers(visitedPlaceConfig);
+        });
 
-        expect(workUsualChoice?.conditional?.(interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.activity')).toEqual(true);
-    });
+        test('workUsual conditional should return false for non-worker occupation without usual work place', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const workUsualChoice = choices.find((c) => c.value === 'workUsual');
+            expect(workUsualChoice).toBeDefined();
 
-    test('workUsual conditional should return true if occupation is not set', () => {
-        const interview = _cloneDeep(interviewAttributesForTestCases);
-        const workUsualChoice = choices.find((c) => c.value === 'workUsual');
-        expect(workUsualChoice).toBeDefined();
+            setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
+            interview.response.household!.persons!.personId1!.occupation = 'fullTimeStudent';
+            interview.response.household!.persons!.personId1!.usualWorkPlace = undefined;
 
-        setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
-        interview.response.household!.persons!.personId1!.occupation = undefined;
-        (interview.response.household!.persons!.personId1! as any).usualWorkPlace = undefined;
+            expect(workUsualChoice?.conditional?.(interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.activity')).toEqual(false);
+        });
 
-        expect(workUsualChoice?.conditional?.(interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.activity')).toEqual(true);
-    });
+        test('workUsual conditional should return true for worker, without usual workplace set', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const workUsualChoice = choices.find((c) => c.value === 'workUsual');
+            expect(workUsualChoice).toBeDefined();
 
-    test('schoolUsual conditional should return false when active person is missing', () => {
-        const interview = _cloneDeep(interviewAttributesForTestCases);
-        // Set wrong active person to trigger invalid person condition in the conditional function
-        setActiveSurveyObjects(interview, { personId: 'personId4', journeyId: 'journeyId4', visitedPlaceId: 'schoolPlace1P4' });
-        const schoolUsualChoice = choices.find((c) => c.value === 'schoolUsual');
-        expect(schoolUsualChoice).toBeDefined();
+            setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
+            interview.response.household!.persons!.personId1!.occupation = 'fullTimeWorker';
+            interview.response.household!.persons!.personId1!.usualWorkPlace = undefined;
 
-        expect(schoolUsualChoice?.conditional?.(interview, 'household.persons.personId3.journeys.journeyId3.visitedPlaces.schoolPlace1P3.activity')).toEqual(false);
-    });
+            expect(workUsualChoice?.conditional?.(interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.activity')).toEqual(true);
+        });
 
-    test('schoolUsual conditional should return true for kindergarten', () => {
-        const interview = _cloneDeep(interviewAttributesForTestCases);
-        const schoolUsualChoice = choices.find((c) => c.value === 'schoolUsual');
-        expect(schoolUsualChoice).toBeDefined();
+        test('workUsual conditional should return true for worker with usual work place type set onLocation', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const workUsualChoice = choices.find((c) => c.value === 'workUsual');
+            expect(workUsualChoice).toBeDefined();
 
-        setActiveSurveyObjects(interview, { personId: 'personId3', journeyId: 'journeyId3', visitedPlaceId: 'schoolPlace1P3' });
-        interview.response.household!.persons!.personId3!.schoolType = 'kindergarten';
+            setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
+            interview.response.household!.persons!.personId1!.occupation = 'fullTimeWorker';
+            interview.response.household!.persons!.personId1!.workPlaceType = 'onLocation';
+            interview.response.household!.persons!.personId1!.usualWorkPlace = undefined;
 
-        expect(schoolUsualChoice?.conditional?.(interview, 'household.persons.personId3.journeys.journeyId3.visitedPlaces.schoolPlace1P3.activity')).toEqual(true);
-    });
+            expect(workUsualChoice?.conditional?.(interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.activity')).toEqual(true);
+        });
 
-    test('schoolUsual conditional should return true if occupation is not set', () => {
-        const interview = _cloneDeep(interviewAttributesForTestCases);
-        const schoolUsualChoice = choices.find((c) => c.value === 'schoolUsual');
-        expect(schoolUsualChoice).toBeDefined();
+        test('workUsual conditional should return false for worker with usual work place type remote', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const workUsualChoice = choices.find((c) => c.value === 'workUsual');
+            expect(workUsualChoice).toBeDefined();
 
-        setActiveSurveyObjects(interview, { personId: 'personId3', journeyId: 'journeyId3', visitedPlaceId: 'schoolPlace1P3' });
-        interview.response.household!.persons!.personId3!.occupation = undefined;
+            setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
+            interview.response.household!.persons!.personId1!.occupation = 'fullTimeWorker';
+            interview.response.household!.persons!.personId1!.workPlaceType = 'remote';
+            interview.response.household!.persons!.personId1!.usualWorkPlace = undefined;
 
-        expect(schoolUsualChoice?.conditional?.(interview, 'household.persons.personId3.journeys.journeyId3.visitedPlaces.schoolPlace1P3.activity')).toEqual(true);
-    });
+            expect(workUsualChoice?.conditional?.(interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.activity')).toEqual(false);
+        });
 
-    test('schoolUsual conditional should return false for non-student without usual school place', () => {
-        const interview = _cloneDeep(interviewAttributesForTestCases);
-        const schoolUsualChoice = choices.find((c) => c.value === 'schoolUsual');
-        expect(schoolUsualChoice).toBeDefined();
+        test('workUsual conditional should return true if occupation is not set', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const workUsualChoice = choices.find((c) => c.value === 'workUsual');
+            expect(workUsualChoice).toBeDefined();
 
-        setActiveSurveyObjects(interview, { personId: 'personId3', journeyId: 'journeyId3', visitedPlaceId: 'schoolPlace1P3' });
-        interview.response.household!.persons!.personId3!.occupation = 'fullTimeWorker';
-        interview.response.household!.persons!.personId3!.age = 30;
-        (interview.response.household!.persons!.personId3! as any).usualSchoolPlace = undefined;
+            setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
+            interview.response.household!.persons!.personId1!.occupation = undefined;
 
-        expect(schoolUsualChoice?.conditional?.(interview, 'household.persons.personId3.journeys.journeyId3.visitedPlaces.schoolPlace1P3.activity')).toEqual(false);
+            expect(workUsualChoice?.conditional?.(interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.activity')).toEqual(true);
+        });
+
+        test('schoolUsual conditional should throw an error when active person is missing', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            // Set wrong active person to trigger invalid person condition in the conditional function
+            setActiveSurveyObjects(interview, { personId: 'personId4', journeyId: 'journeyId4', visitedPlaceId: 'schoolPlace1P4' });
+            const schoolUsualChoice = choices.find((c) => c.value === 'schoolUsual');
+            expect(schoolUsualChoice).toBeDefined();
+
+            expect(() => schoolUsualChoice?.conditional?.(interview, 'household.persons.personId4.journeys.journeyId4.visitedPlaces.schoolPlace1P4.activity')).toThrow(Error);
+        });
+
+        test('schoolUsual conditional should return true for person aged 10 without usual place set', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const schoolUsualChoice = choices.find((c) => c.value === 'schoolUsual');
+            expect(schoolUsualChoice).toBeDefined();
+
+            setActiveSurveyObjects(interview, { personId: 'personId3', journeyId: 'journeyId3', visitedPlaceId: 'schoolPlace1P3' });
+            interview.response.household!.persons!.personId3!.age = 10;
+            interview.response.household!.persons!.personId3!.usualSchoolPlace = undefined;
+
+            expect(schoolUsualChoice?.conditional?.(interview, 'household.persons.personId3.journeys.journeyId3.visitedPlaces.schoolPlace1P3.activity')).toEqual(true);
+        });
+
+        test('schoolUsual conditional should return false for non-student without usual school place', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const schoolUsualChoice = choices.find((c) => c.value === 'schoolUsual');
+            expect(schoolUsualChoice).toBeDefined();
+
+            setActiveSurveyObjects(interview, { personId: 'personId3', journeyId: 'journeyId3', visitedPlaceId: 'schoolPlace1P3' });
+            interview.response.household!.persons!.personId3!.occupation = 'fullTimeWorker';
+            interview.response.household!.persons!.personId3!.age = 30;
+            interview.response.household!.persons!.personId3!.usualSchoolPlace = undefined;
+
+            expect(schoolUsualChoice?.conditional?.(interview, 'household.persons.personId3.journeys.journeyId3.visitedPlaces.schoolPlace1P3.activity')).toEqual(false);
+        });
+
+        test('schoolUsual conditional should return true for student with no usual school place set', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const schoolUsualChoice = choices.find((c) => c.value === 'schoolUsual');
+            expect(schoolUsualChoice).toBeDefined();
+
+            setActiveSurveyObjects(interview, { personId: 'personId3', journeyId: 'journeyId3', visitedPlaceId: 'schoolPlace1P3' });
+            interview.response.household!.persons!.personId3!.occupation = 'fullTimeStudent';
+            interview.response.household!.persons!.personId3!.age = 30;
+            interview.response.household!.persons!.personId3!.usualSchoolPlace = undefined;
+
+            expect(schoolUsualChoice?.conditional?.(interview, 'household.persons.personId3.journeys.journeyId3.visitedPlaces.schoolPlace1P3.activity')).toEqual(true);
+        });
+
+        test('schoolUsual conditional should return true for student with usual school place on location', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const schoolUsualChoice = choices.find((c) => c.value === 'schoolUsual');
+            expect(schoolUsualChoice).toBeDefined();
+
+            setActiveSurveyObjects(interview, { personId: 'personId3', journeyId: 'journeyId3', visitedPlaceId: 'schoolPlace1P3' });
+            interview.response.household!.persons!.personId3!.occupation = 'fullTimeStudent';
+            interview.response.household!.persons!.personId3!.schoolPlaceType = 'onLocation';
+            interview.response.household!.persons!.personId3!.usualSchoolPlace = undefined;
+
+            expect(schoolUsualChoice?.conditional?.(interview, 'household.persons.personId3.journeys.journeyId3.visitedPlaces.schoolPlace1P3.activity')).toEqual(true);
+        });
+
+        test('schoolUsual conditional should return false for student with usual school place type remote', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const schoolUsualChoice = choices.find((c) => c.value === 'schoolUsual');
+            expect(schoolUsualChoice).toBeDefined();
+
+            setActiveSurveyObjects(interview, { personId: 'personId3', journeyId: 'journeyId3', visitedPlaceId: 'schoolPlace1P3' });
+            interview.response.household!.persons!.personId3!.occupation = 'fullTimeStudent';
+            interview.response.household!.persons!.personId3!.schoolPlaceType = 'remote';
+            interview.response.household!.persons!.personId3!.usualSchoolPlace = undefined;
+
+            expect(schoolUsualChoice?.conditional?.(interview, 'household.persons.personId3.journeys.journeyId3.visitedPlaces.schoolPlace1P3.activity')).toEqual(false);
+        });
     });
 
     test('carElectricChargingStation conditional should delegate to hasOrUnknownDrivingLicense', () => {

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetsGeography.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetsGeography.test.ts
@@ -15,16 +15,18 @@ import { loopActivities } from '../../../../odSurvey/types';
 import { VisitedPlaceGeographyWidgetFactory } from '../widgetsGeography';
 import { getActivityMarkerIcon } from '../activityIconMapping';
 import { homeGeographyCoordinates, shoppingPlace1P2Coordinates } from '../../../../../tests/surveys/testCasesInterview';
+import { initializeVisitedPlaceSectionHelpers } from '../helpers';
 
 const visitedPlacesSectionConfig = {
     type: 'visitedPlaces' as const,
     enabled: true,
+    inlineUsualPlacesEntry: false,
     tripDiaryMinTimeOfDay: 4 * 60 * 60, // 4h in seconds
     tripDiaryMaxTimeOfDay: 28 * 60 * 60 // 28h in seconds (i.e. 4h the next day)
 };
 
 describe('VisitedPlaceGeographyWidgetFactory', () => {
-    test('should return expected location widgets configuration', () => {
+    test('should return expected location widgets configuration when inlineUsualPlacesEntry is false', () => {
         const widgetConfig = new VisitedPlaceGeographyWidgetFactory(
             visitedPlacesSectionConfig,
             widgetFactoryOptions
@@ -84,11 +86,76 @@ describe('VisitedPlaceGeographyWidgetFactory', () => {
             }
         });
     });
+
+    test('should return expected location widgets configuration when inlineUsualPlacesEntry is true', () => {
+        const widgetConfig = new VisitedPlaceGeographyWidgetFactory(
+            { ...visitedPlacesSectionConfig, inlineUsualPlacesEntry: true },
+            widgetFactoryOptions
+        ).getWidgetConfigs();
+
+        expect(widgetConfig).toEqual({
+            visitedPlaceName: {
+                type: 'question',
+                inputType: 'string',
+                path: 'name',
+                datatype: 'string',
+                twoColumns: false,
+                containsHtml: true,
+                label: expect.any(Function),
+                conditional: expect.any(Function),
+                validations: expect.any(Function),
+                defaultValue: expect.any(Function),
+                maxLength: undefined,
+                placeholder: undefined,
+                joinWith: 'visitedPlaceGeography',
+                textTransform: undefined
+            },
+            visitedPlaceGeography: {
+                type: 'question',
+                inputType: 'mapFindPlace',
+                path: 'geography',
+                datatype: 'geojson',
+                twoColumns: false,
+                containsHtml: true,
+                label: expect.any(Function),
+                height: '32rem',
+                defaultCenter: expect.any(Function),
+                defaultZoom: undefined,
+                maxZoom: undefined,
+                icon: {
+                    url: expect.any(Function),
+                    size: [70, 70]
+                },
+                placesIcon: {
+                    url: '/dist/icons/interface/markers/marker_round_with_small_circle.svg',
+                    size: [35, 35]
+                },
+                selectedIcon: {
+                    url: '/dist/icons/interface/markers/marker_round_with_small_circle_selected.svg',
+                    size: [35, 35]
+                },
+                geocodingQueryString: expect.any(Function),
+                maxGeocodingResultsBounds: undefined,
+                showSearchPlaceButton: expect.any(Function),
+                searchPlaceButtonColor: undefined,
+                invalidGeocodingResultTypes: expect.any(Array),
+                refreshGeocodingLabel: expect.any(Function),
+                defaultValue: expect.any(Function),
+                resetToDefaultUnlessUserInteracted: true,
+                validations: expect.any(Function),
+                conditional: expect.any(Function)
+            }
+        });
+    });
 });
 
 describe('visitedPlaceName widget', () => {
-    const widgetConfig = new VisitedPlaceGeographyWidgetFactory(
+    const widgetConfigUsualPlacesNotInlined = new VisitedPlaceGeographyWidgetFactory(
         visitedPlacesSectionConfig,
+        widgetFactoryOptions
+    ).getWidgetConfigs()['visitedPlaceName'] as QuestionWidgetConfig & InputStringType;
+    const widgetConfigUsualPlacesInlined = new VisitedPlaceGeographyWidgetFactory(
+        { ...visitedPlacesSectionConfig, inlineUsualPlacesEntry: true },
         widgetFactoryOptions
     ).getWidgetConfigs()['visitedPlaceName'] as QuestionWidgetConfig & InputStringType;
 
@@ -97,7 +164,7 @@ describe('visitedPlaceName widget', () => {
     });
 
     describe('label', () => {
-        const label = widgetConfig.label;
+        const label = widgetConfigUsualPlacesNotInlined.label;
 
         test('should include example help text when i18n key exists and activity is set', () => {
             const interview = _cloneDeep(interviewAttributesForTestCases);
@@ -158,37 +225,15 @@ describe('visitedPlaceName widget', () => {
         });
     });
 
-    describe('conditional', () => {
+    describe.each([
+        { widgetConfig: widgetConfigUsualPlacesNotInlined, description: 'when usual places are not inlined', setup: () => { initializeVisitedPlaceSectionHelpers(visitedPlacesSectionConfig); } },
+        { widgetConfig: widgetConfigUsualPlacesInlined, description: 'when usual places are inlined', setup: () => { initializeVisitedPlaceSectionHelpers({ ...visitedPlacesSectionConfig, inlineUsualPlacesEntry: true }); } }
+    ])('conditional, common cases $description', ({ widgetConfig, setup }) => {
         const conditional = widgetConfig.conditional;
-
-        test('should hide widget and return usual work place name for workUsual activity', () => {
-            const interview = _cloneDeep(interviewAttributesForTestCases);
-            setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
-            // Add the person's usual work place
-            (interview.response.household!.persons!.personId1 as any).usualWorkPlace = { name: 'My usual work place' };
-
-            expect(
-                conditional!(
-                    interview,
-                    'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.name'
-                )
-            ).toEqual([false, 'My usual work place']);
-        });
-
-        test('should hide widget and return usual school place name for schoolUsual activity', () => {
-            const interview = _cloneDeep(interviewAttributesForTestCases);
-            setActiveSurveyObjects(interview, { personId: 'personId3', journeyId: 'journeyId3', visitedPlaceId: 'schoolPlace1P3' });
-            // Set the person's usual school place
-            (interview.response.household!.persons!.personId3 as any).usualSchoolPlace = {
-                name: 'My usual school place'
-            };
-
-            expect(
-                conditional!(
-                    interview,
-                    'household.persons.personId3.journeys.journeyId3.visitedPlaces.schoolPlace1P3.name'
-                )
-            ).toEqual([false, 'My usual school place']);
+        
+        beforeEach(() => {
+            // Setup the helpers for the test
+            setup();
         });
 
         test('should hide widget for home activity', () => {
@@ -257,8 +302,89 @@ describe('visitedPlaceName widget', () => {
         });
     });
 
+    describe('conditional when inline usual places are disabled', () => {
+        const conditional = widgetConfigUsualPlacesNotInlined.conditional;
+
+        beforeEach(() => {
+            initializeVisitedPlaceSectionHelpers(visitedPlacesSectionConfig);
+        });
+
+        test('should hide widget and return usual work place name for workUsual activity', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
+            // Add the person's usual work place
+            interview.response.household!.persons!.personId1.usualWorkPlace = {
+                name: 'My usual work place',
+                geography: {
+                    type: 'Feature',
+                    geometry: { type: 'Point', coordinates: [0, 0] },
+                    properties: { lastAction: 'mapClicked' }
+                }
+            };
+
+            expect(
+                conditional!(
+                    interview,
+                    'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.name'
+                )
+            ).toEqual([false, 'My usual work place']);
+        });
+
+        test('should hide widget and return usual school place name for schoolUsual activity', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            setActiveSurveyObjects(interview, { personId: 'personId3', journeyId: 'journeyId3', visitedPlaceId: 'schoolPlace1P3' });
+            // Set the person's usual school place
+            interview.response.household!.persons!.personId3.usualSchoolPlace = {
+                name: 'My usual school place',
+                geography: {
+                    type: 'Feature',
+                    geometry: { type: 'Point', coordinates: [0, 0] },
+                    properties: { lastAction: 'mapClicked' }
+                }
+            };
+
+            expect(
+                conditional!(
+                    interview,
+                    'household.persons.personId3.journeys.journeyId3.visitedPlaces.schoolPlace1P3.name'
+                )
+            ).toEqual([false, 'My usual school place']);
+        });
+
+    });
+
+    describe('conditional when inline usual places are enabled', () => {
+        initializeVisitedPlaceSectionHelpers({ ...visitedPlacesSectionConfig, inlineUsualPlacesEntry: true });
+        const conditional = widgetConfigUsualPlacesInlined.conditional;
+
+        test('should show widget for workUsual activity', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
+
+            expect(
+                conditional!(
+                    interview,
+                    'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.name'
+                )
+            ).toEqual([true, null]);
+        });
+
+        test('should show widget for schoolUsual activity', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            setActiveSurveyObjects(interview, { personId: 'personId3', journeyId: 'journeyId3', visitedPlaceId: 'schoolPlace1P3' });
+            
+            expect(
+                conditional!(
+                    interview,
+                    'household.persons.personId3.journeys.journeyId3.visitedPlaces.schoolPlace1P3.name'
+                )
+            ).toEqual([true, null]);
+        });
+
+    });
+
     describe('validations', () => {
-        const validations = widgetConfig.validations;
+        const validations = widgetConfigUsualPlacesNotInlined.validations;
 
         test('should require non-blank value', () => {
             const interview = _cloneDeep(interviewAttributesForTestCases);
@@ -282,11 +408,106 @@ describe('visitedPlaceName widget', () => {
             expect(mockedT).toHaveBeenCalledWith('visitedPlaces:activityNameIsRequiredError');
         });
     });
+
+    describe('defaultValues when inline usual places are enabled', () => {
+        const defaultValueFct = widgetConfigUsualPlacesInlined.defaultValue as ParsingFunction<string | undefined>;
+
+        beforeEach(() => {
+            initializeVisitedPlaceSectionHelpers({ ...visitedPlacesSectionConfig, inlineUsualPlacesEntry: true })
+        });
+
+        test('should be empty string if there is no usual work place set yet', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            // Person2 has no usual work place defined yet
+            setActiveSurveyObjects(interview, { personId: 'personId2', journeyId: 'journeyId2', visitedPlaceId: 'otherWorkPlace1P2' });
+            // Set the activity to workUsual and make sure to remove name and geography
+            interview.response.household!.persons!.personId2.journeys!.journeyId2.visitedPlaces!.otherWorkPlace1P2.activity = 'workUsual';
+            delete interview.response.household!.persons!.personId2.journeys!.journeyId2.visitedPlaces!.otherWorkPlace1P2.name;
+            delete interview.response.household!.persons!.personId2.journeys!.journeyId2.visitedPlaces!.otherWorkPlace1P2.geography;
+
+            expect(
+                defaultValueFct!(
+                    interview,
+                    'household.persons.personId2.journeys.journeyId2.visitedPlaces.otherWorkPlace1P2.name'
+                )
+            ).toEqual('');
+        });
+
+        test('should default to value of previous work place if there is one already defined', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            // Person1's workPlace1P1 is a usual work place, so it should default to its name
+            setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'otherPlaceP1' });
+            // Change type of otherPlaceP1 to workUsual to trigger usual work place default value and make sure the widget is shown
+            interview.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!.otherPlaceP1.activity = 'workUsual';
+
+            expect(
+                defaultValueFct!(
+                    interview,
+                    'household.persons.personId1.journeys.journeyId1.visitedPlaces.otherPlaceP1.name'
+                )
+            ).toEqual(interview.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!.workPlace1P1.name);
+        });
+
+        test('should be empty string for other activity', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            // Person1's workPlace1P1 is a usual work place, but the current place is not a work usual activity
+            setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'otherPlaceP1' });
+            
+            expect(
+                defaultValueFct!(
+                    interview,
+                    'household.persons.personId1.journeys.journeyId1.visitedPlaces.otherPlaceP1.name'
+                )
+            ).toEqual('');
+        });
+
+        test('should be empty string if there is no usual school place set yet', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            // Person2 has no school place defined yet
+            setActiveSurveyObjects(interview, { personId: 'personId2', journeyId: 'journeyId2', visitedPlaceId: 'otherWorkPlace1P2' });
+            // Set the activity to schoolUsual and make sure to remove name and geography
+            interview.response.household!.persons!.personId2.journeys!.journeyId2.visitedPlaces!.otherWorkPlace1P2.activity = 'schoolUsual';
+            delete interview.response.household!.persons!.personId2.journeys!.journeyId2.visitedPlaces!.otherWorkPlace1P2.name;
+            delete interview.response.household!.persons!.personId2.journeys!.journeyId2.visitedPlaces!.otherWorkPlace1P2.geography;
+
+            expect(
+                defaultValueFct!(
+                    interview,
+                    'household.persons.personId2.journeys.journeyId2.visitedPlaces.otherWorkPlace1P2.name'
+                )
+            ).toEqual('');
+        });
+
+        test('should default to value of previous work place if there is one already defined', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+
+            // Person3's schoolPlace1P3 is a usual school place, so it should default to its name
+            setActiveSurveyObjects(interview, { personId: 'personId3', journeyId: 'journeyId3', visitedPlaceId: 'newSchoolPlaceP3' });
+            // Add a new place for P3 as there are too few places to test
+            interview.response.household!.persons!.personId3.journeys!.journeyId3.visitedPlaces!.newSchoolPlaceP3 = {
+                _uuid: 'newSchoolPlaceP3',
+                _sequence: 4,
+                activity: 'schoolUsual'
+            };
+
+            expect(
+                defaultValueFct!(
+                    interview,
+                    'household.persons.personId3.journeys.journeyId3.visitedPlaces.newSchoolPlaceP3.name'
+                )
+            ).toEqual(interview.response.household!.persons!.personId3.journeys!.journeyId3.visitedPlaces!.schoolPlace1P3.name);
+        });
+
+    });
 });
 
 describe('visitedPlaceGeography widget', () => {
-    const widgetConfig = new VisitedPlaceGeographyWidgetFactory(
+    const widgetConfigUsualPlacesNotInlined = new VisitedPlaceGeographyWidgetFactory(
         visitedPlacesSectionConfig,
+        widgetFactoryOptions
+    ).getWidgetConfigs()['visitedPlaceGeography'] as QuestionWidgetConfig & InputMapFindPlaceType;
+    const widgetConfigUsualPlacesInlined = new VisitedPlaceGeographyWidgetFactory(
+        { ...visitedPlacesSectionConfig, inlineUsualPlacesEntry: true },
         widgetFactoryOptions
     ).getWidgetConfigs()['visitedPlaceGeography'] as QuestionWidgetConfig & InputMapFindPlaceType;
 
@@ -298,7 +519,7 @@ describe('visitedPlaceGeography widget', () => {
         const mockedT = jest.fn();
         const interview = _cloneDeep(interviewAttributesForTestCases);
 
-        translateString(widgetConfig.label, { t: mockedT } as any, interview, 'path');
+        translateString(widgetConfigUsualPlacesNotInlined.label, { t: mockedT } as any, interview, 'path');
         expect(mockedT).toHaveBeenCalledWith('visitedPlaces:geography');
     });
 
@@ -306,14 +527,14 @@ describe('visitedPlaceGeography widget', () => {
         const mockedT = jest.fn();
         const interview = _cloneDeep(interviewAttributesForTestCases);
 
-        translateString(widgetConfig.refreshGeocodingLabel, { t: mockedT } as any, interview, 'path');
+        translateString(widgetConfigUsualPlacesNotInlined.refreshGeocodingLabel, { t: mockedT } as any, interview, 'path');
         expect(mockedT).toHaveBeenCalledWith('visitedPlaces:refreshGeocodingButton');
     });
 
     describe('icon.url', () => {
         test('should return marker icon for the activity', () => {
             const interview = _cloneDeep(interviewAttributesForTestCases);
-            const iconUrl = widgetConfig.icon!.url as any;
+            const iconUrl = widgetConfigUsualPlacesNotInlined.icon!.url as any;
 
             expect(
                 iconUrl(
@@ -330,7 +551,7 @@ describe('visitedPlaceGeography widget', () => {
                 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.activity',
                 undefined
             );
-            const iconUrl = widgetConfig.icon!.url as any;
+            const iconUrl = widgetConfigUsualPlacesNotInlined.icon!.url as any;
 
             expect(
                 iconUrl(
@@ -342,7 +563,7 @@ describe('visitedPlaceGeography widget', () => {
     });
 
     describe('defaultCenter', () => {
-        const defaultCenter = widgetConfig.defaultCenter as any;
+        const defaultCenter = widgetConfigUsualPlacesNotInlined.defaultCenter as any;
 
         test('should use active previous visited place geography if no geography and a previous place exists', () => {
             const interview = _cloneDeep(interviewAttributesForTestCases);
@@ -376,7 +597,7 @@ describe('visitedPlaceGeography widget', () => {
     });
 
     describe('validations', () => {
-        const validations = widgetConfig.validations;
+        const validations = widgetConfigUsualPlacesNotInlined.validations;
         const mockedT = jest.fn().mockImplementation((key: string) => key);
 
         beforeEach(() => {
@@ -508,8 +729,62 @@ describe('visitedPlaceGeography widget', () => {
         });
     });
 
-    describe('conditional', () => {
+    describe.each([
+        { widgetConfig: widgetConfigUsualPlacesNotInlined, description: 'when usual places are not inlined', setup: () => { initializeVisitedPlaceSectionHelpers(visitedPlacesSectionConfig); } },
+        { widgetConfig: widgetConfigUsualPlacesInlined, description: 'when usual places are inlined', setup: () => { initializeVisitedPlaceSectionHelpers({ ...visitedPlacesSectionConfig, inlineUsualPlacesEntry: true }); } }
+    ])('conditional, common cases $description', ({ widgetConfig, setup }) => {
         const conditional = widgetConfig.conditional;
+        
+        beforeEach(() => {
+            // Setup the helpers for the test
+            setup();
+        });
+
+        test('should hide widget for home activity', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+
+            expect(
+                conditional!(
+                    interview,
+                    'household.persons.personId1.journeys.journeyId1.visitedPlaces.homePlace1P1.geography'
+                )
+            ).toEqual([false, null]);
+        });
+
+        test.each(loopActivities)('should hide widget for loop activity %s', (activity) => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            setResponse(
+                interview,
+                'household.persons.personId1.journeys.journeyId1.visitedPlaces.otherPlaceP1.activity',
+                activity
+            );
+
+            expect(
+                conditional!(
+                    interview,
+                    'household.persons.personId1.journeys.journeyId1.visitedPlaces.otherPlaceP1.geography'
+                )
+            ).toEqual([false, null]);
+        });
+
+        test('should show widget for non-home non-loop activity', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+
+            expect(
+                conditional!(
+                    interview,
+                    'household.persons.personId1.journeys.journeyId1.visitedPlaces.otherPlaceP1.geography'
+                )
+            ).toEqual([true, null]);
+        });
+    });
+
+    describe('conditional when usual places are not inlined', () => {
+        const conditional = widgetConfigUsualPlacesNotInlined.conditional;
+
+        beforeEach(() => {
+            initializeVisitedPlaceSectionHelpers(visitedPlacesSectionConfig);
+        });
 
         test('should hide widget and return usual work place geography for workUsual activity', () => {
             const interview = _cloneDeep(interviewAttributesForTestCases);
@@ -552,48 +827,40 @@ describe('visitedPlaceGeography widget', () => {
             // Should return a clone of the usual school place geography, not the same object
             expect((conditionalResult as [boolean, unknown])[1]).not.toBe(usualSchoolPlaceGeography);
         });
+    });
 
-        test('should hide widget for home activity', () => {
-            const interview = _cloneDeep(interviewAttributesForTestCases);
+    describe('conditional when usual places are inlined', () => {
+        const conditional = widgetConfigUsualPlacesInlined.conditional;
 
-            expect(
-                conditional!(
-                    interview,
-                    'household.persons.personId1.journeys.journeyId1.visitedPlaces.homePlace1P1.geography'
-                )
-            ).toEqual([false, null]);
+        beforeEach(() => {
+            initializeVisitedPlaceSectionHelpers({ ...visitedPlacesSectionConfig, inlineUsualPlacesEntry: true })
         });
 
-        test.each(loopActivities)('should hide widget for loop activity %s', (activity) => {
+        test('should show widget for workUsual activity', () => {
             const interview = _cloneDeep(interviewAttributesForTestCases);
-            setResponse(
+            setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'workPlace1P1' });
+
+            const conditionalResult = conditional!(
                 interview,
-                'household.persons.personId1.journeys.journeyId1.visitedPlaces.otherPlaceP1.activity',
-                activity
+                'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.geography'
             );
-
-            expect(
-                conditional!(
-                    interview,
-                    'household.persons.personId1.journeys.journeyId1.visitedPlaces.otherPlaceP1.geography'
-                )
-            ).toEqual([false, null]);
+            expect(conditionalResult).toEqual([true, null]);
         });
 
-        test('should show widget for non-home non-loop activity', () => {
+        test('should show widget for schoolUsual activity', () => {
             const interview = _cloneDeep(interviewAttributesForTestCases);
-
-            expect(
-                conditional!(
-                    interview,
-                    'household.persons.personId1.journeys.journeyId1.visitedPlaces.otherPlaceP1.geography'
-                )
-            ).toEqual([true, null]);
+            setActiveSurveyObjects(interview, { personId: 'personId3', journeyId: 'journeyId3', visitedPlaceId: 'schoolPlace1P3' });
+            
+            const conditionalResult = conditional!(
+                interview,
+                'household.persons.personId3.journeys.journeyId3.visitedPlaces.schoolPlace1P3.geography'
+            )
+            expect(conditionalResult).toEqual([true, null]);
         });
     });
 
     describe('geocodingQueryString', () => {
-        const geocodingQueryString = widgetConfig.geocodingQueryString;
+        const geocodingQueryString = widgetConfigUsualPlacesNotInlined.geocodingQueryString;
 
         test('should use in-group name field for geocoding query', () => {
             const interview = _cloneDeep(interviewAttributesForTestCases);
@@ -619,7 +886,7 @@ describe('visitedPlaceGeography widget', () => {
     });
 
     describe('showSearchPlaceButton', () => {
-        const showSearchPlaceButton = widgetConfig.showSearchPlaceButton as ParsingFunction<boolean>;
+        const showSearchPlaceButton = widgetConfigUsualPlacesNotInlined.showSearchPlaceButton as ParsingFunction<boolean>;
 
         test('should show search place button when place not a shortcut', () => {
             const interview = _cloneDeep(interviewAttributesForTestCases);
@@ -646,8 +913,16 @@ describe('visitedPlaceGeography widget', () => {
         });
     });
 
-    describe('defaultValue', () => {
+    describe.each([
+        { widgetConfig: widgetConfigUsualPlacesNotInlined, description: 'when usual places are not inlined', setup: () => { initializeVisitedPlaceSectionHelpers(visitedPlacesSectionConfig); } },
+        { widgetConfig: widgetConfigUsualPlacesInlined, description: 'when usual places are inlined', setup: () => { initializeVisitedPlaceSectionHelpers({ ...visitedPlacesSectionConfig, inlineUsualPlacesEntry: true }); } }
+    ])('defaultValue, common cases $description', ({ widgetConfig, setup }) => {
         const defaultValue = widgetConfig.defaultValue as ParsingFunction<GeoJSON.Feature<GeoJSON.Point>>;
+
+        beforeEach(() => {
+            // Setup the helpers for the test
+            setup();
+        });
 
         test('should return undefined if place not a shortcut', () => {
             const interview = _cloneDeep(interviewAttributesForTestCases);
@@ -687,6 +962,97 @@ describe('visitedPlaceGeography widget', () => {
                     'household.persons.personId2.journeys.journeyId2.visitedPlaces.shoppingPlace1P2.geography'
                 )
             ).toBeUndefined();
+        });
+    });
+
+    describe('defaultValue when usual places are inlined', () => {
+        initializeVisitedPlaceSectionHelpers({ ...visitedPlacesSectionConfig, inlineUsualPlacesEntry: true });
+        const defaultValueFct = widgetConfigUsualPlacesInlined.defaultValue as ParsingFunction<GeoJSON.Feature<GeoJSON.Point>>;
+
+        test('should be undefined if there is no usual work place set yet', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            // Person2 has no usual work place defined yet
+            setActiveSurveyObjects(interview, { personId: 'personId2', journeyId: 'journeyId2', visitedPlaceId: 'otherWorkPlace1P2' });
+            // Set the activity to workUsual and make sure to remove name and geography
+            interview.response.household!.persons!.personId2.journeys!.journeyId2.visitedPlaces!.otherWorkPlace1P2.activity = 'workUsual';
+            delete interview.response.household!.persons!.personId2.journeys!.journeyId2.visitedPlaces!.otherWorkPlace1P2.name;
+            delete interview.response.household!.persons!.personId2.journeys!.journeyId2.visitedPlaces!.otherWorkPlace1P2.geography;
+
+            expect(
+                defaultValueFct!(
+                    interview,
+                    'household.persons.personId2.journeys.journeyId2.visitedPlaces.otherWorkPlace1P2.geography'
+                )
+            ).toEqual(undefined);
+        });
+
+        test('should default to value of previous work place if there is one already defined', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            // Person1's workPlace1P1 is a usual work place, so it should default to its name
+            setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'otherPlaceP1' });
+            // Change type of otherPlaceP1 to workUsual to trigger usual work place default value and make sure the widget is shown
+            interview.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!.otherPlaceP1.activity = 'workUsual';
+
+            const defaultValueResult = defaultValueFct!(
+                interview,
+                'household.persons.personId1.journeys.journeyId1.visitedPlaces.otherPlaceP1.geography'
+            )! as GeoJSON.Feature<GeoJSON.Point>;
+            expect(defaultValueResult.geometry).toEqual(interview.response.household!.persons!.personId1!.journeys!.journeyId1!.visitedPlaces!.workPlace1P1.geography!.geometry);               
+            // Make sure the returned geography is a clone, not the same object
+            expect(defaultValueResult).not.toBe(interview.response.household!.persons!.personId1!.journeys!.journeyId1!.visitedPlaces!.workPlace1P1.geography);
+            expect(defaultValueResult.properties!.lastAction).toEqual('copy');
+        });
+
+        test('should be undefined for other activity', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            // Person1's workPlace1P1 is a usual work place, but the current place is not a work usual activity
+            setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'otherPlaceP1' });
+            
+            expect(
+                defaultValueFct!(
+                    interview,
+                    'household.persons.personId1.journeys.journeyId1.visitedPlaces.otherPlaceP1.geography'
+                )
+            ).toEqual(undefined);
+        });
+
+        test('should be undefined if there is no usual school place set yet', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            // Person2 has no school place defined yet
+            setActiveSurveyObjects(interview, { personId: 'personId2', journeyId: 'journeyId2', visitedPlaceId: 'otherWorkPlace1P2' });
+            // Set the activity to schoolUsual and make sure to remove name and geography
+            interview.response.household!.persons!.personId2.journeys!.journeyId2.visitedPlaces!.otherWorkPlace1P2.activity = 'schoolUsual';
+            delete interview.response.household!.persons!.personId2.journeys!.journeyId2.visitedPlaces!.otherWorkPlace1P2.name;
+            delete interview.response.household!.persons!.personId2.journeys!.journeyId2.visitedPlaces!.otherWorkPlace1P2.geography;
+
+            expect(
+                defaultValueFct!(
+                    interview,
+                    'household.persons.personId2.journeys.journeyId2.visitedPlaces.otherWorkPlace1P2.geography'
+                )
+            ).toEqual(undefined);
+        });
+
+        test('should default to value of previous work place if there is one already defined', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+
+            // Person3's schoolPlace1P3 is a usual school place, so it should default to its name
+            setActiveSurveyObjects(interview, { personId: 'personId3', journeyId: 'journeyId3', visitedPlaceId: 'newSchoolPlaceP3' });
+            // Add a new place for P3 as there are too few places to test
+            interview.response.household!.persons!.personId3.journeys!.journeyId3.visitedPlaces!.newSchoolPlaceP3 = {
+                _uuid: 'newSchoolPlaceP3',
+                _sequence: 4,
+                activity: 'schoolUsual'
+            };
+
+            const defaultValueResult = defaultValueFct!(
+                interview,
+                'household.persons.personId3.journeys.journeyId3.visitedPlaces.newSchoolPlaceP3.geography'
+            )! as GeoJSON.Feature<GeoJSON.Point>;
+            expect(defaultValueResult.geometry).toEqual(interview.response.household!.persons!.personId3!.journeys!.journeyId3!.visitedPlaces!.schoolPlace1P3.geography!.geometry);               
+            // Make sure the returned geography is a clone, not the same object
+            expect(defaultValueResult).not.toBe(interview.response.household!.persons!.personId3!.journeys!.journeyId3!.visitedPlaces!.schoolPlace1P3.geography);
+            expect(defaultValueResult.properties!.lastAction).toEqual('copy');
         });
     });
 });

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/helpers.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/helpers.ts
@@ -14,6 +14,8 @@ import {
 } from '../../../odSurvey/types';
 import type {
     Journey,
+    NamedPlace,
+    ParsingFunction,
     Person,
     UserInterviewAttributes,
     VisitedPlace,
@@ -24,6 +26,7 @@ import * as odSurveyHelpers from '../../../odSurvey/helpers';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { toXXhrYYminZZsec } from 'chaire-lib-common/lib/utils/DateTimeUtils';
 import { TFunction } from 'i18next';
+import config from '../../../../config/project.config';
 
 /**
  * Validate that the activity of the previous and next places are not in the
@@ -419,3 +422,157 @@ export const isLastVisitedPlaceConditional: WidgetConditional = (interview, path
         visitedPlacesArray[visitedPlacesArray.length - 1]._uuid === activeVisitedPlace._uuid
     );
 };
+
+// Internal interface for various implementations of the segment next/previous
+// locations, depending on the received configuration.
+interface VisitedPlaceSectionHelpersImplementation {
+    getPersonUsualWorkPlace: ParsingFunction<{
+        mayHaveUsualPlace: boolean;
+        usualPlace: NamedPlace | null;
+    }>;
+    getPersonUsualSchoolPlace: ParsingFunction<{
+        mayHaveUsualPlace: boolean;
+        usualPlace: NamedPlace | null;
+    }>;
+}
+type GetUsualPlaceFct = (person: Person, journey: Journey) => NamedPlace | undefined;
+
+class VisitedPlaceHelpersBaseClass {
+    // The person may have a usual work place if both
+    // 1- the occupation, if set, includes worker
+    // 2- the person's has a usual workPlaceType set and that implies a usual place
+    protected mayHaveUsualWorkPlace = (person: Person) =>
+        (person.occupation === undefined ||
+            ['fullTimeWorker', 'partTimeWorker', 'workerAndStudent'].includes(person.occupation)) &&
+        (person.workPlaceType === undefined ||
+            ['onTheRoadWithUsualPlace', 'onLocation', 'hybrid'].includes(person.workPlaceType));
+
+    // The person may have a usual school place if both
+    // 1- the occupation, if set, includes student or the age is less than the school mandatory age
+    // 2- the person's has a usual schoolPlaceType set and that implies a usual place
+    protected mayHaveUsualSchoolPlace = (person: Person) =>
+        (person.occupation === undefined ||
+            ['fullTimeStudent', 'partTimeStudent', 'workerAndStudent'].includes(person.occupation) ||
+            (!_isBlank(person.age) && person.age! <= config.schoolMandatoryAge)) &&
+        (person.schoolPlaceType === undefined || ['onLocation', 'hybrid'].includes(person.schoolPlaceType));
+
+    protected getPersonUsualPlace: ({
+        mayHavePlaceConditional,
+        getUsualPlaceFct
+    }: {
+        mayHavePlaceConditional: (person: Person) => boolean;
+        getUsualPlaceFct: GetUsualPlaceFct;
+    }) => ParsingFunction<{
+        mayHaveUsualPlace: boolean;
+        usualPlace: NamedPlace | null;
+    }> =
+            ({ mayHavePlaceConditional, getUsualPlaceFct }) =>
+                (interview, path) => {
+                    const journeyContext = odSurveyHelpers.getJourneyContextFromPath({ interview, path });
+                    if (journeyContext === null) {
+                        throw new Error('Journey context not found in interview response');
+                    }
+                    const { journey, person } = journeyContext;
+
+                    // The person may have a usual work place if both
+                    // 1- the occupation, if set, includes worker
+                    // 2- the person's has a usual workPlaceType set and that implies a usual place
+
+                    const mayHaveUsualPlace = mayHavePlaceConditional(person);
+
+                    if (mayHaveUsualPlace) {
+                        const usualPlace = getUsualPlaceFct(person, journey);
+                        if (usualPlace) {
+                            return { mayHaveUsualPlace: mayHaveUsualPlace, usualPlace: usualPlace };
+                        }
+                    }
+
+                    return { mayHaveUsualPlace: mayHaveUsualPlace, usualPlace: null };
+                };
+}
+
+class VisitedPlaceHelpersInline
+    extends VisitedPlaceHelpersBaseClass
+    implements VisitedPlaceSectionHelpersImplementation {
+    private getUsualPlaceFromTripDiary =
+        (usualActivity: 'schoolUsual' | 'workUsual'): GetUsualPlaceFct =>
+            (_person: Person, journey: Journey): NamedPlace | undefined => {
+            // The usual school place may be in the trip diary. If so, return that visited place
+                const visitedPlaces = odSurveyHelpers.getVisitedPlacesArray({ journey });
+                const usualSchoolPlaceVisitedPlace = visitedPlaces.find(
+                    (visitedPlace) => visitedPlace.activity === usualActivity
+                );
+                return usualSchoolPlaceVisitedPlace;
+            };
+
+    getPersonUsualWorkPlace: ParsingFunction<{ mayHaveUsualPlace: boolean; usualPlace: NamedPlace | null }> =
+        this.getPersonUsualPlace({
+            mayHavePlaceConditional: this.mayHaveUsualWorkPlace,
+            getUsualPlaceFct: this.getUsualPlaceFromTripDiary('workUsual')
+        });
+    getPersonUsualSchoolPlace: ParsingFunction<{ mayHaveUsualPlace: boolean; usualPlace: NamedPlace | null }> =
+        this.getPersonUsualPlace({
+            mayHavePlaceConditional: this.mayHaveUsualSchoolPlace,
+            getUsualPlaceFct: this.getUsualPlaceFromTripDiary('schoolUsual')
+        });
+}
+
+class VisitedPlaceHelpersInPersonProfile
+    extends VisitedPlaceHelpersBaseClass
+    implements VisitedPlaceSectionHelpersImplementation {
+    // Get a usual place directly in the person's attributes
+    private getUsualPlaceFromPerson =
+        (placeName: 'usualSchoolPlace' | 'usualWorkPlace'): GetUsualPlaceFct =>
+            (person: Person, _journey: Journey): NamedPlace | undefined => {
+                const usualPlace = person[placeName];
+                return usualPlace && usualPlace.geography ? usualPlace : undefined;
+            };
+
+    getPersonUsualWorkPlace: ParsingFunction<{ mayHaveUsualPlace: boolean; usualPlace: NamedPlace | null }> =
+        this.getPersonUsualPlace({
+            mayHavePlaceConditional: this.mayHaveUsualWorkPlace,
+            getUsualPlaceFct: this.getUsualPlaceFromPerson('usualWorkPlace')
+        });
+    getPersonUsualSchoolPlace: ParsingFunction<{ mayHaveUsualPlace: boolean; usualPlace: NamedPlace | null }> =
+        this.getPersonUsualPlace({
+            mayHavePlaceConditional: this.mayHaveUsualSchoolPlace,
+            getUsualPlaceFct: this.getUsualPlaceFromPerson('usualSchoolPlace')
+        });
+}
+
+const defaultVisitedPlaceSectionHelpers = new VisitedPlaceHelpersInPersonProfile();
+
+let visitedPlaceSectionHelpers: VisitedPlaceSectionHelpersImplementation = defaultVisitedPlaceSectionHelpers;
+
+export const initializeVisitedPlaceSectionHelpers = (visitedPlaceConfig: VisitedPlacesSectionConfiguration): void => {
+    visitedPlaceSectionHelpers =
+        visitedPlaceConfig.inlineUsualPlacesEntry === true
+            ? new VisitedPlaceHelpersInline()
+            : defaultVisitedPlaceSectionHelpers;
+};
+
+/**
+ * Get the person's usual work place
+ *
+ * TODO Eventually support multiple usual places
+ *
+ * @returns Whether the person may have a usual work place from the person's
+ * data, along with that place, if available
+ */
+export const getPersonUsualWorkPlace: ParsingFunction<{ mayHaveUsualPlace: boolean; usualPlace: NamedPlace | null }> = (
+    interview,
+    path
+) => visitedPlaceSectionHelpers.getPersonUsualWorkPlace(interview, path);
+
+/**
+ * Get the person's usual school place
+ *
+ * TODO Eventually support multiple usual places
+ *
+ * @returns Whether the person may have a usual school place from the person's
+ * data, along with that place, if available
+ */
+export const getPersonUsualSchoolPlace: ParsingFunction<{
+    mayHaveUsualPlace: boolean;
+    usualPlace: NamedPlace | null;
+}> = (interview, path) => visitedPlaceSectionHelpers.getPersonUsualSchoolPlace(interview, path);

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/sectionVisitedPlaces.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/sectionVisitedPlaces.ts
@@ -26,6 +26,7 @@ import { PersonVisitedPlacesGroupConfigFactory } from './groupPersonVisitedPlace
 import { getButtonConfirmGotoNextSectionWidgetConfig } from './buttonConfirmGotoNextSection';
 import { tripDiarySectionVisibleConditional } from '../tripDiary/tripDiaryHelpers';
 import { Activity, ActivityCategory } from '../../../odSurvey/types';
+import { initializeVisitedPlaceSectionHelpers } from './helpers';
 
 export class VisitedPlacesSectionFactory implements SectionConfigFactory {
     private _sectionConfig: SectionConfig | undefined = undefined;
@@ -35,7 +36,7 @@ export class VisitedPlacesSectionFactory implements SectionConfigFactory {
         private sectionConfig: VisitedPlacesSectionConfiguration,
         private options: WidgetFactoryOptions
     ) {
-        /** Nothing to do */
+        initializeVisitedPlaceSectionHelpers(this.sectionConfig);
         this.prepareWidgetsAndSection();
     }
 

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetActivity.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetActivity.ts
@@ -6,8 +6,17 @@
  */
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import type { TFunction } from 'i18next';
+import _escape from 'lodash/escape';
 import { getResponse } from '../../../../utils/helpers';
-import type { RadioChoiceType, UserInterviewAttributes, VisitedPlace, WidgetConditional } from '../../types';
+import type {
+    I18nData,
+    NamedPlace,
+    ParsingFunction,
+    RadioChoiceType,
+    UserInterviewAttributes,
+    VisitedPlace,
+    WidgetConditional
+} from '../../types';
 import { VisitedPlacesSectionConfiguration, WidgetConfig } from '../../../questionnaire/types';
 import {
     type Activity,
@@ -19,7 +28,6 @@ import type { WidgetFactoryOptions } from '../types';
 import * as odHelpers from '../../../odSurvey/helpers';
 import { getActivityIcon } from './activityIconMapping';
 import * as visitedPlacesHelpers from './helpers';
-import config from '../../../../config/project.config';
 
 const isInActivityCategoryConditional = (visitedPlace: VisitedPlace, activity: Activity) => {
     if (_isBlank(visitedPlace.activityCategory)) {
@@ -39,74 +47,96 @@ const validateActivityOfNextPrevious = (path: string, interview: UserInterviewAt
     });
 };
 
-const perActivityConditionals: Partial<{ [mode in Activity]: WidgetConditional }> = {
-    // TODO Add any specific conditionals for activities here, for example to hide certain activities based on the person's attributes
-    workUsual: (interview) => {
-        const person = odHelpers.getActivePerson({ interview });
-        const occupation = person?.occupation;
+class ActivityWidgetConfigBuilder {
+    private readonly perActivityLabels: Partial<Record<Activity, I18nData>>;
+    private readonly perActivityConditionals: Partial<Record<Activity, WidgetConditional>>;
 
-        // FIXME Taken from od_nationale, where a usual work place is defined
-        // with the household member section. May not be generic enough. The
-        // condition should be updated.
-        return (
-            !occupation ||
-            (!_isBlank((person as any).usualWorkPlace) &&
-                !_isBlank((person as any).usualWorkPlace.geography) &&
-                ['fullTimeWorker', 'partTimeWorker', 'workerAndStudent'].includes(occupation))
-        );
-    },
-    schoolUsual: (interview) => {
-        const person = odHelpers.getActivePerson({ interview });
-        if (!person) {
-            return false;
-        }
-        const occupation = person.occupation;
+    constructor(sectionConfig: VisitedPlacesSectionConfiguration) {
+        const inlineUsualPlacesEntry = sectionConfig.inlineUsualPlacesEntry === true;
 
-        if (odHelpers.isStudentFromSchoolType({ person })) {
-            return true;
-        }
+        this.perActivityLabels = {
+            workUsual: this.usualPlaceLabelFactory(
+                visitedPlacesHelpers.getPersonUsualWorkPlace,
+                'visitedPlaces:activities.workUsual'
+            ),
+            schoolUsual: this.usualPlaceLabelFactory(
+                visitedPlacesHelpers.getPersonUsualSchoolPlace,
+                'visitedPlaces:activities.schoolUsual'
+            )
+        };
 
-        // FIXME Taken from od_nationale, where a usual school place is defined
-        // with the household member section. May not be generic enough. The
-        // condition should be updated.
-        return (
-            !occupation ||
-            (!_isBlank((person as any).usualSchoolPlace) &&
-                !_isBlank((person as any).usualSchoolPlace.geography) &&
-                (['fullTimeStudent', 'partTimeStudent', 'workerAndStudent'].includes(occupation) ||
-                    (!_isBlank(person.age) && person.age! <= config.schoolMandatoryAge)))
-        );
-    },
-    carElectricChargingStation: (interview) => {
-        // Display to people with a driving license
-        const person = odHelpers.getActivePerson({ interview });
-        if (!person) {
-            return false;
-        }
-        return odHelpers.hasOrUnknownDrivingLicense({ person });
-    },
-    carsharingStation: (interview) => odHelpers.getCarsharingMembersCount({ interview }) > 0
-};
+        this.perActivityConditionals = {
+            workUsual: this.usualPlaceConditionalFactory(
+                visitedPlacesHelpers.getPersonUsualWorkPlace,
+                inlineUsualPlacesEntry
+            ),
+            schoolUsual: this.usualPlaceConditionalFactory(
+                visitedPlacesHelpers.getPersonUsualSchoolPlace,
+                inlineUsualPlacesEntry
+            ),
+            carElectricChargingStation: (interview) => {
+                const person = odHelpers.getActivePerson({ interview });
+                if (!person) {
+                    return false;
+                }
+                return odHelpers.hasOrUnknownDrivingLicense({ person });
+            },
+            carsharingStation: (interview) => odHelpers.getCarsharingMembersCount({ interview }) > 0
+        };
+    }
 
-const getActivityChoices = (filteredActivities: Activity[]): RadioChoiceType[] =>
-    filteredActivities.map((activity) => ({
-        value: activity,
-        label: (t: TFunction) => t(`visitedPlaces:activities.${activity}`),
-        conditional: function (interview, path) {
-            const visitedPlace = getResponse(interview, path, null, '../') as VisitedPlace;
-            // Return false if the activity category of the visited place is not compatible with the activity of the choice
-            if (!isInActivityCategoryConditional(visitedPlace, activity)) {
-                return false;
+    private usualPlaceLabelFactory: (
+        helperFct: ParsingFunction<{ mayHaveUsualPlace: boolean; usualPlace: NamedPlace | null }>,
+        activityLabel: string
+    ) => I18nData = (helperFct, activityLabel) => (t: TFunction, interview, path) => {
+            const { mayHaveUsualPlace, usualPlace } = helperFct(interview, path);
+            if (mayHaveUsualPlace && usualPlace && typeof usualPlace.name === 'string') {
+                return t([`${activityLabel}_withPlace`, activityLabel], {
+                    placeName: _escape(usualPlace.name)
+                });
             }
-            if (!validateActivityOfNextPrevious(path, interview, activity)) {
-                return false;
-            }
-            // Run the perActivity conditional if it exists
-            const conditional = perActivityConditionals[activity];
-            return conditional ? conditional(interview, path) : true;
-        },
-        iconPath: getActivityIcon(activity)
-    }));
+            return t(activityLabel);
+        };
+
+    private usualPlaceConditionalFactory: (
+        helperFct: ParsingFunction<{ mayHaveUsualPlace: boolean; usualPlace: NamedPlace | null }>,
+        inlineUsualPlacesEntry: boolean
+    ) => WidgetConditional = (helperFct, inlineUsualPlacesEntry) =>
+            inlineUsualPlacesEntry
+                ? (interview, path) => {
+                    // When inlining usual place entries, the usual place may not be defined, only return if the person may have a usual place for that type
+                    return helperFct(interview, path).mayHaveUsualPlace;
+                }
+                : (interview, path) => {
+                    // When not inlining, the usual place must be defined to display the activity
+                    const { mayHaveUsualPlace, usualPlace } = helperFct(interview, path);
+                    return mayHaveUsualPlace && usualPlace !== null;
+                };
+
+    createActivityChoices(filteredActivities: Activity[]): RadioChoiceType[] {
+        return filteredActivities.map((activity) => ({
+            value: activity,
+            label: this.perActivityLabels[activity] ?? ((t: TFunction) => t(`visitedPlaces:activities.${activity}`)),
+            conditional: (interview, path) => {
+                const visitedPlaceContext = odHelpers.getVisitedPlaceContextFromPath({ interview, path });
+                if (!visitedPlaceContext) {
+                    throw new Error('Visited place context not found for path: ' + path);
+                }
+                const { visitedPlace } = visitedPlaceContext;
+                // Return false if the activity category of the visited place is not compatible with the activity of the choice
+                if (!isInActivityCategoryConditional(visitedPlace, activity)) {
+                    return false;
+                }
+                if (!validateActivityOfNextPrevious(path, interview, activity)) {
+                    return false;
+                }
+                const conditional = this.perActivityConditionals[activity];
+                return conditional ? conditional(interview, path) : true;
+            },
+            iconPath: getActivityIcon(activity)
+        }));
+    }
+}
 
 export const getActivityWidgetConfig = (
     sectionConfig: VisitedPlacesSectionConfiguration,
@@ -116,7 +146,8 @@ export const getActivityWidgetConfig = (
     if (filteredActivities.length === 0) {
         throw new Error('No available activities to create activity widget configuration');
     }
-    const activityChoices = getActivityChoices(filteredActivities);
+    const activityWidgetConfigBuilder = new ActivityWidgetConfigBuilder(sectionConfig);
+    const activityChoices = activityWidgetConfigBuilder.createActivityChoices(filteredActivities);
 
     return {
         type: 'question',

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetsGeography.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetsGeography.ts
@@ -16,6 +16,7 @@ import * as odHelpers from '../../../odSurvey/helpers';
 import { getResponse } from '../../../../utils/helpers';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { type Activity, loopActivities } from '../../../odSurvey/types';
+import * as visitedPlacesHelpers from './helpers';
 import { getActivityMarkerIcon } from './activityIconMapping';
 
 // This is the minimum zoom required to avoid placement errors when selecting an
@@ -34,12 +35,20 @@ const visitedPlacesMapClickDragDefaultZoom = 15;
  * Widget factory that creates a pair of widgets for a location name and geography
  */
 export class VisitedPlaceGeographyWidgetFactory implements WidgetConfigFactory {
+    private readonly shouldDisplayUsualPlacesGeography: boolean;
+
     constructor(
         private sectionConfig: VisitedPlacesSectionConfiguration,
         private options: WidgetFactoryOptions
     ) {
-        /** Nothing to do */
+        const inlineUsualPlacesEntry = sectionConfig.inlineUsualPlacesEntry === true;
+        this.shouldDisplayUsualPlacesGeography = inlineUsualPlacesEntry;
     }
+
+    private getUsualPlaceHelperFunction = (activity: 'workUsual' | 'schoolUsual') =>
+        activity === 'workUsual'
+            ? visitedPlacesHelpers.getPersonUsualWorkPlace
+            : visitedPlacesHelpers.getPersonUsualSchoolPlace;
 
     private getNameWidgetConfiguration = (): LocationWithNameWidgetOptions['nameWidget'] => ({
         containsHtml: true,
@@ -62,18 +71,14 @@ export class VisitedPlaceGeographyWidgetFactory implements WidgetConfigFactory {
         conditional: (interview, path) => {
             const visitedPlace: any = getResponse(interview, path, null, '../');
             const activity = visitedPlace.activity;
-            const person = odHelpers.getActivePerson({ interview });
 
             // Do not display if the activity is a usual place and that place is set
-            if (activity === 'workUsual' && (person as any).usualWorkPlace && (person as any).usualWorkPlace.name) {
-                return [false, (person as any).usualWorkPlace.name];
-            }
-            if (
-                activity === 'schoolUsual' &&
-                (person as any).usualSchoolPlace &&
-                (person as any).usualSchoolPlace.name
-            ) {
-                return [false, (person as any).usualSchoolPlace.name];
+            // If activity is a usual place and their entry is not inlined, hide and pre-populate with a clone of the geography
+            if ((activity === 'workUsual' || activity === 'schoolUsual') && !this.shouldDisplayUsualPlacesGeography) {
+                const { usualPlace } = this.getUsualPlaceHelperFunction(activity)(interview, path);
+                if (usualPlace && usualPlace.name) {
+                    return [false, usualPlace.name];
+                }
             }
 
             // Do not display for loop activity if activity is not set, if it is
@@ -89,6 +94,30 @@ export class VisitedPlaceGeographyWidgetFactory implements WidgetConfigFactory {
             }
             return [shouldDisplay, null];
         },
+        defaultValue: this.shouldDisplayUsualPlacesGeography
+            ? (interview, path) => {
+                const visitedPlaceContext = odHelpers.getVisitedPlaceContextFromPath({ interview, path });
+                if (visitedPlaceContext === null) {
+                    throw new Error(
+                        'widgetVisitedPlaceGeography: defaultValue function: visited place context not found for path' +
+                              path
+                    );
+                }
+                const { visitedPlace } = visitedPlaceContext || {};
+
+                // If the activity is a usual place and it is inlined, default to the name of that place
+                if (
+                    (visitedPlace.activity === 'workUsual' || visitedPlace.activity === 'schoolUsual') &&
+                      this.shouldDisplayUsualPlacesGeography
+                ) {
+                    const { usualPlace } = this.getUsualPlaceHelperFunction(visitedPlace.activity)(interview, path);
+                    if (usualPlace && usualPlace.name) {
+                        return usualPlace.name;
+                    }
+                }
+                return '';
+            }
+            : undefined,
         validations: (value) => {
             return [
                 {
@@ -174,7 +203,7 @@ export class VisitedPlaceGeographyWidgetFactory implements WidgetConfigFactory {
             ];
             return validations;
         },
-        defaultValue: function (interview, path) {
+        defaultValue: (interview, path) => {
             const visitedPlaceContext = odHelpers.getVisitedPlaceContextFromPath({ interview, path });
             if (visitedPlaceContext === null) {
                 throw new Error(
@@ -202,6 +231,23 @@ export class VisitedPlaceGeographyWidgetFactory implements WidgetConfigFactory {
                     return clonedGeography;
                 }
             }
+            // If the activity is a usual place and it is inlined, default to a
+            // copy of that usual place geography
+
+            // FIXME This implies the geography of other usual locations may
+            // diverge from the first one. This will clone the first one only.
+            // We still need to define the spec for multiple usual places.
+            if (
+                (visitedPlace.activity === 'workUsual' || visitedPlace.activity === 'schoolUsual') &&
+                this.shouldDisplayUsualPlacesGeography
+            ) {
+                const { usualPlace } = this.getUsualPlaceHelperFunction(visitedPlace.activity)(interview, path);
+                if (usualPlace && usualPlace.geography) {
+                    const clonedGeography = _cloneDeep(usualPlace.geography);
+                    clonedGeography.properties!.lastAction = 'copy';
+                    return clonedGeography;
+                }
+            }
             return undefined;
         },
         resetToDefaultUnlessUserInteracted: true,
@@ -214,18 +260,19 @@ export class VisitedPlaceGeographyWidgetFactory implements WidgetConfigFactory {
             const visitedPlaceContext = odHelpers.getVisitedPlaceContextFromPath({ interview, path });
             if (visitedPlaceContext === null) {
                 throw new Error(
-                    'widgetVisitedPlaceShortcut: defaultValue function: visited place context not found for path' + path
+                    'widgetVisitedPlaceGeography: defaultValue function: visited place context not found for path' +
+                        path
                 );
             }
-            const { person, visitedPlace } = visitedPlaceContext || {};
+            const { visitedPlace } = visitedPlaceContext || {};
 
             const activity = visitedPlace.activity;
-            // Do not diplay if the activity is a usual place and that place is set with a geography
-            if (activity === 'workUsual' && person.usualWorkPlace && person.usualWorkPlace.geography) {
-                return [false, _cloneDeep(person.usualWorkPlace.geography)];
-            }
-            if (activity === 'schoolUsual' && person.usualSchoolPlace && person.usualSchoolPlace.geography) {
-                return [false, _cloneDeep(person.usualSchoolPlace.geography)];
+            // If activity is a usual place and their entry is not inlined, hide and pre-populate with a clone of the geography
+            if ((activity === 'workUsual' || activity === 'schoolUsual') && !this.shouldDisplayUsualPlacesGeography) {
+                const { usualPlace } = this.getUsualPlaceHelperFunction(activity)(interview, path);
+                if (usualPlace && usualPlace.geography) {
+                    return [false, _cloneDeep(usualPlace.geography)];
+                }
             }
 
             // Show if the activity is not home or a loop activity. If it is a

--- a/packages/evolution-common/src/services/questionnaire/types/Data.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/Data.ts
@@ -92,7 +92,20 @@ export type Household = HouseholdAttributes & {
 };
 
 type SurveyPointProperties = {
-    lastAction: 'findPlace' | 'shortcut' | 'mapClicked' | 'markerDragged';
+    /**
+     * The type of action done on a point:
+     *
+     * ```
+     * - findPlace: the point was created by geocoding a place with a query
+     * - shortcut: the point was created by using a shortcut to another visited place
+     * - mapClicked: the point was created by clicking on the map
+     * - markerDragged: the point was created by dragging an existing point on the map
+     * - copy: the point was created by copying an existing point (used for usual places when inlined)
+     * ```
+     * This is used to determine how the point was created and can be useful for
+     * validation and analysis.
+     */
+    lastAction: 'findPlace' | 'shortcut' | 'mapClicked' | 'markerDragged' | 'copy';
 };
 
 /**
@@ -110,7 +123,7 @@ export type QuestionnaireObjectWithUuidAndSequence = {
     _sequence: number;
 };
 
-type NamedPlace = {
+export type NamedPlace = {
     name?: string;
     geography?: GeoJSON.Feature<GeoJSON.Point, SurveyPointProperties>;
 };

--- a/packages/evolution-common/src/services/questionnaire/types/SectionConfig.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/SectionConfig.ts
@@ -546,6 +546,16 @@ export type VisitedPlacesSectionConfiguration = {
      */
     activityExclude?: Activity[];
     /**
+     * Specify whether the usual work/school places are expected to be entered
+     * when required (inline) or if they are expected to have been entered
+     * previously as part of each household member's questionnaire. If set to
+     * `true`, the usual places activities will appear even if the place is not
+     * defined, and the participant will have the possibility to enter it.
+     * Otherwise, the activities won't be available if the previous is not
+     * defined. Defaults to `false`.
+     */
+    inlineUsualPlacesEntry?: boolean;
+    /**
      * The minimum time of day for the trip diary, in seconds since midnight.
      *
      * TODO When we support daily or multi-day diaries, this configuration should go only for daily ones. (https://github.com/chairemobilite/evolution/issues/1458)


### PR DESCRIPTION
fixes #1502

Add the `inlineUsualPlacesEntry` option to the trip diary configuration. When `true`, this implies that usual places will be entered while filling the trip diary instead of being declared beforehand for each person. Defaults to `false` for backward-compatibility.

This option affects the following elements:

- `visitiedPlaceActivity`: the `schoolUsual` and `workUsual` should be shown even if the places are not defined yet when inlining.
- `visitedPlaceName`/`visitedPlaceGeography`: when inlining, these widgets should be displayed for usual activities and default to the value of other such places already defined.

New visited places helper functions: `getPersonUsualSchoolPlace` and `getPersonWorkSchoolPlace` return whether the person may have a usual place from its personal characteristics and return the place that matches the type. These functions have 2 variants that depend on the `inlineUsualPlacesEntry` option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `inlineUsualPlacesEntry` configuration to control whether usual work/school places are entered inline.

* **Improvements**
  * Activity labels and option visibility now reflect usual work/school presence (inline vs non-inline).
  * Visited-place name/geography defaulting is improved, including “copy” behavior when inlining usual places.

* **Tests**
  * Expanded Jest coverage for usual work/school parsing and both visited-places widget modes. 

* **API**
  * Exported `NamedPlace` and added usual work/school helper functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->