### PR TITLE
checkConditional: number conditional work only for number or strings

### DIFF
--- a/packages/evolution-common/src/services/widgets/conditionals/__tests__/checkConditionals.test.ts
+++ b/packages/evolution-common/src/services/widgets/conditionals/__tests__/checkConditionals.test.ts
@@ -13,6 +13,8 @@ const interview = {
         _isArray: ['a', 'b', 'c'],
         _isEmptyArray: [],
         _isString: 'a',
+        _isNumericString: '0',
+        _isEmptyString: '',
         _isTrueBoolean: true,
         _isFalseBoolean: false,
         _isNumber1: 1,
@@ -99,6 +101,18 @@ const testCases: Array<{
             }
         ],
         expected: [true, null]
+    },
+    {
+        testTitle:
+            '_isNull === 0 (number), should return false (Number(null) converts to 0, but it should fail).',
+        conditionals: [
+            {
+                path: '_isNull',
+                comparisonOperator: '===',
+                value: 0
+            }
+        ],
+        expected: [false, null]
     },
     {
         testTitle:
@@ -410,6 +424,83 @@ const testCases: Array<{
             }
         ],
         expected: [true, null]
+    },
+    {
+        testTitle: '_isNumericString <= 2, should return true.',
+        conditionals: [
+            {
+                path: '_isNumericString',
+                comparisonOperator: '<=',
+                value: 2
+            }
+        ],
+        expected: [true, null]
+    },
+    {
+        testTitle: '_isNumericString === 0, should return true.',
+        conditionals: [
+            {
+                path: '_isNumericString',
+                comparisonOperator: '===',
+                value: 0
+            }
+        ],
+        expected: [true, null]
+    },
+    {
+        testTitle: '_isNumericString > 2, should return false.',
+        conditionals: [
+            {
+                path: '_isNumericString',
+                comparisonOperator: '>',
+                value: 2
+            }
+        ],
+        expected: [false, null]
+    },
+    {
+        testTitle: '_isEmptyString === 0, should return false.',
+        conditionals: [
+            {
+                path: '_isEmptyString',
+                comparisonOperator: '===',
+                value: 0
+            }
+        ],
+        expected: [false, null]
+    },
+    {
+        testTitle: '_isEmptyString > 0, should return false.',
+        conditionals: [
+            {
+                path: '_isEmptyString',
+                comparisonOperator: '>',
+                value: 0
+            }
+        ],
+        expected: [false, null]
+    },
+    {
+        testTitle: '_isEmptyString < 0, should return false.',
+        conditionals: [
+            {
+                path: '_isEmptyString',
+                comparisonOperator: '<',
+                value: 0
+            }
+        ],
+        expected: [false, null]
+    },
+    {
+        testTitle: '_isString === 0, should return false. The string is not a number',
+        conditionals: [
+            {
+                path: '_isString',
+                comparisonOperator: '===',
+                value: 0
+            }
+        ],
+        expected: [false, null]
     },
     {
         testTitle: 'Wrong comparison operator with number, should return false.',

--- a/packages/evolution-common/src/services/widgets/conditionals/checkConditionals.ts
+++ b/packages/evolution-common/src/services/widgets/conditionals/checkConditionals.ts
@@ -116,26 +116,32 @@ export const checkConditionals = ({
                 conditionMet = false;
                 break;
             }
-        } else if (typeof value === 'number') {
-            // For Number
+        } else if (typeof value === 'number' && (typeof response === 'number' || typeof response === 'string')) {
+            const responseAsNumber =
+                typeof response === 'number'
+                    ? response
+                    : response.trim() !== '' && Number.isFinite(Number(response))
+                        ? Number(response)
+                        : NaN;
+            // For Number values, when response is string or number
             switch (comparisonOperator) {
             case '===':
-                conditionMet = Number(response) === value;
+                conditionMet = responseAsNumber === value;
                 break;
             case '!==':
-                conditionMet = Number(response) !== value;
+                conditionMet = responseAsNumber !== value;
                 break;
             case '>':
-                conditionMet = Number(response) > value;
+                conditionMet = responseAsNumber > value;
                 break;
             case '<':
-                conditionMet = Number(response) < value;
+                conditionMet = responseAsNumber < value;
                 break;
             case '>=':
-                conditionMet = Number(response) >= value;
+                conditionMet = responseAsNumber >= value;
                 break;
             case '<=':
-                conditionMet = Number(response) <= value;
+                conditionMet = responseAsNumber <= value;
                 break;
             default:
                 conditionMet = false;


### PR DESCRIPTION
fixes #1608

The type of the response should be `number` or `string` for correct number comparison. Add a tests with a `null` value and compare with 0, as `Number(null)` converts to 0, but the 0 equality conditional should fail for null values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded conditional comparison coverage for numeric-string inputs and numeric coercion edge cases.
  * Added assertions ensuring the null sentinel (`null`) compared to `0` using strict equality evaluates to `false`.

* **Bug Fixes**
  * Improved numeric conditional evaluation to correctly handle numeric responses provided as strings (including trimming and finite-number validation).
  * Refined equality and relational comparisons to more reliably distinguish `null` from `0` and compare numeric values consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->