### PR TITLE
widgets: add a new `InputSelectFeature` widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Generator conditional hidden values**: In the `Conditionals` Excel sheet, you can now set an optional `value_when_hidden` so a value is applied when the conditional hides the question (fixes [#979](https://github.com/chairemobilite/evolution/issues/979)).
 - **Generator section conditionals**: The `Sections` Excel sheet supports optional `enable_conditional` and `completion_conditional` columns. Set them to a conditional name from the `Conditionals` sheet (generated as `conditionals.<name>`) or to a custom conditional whose name ends with `CustomConditional` (generated as `customConditionals.<name>`). When omitted, the generator keeps the previous defaults (`true` or `isSectionCompleted` with the previous or current section as appropriate). (fixes [#997](https://github.com/chairemobilite/evolution/issues/997)).
 - **Generator selective script generation**: The generator now accepts a `--only` command-line argument to generate only specified scripts (e.g., widgets, conditionals, labels) instead of everything (fixes [#1601](https://github.com/chairemobilite/evolution/issues/1601))
+- **Experimental** Add a `selectFeature` input type that takes a geojson point feature collection and sorts them in a select widget by proximity to a reference geography in the survey (fixes [#1604](https://github.com/chairemobilite/evolution/issues/1604))
 
 ### Changed
 

--- a/packages/evolution-common/src/services/questionnaire/types/WidgetConfig.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/WidgetConfig.ts
@@ -198,6 +198,23 @@ export type InputSelectType = BaseQuestionType & {
     datatype?: 'string' | 'integer' | 'float' | 'text';
 };
 
+/**
+ * Type for a select input whose values are geographical features from a feature
+ * collection. The features are sorted by proximity to a reference geography.
+ * The feature collection is expected to have an `id` field that will be used as
+ * the value of the choices.
+ *
+ * @experimental This widget is still experimental and is implemented for a very
+    specific use case to sort choices wrt a segment's origin/destination. The
+    implementation may change rapidly if new cases are discovered.
+ */
+export type InputSelectFeatureType = BaseQuestionType & {
+    inputType: 'selectFeature';
+    featureCollection: GeoJSON.FeatureCollection<GeoJSON.Point>;
+    labelProperty: string;
+    referenceGeography: ParsingFunction<GeoJSON.Feature<GeoJSON.Point> | null>;
+};
+
 export type InputMultiselectType = BaseQuestionType & {
     inputType: 'multiselect';
     choices: ChoiceType[] | ParsingFunction<ChoiceType[]>;
@@ -395,6 +412,7 @@ export type QuestionWidgetConfig =
     | InputRangeType
     | InputDatePickerType
     | InputSelectType
+    | InputSelectFeatureType
     | InputRadioNumberType;
 
 const inputTypesWithArrayValue: QuestionWidgetConfig['inputType'][] = ['checkbox', 'multiselect'];

--- a/packages/evolution-frontend/src/components/inputs/InputSelectFeature.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputSelectFeature.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import React from 'react';
+import { distance as turfDistance } from '@turf/turf';
+
+import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
+import { InputSelectFeatureType } from 'evolution-common/lib/services/questionnaire/types';
+import { CommonInputProps } from './CommonInputProps';
+
+export type InputSelectFeatureProps = CommonInputProps & {
+    value?: string;
+    inputRef?: React.RefObject<HTMLInputElement | null>;
+    widgetConfig: InputSelectFeatureType;
+};
+
+export interface FeaturesToChoicesProps {
+    widgetConfig: InputSelectFeatureType;
+    referenceGeography: GeoJSON.Feature<GeoJSON.Point> | null;
+}
+
+const FeaturesToChoices = (props: FeaturesToChoicesProps) => {
+    const referenceGeographyKey = props.referenceGeography
+        ? `${props.referenceGeography.geometry.type}:${props.referenceGeography.geometry.coordinates.join(',')}`
+        : null;
+
+    // Memoized sorted choices, to avoid recalculating distances every time the widget renders
+    const sortedChoices = React.useMemo(() => {
+        // Sort features by distance to reference geography
+        const features = props.widgetConfig.featureCollection.features as GeoJSON.Feature<GeoJSON.Point>[];
+        const choiceFeatures =
+            props.referenceGeography === null
+                ? features
+                : features
+                    .map(
+                        (feature) =>
+                              ({
+                                  ...feature,
+                                  properties: {
+                                      ...feature.properties,
+                                      distance: turfDistance(props.referenceGeography!, feature)
+                                  }
+                              }) as GeoJSON.Feature<GeoJSON.Point, { distance: number }>
+                    )
+                    .sort((featureA, featureB) => featureA.properties.distance - featureB.properties.distance);
+        return choiceFeatures.map((choiceFeature: GeoJSON.Feature<GeoJSON.Point, any>) => {
+            const choiceId = choiceFeature.id;
+            const choiceLabel = choiceFeature.properties[props.widgetConfig.labelProperty];
+            return (
+                <option key={`input-select-container__${choiceId}`} value={choiceId} className={'input-select-option'}>
+                    {choiceLabel}
+                </option>
+            );
+        });
+    }, [props.widgetConfig, referenceGeographyKey]);
+
+    return sortedChoices;
+};
+
+export const InputSelectFeature = (props: InputSelectFeatureProps) => {
+    const referenceGeography =
+        typeof props.widgetConfig.referenceGeography === 'function'
+            ? props.widgetConfig.referenceGeography(props.interview, props.path, props.user)
+            : null;
+
+    return (
+        <div className="survey-question__input-select-container">
+            <select
+                id={props.id}
+                onChange={props.onValueChange}
+                value={_isBlank(props.value) ? '' : props.value}
+                style={{
+                    overflow: 'hidden',
+                    whiteSpace: 'nowrap',
+                    textOverflow: 'ellipsis',
+                    maxWidth: '100%'
+                }}
+            >
+                <option key={'input-select-container__blank'} value="" className={'input-select-option'}></option>
+
+                <FeaturesToChoices widgetConfig={props.widgetConfig} referenceGeography={referenceGeography ?? null} />
+            </select>
+        </div>
+    );
+};
+
+export default InputSelectFeature;

--- a/packages/evolution-frontend/src/components/inputs/__tests__/InputSelectFeature.test.tsx
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/InputSelectFeature.test.tsx
@@ -1,0 +1,107 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { interviewAttributes } from './interviewData';
+import InputSelectFeature from '../InputSelectFeature';
+import i18next from 'i18next';
+
+const userAttributes = {
+    id: 1,
+    username: 'foo',
+    preferences: {  },
+    serializedPermissions: [],
+    isAuthorized: () => true,
+    is_admin: false,
+    pages: [],
+    showUserInfo: true
+};
+
+const testFeatureCollection = {
+    type: 'FeatureCollection' as const,
+    features: [
+        { type: 'Feature' as const, id: 'feature1', properties: { label: 'Label For Feature 1' }, geometry: { type: 'Point' as const, coordinates: [0,0] } },
+        { type: 'Feature' as const, id: 'feature2', properties: { label: 'Label For Feature 2' }, geometry: { type: 'Point' as const, coordinates: [1,1] } },
+        { type: 'Feature' as const, id: 'feature3', properties: { label: 'Label For Feature 3' }, geometry: { type: 'Point' as const, coordinates: [2,3] } },
+        { type: 'Feature' as const, id: 'feature4', properties: { label: 'Label For Feature 4' }, geometry: { type: 'Point' as const, coordinates: [3,1] } }
+    ]
+};
+
+test('Render InputSelect with normal option type, no sorting', () => {
+
+    // Return null for ref geography, features should not be sorted
+    const refGeographyFct = jest.fn().mockReturnValue(null);
+
+    const widgetConfig = {
+        type: 'question' as const,
+        twoColumns: true,
+        path: 'test.foo',
+        inputType: 'selectFeature' as const,
+        featureCollection: testFeatureCollection,
+        labelProperty: 'label',
+        referenceGeography: refGeographyFct,
+        size: 'medium',
+        containsHtml: true,
+        label: {
+            fr: `Texte en français`,
+            en: `English text`
+        }
+    };
+    
+    const { container } = render(
+        <InputSelectFeature
+            id={'test'}
+            onValueChange={() => { /* nothing to do */}}
+            widgetConfig={widgetConfig}
+            value='value'
+            inputRef={React.createRef()}
+            interview={interviewAttributes}
+            user={userAttributes}
+            path='foo.test'
+        />
+    );
+    expect(container).toMatchSnapshot();
+    expect(refGeographyFct).toHaveBeenCalledWith(interviewAttributes, 'foo.test', userAttributes);
+});
+
+test('Render InputSelect with normal option type, proximity sorting', () => {
+
+    // Return geography, sorting should be features 4, 2, 1, 3
+    const refGeographyFct = jest.fn().mockReturnValue({ type: 'Feature' as const, geometry: { type: 'Point', coordinates: [2.5, 0] }, properties: {} });
+
+    const widgetConfig = {
+        type: 'question' as const,
+        twoColumns: true,
+        path: 'test.foo',
+        inputType: 'selectFeature' as const,
+        featureCollection: testFeatureCollection,
+        labelProperty: 'label',
+        referenceGeography: refGeographyFct,
+        size: 'medium',
+        containsHtml: true,
+        label: {
+            fr: `Texte en français`,
+            en: `English text`
+        }
+    };
+    
+    const { container } = render(
+        <InputSelectFeature
+            id={'test'}
+            onValueChange={() => { /* nothing to do */}}
+            widgetConfig={widgetConfig}
+            value='value'
+            inputRef={React.createRef()}
+            interview={interviewAttributes}
+            user={userAttributes}
+            path='foo.test'
+        />
+    );
+    expect(container).toMatchSnapshot();
+    expect(refGeographyFct).toHaveBeenCalledWith(interviewAttributes, 'foo.test', userAttributes);
+});

--- a/packages/evolution-frontend/src/components/inputs/__tests__/__snapshots__/InputSelectFeature.test.tsx.snap
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/__snapshots__/InputSelectFeature.test.tsx.snap
@@ -1,0 +1,85 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Render InputSelect with normal option type, no sorting 1`] = `
+<div>
+  <div
+    class="survey-question__input-select-container"
+  >
+    <select
+      id="test"
+      style="overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 100%;"
+    >
+      <option
+        class="input-select-option"
+        value=""
+      />
+      <option
+        class="input-select-option"
+        value="feature1"
+      >
+        Label For Feature 1
+      </option>
+      <option
+        class="input-select-option"
+        value="feature2"
+      >
+        Label For Feature 2
+      </option>
+      <option
+        class="input-select-option"
+        value="feature3"
+      >
+        Label For Feature 3
+      </option>
+      <option
+        class="input-select-option"
+        value="feature4"
+      >
+        Label For Feature 4
+      </option>
+    </select>
+  </div>
+</div>
+`;
+
+exports[`Render InputSelect with normal option type, proximity sorting 1`] = `
+<div>
+  <div
+    class="survey-question__input-select-container"
+  >
+    <select
+      id="test"
+      style="overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 100%;"
+    >
+      <option
+        class="input-select-option"
+        value=""
+      />
+      <option
+        class="input-select-option"
+        value="feature4"
+      >
+        Label For Feature 4
+      </option>
+      <option
+        class="input-select-option"
+        value="feature2"
+      >
+        Label For Feature 2
+      </option>
+      <option
+        class="input-select-option"
+        value="feature1"
+      >
+        Label For Feature 1
+      </option>
+      <option
+        class="input-select-option"
+        value="feature3"
+      >
+        Label For Feature 3
+      </option>
+    </select>
+  </div>
+</div>
+`;

--- a/packages/evolution-frontend/src/components/survey/Question.tsx
+++ b/packages/evolution-frontend/src/components/survey/Question.tsx
@@ -26,6 +26,7 @@ import InputMultiselect from '../inputs/InputMultiselect';
 import InputTime from '../inputs/InputTime';
 import InputRadioNumber from '../inputs/InputRadioNumber';
 import InputText from '../inputs/InputText';
+import InputSelectFeature from '../inputs/InputSelectFeature';
 import Modal from 'react-modal';
 import { checkValidations } from '../../actions/utils';
 import { withSurveyContext, WithSurveyContextProps } from '../hoc/WithSurveyContextHoc';
@@ -283,6 +284,14 @@ export class Question extends React.Component<QuestionProps & WithSurveyContextP
             case 'select':
                 return (
                     <InputSelect
+                        {...commonProps}
+                        value={widgetStatus.value as any}
+                        widgetConfig={widgetConfig as any}
+                    />
+                );
+            case 'selectFeature':
+                return (
+                    <InputSelectFeature
                         {...commonProps}
                         value={widgetStatus.value as any}
                         widgetConfig={widgetConfig as any}

--- a/packages/evolution-frontend/src/components/survey/__tests__/Question.test.tsx
+++ b/packages/evolution-frontend/src/components/survey/__tests__/Question.test.tsx
@@ -16,6 +16,7 @@ expect.extend(toHaveNoViolations);
 import { interviewAttributes } from '../../inputs/__tests__/interviewData';
 import Question from '../Question';
 import { WidgetStatus } from 'evolution-common/lib/services/questionnaire/types';
+import { featureCollection } from '@turf/turf';
 
 // Mock react-markdown and remark-gfm as they use syntax not supported by jest
 jest.mock('react-markdown', () => 'Markdown');
@@ -82,6 +83,17 @@ const defaultWidgetStatus: WidgetStatus = {
     value: null
 };
 
+// Feature collection for the inputSelectFeature test
+const testFeatureCollection = {
+    type: 'FeatureCollection' as const,
+    features: [
+        { type: 'Feature' as const, id: 'feature1', properties: { label: 'Label For Feature 1' }, geometry: { type: 'Point' as const, coordinates: [0,0] } },
+        { type: 'Feature' as const, id: 'feature2', properties: { label: 'Label For Feature 2' }, geometry: { type: 'Point' as const, coordinates: [1,1] } },
+        { type: 'Feature' as const, id: 'feature3', properties: { label: 'Label For Feature 3' }, geometry: { type: 'Point' as const, coordinates: [2,3] } },
+        { type: 'Feature' as const, id: 'feature4', properties: { label: 'Label For Feature 4' }, geometry: { type: 'Point' as const, coordinates: [3,1] } }
+    ]
+}
+
 each([
     ['InputSelect', { ...commonWidgetConfig, inputType: 'select', choices: [{ label: 'choice 1', value: 'c1' }, { label: 'choice 2', value: 'c2' }] }, 'c2'],
     ['InputRadio', { ...commonWidgetConfig, inputType: 'radio', choices: [{ label: 'choice 1', value: 'c1' }, { label: 'choice 2', value: 'c2' }] }, 'c2'],
@@ -94,6 +106,7 @@ each([
     ['InputText', { ...commonWidgetConfig, inputType: 'text' }, 'foo'], // This test needs a value
     ['InputString', { ...commonWidgetConfig, inputType: 'string' }],
     ['InputTime', { ...commonWidgetConfig, inputType: 'time', minTimeSecondsSinceMidnight: 3600, maxTimeSecondsSinceMidnight: 7200, minuteStep: 10 }, 3660], // This test needs a value
+    ['InputSelectFeature', { ...commonWidgetConfig, inputType: 'selectFeature', featureCollection: testFeatureCollection, labelProperty: 'label', referenceGeography: jest.fn().mockReturnValue(null) }],
 ]).describe('Question with widget %s', (_widget, widgetConfig, value: unknown = undefined) => {
 
     const widgetStatus = _cloneDeep(defaultWidgetStatus);

--- a/packages/evolution-frontend/src/components/survey/__tests__/__snapshots__/Question.test.tsx.snap
+++ b/packages/evolution-frontend/src/components/survey/__tests__/__snapshots__/Question.test.tsx.snap
@@ -735,6 +735,68 @@ exports[`Question with widget InputSelect Render widget 1`] = `
 </div>
 `;
 
+exports[`Question with widget InputSelectFeature Render widget 1`] = `
+<div>
+  <div
+    class="apptr__form-container two-columns question-type-selectFeature question-filled question-valid"
+    style="position: relative;"
+  >
+    <div
+      class="apptr__form-label-container two-columns"
+    >
+      <label
+        for="survey-question__home.region"
+      >
+        <div>
+          English text
+        </div>
+      </label>
+    </div>
+    <div
+      class="apptr__form-input-container two-columns"
+    >
+      <div
+        class="survey-question__input-select-container"
+      >
+        <select
+          id="survey-question__home.region"
+          style="overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 100%;"
+        >
+          <option
+            class="input-select-option"
+            value=""
+          />
+          <option
+            class="input-select-option"
+            value="feature1"
+          >
+            Label For Feature 1
+          </option>
+          <option
+            class="input-select-option"
+            value="feature2"
+          >
+            Label For Feature 2
+          </option>
+          <option
+            class="input-select-option"
+            value="feature3"
+          >
+            Label For Feature 3
+          </option>
+          <option
+            class="input-select-option"
+            value="feature4"
+          >
+            Label For Feature 4
+          </option>
+        </select>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Question with widget InputString Render widget 1`] = `
 <div>
   <div


### PR DESCRIPTION
fixes #1604

This adds a new experimental input type that takes the following attributes:

* featureCollection: a feature collection of points to use as choices. The `id` of the feature is used as `value` for choices.
* labelProperty: the property of the feature to use as the `label` of the corresponding choice.
* referenceGeography: a parsing function that takes the interview and path and returns a possibly `null` reference point to use to sort the features of the collection

A new widget is added, which sorts the features according to the distance to the reference geography and converts to select choices, using the field attributes.

This widget is still experimental and is implemented for a very specific need. It may be refined later.