### PR TITLE
Filter validation list by a list of access codes (od_mtl #68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Validation list: filter by several access codes at once, typed or imported from a CSV file (fixes [#1660](https://github.com/chairemobilite/evolution/issues/1660)).
 - **Generator Excel to CSV copy**: Generator can now write one CSV file per Excel sheet in a `<Name_Excel_File>_csv` folder next to the Excel file, making Excel changes easier to review in git diffs. To enable it, add `copy_excel_to_csv: true` under `enabled_scripts` in your `generatorConfig.yaml` (fixes [#1580](https://github.com/chairemobilite/evolution/issues/1580)).
 - **CSS refresh in dev mode**: Changes to `.scss` files are automatically picked up by `yarn build:dev` and apply after a page reload (fixes [#1403](https://github.com/chairemobilite/evolution/issues/1403)). Survey projects that want the same: see [#1407](https://github.com/chairemobilite/evolution/pull/1407) for the webpack modifications.
 - Added `maxAccessEgressTravelTimeMinutes` and `walkingSpeedKmPerHour` to accessibility map calculation parameters ([#1379](https://github.com/chairemobilite/evolution/pull/1379))

--- a/locales/en/admin.json
+++ b/locales/en/admin.json
@@ -101,7 +101,12 @@
     },
     "interviewByCodeFilter": {
         "title": "Access Code",
-        "button": "Filter by access code"
+        "button": "Filter by access code",
+        "placeholder": "One or more access codes, separated by commas or new lines",
+        "importButton": "Import a list of access codes (CSV, one code per line)",
+        "importedCount_one": "{{count}} code imported",
+        "importedCount_other": "{{count}} codes imported",
+        "importError": "Could not read the file."
     },
     "interviewByDateFilter": {
         "title": "Interview date",

--- a/locales/fr/admin.json
+++ b/locales/fr/admin.json
@@ -101,7 +101,12 @@
     },
     "interviewByCodeFilter": {
         "title": "Code d'accès",
-        "button": "Filtrer par code d'accès"
+        "button": "Filtrer par code d'accès",
+        "placeholder": "Un ou plusieurs codes d'accès, séparés par des virgules ou des retours de ligne",
+        "importButton": "Importer une liste de codes d'accès (CSV, un code par ligne)",
+        "importedCount_one": "{{count}} code importé",
+        "importedCount_other": "{{count}} codes importés",
+        "importError": "Impossible de lire le fichier."
     },
     "interviewByDateFilter": {
         "title": "Date d'entrevue",

--- a/packages/evolution-backend/src/models/__tests__/interviews.db.test.ts
+++ b/packages/evolution-backend/src/models/__tests__/interviews.db.test.ts
@@ -723,6 +723,14 @@ describe('list interviews', () => {
             .rejects
             .toThrow('Cannot get interview list in table sv_interviews database (knex error: Invalid field for where clause in sv_interviews database (DBQCR0005))');
 
+        // The `in` operator is only allowed on response.* fields, should throw an error otherwise
+        await expect(dbQueries.getList({
+            filters: { uuid: { value: ['some-uuid'], op: 'in' } },
+            pageIndex: 0, pageSize: -1
+        }))
+            .rejects
+            .toThrow('Cannot get interview list in table sv_interviews database (knex error: The \'in\' operator is only supported for response fields in sv_interviews database (DBQCR0007))');
+
     });
 
     test('Get list by geographic filter', async () => {

--- a/packages/evolution-backend/src/models/__tests__/interviews.db.test.ts
+++ b/packages/evolution-backend/src/models/__tests__/interviews.db.test.ts
@@ -582,6 +582,27 @@ describe('list interviews', () => {
         expect(filterAccessCodeArrayRes.length).toEqual(1);
         expect((filterAccessCodeArrayRes[0].response as any).accessCode).toEqual(localUserInterviewAttributes.response.accessCode);
 
+        // Query with the `in` operator: matches interviews whose access code is any of the
+        // listed codes (e.g. a list imported from a CSV). Cannot use test.each here since
+        // this runs inside a single test that relies on the seeded data above.
+        const localAccessCode = localUserInterviewAttributes.response.accessCode;
+        const googleAccessCode = googleUserInterviewAttributes.response.accessCode;
+        const inCases: [string, string[], number][] = [
+            ['both existing codes', [localAccessCode, googleAccessCode], 2],
+            ['one existing and one unknown code', [localAccessCode, 'unknown-code'], 1],
+            ['only unknown codes', ['unknown-1', 'unknown-2'], 0],
+            ['empty list matches nothing', [], 0]
+        ];
+        for (const [, codes, expectedCount] of inCases) {
+            const { interviews, totalCount } = await dbQueries.getList({
+                filters: { 'response.accessCode': { value: codes, op: 'in' } },
+                pageIndex: 0,
+                pageSize: -1
+            });
+            expect(totalCount).toEqual(expectedCount);
+            expect(interviews.length).toEqual(expectedCount);
+        }
+
     });
 
     test('Combine filter and paging', async () => {

--- a/packages/evolution-backend/src/models/interviews.db.queries.ts
+++ b/packages/evolution-backend/src/models/interviews.db.queries.ts
@@ -280,7 +280,7 @@ const update = async (
 /**
  * Array of valid operator keys for ValueFilterType
  */
-export const VALID_OPERATORS = ['eq', 'gt', 'lt', 'gte', 'lte', 'not', 'like'] as const;
+export const VALID_OPERATORS = ['eq', 'gt', 'lt', 'gte', 'lte', 'not', 'like', 'in'] as const;
 
 /**
  * An enumeration of operator keys that can be used in filters
@@ -296,7 +296,11 @@ const operatorSigns: OperatorSigns = {
     gte: '>=',
     lte: '<=',
     not: '!=',
-    like: 'like'
+    like: 'like',
+    // `in` is handled as a special case (it expands to `IN (?, ?, ...)`) and is
+    // only supported for `response.*` fields, but it is listed here to keep the
+    // operator map exhaustive with VALID_OPERATORS.
+    in: 'in'
 };
 
 // Even if it is typed, in reality, this data comes from the universe and can be anything. Make sure we don't inject sql
@@ -363,14 +367,15 @@ const addLikeBinding = (operator: keyof OperatorSigns | undefined, binding: stri
  * Create a raw where clause from a filter
  *
  * @returns Either a string with the raw where clause, an array where the first
- * element is the raw where clause and the second is the value to bind with they
- * query, or undefined if the field is unknown
+ * element is the raw where clause and the second is the value (or array of
+ * values, for the `in` operator) to bind with the query, or undefined if the
+ * field is unknown
  */
 const getRawWhereClause = (
     field: string,
     filter: ValueFilterType,
     tblAlias: string
-): (string | [string, string | boolean | number] | undefined)[] => {
+): (string | [string, string | boolean | number | (string | boolean | number)[]] | undefined)[] => {
     // Make sure the field is a legitimate field to avoid sql injection. Field
     // is either the name of a field, or a dot-separated path in a json object
     // of the 'response' field. We should not accept anything else.
@@ -462,6 +467,16 @@ const getRawWhereClause = (
                 `${prefix}->'${field}' is not null AND ST_CONTAINS(${st.geomFromGeoJSON(JSON.stringify((filter.value as GeoJSON.Feature<GeoJSON.Polygon>).geometry))}, ST_GeomFromGeoJSON(${prefix}->'${field}'->'geometry'))`
             ];
         }
+        // The `in` operator matches any of the provided values (e.g. a list of
+        // access codes imported from a CSV). An empty list matches nothing.
+        if (filter.op === 'in') {
+            const values = Array.isArray(filter.value) ? filter.value : [filter.value];
+            if (values.length === 0) {
+                return ['FALSE'];
+            }
+            const placeholders = values.map(() => '?').join(', ');
+            return [[`${prefix}->>'${field}' IN (${placeholders})`, values as (string | boolean | number)[]]];
+        }
         return filter.value === null
             ? [`${prefix}->>'${field}' ${filter.op === 'not' ? ' IS NOT NULL' : ' IS NULL'}`]
             : Array.isArray(filter.value)
@@ -512,7 +527,13 @@ const updateRawWhereClause = (
                 rawFilter += ` AND ${whereClause}`;
             } else if (Array.isArray(whereClause)) {
                 rawFilter += ` AND ${whereClause[0]}`;
-                bindings.push(whereClause[1]);
+                // The binding may be a single value or, for the `in` operator, an
+                // array of values to spread into the bindings (one per `?`).
+                if (Array.isArray(whereClause[1])) {
+                    bindings.push(...whereClause[1]);
+                } else {
+                    bindings.push(whereClause[1]);
+                }
             }
         });
     });

--- a/packages/evolution-backend/src/models/interviews.db.queries.ts
+++ b/packages/evolution-backend/src/models/interviews.db.queries.ts
@@ -391,6 +391,16 @@ const getRawWhereClause = (
             'DatabaseInvalidWhereClauseUserEntry'
         );
     }
+    // The `in` operator expands to a SQL `IN (...)` clause and is only supported
+    // for response.* fields. Reject it early on other fields to avoid generating
+    // invalid SQL.
+    if (filter.op === 'in' && field.split('.')[0] !== 'response') {
+        throw new TrError(
+            `The 'in' operator is only supported for response fields in ${tableName} database`,
+            'DBQCR0007',
+            'DatabaseInvalidWhereClauseUserEntry'
+        );
+    }
     const getBooleanFilter = (fieldName: string, filter: ValueFilterType) => {
         const validityValue = _booleish(filter.value);
         const notStr = filter.op === 'not' ? ' NOT ' : '';
@@ -468,14 +478,20 @@ const getRawWhereClause = (
             ];
         }
         // The `in` operator matches any of the provided values (e.g. a list of
-        // access codes imported from a CSV). An empty list matches nothing.
+        // access codes imported from a CSV). Only scalar values are kept, since
+        // they are bound to a SQL `IN (...)` clause; an empty list (or a list
+        // with no scalar value) matches nothing.
         if (filter.op === 'in') {
-            const values = Array.isArray(filter.value) ? filter.value : [filter.value];
+            const rawValues = Array.isArray(filter.value) ? filter.value : [filter.value];
+            const values = rawValues.filter(
+                (value): value is string | boolean | number =>
+                    typeof value === 'string' || typeof value === 'boolean' || typeof value === 'number'
+            );
             if (values.length === 0) {
                 return ['FALSE'];
             }
             const placeholders = values.map(() => '?').join(', ');
-            return [[`${prefix}->>'${field}' IN (${placeholders})`, values as (string | boolean | number)[]]];
+            return [[`${prefix}->>'${field}' IN (${placeholders})`, values]];
         }
         return filter.value === null
             ? [`${prefix}->>'${field}' ${filter.op === 'not' ? ' IS NOT NULL' : ' IS NULL'}`]

--- a/packages/evolution-frontend/src/components/admin/validations/InterviewByCodeFilter.tsx
+++ b/packages/evolution-frontend/src/components/admin/validations/InterviewByCodeFilter.tsx
@@ -8,14 +8,20 @@ import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { FilterProps } from 'react-table';
 import { faCheckCircle } from '@fortawesome/free-solid-svg-icons/faCheckCircle';
+import { faFileImport } from '@fortawesome/free-solid-svg-icons/faFileImport';
 
-import InputString from 'chaire-lib-frontend/lib/components/input/InputString';
+import InputText from 'chaire-lib-frontend/lib/components/input/InputText';
 import InputButton from 'chaire-lib-frontend/lib/components/input/Button';
+import FormErrors from 'chaire-lib-frontend/lib/components/pageParts/FormErrors';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { InterviewListAttributes } from 'evolution-common/lib/services/questionnaire/types';
+import { parseAccessCodesFromCsv } from './parseAccessCodesFromCsv';
 
 /**
- * Textbox input for access code filter
+ * Filter for the access code column. Access codes can be typed (one or several,
+ * separated by commas or new lines) or imported from a CSV file (one code per
+ * line). A single code is matched exactly; several codes match any interview
+ * having one of them.
  *
  * @param param0 description of the filtered column
  * @returns
@@ -24,25 +30,101 @@ export const InterviewByCodeFilter = ({
     t,
     column: { filterValue, setFilter }
 }: FilterProps<InterviewListAttributes> & WithTranslation) => {
+    // Normalize the active filter value to a string for the textarea. A list
+    // filter (op `in`) stores an array of codes, shown comma-separated so it can
+    // be re-parsed by applyTypedFilter; a single code is a string.
+    const initialValue = !_isBlank(filterValue) && filterValue.value ? filterValue.value : filterValue;
     const [currentValue, setCurrentValue] = React.useState(
-        !_isBlank(filterValue) && filterValue.value ? filterValue.value : filterValue
+        Array.isArray(initialValue) ? initialValue.join(',') : typeof initialValue === 'string' ? initialValue : ''
     );
+    // Number of access codes loaded from the last imported CSV file, used to
+    // give feedback to the validator. Undefined when no file is loaded.
+    const [importedCodeCount, setImportedCodeCount] = React.useState<number | undefined>(undefined);
+    // Whether reading the last imported CSV file failed, to give feedback to the validator.
+    const [importError, setImportError] = React.useState(false);
+    const fileInputRef = React.useRef<HTMLInputElement>(null);
+
+    // Apply the typed access code(s), separated by commas or new lines. A single
+    // code is matched exactly (`eq`), while several codes are matched as a list
+    // (`in`). A blank value clears the filter.
+    const applyTypedFilter = () => {
+        if (_isBlank(currentValue)) {
+            setFilter(currentValue);
+            return;
+        }
+        const codes = currentValue
+            .split(/[\n,]/)
+            .map((code) => code.trim())
+            .filter((code) => code.length > 0);
+        if (codes.length === 0) {
+            // Input contained only delimiters (e.g. ",,," or new lines): clear the filter.
+            setFilter(undefined);
+            return;
+        }
+        setFilter(codes.length > 1 ? { value: codes, op: 'in' } : { value: codes[0], op: 'eq' });
+    };
+
+    const handleFileSelected = async (event: React.ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0];
+        // Reset the input so selecting the same file again still triggers a change event.
+        event.target.value = '';
+        if (!file) {
+            return;
+        }
+        try {
+            const codes = parseAccessCodesFromCsv(await file.text());
+            setImportError(false);
+            setImportedCodeCount(codes.length);
+            setCurrentValue('');
+            setFilter(codes.length > 0 ? { value: codes, op: 'in' } : undefined);
+        } catch {
+            // Reading the file can fail (e.g. corrupted or unreadable file): give feedback.
+            setImportError(true);
+            setImportedCodeCount(undefined);
+        }
+    };
 
     return (
         <div style={{ display: 'flex', alignItems: 'center' }}>
             <label htmlFor={'accessCodeSearchInput'}>{t('admin:interviewByCodeFilter:title')}</label>
-            <InputString
+            <InputText
                 id="accessCodeSearchInput"
+                rows={3}
                 value={currentValue}
-                onValueUpdated={(newValue) => setCurrentValue(newValue.value)}
+                placeholder={t('admin:interviewByCodeFilter:placeholder')}
+                onValueChange={(event) => {
+                    setCurrentValue(event.target.value);
+                    setImportedCodeCount(undefined);
+                    setImportError(false);
+                }}
             />
             <InputButton
-                onClick={() => setFilter(!_isBlank(currentValue) ? { value: currentValue, op: 'eq' } : currentValue)}
+                onClick={applyTypedFilter}
                 icon={faCheckCircle}
                 label=""
                 size="small"
                 title={t('admin:interviewByCodeFilter:button')}
             />
+            <input
+                type="file"
+                accept=".csv,text/csv,text/plain"
+                ref={fileInputRef}
+                style={{ display: 'none' }}
+                onChange={handleFileSelected}
+            />
+            <InputButton
+                onClick={() => fileInputRef.current?.click()}
+                icon={faFileImport}
+                label=""
+                size="small"
+                title={t('admin:interviewByCodeFilter:importButton')}
+            />
+            {importedCodeCount !== undefined && (
+                <span style={{ marginLeft: '0.5rem' }}>
+                    {t('admin:interviewByCodeFilter:importedCount', { count: importedCodeCount })}
+                </span>
+            )}
+            {importError && <FormErrors errors={['admin:interviewByCodeFilter:importError']} />}
         </div>
     );
 };

--- a/packages/evolution-frontend/src/components/admin/validations/__tests__/parseAccessCodesFromCsv.test.ts
+++ b/packages/evolution-frontend/src/components/admin/validations/__tests__/parseAccessCodesFromCsv.test.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { parseAccessCodesFromCsv } from '../parseAccessCodesFromCsv';
+
+describe('parseAccessCodesFromCsv', () => {
+    // Access codes use the default format (eight digits, optional dash/space in the middle).
+    test.each([
+        ['empty content', '', []],
+        ['single code', '1111-1111', ['1111-1111']],
+        ['one code per line', '1111-1111\n2222-2222\n3333-3333', ['1111-1111', '2222-2222', '3333-3333']],
+        ['windows line endings', '1111-1111\r\n2222-2222', ['1111-1111', '2222-2222']],
+        ['trailing newline and blank lines', '1111-1111\n\n2222-2222\n', ['1111-1111', '2222-2222']],
+        ['surrounding whitespace', '  1111-1111  \n\t2222-2222\t', ['1111-1111', '2222-2222']],
+        ['quoted cells', '"1111-1111"\n"2222-2222"', ['1111-1111', '2222-2222']],
+        ['only first column of a multi-column row', '1111-1111,extra,data\n2222-2222,more', ['1111-1111', '2222-2222']],
+        ['duplicate codes removed, order preserved', '1111-1111\n2222-2222\n1111-1111', ['1111-1111', '2222-2222']],
+        ['header row is dropped', 'accessCode\n1111-1111\n2222-2222', ['1111-1111', '2222-2222']],
+        ['invalid codes are dropped', '1111-1111\nnot-a-code\n2222-2222', ['1111-1111', '2222-2222']]
+    ])('%s', (_label, content, expected) => {
+        expect(parseAccessCodesFromCsv(content)).toEqual(expected);
+    });
+});

--- a/packages/evolution-frontend/src/components/admin/validations/parseAccessCodesFromCsv.ts
+++ b/packages/evolution-frontend/src/components/admin/validations/parseAccessCodesFromCsv.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { accessCodeValidation } from 'evolution-common/lib/services/widgets/validations/validations';
+import { type UserInterviewAttributes } from 'evolution-common/lib/services/questionnaire/types';
+
+/**
+ * Whether a value passes the access code validation. `accessCodeValidation`
+ * returns one entry per validation rule, where `validation === true` means the
+ * rule failed, so a value is valid only when no rule failed. It only depends on
+ * the value, so the interview and path arguments are placeholders.
+ *
+ * @param value The candidate access code
+ * @returns true if the value is a valid access code
+ */
+const isValidAccessCode = (value: string): boolean =>
+    !accessCodeValidation(value, undefined, {} as UserInterviewAttributes, 'accessCode').some(
+        (rule) => rule.validation === true
+    );
+
+/**
+ * Parse a list of access codes from the raw text content of a CSV file.
+ *
+ * The expected format is intentionally lenient: one access code per line. If a
+ * line contains multiple comma-separated values (a true CSV row), only the
+ * first column is used, which lets validators export a single-column CSV from a
+ * spreadsheet without extra formatting. Blank lines, surrounding whitespace and
+ * quotes are ignored. Values that fail the access code validation are dropped
+ * (this also discards a header row such as "accessCode"), and duplicates are
+ * removed while preserving order.
+ *
+ * @param content The raw text content of the uploaded CSV file
+ * @returns The de-duplicated list of valid access codes, in file order
+ */
+export const parseAccessCodesFromCsv = (content: string): string[] => {
+    const codes = content
+        .split(/\r?\n/)
+        .map((line) => line.split(',')[0])
+        .map((cell) => cell.trim().replace(/^"|"$/g, '').trim())
+        .filter((code) => isValidAccessCode(code));
+    return Array.from(new Set(codes));
+};


### PR DESCRIPTION
## Summary

Lets validators filter the admin validation list by **several access codes at once**, instead of searching codes one by one. Implements od_mtl [#68](https://github.com/chairemobilite/od_mtl/issues/68).

- The access code filter accepts several codes, either **typed** (separated by commas or new lines) or **imported from a CSV file** (one code per line).
- A single code keeps the existing exact-match behavior; several codes match any interview having one of them.
- CSV values are validated with the existing `accessCodeValidation`, which also discards a header row (e.g. `accessCode`).

## Changes

**Backend** (commit 1)
- New `in` operator for the interview list query filters. It expands to a SQL `IN (?, ?, ...)` clause on `response.*` fields (parameterized, no SQL injection). An empty list matches nothing. Array values with other operators keep their previous AND semantics.

**Frontend** (commit 2)
- `InterviewByCodeFilter`: the input becomes a small textarea; codes can be comma/newline separated. Added a CSV import button (the typed field is not filled on import, only a "N codes imported" counter is shown, to avoid a huge field).
- New `parseAccessCodesFromCsv` util (one code per line, first column only, trims quotes/whitespace, dedupes, validates format).
- i18n keys (fr/en) and CHANGELOG entry.

## Notes

- Access code format validation reuses `accessCodeValidation` (evolution-common), i.e. the default 8-digit format. Projects using a different format would need a parameterizable validator (out of scope here).
- Known, **separate pre-existing issue**: the validation list reads/filters `response.accessCode`, not `corrected_response.accessCode`, so a validator-corrected access code is not reflected in the list. Tracked separately, not addressed here.

## Test plan

- [x] `parseAccessCodesFromCsv` parametric unit tests (header dropped, invalid codes dropped, dedupe, multi-column, CRLF, quotes)
- [x] `interviews.db` `in` operator tests (both codes, partial, none, empty list)
- [x] Type-check (backend + frontend)
- [x] Manual: type `1111-1111,2222-2222`, and import a CSV with a header row, confirm the list filters correctly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for filtering interviews by one or multiple access codes, entered as comma/newline-separated text or imported from a CSV/plain-text file (one code per line).
  * Updated admin filter behavior to match any provided code, with UI feedback for imported counts and import errors.

* **Tests**
  * Added backend and frontend test coverage for multi-code “in” filtering and robust CSV parsing (including edge cases and validation).

* **Documentation / Localization**
  * Expanded admin UI translations for the new filter input, import controls, and related messages (including pluralization and error text).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->