### PR TITLE
audits: add household car number per potential driving license check

### DIFF
--- a/locales/en/audits.json
+++ b/locales/en/audits.json
@@ -12,6 +12,7 @@
     "HH_M_Size": "Household size is missing",
     "HH_M_CarNumber": "Car number is missing",
     "HH_I_CarNumber": "Car number is out of range (should be an integer between 0 and 13)",
+    "HH_L_CarNumberPerPotentialDrivingLicenseTooHigh": "Car number per potential driving license holder > 3",
     "HH_L_SizeMembersCountMismatch": "Size and members count mismatch",
     "HH_L_InvalidPersonSequences": "At least one person sequence is invalid",
     "HH_L_CarNumberVehiclesCountMismatch": "Car number and vehicles count mismatch",

--- a/locales/fr/audits.json
+++ b/locales/fr/audits.json
@@ -12,6 +12,7 @@
     "HH_M_Size": "La taille du ménage est manquante",
     "HH_M_CarNumber": "Le nombre de véhicules automobiles est manquant",
     "HH_I_CarNumber": "Le nombre de véhicules automobiles est en dehors de la plage autorisée (devrait être un entier entre 0 et 13)",
+    "HH_L_CarNumberPerPotentialDrivingLicenseTooHigh": "Le nombre de véhicules automobiles par titulaire potentiel d'un permis de conduire > 3",
     "HH_L_SizeMembersCountMismatch": "La taille du ménage et le nombre de personnes ne correspondent pas",
     "HH_L_InvalidPersonSequences": "Le numéro de séquence d'au moins une personne est invalide",
     "HH_L_CarNumberVehiclesCountMismatch": "Le nombre de véhicules automobiles et le nombre de véhicules déclarés ne correspondent pas",

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/HouseholdAuditChecks.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/HouseholdAuditChecks.ts
@@ -5,9 +5,6 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 
-import { hasOrUnknownDrivingLicense } from 'evolution-common/lib/services/odSurvey/helpers';
-import type { Person as ResponsePerson } from 'evolution-common/lib/services/questionnaire/types';
-
 import type { AuditForObject } from 'evolution-common/lib/services/audits/types';
 import type { HouseholdAuditCheckContext, HouseholdAuditCheckFunction } from '../AuditCheckContexts';
 
@@ -244,10 +241,8 @@ export const householdAuditChecks: { [errorCode: string]: HouseholdAuditCheckFun
     ): AuditForObject | undefined => {
         const { household } = context;
         const carNumber = household.carNumber;
-        // household.members are base object Person instances; they expose the same
-        // drivingLicenseOwnership/age attributes the helper reads (getters of the same name).
         const potentialDrivingLicenseCount = (household.members ?? []).filter((person) =>
-            hasOrUnknownDrivingLicense({ person: person as unknown as ResponsePerson })
+            person.hasOrUnknownDrivingLicense()
         ).length;
 
         // No cars: nothing to flag. With cars, flag when there is no potential driver,

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/HouseholdAuditChecks.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/HouseholdAuditChecks.ts
@@ -5,8 +5,16 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 
+import { hasOrUnknownDrivingLicense } from 'evolution-common/lib/services/odSurvey/helpers';
+import type { Person as ResponsePerson } from 'evolution-common/lib/services/questionnaire/types';
+
 import type { AuditForObject } from 'evolution-common/lib/services/audits/types';
 import type { HouseholdAuditCheckContext, HouseholdAuditCheckFunction } from '../AuditCheckContexts';
+
+// Above this number of cars per potential driving license holder, the car number
+// is considered suspiciously high and flagged for validation (warning only, not an error).
+// TODO: make this threshold configurable per survey with a default from project config.
+export const MAX_CAR_NUMBER_PER_POTENTIAL_DRIVING_LICENSE = 3;
 
 export const householdAuditChecks: { [errorCode: string]: HouseholdAuditCheckFunction } = {
     /**
@@ -214,6 +222,52 @@ export const householdAuditChecks: { [errorCode: string]: HouseholdAuditCheckFun
                 version: 1,
                 level: 'error',
                 message: 'At least one person with disability is missing',
+                ignore: false
+            };
+        }
+
+        return undefined; // No audit needed
+    },
+
+    /**
+     * Check if the number of cars is suspiciously high compared to the number of potential
+     * driving license holders. This ratio is not validated live during the interview, so it
+     * is audited here. Two situations are flagged:
+     * - cars but no potential driver at all (nobody can legally drive them), or
+     * - more than MAX_CAR_NUMBER_PER_POTENTIAL_DRIVING_LICENSE cars per potential driver.
+     * Warning only: both are unusual but not necessarily errors.
+     * @param context - HouseholdAuditCheckContext
+     * @returns AuditForObject
+     */
+    HH_L_CarNumberPerPotentialDrivingLicenseTooHigh: (
+        context: HouseholdAuditCheckContext
+    ): AuditForObject | undefined => {
+        const { household } = context;
+        const carNumber = household.carNumber;
+        // household.members are base object Person instances; they expose the same
+        // drivingLicenseOwnership/age attributes the helper reads (getters of the same name).
+        const potentialDrivingLicenseCount = (household.members ?? []).filter((person) =>
+            hasOrUnknownDrivingLicense({ person: person as unknown as ResponsePerson })
+        ).length;
+
+        // No cars: nothing to flag. With cars, flag when there is no potential driver,
+        // or when the cars-per-potential-driver ratio exceeds the threshold.
+        if (carNumber === undefined || !Number.isInteger(carNumber) || carNumber <= 0) {
+            return undefined;
+        }
+
+        const ratioTooHigh =
+            potentialDrivingLicenseCount === 0 ||
+            carNumber / potentialDrivingLicenseCount > MAX_CAR_NUMBER_PER_POTENTIAL_DRIVING_LICENSE;
+
+        if (ratioTooHigh) {
+            return {
+                objectType: 'household',
+                objectUuid: household._uuid!,
+                errorCode: 'HH_L_CarNumberPerPotentialDrivingLicenseTooHigh',
+                version: 1,
+                level: 'warning',
+                message: 'Car number per potential driving license holder > 3',
                 ignore: false
             };
         }

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/household/HH_L_CarNumberPerPotentialDrivingLicenseTooHigh.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/household/HH_L_CarNumberPerPotentialDrivingLicenseTooHigh.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { v4 as uuidV4 } from 'uuid';
+import { Person } from 'evolution-common/lib/services/baseObjects/Person';
+import { householdAuditChecks, MAX_CAR_NUMBER_PER_POTENTIAL_DRIVING_LICENSE } from '../../HouseholdAuditChecks';
+import { createContextWithHouseholdAndHome } from './testHelper';
+
+describe('HH_L_CarNumberPerPotentialDrivingLicenseTooHigh audit check', () => {
+    const validHouseholdUuid = uuidV4();
+    const validHomeUuid = uuidV4();
+
+    // Members are plain objects cast as Person, consistent with the other household test helpers.
+    const licenseHolder = { drivingLicenseOwnership: 'yes' } as Person;
+    const adultUnknownLicense = { age: 40, drivingLicenseOwnership: 'dontKnow' } as Person;
+    const adultMissingLicenseOwnership = { age: 40 } as Person;
+    const childNoLicense = { age: 10, drivingLicenseOwnership: 'dontKnow' } as Person;
+    const childMissingLicenseOwnership = { age: 10 } as Person;
+    const adultNoLicense = { age: 40, drivingLicenseOwnership: 'no' } as Person;
+    const memberMissingAgeAndLicense = {} as Person;
+
+    // [title, carNumber, members, shouldWarn]
+    const cases: [string, number | undefined, Person[], boolean][] = [
+        [
+            'ratio at the threshold does not warn',
+            MAX_CAR_NUMBER_PER_POTENTIAL_DRIVING_LICENSE,
+            [licenseHolder],
+            false
+        ],
+        ['ratio above the threshold warns', MAX_CAR_NUMBER_PER_POTENTIAL_DRIVING_LICENSE + 1, [licenseHolder], true],
+        ['adult with unknown license counts as a potential driver', 4, [adultUnknownLicense], true],
+        [
+            'adult without drivingLicenseOwnership counts as a potential driver',
+            4,
+            [adultMissingLicenseOwnership],
+            true
+        ],
+        [
+            'one car with adult without drivingLicenseOwnership does not warn',
+            1,
+            [adultMissingLicenseOwnership],
+            false
+        ],
+        ['cars but only a child (no potential driver) warns', 1, [childNoLicense], true],
+        [
+            'child without drivingLicenseOwnership does not count as a potential driver',
+            1,
+            [childMissingLicenseOwnership],
+            true
+        ],
+        ['cars but only an adult without license (no potential driver) warns', 2, [adultNoLicense], true],
+        [
+            'member without age or drivingLicenseOwnership does not count as a potential driver',
+            2,
+            [memberMissingAgeAndLicense],
+            true
+        ],
+        ['cars but no members at all (no potential driver) warns', 5, [], true],
+        ['low ratio does not warn', 4, [licenseHolder, adultUnknownLicense], false],
+        ['undefined car number does not warn', undefined, [licenseHolder], false],
+        ['no cars does not warn even without a potential driver', 0, [childNoLicense], false]
+    ];
+
+    it.each(cases)('%s', (_title, carNumber, members, shouldWarn) => {
+        const context = createContextWithHouseholdAndHome(
+            { carNumber, members },
+            undefined,
+            validHouseholdUuid,
+            validHomeUuid
+        );
+
+        const result = householdAuditChecks.HH_L_CarNumberPerPotentialDrivingLicenseTooHigh(context);
+
+        if (shouldWarn) {
+            expect(result).toMatchObject({
+                objectType: 'household',
+                objectUuid: validHouseholdUuid,
+                errorCode: 'HH_L_CarNumberPerPotentialDrivingLicenseTooHigh',
+                version: 1,
+                level: 'warning',
+                message: 'Car number per potential driving license holder > 3',
+                ignore: false
+            });
+        } else {
+            expect(result).toBeUndefined();
+        }
+    });
+});

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/household/HH_L_CarNumberPerPotentialDrivingLicenseTooHigh.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/household/HH_L_CarNumberPerPotentialDrivingLicenseTooHigh.test.ts
@@ -7,21 +7,26 @@
 
 import { v4 as uuidV4 } from 'uuid';
 import { Person } from 'evolution-common/lib/services/baseObjects/Person';
+import type { PersonAttributes } from 'evolution-common/lib/services/baseObjects/Person';
 import { householdAuditChecks, MAX_CAR_NUMBER_PER_POTENTIAL_DRIVING_LICENSE } from '../../HouseholdAuditChecks';
 import { createContextWithHouseholdAndHome } from './testHelper';
+import { SurveyObjectsRegistry } from 'evolution-common/lib/services/baseObjects/SurveyObjectsRegistry';
 
 describe('HH_L_CarNumberPerPotentialDrivingLicenseTooHigh audit check', () => {
     const validHouseholdUuid = uuidV4();
     const validHomeUuid = uuidV4();
+    const surveyObjectsRegistry = new SurveyObjectsRegistry();
 
-    // Members are plain objects cast as Person, consistent with the other household test helpers.
-    const licenseHolder = { drivingLicenseOwnership: 'yes' } as Person;
-    const adultUnknownLicense = { age: 40, drivingLicenseOwnership: 'dontKnow' } as Person;
-    const adultMissingLicenseOwnership = { age: 40 } as Person;
-    const childNoLicense = { age: 10, drivingLicenseOwnership: 'dontKnow' } as Person;
-    const childMissingLicenseOwnership = { age: 10 } as Person;
-    const adultNoLicense = { age: 40, drivingLicenseOwnership: 'no' } as Person;
-    const memberMissingAgeAndLicense = {} as Person;
+    const makeMember = (attrs: Partial<PersonAttributes> = {}) =>
+        new Person({ _uuid: uuidV4(), ...attrs }, surveyObjectsRegistry);
+
+    const licenseHolder = makeMember({ drivingLicenseOwnership: 'yes' });
+    const adultUnknownLicense = makeMember({ age: 40, drivingLicenseOwnership: 'dontKnow' });
+    const adultMissingLicenseOwnership = makeMember({ age: 40 });
+    const childNoLicense = makeMember({ age: 10, drivingLicenseOwnership: 'dontKnow' });
+    const childMissingLicenseOwnership = makeMember({ age: 10 });
+    const adultNoLicense = makeMember({ age: 40, drivingLicenseOwnership: 'no' });
+    const memberMissingAgeAndLicense = makeMember();
 
     // [title, carNumber, members, shouldWarn]
     const cases: [string, number | undefined, Person[], boolean][] = [
@@ -32,18 +37,14 @@ describe('HH_L_CarNumberPerPotentialDrivingLicenseTooHigh audit check', () => {
             false
         ],
         ['ratio above the threshold warns', MAX_CAR_NUMBER_PER_POTENTIAL_DRIVING_LICENSE + 1, [licenseHolder], true],
-        ['adult with unknown license counts as a potential driver', 4, [adultUnknownLicense], true],
+        ['adult with unknown license counts as a potential driver', 1, [adultUnknownLicense], false],
+        ['adult with unknown license, ratio above threshold warns', 4, [adultUnknownLicense], true],
+        ['adult without drivingLicenseOwnership counts as a potential driver', 1, [adultMissingLicenseOwnership], false],
         [
-            'adult without drivingLicenseOwnership counts as a potential driver',
+            'adult without drivingLicenseOwnership, ratio above threshold warns',
             4,
             [adultMissingLicenseOwnership],
             true
-        ],
-        [
-            'one car with adult without drivingLicenseOwnership does not warn',
-            1,
-            [adultMissingLicenseOwnership],
-            false
         ],
         ['cars but only a child (no potential driver) warns', 1, [childNoLicense], true],
         [

--- a/packages/evolution-common/src/services/baseObjects/Person.ts
+++ b/packages/evolution-common/src/services/baseObjects/Person.ts
@@ -302,6 +302,25 @@ export class Person extends SurveyObject {
         this._attributes.drivingLicenseOwnership = value;
     }
 
+    /**
+     * Return whether this person has a driving license or is a potential driver
+     * (driving age with unknown license ownership).
+     *
+     * TODO: consolidate with `hasOrUnknownDrivingLicense` in `odSurvey/helpers.ts`;
+     * duplicate logic until questionnaire helpers and base object methods are unified.
+     *
+     * @returns `true` if the person has a license or is of driving age with unknown ownership
+     */
+    hasOrUnknownDrivingLicense(): boolean {
+        const drivingLicenseOwnership = this.drivingLicenseOwnership ?? 'dontKnow';
+        return (
+            drivingLicenseOwnership === 'yes' ||
+            (this.age !== undefined &&
+                this.age >= projectConfig.drivingLicenseAge &&
+                drivingLicenseOwnership === 'dontKnow')
+        );
+    }
+
     get transitPassOwnership(): Optional<PAttr.TransitPassOwnership> {
         return this._attributes.transitPassOwnership;
     }

--- a/packages/evolution-common/src/services/baseObjects/__tests__/Person.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/Person.test.ts
@@ -17,6 +17,7 @@ import { VisitedPlace } from '../VisitedPlace';
 import { isOk, hasErrors, unwrap } from '../../../types/Result.type';
 import { WeightMethod, WeightMethodAttributes } from '../WeightMethod';
 import { SurveyObjectsRegistry } from '../SurveyObjectsRegistry';
+import projectConfig from '../../../config/project.config';
 import {
     describeCompletableSurveyObjectMixinValues,
     describeCreateRejectsNonBooleanCompletableParams
@@ -943,6 +944,28 @@ describe('Person', () => {
             const value = valueFactory();
             person[attribute] = value;
             expect(person[attribute]).toEqual(value);
+        });
+    });
+
+    describe('hasOrUnknownDrivingLicense', () => {
+        test.each([
+            ['explicit yes', { drivingLicenseOwnership: 'yes' }, 18, true],
+            ['explicit no, adult age', { age: 35, drivingLicenseOwnership: 'no' }, 18, false],
+            ['dont know, below driving age', { age: 17, drivingLicenseOwnership: 'dontKnow' }, 18, false],
+            ['dont know, at driving age threshold', { age: 18, drivingLicenseOwnership: 'dontKnow' }, 18, true],
+            ['undefined ownership, above driving age', { age: 20 }, 18, true],
+            ['undefined ownership, below driving age', { age: 10 }, 18, false],
+            ['undefined ownership and age', {}, 18, false],
+            ['custom threshold is respected', { age: 20, drivingLicenseOwnership: 'dontKnow' }, 21, false]
+        ] as const)('%s', (_title, attrs, drivingLicenseAge, expected) => {
+            const originalDrivingLicenseAge = projectConfig.drivingLicenseAge;
+            projectConfig.drivingLicenseAge = drivingLicenseAge;
+            try {
+                const person = new Person({ _uuid: uuidV4(), ...attrs }, registry);
+                expect(person.hasOrUnknownDrivingLicense()).toEqual(expected);
+            } finally {
+                projectConfig.drivingLicenseAge = originalDrivingLicenseAge;
+            }
         });
     });
 

--- a/packages/evolution-common/src/services/odSurvey/helpers.ts
+++ b/packages/evolution-common/src/services/odSurvey/helpers.ts
@@ -545,6 +545,9 @@ export const isStudentFromSchoolType = ({ person }: { person: Person }): boolean
  * they are of driving age and did not answer the question about driving license
  * ownership.
  *
+ * TODO: consolidate with `Person.hasOrUnknownDrivingLicense`; this helper reads
+ * interview response Person shapes while audits use base object Person instances.
+ *
  * @param {Object} options - The options object.
  * @param {Person} options.person The current person
  * @returns {boolean} `true` if the person either has a driving license or the


### PR DESCRIPTION
## Summary

Adds `HH_L_CarNumberPerPotentialDrivingLicenseTooHigh`, a warning-level household audit check. The number of cars versus the number of potential driving license holders is not validated live during the interview, so it is audited here.

It flags a household when it has cars but:

- no potential driving license holder at all (nobody can legally drive them), or
- more than `MAX_CAR_NUMBER_PER_POTENTIAL_DRIVING_LICENSE` (3) cars per potential driving license holder.

Potential drivers are counted by reusing the existing `hasOrUnknownDrivingLicense` helper (self-declared license, or driving age + unknown).

This is ported from od_mtl_2023's `H_I_carNumberPerPersonTooHigh`, generalized to use potential driving license holders instead of household size, which is the meaningful ratio.

## Notes

- `_L_` prefix (logical inconsistency between fields), consistent with `HH_L_CarNumberVehiclesCountMismatch`.
- Threshold extracted as exported constant `MAX_CAR_NUMBER_PER_POTENTIAL_DRIVING_LICENSE`; TODO to make it configurable per survey.
- en/fr audit translations added.

## Test plan

- Parametric unit tests in `HH_L_CarNumberPerPotentialDrivingLicenseTooHigh.test.ts` (ratio at/above threshold, adult with unknown license counts, cars but only a child / adult without license / no members, low ratio, undefined car number, no cars).
- `AuditLocales` test passes (en/fr translations present).
- Backend type-check (`tsc`) passes.