### PR TITLE
segments: allow to customize widgets of the `personTrips` group

### DIFF
--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/groupPersonTrips.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/groupPersonTrips.test.ts
@@ -146,3 +146,52 @@ describe('PersonsTripsGroupConfigFactory main group config', () => {
     });
 
 });
+
+describe('PersonsTripsGroupConfigFactory segments GroupConfig widget with additional widget names', () => {
+
+    test('should return correct widget names when no duplicate', () => {
+        const segmentSectionConfigWithWidgets: SegmentSectionConfiguration = _cloneDeep(segmentSectionConfig);
+        segmentSectionConfigWithWidgets.additionalTripsWidgetNames = ['customWidget1', 'customWidget2'];
+        const widgetConfig = new PersonTripsGroupConfigFactory(segmentSectionConfigWithWidgets, widgetFactoryOptions).getWidgetConfigs()['personTrips'] as GroupConfig;
+        expect(widgetConfig).toEqual({
+            type: 'group',
+            path: 'household.persons.{_activePersonId}.journeys.{_activeJourneyId}.trips',
+            title: expect.any(Function),
+            filter: expect.any(Function),
+            showTitle: false,
+            showGroupedObjectDeleteButton: false,
+            showGroupedObjectAddButton: false,
+            widgets: [
+                'segmentIntro',
+                'segments',
+                'customWidget1',
+                'customWidget2',
+                'buttonSaveTrip'
+            ]
+        });
+    });
+
+    test('should not return duplicate widget names', () => {
+        const segmentSectionConfigWithWidgets: SegmentSectionConfiguration = _cloneDeep(segmentSectionConfig);
+        segmentSectionConfigWithWidgets.additionalTripsWidgetNames = ['customWidget1', 'segments', 'customWidget2', 'buttonSaveTrip'];
+        // Custom segment widgets should not be there
+        segmentSectionConfigWithWidgets.additionalSegmentWidgetNames = ['customWidget3', 'customWidget4'];
+        const widgetConfig = new PersonTripsGroupConfigFactory(segmentSectionConfigWithWidgets, widgetFactoryOptions).getWidgetConfigs()['personTrips'] as GroupConfig;
+        expect(widgetConfig).toEqual({
+            type: 'group',
+            path: 'household.persons.{_activePersonId}.journeys.{_activeJourneyId}.trips',
+            title: expect.any(Function),
+            filter: expect.any(Function),
+            showTitle: false,
+            showGroupedObjectDeleteButton: false,
+            showGroupedObjectAddButton: false,
+            widgets: [
+                'segmentIntro',
+                'segments',
+                'customWidget1',
+                'customWidget2',
+                'buttonSaveTrip'
+            ]
+        });
+    });
+});

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/groupPersonTrips.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/groupPersonTrips.ts
@@ -21,39 +21,47 @@ export class PersonTripsGroupConfigFactory implements WidgetConfigFactory {
         /** Nothing to do */
     }
 
+    private getGroupWidgetNames = (): string[] => {
+        const additionalWidgetNames = this.sectionConfig.additionalTripsWidgetNames || [];
+        const personTripsWidgetNames = [
+            // Hard-coded, mandatory questions
+            'segmentIntro',
+            'segments',
+            // Add custom widgets before save button
+            ...additionalWidgetNames,
+            'buttonSaveTrip'
+        ];
+        return Array.from(new Set(personTripsWidgetNames));
+    };
+
+    private getTripsGroupConfig = (): GroupConfig => {
+        return {
+            type: 'group',
+            // FIXME Why do we have the full path here, but a relative path in the segments group? This should be consistent, but it's probably how evolution is structured
+            path: 'household.persons.{_activePersonId}.journeys.{_activeJourneyId}.trips',
+            title: (t: TFunction) => t(['customSurvey:segments:TripsTitle', 'segments:TripsTitle']),
+            filter: function (interview, groupedObjects) {
+                // Only the active trip should be shown with its widgets, if no active trip, return an empty object
+                const activeTripId = getResponse(interview, '_activeTripId', null);
+                if (typeof activeTripId === 'string' && groupedObjects[activeTripId]) {
+                    return { [activeTripId]: groupedObjects[activeTripId] };
+                }
+                return {};
+            },
+            showTitle: false,
+            showGroupedObjectDeleteButton: false,
+            showGroupedObjectAddButton: false,
+            widgets: this.getGroupWidgetNames()
+        };
+    };
+
     getWidgetConfigs = (): Record<string, WidgetConfig> => {
         const segmentGroupConfig = new SegmentsGroupConfigFactory(this.sectionConfig, this.options);
         return {
-            personTrips: personsTripsGroupConfig,
+            personTrips: this.getTripsGroupConfig(),
             segmentIntro: getTripSegmentsIntro(this.options),
             ...segmentGroupConfig.getWidgetConfigs(),
             buttonSaveTrip: getButtonSaveTripSegmentsConfig(this.options)
         };
     };
 }
-
-const personsTripsGroupConfig: GroupConfig = {
-    type: 'group',
-    // FIXME Why do we have the full path here, but a relative path in the segments group? This should be consistent, but it's probably how evolution is structured
-    path: 'household.persons.{_activePersonId}.journeys.{_activeJourneyId}.trips',
-    title: (t: TFunction) => t(['customSurvey:segments:TripsTitle', 'segments:TripsTitle']),
-    filter: function (interview, groupedObjects) {
-        // Only the active trip should be shown with its widgets, if no active trip, return an empty object
-        const activeTripId = getResponse(interview, '_activeTripId', null);
-        if (typeof activeTripId === 'string' && groupedObjects[activeTripId]) {
-            return { [activeTripId]: groupedObjects[activeTripId] };
-        }
-        return {};
-    },
-    showTitle: false,
-    showGroupedObjectDeleteButton: false,
-    showGroupedObjectAddButton: false,
-    widgets: [
-        // TODO Those widget names do not link to anything! They should accompany their actual widgets somewhere
-        // Hard-coded, mandatory questions
-        'segmentIntro',
-        'segments',
-        'buttonSaveTrip'
-        // TODO Add more configurable widgets here, either custom or depending on the segments section configuration
-    ]
-};

--- a/packages/evolution-common/src/services/questionnaire/types/SectionConfig.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/SectionConfig.ts
@@ -512,6 +512,13 @@ export type SegmentSectionConfiguration = {
      */
     additionalSegmentWidgetNames?: string[];
     /**
+     * Names of additional widgets to include in the person's trips group of the
+     * section. The widgets need to be defined by these names in the survey's
+     * widget configuration. They will be added after segment group, before the
+     * save button.
+     */
+    additionalTripsWidgetNames?: string[];
+    /**
      * Whether to ask the segment driver question to car passengers in the
      * segments section.  Defaults to `false`. If set to `true`, the segment
      * driver question will be added with the additional questions


### PR DESCRIPTION
fixes #1663

Add the `additionalTripsWidgetNames` option to the `SegmentSectionConfiguration` type to list the names of the widgets to display in the person's trips group.

The additional widgets will be added after the `segments` group, before the `save` button.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended the person's trips section configuration to support additional custom widgets with automatic duplicate prevention.

* **Tests**
  * Added comprehensive test coverage for person's trips widget composition, validating proper handling of duplicate widget names and widget list organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->