### PR TITLE
selectFeature: make the select box searchable

### DIFF
--- a/packages/evolution-frontend/src/components/inputs/InputSelectFeature.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputSelectFeature.tsx
@@ -5,6 +5,7 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import React from 'react';
+import Select, { SelectInstance } from 'react-select';
 import { distance as turfDistance } from '@turf/turf';
 
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
@@ -17,47 +18,40 @@ export type InputSelectFeatureProps = CommonInputProps & {
     widgetConfig: InputSelectFeatureType;
 };
 
-export interface FeaturesToChoicesProps {
-    widgetConfig: InputSelectFeatureType;
-    referenceGeography: GeoJSON.Feature<GeoJSON.Point> | null;
-}
+type OptionType = { label: string; value: string };
 
-const FeaturesToChoices = (props: FeaturesToChoicesProps) => {
-    const referenceGeographyKey = props.referenceGeography
-        ? `${props.referenceGeography.geometry.type}:${props.referenceGeography.geometry.coordinates.join(',')}`
+/**
+ * Build the select options from the feature collection, sorted by proximity to
+ * the reference geography (closest first). When there is no reference geography,
+ * the original collection order is kept.
+ * @param widgetConfig - The selectFeature widget configuration
+ * @param referenceGeography - The point used to sort features by distance, or null
+ * @returns The options to feed to the searchable select, in display order
+ */
+const useFeatureOptions = (
+    widgetConfig: InputSelectFeatureType,
+    referenceGeography: GeoJSON.Feature<GeoJSON.Point> | null
+): OptionType[] => {
+    const referenceGeographyKey = referenceGeography
+        ? `${referenceGeography.geometry.type}:${referenceGeography.geometry.coordinates.join(',')}`
         : null;
 
-    // Memoized sorted choices, to avoid recalculating distances every time the widget renders
-    const sortedChoices = React.useMemo(() => {
-        // Sort features by distance to reference geography
-        const features = props.widgetConfig.featureCollection.features as GeoJSON.Feature<GeoJSON.Point>[];
-        const choiceFeatures =
-            props.referenceGeography === null
+    // Memoized sorted options, to avoid recalculating distances on every render
+    return React.useMemo(() => {
+        const features = widgetConfig.featureCollection.features as GeoJSON.Feature<GeoJSON.Point>[];
+        const sortedFeatures =
+            referenceGeography === null
                 ? features
-                : features
-                    .map(
-                        (feature) =>
-                              ({
-                                  ...feature,
-                                  properties: {
-                                      ...feature.properties,
-                                      distance: turfDistance(props.referenceGeography!, feature)
-                                  }
-                              }) as GeoJSON.Feature<GeoJSON.Point, { distance: number }>
-                    )
-                    .sort((featureA, featureB) => featureA.properties.distance - featureB.properties.distance);
-        return choiceFeatures.map((choiceFeature: GeoJSON.Feature<GeoJSON.Point, any>) => {
-            const choiceId = choiceFeature.id;
-            const choiceLabel = choiceFeature.properties[props.widgetConfig.labelProperty];
-            return (
-                <option key={`input-select-container__${choiceId}`} value={choiceId} className={'input-select-option'}>
-                    {choiceLabel}
-                </option>
-            );
-        });
-    }, [props.widgetConfig, referenceGeographyKey]);
-
-    return sortedChoices;
+                : // Precompute each distance once, then sort, to avoid recomputing during comparisons
+                features
+                    .map((feature) => ({ feature, distance: turfDistance(referenceGeography, feature) }))
+                    .sort((featureA, featureB) => featureA.distance - featureB.distance)
+                    .map(({ feature }) => feature);
+        return sortedFeatures.map((feature) => ({
+            value: String(feature.id),
+            label: feature.properties?.[widgetConfig.labelProperty]
+        }));
+    }, [widgetConfig, referenceGeographyKey]);
 };
 
 export const InputSelectFeature = (props: InputSelectFeatureProps) => {
@@ -66,23 +60,40 @@ export const InputSelectFeature = (props: InputSelectFeatureProps) => {
             ? props.widgetConfig.referenceGeography(props.interview, props.path, props.user)
             : null;
 
+    const options = useFeatureOptions(props.widgetConfig, referenceGeography ?? null);
+
+    // react-select returns the selected option (or null when cleared); adapt it to
+    // the event-like shape ({ target: { value } }) expected by the survey layer.
+    const onChange = (option: OptionType | null) => {
+        props.onValueChange({ target: { value: option ? option.value : null } });
+    };
+
+    const selectedOption = _isBlank(props.value) ? null : options.find((option) => option.value === props.value);
+
+    // Bridge the react-select instance to props.inputRef so Question.tsx can call
+    // focus() on validation error (the instance exposes a focus() method).
+    const setSelectRef = (instance: SelectInstance<OptionType> | null) => {
+        if (props.inputRef) {
+            props.inputRef.current = instance as unknown as HTMLInputElement | null;
+        }
+    };
+
     return (
         <div className="survey-question__input-select-container">
-            <select
-                id={props.id}
-                onChange={props.onValueChange}
-                value={_isBlank(props.value) ? '' : props.value}
-                style={{
-                    overflow: 'hidden',
-                    whiteSpace: 'nowrap',
-                    textOverflow: 'ellipsis',
-                    maxWidth: '100%'
-                }}
-            >
-                <option key={'input-select-container__blank'} value="" className={'input-select-option'}></option>
-
-                <FeaturesToChoices widgetConfig={props.widgetConfig} referenceGeography={referenceGeography ?? null} />
-            </select>
+            <Select
+                ref={setSelectRef}
+                inputId={props.id}
+                aria-labelledby={`${props.id}_label`}
+                options={options}
+                value={selectedOption ?? null}
+                onChange={onChange}
+                isSearchable={true}
+                isClearable={true}
+                placeholder=""
+                name={`survey-question__input-select-feature-${props.path}`}
+                className="react-select-container"
+                classNamePrefix="react-select"
+            />
         </div>
     );
 };

--- a/packages/evolution-frontend/src/components/inputs/__tests__/InputSelectFeature.test.tsx
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/InputSelectFeature.test.tsx
@@ -5,7 +5,8 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { interviewAttributes } from './interviewData';
 import InputSelectFeature from '../InputSelectFeature';
@@ -14,7 +15,7 @@ import i18next from 'i18next';
 const userAttributes = {
     id: 1,
     username: 'foo',
-    preferences: {  },
+    preferences: {},
     serializedPermissions: [],
     isAuthorized: () => true,
     is_admin: false,
@@ -25,15 +26,34 @@ const userAttributes = {
 const testFeatureCollection = {
     type: 'FeatureCollection' as const,
     features: [
-        { type: 'Feature' as const, id: 'feature1', properties: { label: 'Label For Feature 1' }, geometry: { type: 'Point' as const, coordinates: [0,0] } },
-        { type: 'Feature' as const, id: 'feature2', properties: { label: 'Label For Feature 2' }, geometry: { type: 'Point' as const, coordinates: [1,1] } },
-        { type: 'Feature' as const, id: 'feature3', properties: { label: 'Label For Feature 3' }, geometry: { type: 'Point' as const, coordinates: [2,3] } },
-        { type: 'Feature' as const, id: 'feature4', properties: { label: 'Label For Feature 4' }, geometry: { type: 'Point' as const, coordinates: [3,1] } }
+        {
+            type: 'Feature' as const,
+            id: 'feature1',
+            properties: { label: 'Label For Feature 1' },
+            geometry: { type: 'Point' as const, coordinates: [0, 0] }
+        },
+        {
+            type: 'Feature' as const,
+            id: 'feature2',
+            properties: { label: 'Label For Feature 2' },
+            geometry: { type: 'Point' as const, coordinates: [1, 1] }
+        },
+        {
+            type: 'Feature' as const,
+            id: 'feature3',
+            properties: { label: 'Label For Feature 3' },
+            geometry: { type: 'Point' as const, coordinates: [2, 3] }
+        },
+        {
+            type: 'Feature' as const,
+            id: 'feature4',
+            properties: { label: 'Label For Feature 4' },
+            geometry: { type: 'Point' as const, coordinates: [3, 1] }
+        }
     ]
 };
 
-test('Render InputSelect with normal option type, no sorting', () => {
-
+test('Render InputSelect with normal option type, no sorting', async () => {
     // Return null for ref geography, features should not be sorted
     const refGeographyFct = jest.fn().mockReturnValue(null);
 
@@ -52,27 +72,150 @@ test('Render InputSelect with normal option type, no sorting', () => {
             en: `English text`
         }
     };
-    
+
+    const user = userEvent.setup();
     const { container } = render(
         <InputSelectFeature
             id={'test'}
-            onValueChange={() => { /* nothing to do */}}
+            onValueChange={() => {
+                /* nothing to do */
+            }}
             widgetConfig={widgetConfig}
-            value='value'
+            value="value"
             inputRef={React.createRef()}
             interview={interviewAttributes}
             user={userAttributes}
-            path='foo.test'
+            path="foo.test"
         />
     );
+    // Open the menu so the options (in collection order) appear in the snapshot
+    await user.click(screen.getByRole('combobox'));
     expect(container).toMatchSnapshot();
     expect(refGeographyFct).toHaveBeenCalledWith(interviewAttributes, 'foo.test', userAttributes);
 });
 
-test('Render InputSelect with normal option type, proximity sorting', () => {
+const widgetConfigWithRef = (refGeographyFct) => ({
+    type: 'question' as const,
+    twoColumns: true,
+    path: 'test.foo',
+    inputType: 'selectFeature' as const,
+    featureCollection: testFeatureCollection,
+    labelProperty: 'label',
+    referenceGeography: refGeographyFct,
+    size: 'medium',
+    containsHtml: true,
+    label: { fr: `Texte en français`, en: `English text` }
+});
 
+describe('InputSelectFeature searchable behavior', () => {
+    // Reference at [2.5, 0] so the proximity order is features 4, 2, 1, 3
+    const refGeographyFct = () => ({
+        type: 'Feature' as const,
+        geometry: { type: 'Point' as const, coordinates: [2.5, 0] },
+        properties: {}
+    });
+
+    test('shows all options in proximity order when opened', async () => {
+        const user = userEvent.setup();
+        render(
+            <InputSelectFeature
+                id={'test'}
+                onValueChange={() => {
+                    /* nothing to do */
+                }}
+                widgetConfig={widgetConfigWithRef(refGeographyFct)}
+                interview={interviewAttributes}
+                user={userAttributes}
+                path="foo.test"
+            />
+        );
+
+        await user.click(screen.getByRole('combobox'));
+
+        const options = screen.getAllByText(/Label For Feature/).map((node) => node.textContent);
+        expect(options).toEqual([
+            'Label For Feature 4',
+            'Label For Feature 2',
+            'Label For Feature 1',
+            'Label For Feature 3'
+        ]);
+    });
+
+    test('filters options as the user types', async () => {
+        const user = userEvent.setup();
+        render(
+            <InputSelectFeature
+                id={'test'}
+                onValueChange={() => {
+                    /* nothing to do */
+                }}
+                widgetConfig={widgetConfigWithRef(refGeographyFct)}
+                interview={interviewAttributes}
+                user={userAttributes}
+                path="foo.test"
+            />
+        );
+
+        await user.type(screen.getByRole('combobox'), 'Feature 3');
+
+        expect(screen.queryByText('Label For Feature 3')).not.toBeNull();
+        expect(screen.queryByText('Label For Feature 1')).toBeNull();
+        expect(screen.queryByText('Label For Feature 2')).toBeNull();
+    });
+
+    test('calls onValueChange with the selected feature id', async () => {
+        const user = userEvent.setup();
+        const onValueChange = jest.fn();
+        render(
+            <InputSelectFeature
+                id={'test'}
+                onValueChange={onValueChange}
+                widgetConfig={widgetConfigWithRef(refGeographyFct)}
+                interview={interviewAttributes}
+                user={userAttributes}
+                path="foo.test"
+            />
+        );
+
+        await user.click(screen.getByRole('combobox'));
+        await user.click(screen.getByText('Label For Feature 2'));
+
+        expect(onValueChange).toHaveBeenCalledWith({ target: { value: 'feature2' } });
+    });
+
+    test('calls onValueChange with null when the selection is cleared', async () => {
+        const user = userEvent.setup();
+        const onValueChange = jest.fn();
+        const { container } = render(
+            <InputSelectFeature
+                id={'test'}
+                onValueChange={onValueChange}
+                widgetConfig={widgetConfigWithRef(refGeographyFct)}
+                value="feature2"
+                interview={interviewAttributes}
+                user={userAttributes}
+                path="foo.test"
+            />
+        );
+
+        // react-select renders a clear indicator (no role/label) when clearable and a value is set
+        const clearIndicator = container.querySelector('.react-select__clear-indicator');
+        expect(clearIndicator).not.toBeNull();
+        await user.click(clearIndicator as Element);
+
+        expect(onValueChange).toHaveBeenCalledWith({ target: { value: null } });
+    });
+});
+
+test('Render InputSelect with normal option type, proximity sorting', async () => {
     // Return geography, sorting should be features 4, 2, 1, 3
-    const refGeographyFct = jest.fn().mockReturnValue({ type: 'Feature' as const, geometry: { type: 'Point', coordinates: [2.5, 0] }, properties: {} });
+    const refGeographyFct = jest
+        .fn()
+        .mockReturnValue({
+            type: 'Feature' as const,
+            geometry: { type: 'Point', coordinates: [2.5, 0] },
+            properties: {}
+        });
 
     const widgetConfig = {
         type: 'question' as const,
@@ -89,19 +232,24 @@ test('Render InputSelect with normal option type, proximity sorting', () => {
             en: `English text`
         }
     };
-    
+
+    const user = userEvent.setup();
     const { container } = render(
         <InputSelectFeature
             id={'test'}
-            onValueChange={() => { /* nothing to do */}}
+            onValueChange={() => {
+                /* nothing to do */
+            }}
             widgetConfig={widgetConfig}
-            value='value'
+            value="value"
             inputRef={React.createRef()}
             interview={interviewAttributes}
             user={userAttributes}
-            path='foo.test'
+            path="foo.test"
         />
     );
+    // Open the menu so the proximity-sorted options (features 4, 2, 1, 3) appear in the snapshot
+    await user.click(screen.getByRole('combobox'));
     expect(container).toMatchSnapshot();
     expect(refGeographyFct).toHaveBeenCalledWith(interviewAttributes, 'foo.test', userAttributes);
 });

--- a/packages/evolution-frontend/src/components/inputs/__tests__/__snapshots__/InputSelectFeature.test.tsx.snap
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/__snapshots__/InputSelectFeature.test.tsx.snap
@@ -5,39 +5,155 @@ exports[`Render InputSelect with normal option type, no sorting 1`] = `
   <div
     class="survey-question__input-select-container"
   >
-    <select
-      id="test"
-      style="overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 100%;"
+    <div
+      class="react-select-container css-b62m3t-container"
     >
-      <option
-        class="input-select-option"
+      <span
+        class="css-1f43avz-a11yText-A11yText"
+        id="react-select-2-live-region"
+      />
+      <span
+        aria-atomic="false"
+        aria-live="polite"
+        aria-relevant="additions text"
+        class="css-1f43avz-a11yText-A11yText"
+        role="log"
+      >
+        <span
+          id="aria-selection"
+        />
+        <span
+          id="aria-focused"
+        />
+        <span
+          id="aria-results"
+        >
+          4 results available.
+        </span>
+        <span
+          id="aria-guidance"
+        >
+          Use Up and Down to choose options, press Enter to select the currently focused option, press Escape to exit the menu, press Tab to select the option and exit the menu.
+        </span>
+      </span>
+      <div
+        class="react-select__control react-select__control--is-focused react-select__control--menu-is-open css-t3ipsp-control"
+      >
+        <div
+          class="react-select__value-container css-1fdsijx-ValueContainer"
+        >
+          <div
+            class="react-select__placeholder css-1jqq78o-placeholder"
+            id="react-select-2-placeholder"
+          />
+          <div
+            class="react-select__input-container css-qbdosj-Input"
+            data-value=""
+          >
+            <input
+              aria-activedescendant="react-select-2-option-0"
+              aria-autocomplete="list"
+              aria-controls="react-select-2-listbox"
+              aria-describedby="react-select-2-placeholder"
+              aria-expanded="true"
+              aria-haspopup="true"
+              aria-labelledby="test_label"
+              autocapitalize="none"
+              autocomplete="off"
+              autocorrect="off"
+              class="react-select__input"
+              id="test"
+              role="combobox"
+              spellcheck="false"
+              style="color: inherit; background: 0px; opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
+              tabindex="0"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          class="react-select__indicators css-1hb7zxy-IndicatorsContainer"
+        >
+          <span
+            class="react-select__indicator-separator css-1u9des2-indicatorSeparator"
+          />
+          <div
+            aria-hidden="true"
+            class="react-select__indicator react-select__dropdown-indicator css-15lsz6c-indicatorContainer"
+          >
+            <svg
+              aria-hidden="true"
+              class="css-tj5bde-Svg"
+              focusable="false"
+              height="20"
+              viewBox="0 0 20 20"
+              width="20"
+            >
+              <path
+                d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+      <div
+        class="react-select__menu css-1nmdiq5-menu"
+      >
+        <div
+          aria-multiselectable="false"
+          class="react-select__menu-list css-1n6sfyn-MenuList"
+          id="react-select-2-listbox"
+          role="listbox"
+        >
+          <div
+            aria-disabled="false"
+            aria-selected="false"
+            class="react-select__option react-select__option--is-focused css-d7l1ni-option"
+            id="react-select-2-option-0"
+            role="option"
+            tabindex="-1"
+          >
+            Label For Feature 1
+          </div>
+          <div
+            aria-disabled="false"
+            aria-selected="false"
+            class="react-select__option css-10wo9uf-option"
+            id="react-select-2-option-1"
+            role="option"
+            tabindex="-1"
+          >
+            Label For Feature 2
+          </div>
+          <div
+            aria-disabled="false"
+            aria-selected="false"
+            class="react-select__option css-10wo9uf-option"
+            id="react-select-2-option-2"
+            role="option"
+            tabindex="-1"
+          >
+            Label For Feature 3
+          </div>
+          <div
+            aria-disabled="false"
+            aria-selected="false"
+            class="react-select__option css-10wo9uf-option"
+            id="react-select-2-option-3"
+            role="option"
+            tabindex="-1"
+          >
+            Label For Feature 4
+          </div>
+        </div>
+      </div>
+      <input
+        name="survey-question__input-select-feature-foo.test"
+        type="hidden"
         value=""
       />
-      <option
-        class="input-select-option"
-        value="feature1"
-      >
-        Label For Feature 1
-      </option>
-      <option
-        class="input-select-option"
-        value="feature2"
-      >
-        Label For Feature 2
-      </option>
-      <option
-        class="input-select-option"
-        value="feature3"
-      >
-        Label For Feature 3
-      </option>
-      <option
-        class="input-select-option"
-        value="feature4"
-      >
-        Label For Feature 4
-      </option>
-    </select>
+    </div>
   </div>
 </div>
 `;
@@ -47,39 +163,155 @@ exports[`Render InputSelect with normal option type, proximity sorting 1`] = `
   <div
     class="survey-question__input-select-container"
   >
-    <select
-      id="test"
-      style="overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 100%;"
+    <div
+      class="react-select-container css-b62m3t-container"
     >
-      <option
-        class="input-select-option"
+      <span
+        class="css-1f43avz-a11yText-A11yText"
+        id="react-select-7-live-region"
+      />
+      <span
+        aria-atomic="false"
+        aria-live="polite"
+        aria-relevant="additions text"
+        class="css-1f43avz-a11yText-A11yText"
+        role="log"
+      >
+        <span
+          id="aria-selection"
+        />
+        <span
+          id="aria-focused"
+        />
+        <span
+          id="aria-results"
+        >
+          4 results available.
+        </span>
+        <span
+          id="aria-guidance"
+        >
+          Use Up and Down to choose options, press Enter to select the currently focused option, press Escape to exit the menu, press Tab to select the option and exit the menu.
+        </span>
+      </span>
+      <div
+        class="react-select__control react-select__control--is-focused react-select__control--menu-is-open css-t3ipsp-control"
+      >
+        <div
+          class="react-select__value-container css-1fdsijx-ValueContainer"
+        >
+          <div
+            class="react-select__placeholder css-1jqq78o-placeholder"
+            id="react-select-7-placeholder"
+          />
+          <div
+            class="react-select__input-container css-qbdosj-Input"
+            data-value=""
+          >
+            <input
+              aria-activedescendant="react-select-7-option-0"
+              aria-autocomplete="list"
+              aria-controls="react-select-7-listbox"
+              aria-describedby="react-select-7-placeholder"
+              aria-expanded="true"
+              aria-haspopup="true"
+              aria-labelledby="test_label"
+              autocapitalize="none"
+              autocomplete="off"
+              autocorrect="off"
+              class="react-select__input"
+              id="test"
+              role="combobox"
+              spellcheck="false"
+              style="color: inherit; background: 0px; opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
+              tabindex="0"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          class="react-select__indicators css-1hb7zxy-IndicatorsContainer"
+        >
+          <span
+            class="react-select__indicator-separator css-1u9des2-indicatorSeparator"
+          />
+          <div
+            aria-hidden="true"
+            class="react-select__indicator react-select__dropdown-indicator css-15lsz6c-indicatorContainer"
+          >
+            <svg
+              aria-hidden="true"
+              class="css-tj5bde-Svg"
+              focusable="false"
+              height="20"
+              viewBox="0 0 20 20"
+              width="20"
+            >
+              <path
+                d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+      <div
+        class="react-select__menu css-1nmdiq5-menu"
+      >
+        <div
+          aria-multiselectable="false"
+          class="react-select__menu-list css-1n6sfyn-MenuList"
+          id="react-select-7-listbox"
+          role="listbox"
+        >
+          <div
+            aria-disabled="false"
+            aria-selected="false"
+            class="react-select__option react-select__option--is-focused css-d7l1ni-option"
+            id="react-select-7-option-0"
+            role="option"
+            tabindex="-1"
+          >
+            Label For Feature 4
+          </div>
+          <div
+            aria-disabled="false"
+            aria-selected="false"
+            class="react-select__option css-10wo9uf-option"
+            id="react-select-7-option-1"
+            role="option"
+            tabindex="-1"
+          >
+            Label For Feature 2
+          </div>
+          <div
+            aria-disabled="false"
+            aria-selected="false"
+            class="react-select__option css-10wo9uf-option"
+            id="react-select-7-option-2"
+            role="option"
+            tabindex="-1"
+          >
+            Label For Feature 1
+          </div>
+          <div
+            aria-disabled="false"
+            aria-selected="false"
+            class="react-select__option css-10wo9uf-option"
+            id="react-select-7-option-3"
+            role="option"
+            tabindex="-1"
+          >
+            Label For Feature 3
+          </div>
+        </div>
+      </div>
+      <input
+        name="survey-question__input-select-feature-foo.test"
+        type="hidden"
         value=""
       />
-      <option
-        class="input-select-option"
-        value="feature4"
-      >
-        Label For Feature 4
-      </option>
-      <option
-        class="input-select-option"
-        value="feature2"
-      >
-        Label For Feature 2
-      </option>
-      <option
-        class="input-select-option"
-        value="feature1"
-      >
-        Label For Feature 1
-      </option>
-      <option
-        class="input-select-option"
-        value="feature3"
-      >
-        Label For Feature 3
-      </option>
-    </select>
+    </div>
   </div>
 </div>
 `;

--- a/packages/evolution-frontend/src/components/survey/__tests__/__snapshots__/Question.test.tsx.snap
+++ b/packages/evolution-frontend/src/components/survey/__tests__/__snapshots__/Question.test.tsx.snap
@@ -758,39 +758,86 @@ exports[`Question with widget InputSelectFeature Render widget 1`] = `
       <div
         class="survey-question__input-select-container"
       >
-        <select
-          id="survey-question__home.region"
-          style="overflow: hidden; white-space: nowrap; text-overflow: ellipsis; max-width: 100%;"
+        <div
+          class="react-select-container css-b62m3t-container"
         >
-          <option
-            class="input-select-option"
+          <span
+            class="css-1f43avz-a11yText-A11yText"
+            id="react-select-4-live-region"
+          />
+          <span
+            aria-atomic="false"
+            aria-live="polite"
+            aria-relevant="additions text"
+            class="css-1f43avz-a11yText-A11yText"
+            role="log"
+          />
+          <div
+            class="react-select__control css-13cymwt-control"
+          >
+            <div
+              class="react-select__value-container css-1fdsijx-ValueContainer"
+            >
+              <div
+                class="react-select__placeholder css-1jqq78o-placeholder"
+                id="react-select-4-placeholder"
+              />
+              <div
+                class="react-select__input-container css-qbdosj-Input"
+                data-value=""
+              >
+                <input
+                  aria-activedescendant=""
+                  aria-autocomplete="list"
+                  aria-describedby="react-select-4-placeholder"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-labelledby="survey-question__home.region_label"
+                  autocapitalize="none"
+                  autocomplete="off"
+                  autocorrect="off"
+                  class="react-select__input"
+                  id="survey-question__home.region"
+                  role="combobox"
+                  spellcheck="false"
+                  style="color: inherit; background: 0px; opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
+                  tabindex="0"
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              class="react-select__indicators css-1hb7zxy-IndicatorsContainer"
+            >
+              <span
+                class="react-select__indicator-separator css-1u9des2-indicatorSeparator"
+              />
+              <div
+                aria-hidden="true"
+                class="react-select__indicator react-select__dropdown-indicator css-1xc3v61-indicatorContainer"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="css-tj5bde-Svg"
+                  focusable="false"
+                  height="20"
+                  viewBox="0 0 20 20"
+                  width="20"
+                >
+                  <path
+                    d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </div>
+          <input
+            name="survey-question__input-select-feature-home.region"
+            type="hidden"
             value=""
           />
-          <option
-            class="input-select-option"
-            value="feature1"
-          >
-            Label For Feature 1
-          </option>
-          <option
-            class="input-select-option"
-            value="feature2"
-          >
-            Label For Feature 2
-          </option>
-          <option
-            class="input-select-option"
-            value="feature3"
-          >
-            Label For Feature 3
-          </option>
-          <option
-            class="input-select-option"
-            value="feature4"
-          >
-            Label For Feature 4
-          </option>
-        </select>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary

Makes the `selectFeature` widget searchable: the select box can now be filtered by typing, instead of scrolling a proximity-sorted list (fixes #1657).

- Replaces the native `<select>` of `InputSelectFeature` with a single-selection, searchable `react-select` (same library already used by `InputMultiselect`).
- The proximity sort order is preserved: options are fed to react-select already sorted by distance to the reference geography.
- The react-select `onChange` is adapted to the existing event-like `onValueChange` API (`{ target: { value } }`), mirroring `InputMultiselect`. The box is clearable.

## Notes

- Labels keep the current behavior (raw `labelProperty` string, no i18n) — out of scope for this issue.
- The widget is still marked `@experimental`.

## Test plan

- [x] `InputSelectFeature.test.tsx`: existing snapshots regenerated, plus new behavior tests using `user-event`:
  - [x] options shown in proximity order when the menu is opened,
  - [x] options filtered as the user types,
  - [x] `onValueChange` called with the selected feature id.
- [x] `Question.test.tsx` snapshot updated (renders `selectFeature` via the question switch).
- [x] Frontend type-check (`tsc`) passes.
- [x] Manually tested in the demo survey (a searchable "nearby place" example, kept local).

code by Claude Opus 4.8, reviewed by @kaligrafy 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feature selection now uses a searchable dropdown for easier finding and choosing items.
  * Options can be shown in distance-based order when a reference location is available.

* **Bug Fixes**
  * Clearing the selection now properly resets the field.
  * Selected values continue to work with the existing form behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->