### PR TITLE
Make the access code format configurable per survey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Config: Support several access code formats. Set the `accessCodeFormat` config option to one of the predefined formats (e.g. `'0000-0000'` (default), `'000-000-000'`, `'ABCD-ABCD'`, `'ABC-000-000'`) to choose your survey's format (fixes [#1668](https://github.com/chairemobilite/evolution/issues/1668)).
 - Validation list: filter by several access codes at once, typed or imported from a CSV file (fixes [#1660](https://github.com/chairemobilite/evolution/issues/1660)).
 - **Generator Excel to CSV copy**: Generator can now write one CSV file per Excel sheet in a `<Name_Excel_File>_csv` folder next to the Excel file, making Excel changes easier to review in git diffs. To enable it, add `copy_excel_to_csv: true` under `enabled_scripts` in your `generatorConfig.yaml` (fixes [#1580](https://github.com/chairemobilite/evolution/issues/1580)).
 - **CSS refresh in dev mode**: Changes to `.scss` files are automatically picked up by `yarn build:dev` and apply after a page reload (fixes [#1403](https://github.com/chairemobilite/evolution/issues/1403)). Survey projects that want the same: see [#1407](https://github.com/chairemobilite/evolution/pull/1407) for the webpack modifications.
@@ -67,6 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+- `eightDigitsAccessCodeFormatter` is deprecated. Set the `accessCodeFormat` config option to `'0000-0000'` (the default) and use `accessCodeFormatter` instead (fixes [#1668](https://github.com/chairemobilite/evolution/issues/1668)).
 - The evolution-frontend's `frontendHelper#getVisitedPlaceDescription` has been deprecated. Use the `getVisitedPlaceDescription` OD survey helper function from `evolution-common/lib/services/odSurvey/helpers` (commit [d203578](https://github.com/chairemobilite/evolution/commit/d20357804046c1691278b97a5fd9caa74a2d587a))
 - The `InputMapPoint` widget (and the underlying `geocodeSinglePoint` helper) is deprecated in favor of `InputMapFindPlace`. `InputMapPoint` silently auto-selects the first geocoding result, which can mask wrong matches; `InputMapFindPlace` surfaces all candidates to the participant and auto-selects only when there is a single result. New surveys should use `InputMapFindPlace` for all map point inputs. (commit [59d66d7](https://github.com/chairemobilite/evolution/commit/59d66d7341c00541528e9b453d869f1c85809454))
 

--- a/example/demo_generator/config.js
+++ b/example/demo_generator/config.js
@@ -66,6 +66,8 @@ module.exports = {
         }
     ],
     postalCodeRegion: 'canada',
+    // Access code format, chosen among the predefined formats (see accessCodeFormats catalog), e.g. '000-000-000'. Defaults to '0000-0000'.
+    accessCodeFormat: '0000-0000',
     detectLanguageFromUrl: true,
     detectLanguage: true,
     languages: ['fr', 'en'],

--- a/example/demo_generator/src/survey/server/serverValidations.ts
+++ b/example/demo_generator/src/survey/server/serverValidations.ts
@@ -4,11 +4,10 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import { validateAccessCode, registerAccessCodeValidationFunction } from 'evolution-backend/lib/services/accessCode';
+import { validateAccessCode } from 'evolution-backend/lib/services/accessCode';
 import { getResponse } from 'evolution-common/lib/utils/helpers';
 
-// Access code is 4 digits, dash, 4 digits
-registerAccessCodeValidationFunction((accessCode) => accessCode.match(/^\d{4}-? *\d{4}$/gi) !== null);
+// The access code format is enforced by the configured `accessCodeFormat` (here the default '0000-0000').
 
 export default {
     accessCode: {

--- a/example/demo_survey/config.js
+++ b/example/demo_survey/config.js
@@ -58,6 +58,8 @@ module.exports = {
     postalCodeRegion: 'canada',
     logDatabaseUpdates: true,
     askForAccessCode: true,
+    // Access code format, chosen among the predefined formats (see accessCodeFormats catalog), e.g. '000-000-000'. Defaults to '0000-0000'.
+    accessCodeFormat: '0000-0000',
     surveySupportForm: true,
     captchaComponentType: 'capjs',
     interviewableAge: 5,

--- a/packages/evolution-backend/src/services/__tests__/accessCode.test.ts
+++ b/packages/evolution-backend/src/services/__tests__/accessCode.test.ts
@@ -4,20 +4,78 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import { validateAccessCode, registerAccessCodeValidationFunction } from '../accessCode';
+import {
+    validateAccessCode,
+    registerAccessCodeValidationFunction,
+    matchesConfiguredAccessCodeFormat,
+    normalizeAccessCode
+} from '../accessCode';
+import projectConfig from 'evolution-common/lib/config/project.config';
 import each from 'jest-each';
 
-describe('Access code validation', () => {
-    const validCode = '7145328';
-    registerAccessCodeValidationFunction((accessCode) => accessCode === validCode);
+describe('normalizeAccessCode (configured format)', () => {
+    afterEach(() => {
+        projectConfig.accessCodeFormat = '0000-0000';
+    });
+
     each([
-        ['Too short', '14323', false],
-        ['Too long', '1542927564892', false],
-        ['valid code 2', validCode, true],
-        ['Changed first digit', (parseInt(validCode[0]) + 1 % 10) + validCode.slice(1), false],
-        ['Changed last digit', validCode.slice(0, validCode.length - 1) + (parseInt(validCode[validCode.length - 1]) + 1 % 10), false],
-        ['Alphanumeric', '83abcd734', false],
-    ]).test('%s', (_description, accessCode, result) => {
+        // [format, input, canonical output]
+        ['0000-0000', '12345678', '1234-5678'], // missing dash
+        ['0000-0000', '1234 5678', '1234-5678'], // spaces
+        ['0000-0000', '  1234-5678  ', '1234-5678'], // surrounding whitespace
+        ['000-000-000', '123456789', '123-456-789'],
+        ['ABC-000-000', 'abc123456', 'ABC-123-456'], // lower-cased
+        // Codes that do not match the configured format are returned trimmed but unchanged
+        ['0000-0000', '  7145328  ', '7145328'],
+        ['0000-0000', 'custom-code', 'custom-code']
+    ]).test('format %s normalizes %s to %s', (format, input, expected) => {
+        projectConfig.accessCodeFormat = format;
+        expect(normalizeAccessCode(input)).toEqual(expected);
+    });
+});
+
+describe('matchesConfiguredAccessCodeFormat', () => {
+    afterEach(() => {
+        projectConfig.accessCodeFormat = '0000-0000';
+    });
+
+    each([
+        // [configured format, access code, matches]
+        ['0000-0000', '1234-5678', true],
+        ['0000-0000', '12345678', true],
+        ['0000-0000', '1234567', false],
+        ['0000-0000', '123-456-789', false],
+        ['000-000-000', '123-456-789', true],
+        ['000-000-000', '123456789', true],
+        ['000-000-000', '1234-5678', false],
+        ['000-000-000', 'abc-def-ghi', false],
+        ['ABC-000-000', 'ABC-123-456', true],
+        ['ABC-000-000', '123-123-456', false],
+        ['0000-0000', '', false]
+    ]).test('format %s matches %s as %s', (format, accessCode, result) => {
+        projectConfig.accessCodeFormat = format;
+        expect(matchesConfiguredAccessCodeFormat(accessCode)).toEqual(result);
+    });
+});
+
+describe('validateAccessCode enforces the configured format and an additional check', () => {
+    // The additional check only accepts this specific (format-matching) code
+    const issuedCode = '1234-5678';
+    beforeAll(() => {
+        registerAccessCodeValidationFunction((accessCode) => accessCode === issuedCode);
+    });
+    afterAll(() => {
+        registerAccessCodeValidationFunction(() => true);
+    });
+
+    each([
+        ['matches format and passes additional check', issuedCode, true],
+        ['surrounding whitespace is trimmed before validation', '  1234-5678  ', true],
+        ['matches format but fails additional check', '9999-9999', false],
+        ['matches format (no dash) but fails additional check', '99999999', false],
+        ['does not match the configured format', '7145328', false],
+        ['blank', '', false]
+    ]).test('%s: %s => %s', (_description, accessCode, result) => {
         expect(validateAccessCode(accessCode)).toEqual(result);
     });
 });

--- a/packages/evolution-backend/src/services/accessCode.ts
+++ b/packages/evolution-backend/src/services/accessCode.ts
@@ -5,24 +5,75 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
+import projectConfig from 'evolution-common/lib/config/project.config';
+import {
+    getAccessCodeFormat,
+    matchesAccessCodeFormat,
+    normalizeAccessCode as normalizeAccessCodeForFormat
+} from 'evolution-common/lib/services/accessCode/accessCodeFormats';
 
 export const oneDigitHashSum = 0;
 
-// By default, all access codes are valid
-let accessCodeValidationFunction = (accessCode: string): boolean => !_isBlank(accessCode);
+/** The access code format configured for the survey (see the `accessCodeFormat` project config option). */
+const configuredAccessCodeFormat = () => getAccessCodeFormat(projectConfig.accessCodeFormat);
 
 /**
- * Register the access code validation function for a project
- * @param isAccessCodeValid The function to validate the access code. It takes
- * an accessCode as parameter and returns whether it is valid or not.
+ * Whether an access code matches the format configured for the survey (see the
+ * `accessCodeFormat` project config option).
+ * @param accessCode The access code to check
+ * @returns Whether the access code matches the configured format
  */
-export const registerAccessCodeValidationFunction = (isAccessCodeValid: (accessCode: string) => boolean) => {
-    accessCodeValidationFunction = isAccessCodeValid;
+export const matchesConfiguredAccessCodeFormat = (accessCode: string): boolean =>
+    !_isBlank(accessCode) && matchesAccessCodeFormat(accessCode, configuredAccessCodeFormat());
+
+/**
+ * Normalize an access code to its canonical stored form (dashes, upper-cased,
+ * trimmed) for the format configured for the survey. Use it before storing or
+ * searching access codes, so accepted input variants always match the stored
+ * value.
+ *
+ * Only codes that match the configured format are normalized; any other code is
+ * returned trimmed but otherwise unchanged (it would be rejected by validation
+ * anyway).
+ * @param accessCode The raw access code
+ * @returns The canonical access code
+ */
+export const normalizeAccessCode = (accessCode: string): string => {
+    const trimmed = accessCode.trim();
+    if (!matchesConfiguredAccessCodeFormat(trimmed)) {
+        return trimmed;
+    }
+    return normalizeAccessCodeForFormat(trimmed, configuredAccessCodeFormat());
 };
 
+// Additional, survey-specific access code check applied on top of the configured
+// format. Defaults to no extra check.
+let additionalAccessCodeValidation = (_accessCode: string): boolean => true;
+
+/**
+ * Register an additional, survey-specific access code validation, applied on top
+ * of the configured format. The configured `accessCodeFormat` is always
+ * enforced; this check can only add constraints (logical AND), it cannot accept
+ * codes that do not match the configured format. Use it for survey-specific
+ * checks, e.g. verifying that a code was actually issued.
+ * @param isAccessCodeValid Additional check, returns whether the code is valid
+ */
+export const registerAccessCodeValidationFunction = (isAccessCodeValid: (accessCode: string) => boolean) => {
+    additionalAccessCodeValidation = isAccessCodeValid;
+};
+
+/**
+ * Validate an access code: it must match the configured format and pass the
+ * registered additional check, if any.
+ * @param accessCode The access code to validate
+ * @returns Whether the access code is valid
+ */
 export const validateAccessCode = (accessCode: string): boolean => {
     try {
-        return accessCodeValidationFunction(accessCode);
+        // Normalize first so accepted input variants (surrounding whitespace, missing
+        // dash, letter case) are validated and checked in their canonical stored form.
+        const normalized = normalizeAccessCode(accessCode);
+        return matchesConfiguredAccessCodeFormat(normalized) && additionalAccessCodeValidation(normalized);
     } catch {
         return false;
     }

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/InterviewAuditChecks.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/InterviewAuditChecks.ts
@@ -157,7 +157,8 @@ export const interviewAuditChecks: { [errorCode: string]: InterviewAuditCheckFun
      * It does not verify that the access code is valid
      * (for instance it does not check if a letter has been sent with this access code)
      * Some surveys may not implement access codes at all.
-     * The validateAccessCode function is defined in the survey project.
+     * The format is validated against the configured accessCodeFormat; surveys
+     * can register an additional check for survey-specific validation.
      * @param context - InterviewAuditCheckContext
      * @returns {AuditForObject | undefined}
      */

--- a/packages/evolution-backend/src/services/interviews/__tests__/interviews.test.ts
+++ b/packages/evolution-backend/src/services/interviews/__tests__/interviews.test.ts
@@ -68,16 +68,33 @@ mockDbCreate.mockImplementation(async (newObject: Partial<InterviewAttributes>, 
 (interviewsQueries.getValidationAuditStats as any).mockResolvedValue({ audits: [] });
 
 describe('Find by access code', () => {
-    const validCode = '7145328';
-    registerAccessCodeValidationFunction((accessCode) => accessCode === validCode);
+    // Canonical 8-digit code (matches the default '0000-0000' format)
+    const validCode = '1234-5678';
+
+    beforeAll(() => {
+        // Rely on the configured format only (no additional survey-specific check)
+        registerAccessCodeValidationFunction(() => true);
+    });
+
+    afterAll(() => {
+        // Reset to default permissive validation
+        registerAccessCodeValidationFunction(() => true);
+    });
 
     beforeEach(async () => {
         (interviewsQueries.findByResponse as any).mockClear();
     });
 
     test('Get all users', async() => {
-
         const response = await Interviews.findByAccessCode(validCode);
+        expect(interviewsQueries.findByResponse).toHaveBeenCalledTimes(1);
+        expect(interviewsQueries.findByResponse).toHaveBeenCalledWith({ accessCode: validCode });
+        expect(response.length).toBeGreaterThan(0);
+    });
+
+    test('Accepted variant is searched in canonical form', async() => {
+        // '12345678' is a valid variant of '1234-5678' and must be normalized before searching
+        const response = await Interviews.findByAccessCode('12345678');
         expect(interviewsQueries.findByResponse).toHaveBeenCalledTimes(1);
         expect(interviewsQueries.findByResponse).toHaveBeenCalledWith({ accessCode: validCode });
         expect(response.length).toBeGreaterThan(0);

--- a/packages/evolution-backend/src/services/interviews/interviews.ts
+++ b/packages/evolution-backend/src/services/interviews/interviews.ts
@@ -7,7 +7,7 @@
 import _cloneDeep from 'lodash/cloneDeep';
 import moment from 'moment';
 import { updateInterview, copyResponseToCorrectedResponse } from './interview';
-import { validateAccessCode } from '../accessCode';
+import { validateAccessCode, normalizeAccessCode } from '../accessCode';
 import { validate as validateUuid } from 'uuid';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import interviewsDbQueries, {
@@ -81,7 +81,8 @@ export default class Interviews {
         if (!validateAccessCode(accessCode)) {
             return [];
         }
-        return await interviewsDbQueries.findByResponse({ accessCode });
+        // Search the canonical form so accepted input variants (no dash, spaces, lower case) match the stored value
+        return await interviewsDbQueries.findByResponse({ accessCode: normalizeAccessCode(accessCode) });
     };
 
     static getInterviewByUuid = async (interviewId: string): Promise<InterviewAttributes | undefined> => {

--- a/packages/evolution-common/src/config/project.config.ts
+++ b/packages/evolution-common/src/config/project.config.ts
@@ -10,6 +10,7 @@ import projectConfig, {
 } from 'chaire-lib-common/lib/config/shared/project.config';
 import { ISODateTimeStringWithTimezoneOffset } from '../utils/DateTimeUtils';
 import { AuditChecksGroup, SurveyBase, AuditRequiredFieldsBySurveyObject } from '../services/audits/types';
+import { AccessCodeFormatName } from '../services/accessCode/accessCodeFormats';
 
 /**
  * Specific configuration for the Evolution project
@@ -144,6 +145,29 @@ export type EvolutionProjectConfiguration = {
     hasAccessCode: boolean;
 
     /**
+     * The expected access code format, chosen among the predefined formats in
+     * the catalog (see `accessCodeFormats`). The name matches the example, e.g.
+     * `'0000-0000'` (8 digits), `'000-000-000'` (9 digits) or `'ABC-000-000'`.
+     * Defaults to `'0000-0000'`.
+     *
+     * Set it in the survey's `config.js`, for example:
+     * ```js
+     * accessCodeFormat: '000-000-000'
+     * ```
+     *
+     * It is the single source of truth for the access code format: it drives
+     * the widget validation and live formatting, the admin validation list
+     * filter and CSV import, and the default backend audit check
+     * (`I_I_InvalidAccessCodeFormat`). Surveys can still override the backend
+     * validation with `registerAccessCodeValidationFunction` for
+     * survey-specific checks (e.g. verifying a code was actually issued).
+     *
+     * To support a new format, add an entry to the `accessCodeFormats` catalog
+     * (ideally via an issue/PR on evolution so it is shared).
+     */
+    accessCodeFormat: AccessCodeFormatName;
+
+    /**
      * Color palette for person visualization in maps and charts
      */
     personColorsPalette: string[];
@@ -235,6 +259,7 @@ const defaultConfig = {
     title: { en: 'Survey', fr: 'Enquête' },
     postalCodeRegion: 'other',
     hasAccessCode: false,
+    accessCodeFormat: '0000-0000',
     personColorsPalette: [
         // FIXME See this issue https://github.com/chairemobilite/evolution/issues/1246
         '#FFAE70',

--- a/packages/evolution-common/src/services/accessCode/__tests__/accessCodeFormats.test.ts
+++ b/packages/evolution-common/src/services/accessCode/__tests__/accessCodeFormats.test.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import {
+    accessCodeFormats,
+    getAccessCodeFormat,
+    matchesAccessCodeFormat,
+    normalizeAccessCode,
+    defaultAccessCodeFormatName,
+    type AccessCodeFormatName
+} from '../accessCodeFormats';
+
+describe('getAccessCodeFormat', () => {
+    test('returns the requested format', () => {
+        expect(getAccessCodeFormat('000-000-000')).toBe(accessCodeFormats['000-000-000']);
+    });
+
+    test('falls back to the default format for an unknown name', () => {
+        expect(getAccessCodeFormat('unknown' as AccessCodeFormatName)).toBe(
+            accessCodeFormats[defaultAccessCodeFormatName]
+        );
+    });
+});
+
+describe('each format carries a regex and a placeholder', () => {
+    test.each(Object.keys(accessCodeFormats) as AccessCodeFormatName[])('format %s is well-formed', (formatName) => {
+        const format = accessCodeFormats[formatName];
+        expect(format.regex).toBeInstanceOf(RegExp);
+        // The placeholder is itself a valid code for the format (it drives normalization)
+        expect(matchesAccessCodeFormat(format.placeholder, format)).toBe(true);
+    });
+});
+
+describe('matchesAccessCodeFormat validates against the format regex', () => {
+    // Test case format: [format name, value, isValid]
+    test.each([
+        ['0000-0000', '1234-5678', true],
+        ['0000-0000', '12345678', true],
+        ['0000-0000', '1234 5678', true],
+        ['0000-0000', '1234567', false],
+        ['0000-0000', 'abcd-efgh', false],
+        ['0000-0000', '123-456-789', false],
+        ['000-000-000', '123-456-789', true],
+        ['000-000-000', '123456789', true],
+        ['000-000-000', '1234-5678', false],
+        ['000-000-000', 'abc-def-ghi', false],
+        ['ABCD-ABCD', 'ABCD-EFGH', true],
+        ['ABCD-ABCD', 'abcd-efgh', true], // case-insensitive
+        ['ABCD-ABCD', 'ABC1-EFGH', false],
+        ['ABC-ABC-ABC', 'ABC-DEF-GHI', true],
+        ['ABC-ABC-ABC', 'abcdefghi', true],
+        ['ABC-ABC-ABC', 'ABC-12C-GHI', false],
+        ['ABCD-0000', 'ABCD-1234', true],
+        ['ABCD-0000', 'abcd1234', true],
+        ['ABCD-0000', '1234-1234', false],
+        ['ABC-000-000', 'ABC-123-456', true],
+        ['ABC-000-000', 'abc123456', true],
+        ['ABC-000-000', 'ABC-ABC-456', false],
+        ['ABC-000-000', '123-123-456', false]
+    ] as [AccessCodeFormatName, string, boolean][])(
+        'format %s validates %s as %s',
+        (formatName, value, isValid) => {
+            expect(matchesAccessCodeFormat(value, getAccessCodeFormat(formatName))).toBe(isValid);
+        }
+    );
+});
+
+describe('normalizeAccessCode returns the canonical stored form', () => {
+    // Test case format: [format name, input, canonical output]
+    test.each([
+        ['0000-0000', '1234-5678', '1234-5678'],
+        ['0000-0000', '12345678', '1234-5678'], // missing dash
+        ['0000-0000', '1234 5678', '1234-5678'], // spaces
+        ['0000-0000', '  1234-5678  ', '1234-5678'], // surrounding whitespace
+        ['0000-0000', '12-345678', '1234-5678'], // dash at the wrong place
+        ['0000-0000', '123-45678', '1234-5678'], // dash at the wrong place
+        ['000-000-000', '1234-56789', '123-456-789'], // dashes at the wrong place
+        ['000-000-000', '123456789', '123-456-789'],
+        ['ABCD-ABCD', 'abcdefgh', 'ABCD-EFGH'], // lower-cased
+        ['ABCD-ABCD', 'abcd-efgh', 'ABCD-EFGH'],
+        ['ABC-000-000', 'abc123456', 'ABC-123-456'],
+        ['ABC-000-000', 'ABC-123-456', 'ABC-123-456'],
+        ['0000-0000', '123', '123'] // partial input keeps no trailing dash
+    ] as [AccessCodeFormatName, string, string][])(
+        'format %s normalizes %s to %s',
+        (formatName, input, expected) => {
+            expect(normalizeAccessCode(input, getAccessCodeFormat(formatName))).toBe(expected);
+        }
+    );
+});

--- a/packages/evolution-common/src/services/accessCode/accessCodeFormats.ts
+++ b/packages/evolution-common/src/services/accessCode/accessCodeFormats.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+/**
+ * A predefined access code format. It is the single source of truth for a given
+ * format:
+ * - `regex` validates a full access code (case-insensitive, dashes/spaces
+ *   optional, so `12345678`, `1234-5678` and `1234 5678` are all accepted for
+ *   `'0000-0000'`);
+ * - `placeholder` is the example shown in the input and also drives the
+ *   normalization/live dash placement: each dash-separated group describes its
+ *   length and type (digits if it contains `0-9`, otherwise letters), e.g.
+ *   `'ABC-000-000'` is a letter group then two digit groups of length 3.
+ *
+ * Note: each group is homogeneous (all digits or all letters). Mixed groups
+ * (e.g. a postal-code-like `A0A 0A0`) are not supported yet.
+ */
+export type AccessCodeFormat = {
+    /** Validation regex for a full access code. */
+    regex: RegExp;
+    /** Example access code, used as input placeholder and to derive the groups. */
+    placeholder: string;
+};
+
+/** A single group of an access code, derived from the placeholder: its `length` and whether it is made of digits. */
+type AccessCodeGroup = { length: number; isDigit: boolean };
+
+/**
+ * Derive the successive groups of an access code from its placeholder. Groups
+ * are the dash-separated segments; a group is a digit group if its first
+ * character is a digit, otherwise a letter group.
+ * @param placeholder The format placeholder (e.g. `'ABC-000-000'`)
+ * @returns The successive groups
+ */
+const getGroupsFromPlaceholder = (placeholder: string): AccessCodeGroup[] =>
+    placeholder.split('-').map((segment) => ({ length: segment.length, isDigit: /\d/.test(segment[0]) }));
+
+/** Whether a character is valid for the given group type. Letters are case-insensitive. */
+const charMatchesGroup = (char: string, isDigit: boolean): boolean => (isDigit ? /\d/.test(char) : /[a-z]/i.test(char));
+
+/**
+ * Catalogue of supported access code formats, keyed by a pattern-like name that
+ * matches the placeholder (e.g. `'000-000-000'`). Each format gives its
+ * validation `regex` and `placeholder` (which also drives normalization, see
+ * {@link AccessCodeFormat}). In the regex, the dash and spaces between groups
+ * are optional so input variants are accepted; it is case-insensitive so letter
+ * groups accept both cases. To add a new format, add an entry here (and ideally
+ * open an issue/PR on evolution so it is shared).
+ */
+export const accessCodeFormats = {
+    '0000-0000': { regex: /^\d{4}-? *\d{4}$/i, placeholder: '0000-0000' },
+    '000-000-000': { regex: /^\d{3}-? *\d{3}-? *\d{3}$/i, placeholder: '000-000-000' },
+    'ABCD-ABCD': { regex: /^[a-z]{4}-? *[a-z]{4}$/i, placeholder: 'ABCD-ABCD' },
+    'ABC-ABC-ABC': { regex: /^[a-z]{3}-? *[a-z]{3}-? *[a-z]{3}$/i, placeholder: 'ABC-ABC-ABC' },
+    'ABCD-0000': { regex: /^[a-z]{4}-? *\d{4}$/i, placeholder: 'ABCD-0000' },
+    'ABC-000-000': { regex: /^[a-z]{3}-? *\d{3}-? *\d{3}$/i, placeholder: 'ABC-000-000' }
+} as const satisfies Record<string, AccessCodeFormat>;
+
+/** Name of a supported access code format (key of {@link accessCodeFormats}). */
+export type AccessCodeFormatName = keyof typeof accessCodeFormats;
+
+/** The default access code format name, kept for backward compatibility. */
+export const defaultAccessCodeFormatName: AccessCodeFormatName = '0000-0000';
+
+/**
+ * Get the access code format for the given name, falling back to the default
+ * format if the name is unknown.
+ * @param name The access code format name (see {@link accessCodeFormats})
+ * @returns The matching access code format
+ */
+export const getAccessCodeFormat = (name: AccessCodeFormatName): AccessCodeFormat =>
+    accessCodeFormats[name] ?? accessCodeFormats[defaultAccessCodeFormatName];
+
+/**
+ * Whether an access code matches the given format (using its regex). Accepted
+ * input variants (missing dash, spaces, letter case) are considered valid; use
+ * {@link normalizeAccessCode} to get the canonical stored form.
+ * @param accessCode The access code to check
+ * @param format The access code format to validate against
+ * @returns Whether the access code matches the format
+ */
+export const matchesAccessCodeFormat = (accessCode: string, format: AccessCodeFormat): boolean =>
+    format.regex.test(accessCode);
+
+/**
+ * Normalize an access code to its canonical form for the given format: groups
+ * separated by a dash, letters upper-cased, characters not belonging to the
+ * current group (wrong type or extra) dropped. This is the form that should be
+ * stored and searched, so that accepted input variants (e.g. `12345678`,
+ * `1234 5678`, lower-cased letters) always match the stored value.
+ *
+ * Partial input is normalized as far as it goes (e.g. an incomplete first group
+ * is returned without a trailing dash), which also makes it suitable as the
+ * live input formatter. As a result the returned canonical code may still be
+ * invalid (incomplete or too short); validate it with {@link matchesAccessCodeFormat}
+ * if needed.
+ * @param input The raw access code input
+ * @param format The access code format
+ * @returns The canonical access code (possibly still invalid)
+ */
+export const normalizeAccessCode = (input: string, format: AccessCodeFormat): string => {
+    const chars = input.toUpperCase().replace(/[^A-Z0-9]/g, ''); // Keep only letters and digits
+    const result: string[] = [];
+    let offset = 0;
+    for (const group of getGroupsFromPlaceholder(format.placeholder)) {
+        let current = '';
+        // Take the next valid characters for this group, skipping invalid ones
+        while (offset < chars.length && current.length < group.length) {
+            if (charMatchesGroup(chars[offset], group.isDigit)) {
+                current += chars[offset];
+            }
+            offset += 1;
+        }
+        if (current.length === 0) {
+            break;
+        }
+        result.push(current);
+    }
+    return result.join('-');
+};

--- a/packages/evolution-common/src/services/widgets/validations/__tests__/validations.test.ts
+++ b/packages/evolution-common/src/services/widgets/validations/__tests__/validations.test.ts
@@ -8,9 +8,10 @@
 import * as validations from '../validations';
 import projectConfig from '../../../../config/project.config';
 
-// Mock the project config to be able to change the postalCodeRegion
+// Mock the project config to be able to change the postalCodeRegion and accessCodeFormat
 jest.mock('../../../../config/project.config', () => ({
-    postalCodeRegion: 'canada'  // Default for tests
+    postalCodeRegion: 'canada', // Default for tests
+    accessCodeFormat: '0000-0000' // Default 8-digits format for tests
 }));
 
 describe('postalCodeValidation', () => {
@@ -277,7 +278,10 @@ describe('accessCodeValidation', () => {
     });
     
     describe('eight digits access code validation', () => {
-        
+        beforeEach(() => {
+            projectConfig.accessCodeFormat = '0000-0000';
+        });
+
         test.each([
             '2345-2345', 
             '1234 1234',
@@ -302,5 +306,32 @@ describe('accessCodeValidation', () => {
             expect(mockTranslation).toHaveBeenLastCalledWith('survey:errors:accessCodeInvalid');
         });
     });
-    
+
+    describe('nine digits access code validation', () => {
+        beforeEach(() => {
+            projectConfig.accessCodeFormat = '000-000-000';
+        });
+
+        test.each([
+            '234-234-234',
+            '234 234 234',
+            '234234234'
+        ])('should accept valid 9-digits access codes: %s', (accessCode) => {
+            const result = validations.accessCodeValidation(accessCode, undefined, {} as any, 'accessCode');
+            expect(result[0].validation).toBe(false); // Empty validation passes
+            expect(result[1].validation).toBe(false); // Should be valid
+        });
+
+        test.each([
+            ['234-abc-234', 'Contains letters'],
+            ['234-234', 'Too short (8 digits)'],
+            ['234-234-2345', 'Too long'],
+            ['23-4234-234', 'Misplaced dash']
+        ])('should reject invalid 9-digits access code: %s (%s)', (accessCode, _reason) => {
+            const result = validations.accessCodeValidation(accessCode, undefined, {} as any, 'accessCode');
+            expect(result[0].validation).toBe(false); // Empty validation passes
+            expect(result[1].validation).toBe(true); // Should be invalid
+        });
+    });
+
 });

--- a/packages/evolution-common/src/services/widgets/validations/validations.ts
+++ b/packages/evolution-common/src/services/widgets/validations/validations.ts
@@ -8,6 +8,7 @@ import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { type ValidationFunction } from '../../questionnaire/types';
 import * as surveyHelperNew from '../../../utils/helpers';
 import projectConfig from '../../../config/project.config';
+import { getAccessCodeFormat, matchesAccessCodeFormat } from '../../accessCode/accessCodeFormats';
 
 /**
  * Make sure the question is answered.
@@ -365,10 +366,6 @@ export const postalCodeValidation: ValidationFunction = (value) => {
     ];
 };
 
-// Eight digits access code validation regex
-const eightDigitsAccessCodeValidation = /^\d{4}-? *\d{4}$/i;
-// FIXME Support more access code formats in the future. For now, only one format is supported if using this validation function
-const getAccessCodeRegex = () => eightDigitsAccessCodeValidation;
 export const accessCodeValidation: ValidationFunction = (value) => {
     return [
         {
@@ -376,7 +373,7 @@ export const accessCodeValidation: ValidationFunction = (value) => {
             errorMessage: (t) => t('survey:errors:accessCodeRequired')
         },
         {
-            validation: !getAccessCodeRegex().test(String(value)),
+            validation: !matchesAccessCodeFormat(String(value), getAccessCodeFormat(projectConfig.accessCodeFormat)),
             errorMessage: (t) => t('survey:errors:accessCodeInvalid')
         }
     ];

--- a/packages/evolution-common/src/utils/__tests__/formatters.test.ts
+++ b/packages/evolution-common/src/utils/__tests__/formatters.test.ts
@@ -5,37 +5,48 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 
-import { canadianPostalCodeFormatter, eightDigitsAccessCodeFormatter } from '../formatters';
+import { accessCodeFormatter, canadianPostalCodeFormatter, eightDigitsAccessCodeFormatter } from '../formatters';
+import { getAccessCodeFormat } from '../../services/accessCode/accessCodeFormats';
 
 describe('helper', () => {
+  describe('accessCodeFormatter', () => {
+    test.each([
+      // Test case format: [description, format name, input, expected output]
+      // Dashes are inserted eagerly as soon as a group is complete, letters are upper-cased.
+      ['8 digits formats as 0000-0000', '0000-0000', '12345678', '1234-5678'],
+      ['8 digits removes letters and special characters', '0000-0000', 'ab12cd34ef56gh78', '1234-5678'],
+      ['8 digits truncates extra digits', '0000-0000', '1234567890', '1234-5678'],
+      ['8 digits dash inserted once first group is complete', '0000-0000', '123456', '1234-56'],
+      ['8 digits partial first group kept as-is', '0000-0000', '123', '123'],
+      ['8 digits ignores typed dashes and spaces', '0000-0000', '12-34 5678', '1234-5678'],
+      ['8 digits handles empty string', '0000-0000', '', ''],
+      ['9 digits formats as 000-000-000', '000-000-000', '123456789', '123-456-789'],
+      ['9 digits truncates extra digits', '000-000-000', '1234567890', '123-456-789'],
+      ['9 digits dash at the wrong place', '000-000-000', '12-3456789', '123-456-789'],
+      ['8 letters formats as ABCD-ABCD upper-cased', 'ABCD-ABCD', 'abcdefgh', 'ABCD-EFGH'],
+      ['8 letters drops digits', 'ABCD-ABCD', 'ab12cdef34gh', 'ABCD-EFGH'],
+      ['9 letters formats as ABC-ABC-ABC', 'ABC-ABC-ABC', 'abcdefghi', 'ABC-DEF-GHI'],
+      ['letters then digits ABCD-0000', 'ABCD-0000', 'abcd1234', 'ABCD-1234'],
+      ['letters then digits drops wrong-type chars', 'ABCD-0000', 'ab12cd1234', 'ABCD-1234'],
+      ['letters then digits ABC-000-000', 'ABC-000-000', 'abc123456', 'ABC-123-456'],
+      ['mixed ABC-000-000 with typed dashes', 'ABC-000-000', 'abc-123-456', 'ABC-123-456'],
+    ])('%s: %s => %s', (_, formatName, input, expected) => {
+      expect(accessCodeFormatter(input, getAccessCodeFormat(formatName as any))).toBe(expected);
+    });
+  });
+
   describe('eightDigitsAccessCodeFormatter', () => {
     test.each([
       // Test case format: [description, input, expected output]
-      ['formats 8 digits as XXXX-XXXX', '12345678', '1234-5678'],
+      ['formats 8 digits as 0000-0000', '12345678', '1234-5678'],
       ['converts existing dashes correctly', '1234-5678', '1234-5678'],
-      ['converts underscores to dashes', '1234_5678', '1234-5678'],
       ['removes letters and special characters', 'ab12cd34ef56gh78', '1234-5678'],
-      ['handles mixed special characters', '12_34-ab56!78', '1234-5678'],
-      ['keeps dashes but removes other special chars', '12-34-56-78', '1234-5678'],
-      ['smaller code with dashes', '123-456', '123-456'],
       ['8 digits with dash at the wrong place', '123-45678', '1234-5678'],
-      ['does not format if less than 8 digits', '123456', '123456'],
-      ['truncates to 9 characters max', '1234567890', '1234-5678'],
+      ['truncates extra digits', '1234567890', '1234-5678'],
       ['handles input with spaces', '1234 5678', '1234-5678'],
-      ['handles input with spaces before and after', '   12 34 5678  ', '1234-5678'],
       ['handles empty string', '', ''],
-      ['9 characters, but less than 8 digits', '123-45-6-', '1234-56'],
-      ['handles with non-numeric at the end', '1234db', '1234'],
-      ['partial access code, 1 character', '1', '1'],
-      ['partial access code, 2 characters', '12', '12'],
-      ['partial access code, 3 characters', '123', '123'],
-      ['partial access code, 4 characters', '1234', '1234'],
-      // FIXME The dash should remain in the formatted code, but it is not the case currently with the delimiterLazyShow
-      ['partial access code, 4 characters + dash', '1234-', '1234-'],
-      ['partial access code, 4 characters + dash + 2 characters', '1234-23', '1234-23'],
-      ['partial access code, 5 characters', '12345', '12345'],
-      ['partial access code, 6 characters', '123456', '123456'],
-      ['partial access code, 7 characters', '1234567', '1234567'],
+      ['dash inserted once first group is complete', '123456', '1234-56'],
+      ['partial first group kept as-is', '123', '123'],
     ])('%s: %s => %s', (_, input, expected) => {
       expect(eightDigitsAccessCodeFormatter(input)).toBe(expected);
     });

--- a/packages/evolution-common/src/utils/formatters.ts
+++ b/packages/evolution-common/src/utils/formatters.ts
@@ -5,25 +5,37 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 
+import {
+    type AccessCodeFormat,
+    getAccessCodeFormat,
+    normalizeAccessCode
+} from '../services/accessCode/accessCodeFormats';
+
 /**
- * Format an access code to the format "XXXX-XXXX" where X is a digit.
- * If the input contains less than 8 digits, it will return the code as is
- * If the input contains 8 or more digits, it will format the first 8 digits
- * as "XXXX-XXXX".
+ * Format an access code while typing, following the provided format. For
+ * example, `'0000-0000'` produces `1234-5678` and `'ABC-000-000'` produces
+ * `ABC-123-456`. This is the canonical normalization (see
+ * {@link normalizeAccessCode}): letters are upper-cased, invalid characters are
+ * dropped and dashes are inserted at group boundaries.
+ *
+ * @param input The input to format
+ * @param format The access code format describing the successive groups
+ * @returns The formatted access code
+ */
+export const accessCodeFormatter = (input: string, format: AccessCodeFormat): string =>
+    normalizeAccessCode(input, format);
+
+/**
+ * Format an access code to the format "0000-0000" (8 digits).
+ *
+ * @deprecated Prefer {@link accessCodeFormatter} with the survey's configured
+ * `accessCodeFormat`, so the format stays consistent with validation. Kept for
+ * backward compatibility with surveys explicitly wired to the 8-digit format.
  * @param input The input to format
  * @returns The formatted access code
  */
-export const eightDigitsAccessCodeFormatter = (input: string): string => {
-    input = input.replace('_', '-'); // change _ to -
-    input = input.replace(/[^-\d]/g, ''); // Remove everything but numbers and -
-    // Get only the digits. If we have 8 or if total input length is 9, we can automatically format the access code.
-    const digits = input.replace(/\D+/g, '');
-    if (digits.length >= 8 || input.length === 9) {
-        return digits.slice(0, 4) + (digits.length > 4 ? '-' + digits.slice(4, 8) : '');
-    }
-    // Prevent entering more than 9 characters (8 digit access code and a dash)
-    return input.slice(0, 9);
-};
+export const eightDigitsAccessCodeFormatter = (input: string): string =>
+    accessCodeFormatter(input, getAccessCodeFormat('0000-0000'));
 
 /**
  * Formats a canadian postal code as 2 blocks of 3 characters. Note that this

--- a/packages/evolution-frontend/src/components/admin/validations/__tests__/parseAccessCodesFromCsv.test.ts
+++ b/packages/evolution-frontend/src/components/admin/validations/__tests__/parseAccessCodesFromCsv.test.ts
@@ -5,9 +5,11 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import { parseAccessCodesFromCsv } from '../parseAccessCodesFromCsv';
+import projectConfig from 'evolution-common/lib/config/project.config';
 
 describe('parseAccessCodesFromCsv', () => {
-    // Access codes use the default format (eight digits, optional dash/space in the middle).
+    // Validation follows the configured `accessCodeFormat`. These tests use the
+    // default format '0000-0000' (eight digits, optional dash/space in the middle).
     test.each([
         ['empty content', '', []],
         ['single code', '1111-1111', ['1111-1111']],
@@ -22,5 +24,29 @@ describe('parseAccessCodesFromCsv', () => {
         ['invalid codes are dropped', '1111-1111\nnot-a-code\n2222-2222', ['1111-1111', '2222-2222']]
     ])('%s', (_label, content, expected) => {
         expect(parseAccessCodesFromCsv(content)).toEqual(expected);
+    });
+});
+
+describe('parseAccessCodesFromCsv follows the configured accessCodeFormat', () => {
+    const defaultFormat = projectConfig.accessCodeFormat;
+    afterEach(() => {
+        projectConfig.accessCodeFormat = defaultFormat;
+    });
+
+    // The same mixed content is filtered differently depending on the configured
+    // format: only codes matching the configured number of digits are kept.
+    const mixedContent = '1234-5678\n123-456-789\nABC-123-456';
+    test.each([
+        ['eight-digits format 0000-0000', '0000-0000', ['1234-5678']],
+        ['nine-digits format 000-000-000', '000-000-000', ['123-456-789']],
+        ['alphanumeric format ABC-000-000', 'ABC-000-000', ['ABC-123-456']]
+    ])('%s keeps only matching codes', (_label, format, expected) => {
+        projectConfig.accessCodeFormat = format as typeof projectConfig.accessCodeFormat;
+        expect(parseAccessCodesFromCsv(mixedContent)).toEqual(expected);
+    });
+
+    test('normalizes accepted variants to the canonical stored form and de-duplicates them', () => {
+        // All three are valid variants of the same 8-digit code and must collapse to one canonical value
+        expect(parseAccessCodesFromCsv('12345678\n1234 5678\n1234-5678')).toEqual(['1234-5678']);
     });
 });

--- a/packages/evolution-frontend/src/components/admin/validations/parseAccessCodesFromCsv.ts
+++ b/packages/evolution-frontend/src/components/admin/validations/parseAccessCodesFromCsv.ts
@@ -7,6 +7,8 @@
 
 import { accessCodeValidation } from 'evolution-common/lib/services/widgets/validations/validations';
 import { type UserInterviewAttributes } from 'evolution-common/lib/services/questionnaire/types';
+import projectConfig from 'evolution-common/lib/config/project.config';
+import { getAccessCodeFormat, normalizeAccessCode } from 'evolution-common/lib/services/accessCode/accessCodeFormats';
 
 /**
  * Whether a value passes the access code validation. `accessCodeValidation`
@@ -30,17 +32,20 @@ const isValidAccessCode = (value: string): boolean =>
  * first column is used, which lets validators export a single-column CSV from a
  * spreadsheet without extra formatting. Blank lines, surrounding whitespace and
  * quotes are ignored. Values that fail the access code validation are dropped
- * (this also discards a header row such as "accessCode"), and duplicates are
- * removed while preserving order.
+ * (this also discards a header row such as "accessCode"). Valid codes are
+ * normalized to their canonical stored form (dashes, upper-cased) so they match
+ * the stored values, and duplicates are removed while preserving order.
  *
  * @param content The raw text content of the uploaded CSV file
- * @returns The de-duplicated list of valid access codes, in file order
+ * @returns The de-duplicated list of canonical valid access codes, in file order
  */
 export const parseAccessCodesFromCsv = (content: string): string[] => {
+    const format = getAccessCodeFormat(projectConfig.accessCodeFormat);
     const codes = content
         .split(/\r?\n/)
         .map((line) => line.split(',')[0])
         .map((cell) => cell.trim().replace(/^"|"$/g, '').trim())
-        .filter((code) => isValidAccessCode(code));
+        .filter((code) => isValidAccessCode(code))
+        .map((code) => normalizeAccessCode(code, format));
     return Array.from(new Set(codes));
 };


### PR DESCRIPTION
## Summary

Makes the access code format configurable per survey, lifting the previous hardcoded 8-digit `XXXX-XXXX` assumption (and the existing `FIXME` next to it).

- Adds an `accessCodeFormats` catalog of predefined formats (digit, letter and mixed groups), each describing its groups (driving both the validation regex and the live dash placement) and a placeholder. Starting set: `'0000-0000'`, `'000-000-000'`, `'ABCD-ABCD'`, `'ABC-ABC-ABC'`, `'ABCD-0000'`, `'ABC-000-000'`. New formats are added by extending the catalog.
- Adds the `accessCodeFormat` project config option (a catalog name, default `'0000-0000'`, fully backward compatible). It is the single source of truth and drives the widget validation and live formatting, the admin validation list filter and CSV import, and the backend access code audit (`I_I_InvalidAccessCodeFormat`).
- Adds the generic `accessCodeFormatter` (handles letter groups, upper-cased, dashes inserted at group boundaries); `eightDigitsAccessCodeFormatter` is now a deprecated alias.
- Normalizes accepted input variants (missing dash, spaces, lower-cased letters) to a canonical stored form (dashes, upper-cased, trimmed) before searching access codes (login, admin filter, CSV import), so variants match the stored value.
- The configured format is always enforced on the backend: `registerAccessCodeValidationFunction` now registers an *additional* survey-specific check applied on top of the format (logical AND), e.g. verifying a code was actually issued, rather than replacing the format validation.

Downstream: requested by od_mtl, which needs a 9-digit `XXX-XXX-XXX` access code (chairemobilite/od_mtl#162).

Fixes #1668

## Test plan

- [x] `accessCodeFormats` catalog: validation regex and `normalizeAccessCode` for all formats, including alphanumeric (parametric tests)
- [x] `accessCodeFormatter` and `accessCodeValidation` for digit, letter and mixed formats
- [x] Backend: `validateAccessCode` enforces the configured format and the additional check (AND); `findByAccessCode` searches the canonical form for accepted variants
- [x] Admin CSV import filters and normalizes codes according to the configured format
- [x] Set `accessCodeFormat: '000-000-000'` in a survey config and confirm 9-digit codes are accepted end to end

Code by Claude Opus 4.8, reviewed by @kaligrafy 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Access code formats are now configurable per survey via `accessCodeFormat`, supporting the default plus formats like eight-digit, nine-digit, and alphanumeric patterns.
  * Access codes are automatically normalized to a canonical stored form for consistent validation, CSV import, and database lookup.
  * Survey-specific validation can be added on top of the configured format enforcement.

* **Bug Fixes**
  * Access-code lookups now match the stored canonical form, improving reliability with input variants (spacing/dashes/case).

* **Deprecations**
  * `eightDigitsAccessCodeFormatter` is deprecated; use `accessCodeFormatter` with your configured `accessCodeFormat`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->