### PR TITLE
Provide a default Google map id

### DIFF
--- a/packages/evolution-frontend/src/config/googleMaps.config.ts
+++ b/packages/evolution-frontend/src/config/googleMaps.config.ts
@@ -45,9 +45,12 @@ export const getCurrentGoogleMapConfig = (language = projectConfig.defaultLocale
 
 /**
  * Returns the Google Cloud Map ID configured via the `GOOGLE_MAP_ID` env var, or
- * `undefined` when not set. Required to enable `<AdvancedMarker>`; when absent,
+ * the default one when not set. Required to enable `<AdvancedMarker>`; when absent,
  * the map widgets fall back to the legacy `<Marker>` component.
  *
  * See https://developers.google.com/maps/documentation/get-map-id
+ *
+ * We created a default public style for every use which will provide
+ * the default Evolution style. People can still override it. It's define in chairemobilite's google project
  */
-export const getGoogleMapId = (): string | undefined => process.env.GOOGLE_MAP_ID || undefined;
+export const getGoogleMapId = (): string => process.env.GOOGLE_MAP_ID || '6af0f7e6a40bebff21ac2b52';


### PR DESCRIPTION
The Map ID are not secret information, just a style to use for the map. Instead of asking every users to create a new one, with potential errors, we provide a default one here. It was created on the chairemobilite google project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Google Maps configuration reliability by ensuring a valid map ID is always available, even when environment variables are not set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->