### PR TITLE
widgets: support extra label interpolation strings in builtin

### DIFF
--- a/packages/evolution-common/src/services/questionnaire/sections/common/__tests__/applyAdditionalLabelOptions.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/common/__tests__/applyAdditionalLabelOptions.test.ts
@@ -1,0 +1,171 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import _cloneDeep from 'lodash/cloneDeep';
+import { interviewAttributesForTestCases } from '../../../../../tests/surveys';
+import { VisitedPlacesSectionConfiguration } from '../../../types';
+import { TFunction } from 'i18next';
+import { applySectionAdditionalLabelOptions } from '../applyAdditionalLabelOptions';
+
+const defaultVisitedPlaceConfig: VisitedPlacesSectionConfiguration = {
+    type: 'visitedPlaces' as const,
+    enabled: true,
+    tripDiaryMinTimeOfDay: 4 * 60 * 60, // 4h in seconds
+    tripDiaryMaxTimeOfDay: 28 * 60 * 60 // 28h in seconds (i.e. 4h the next day)
+};
+
+describe('applyVisitedPlaceAdditionalLabelOptions', () => {
+    const defaultWidgetConfig = {
+        type: 'question' as const,
+        inputType: 'string' as const,
+        path: 'test',
+        label: jest.fn()
+    };
+
+    test('no additional options functions', () => {
+        // Setup widget configs
+        const widgetsConfig = { testWidget: defaultWidgetConfig };
+
+        // apply option functions
+        const updatedWidgetsConfig = applySectionAdditionalLabelOptions(widgetsConfig, defaultVisitedPlaceConfig.additionalLabelOptionFunctions);
+        // Updated config should be identical to the original
+        expect(updatedWidgetsConfig).toBe(widgetsConfig);
+    });
+
+    test('test with an additional options function for a single widget', () => {
+        // Setup widget configs
+        const widgetsConfig = { testWidget: defaultWidgetConfig };
+        // Setup configuration with some functions
+        const sectionConfig = _cloneDeep(defaultVisitedPlaceConfig);
+        sectionConfig.additionalLabelOptionFunctions = { testWidget: jest.fn() }
+
+        // Apply the configuration
+        const updatedWidgetsConfig = applySectionAdditionalLabelOptions(widgetsConfig, sectionConfig.additionalLabelOptionFunctions);
+        expect(updatedWidgetsConfig).not.toBe(widgetsConfig);
+        expect(updatedWidgetsConfig).toEqual({
+            testWidget: {
+                ...defaultWidgetConfig,
+                label: expect.any(Function)
+            }
+        });
+    });
+
+    test('test with an additional options function for text field', () => {
+        const widgetsConfig = {
+            testWidget: {
+                type: 'text' as const,
+                text: jest.fn()
+            }
+        };
+        const sectionConfig = _cloneDeep(defaultVisitedPlaceConfig);
+        sectionConfig.additionalLabelOptionFunctions = { testWidget: jest.fn() }
+
+        const updatedWidgetsConfig = applySectionAdditionalLabelOptions(widgetsConfig, sectionConfig.additionalLabelOptionFunctions);
+        expect(updatedWidgetsConfig).not.toBe(widgetsConfig);
+        expect(updatedWidgetsConfig).toEqual({
+            testWidget: {
+                type: 'text',
+                text: expect.any(Function)
+            }
+        });
+    });
+
+    test('test with an additional options function on a widget where label is not a function', () => {
+        // Setup widget configs
+        const widgetsConfig = { testWidget: { ...defaultWidgetConfig, label: 'hardcoded' } };
+        // Setup configuration with some functions
+        const sectionConfig = _cloneDeep(defaultVisitedPlaceConfig);
+        sectionConfig.additionalLabelOptionFunctions = { testWidget: jest.fn() }
+
+        // Apply the configuration
+        const updatedWidgetsConfig = applySectionAdditionalLabelOptions(widgetsConfig, sectionConfig.additionalLabelOptionFunctions);
+        expect(updatedWidgetsConfig.testWidget).toBe(widgetsConfig.testWidget);
+    });
+
+    test('test with many widgets, some with additional options', () => {
+        // Setup widget configs
+        const widgetsConfig = {
+            testWidget1: defaultWidgetConfig,
+            testWidget2: {
+                ...defaultWidgetConfig,
+                label: jest.fn()
+            }
+        };
+        // Setup configuration with some functions for testWidget2 (testWidget1 should remain unchanged)
+        const sectionConfig = _cloneDeep(defaultVisitedPlaceConfig);
+        sectionConfig.additionalLabelOptionFunctions = { testWidget2: jest.fn() }
+
+        // Apply the configuration
+        const updatedWidgetsConfig = applySectionAdditionalLabelOptions(widgetsConfig, sectionConfig.additionalLabelOptionFunctions);
+        expect(updatedWidgetsConfig).toEqual({
+            testWidget1: {
+                ...defaultWidgetConfig,
+                label: expect.any(Function)
+            },
+            testWidget2: {
+                ...defaultWidgetConfig,
+                label: expect.any(Function)
+            }
+        });
+        // testWidget1 should be the same, testWidget2 should be different
+        expect(updatedWidgetsConfig.testWidget1).toBe(widgetsConfig.testWidget1);
+        expect(updatedWidgetsConfig.testWidget2).not.toBe(widgetsConfig.testWidget2);
+    });
+
+    test.each([
+        {
+            testCase: 'label function with only the key',
+            originalFunction: (t: TFunction) => t('test.key'),
+            additionalOptions: { interpolation: 'hello' },
+            expected: ['test.key', { interpolation: 'hello' }]
+        },
+        {
+            testCase: 'label function with other options and array of keys',
+            originalFunction: (t: TFunction) => t(['test.key_withContext', 'test.key'], { opt1: 'value' }),
+            additionalOptions: { interpolation: 'hello', otherInterpolation: '' },
+            expected: [['test.key_withContext', 'test.key'], { opt1: 'value', interpolation: 'hello', otherInterpolation: '' }]
+        },
+        {
+            testCase: 'unsupported with more than two parameters',
+            originalFunction: (t: TFunction) => t('test.key', 'default', { opt1: 'value' }),
+            additionalOptions: { interpolation: 'hello', otherInterpolation: '' },
+            expected: ['test.key', 'default', { opt1: 'value' }]
+        },
+        {
+            testCase: 'unsupported with default string as second parameter',
+            originalFunction: (t: TFunction) => t('test.key', 'default'),
+            additionalOptions: { interpolation: 'hello', otherInterpolation: '' },
+            expected: ['test.key', 'default']
+        }
+    ])('$testCase', ({ originalFunction, additionalOptions, expected }) => {
+        // Setup widget configs with the original function
+        const widgetsConfig = { testWidget: { ...defaultWidgetConfig, label: originalFunction } };
+        // Setup configuration with some functions
+        const sectionConfig = _cloneDeep(defaultVisitedPlaceConfig);
+        const mockedAdditionalOptionFct = jest.fn().mockReturnValue(additionalOptions);
+        sectionConfig.additionalLabelOptionFunctions = { testWidget: mockedAdditionalOptionFct }
+
+        // Apply the configuration
+        const updatedWidgetsConfig = applySectionAdditionalLabelOptions(widgetsConfig, sectionConfig.additionalLabelOptionFunctions);
+
+        // Call the `label` function with interview data and make sure the `t` function was correctly called
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        const updatedLblFunction = (updatedWidgetsConfig.testWidget as any).label;
+        const mockedT = jest.fn().mockReturnValue('translated')
+        const path = 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1';
+        const lbl = updatedLblFunction(mockedT, interview, path);
+
+        // Validate the various calls.
+        expect(mockedAdditionalOptionFct).toHaveBeenCalledWith({
+            interview,
+            t: mockedT,
+            path
+        })
+        expect(mockedT).toHaveBeenCalledWith(...expected);
+        expect(lbl).toEqual('translated');
+    })
+});

--- a/packages/evolution-common/src/services/questionnaire/sections/common/applyAdditionalLabelOptions.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/common/applyAdditionalLabelOptions.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { TFunction } from 'i18next';
+import type { TranslatableStringFunction, UserInterviewAttributes, WidgetConfig } from '../../types';
+import type { AdditionalSectionLabelOptionFct } from '../../types';
+
+const widgetI18nField = ['label', 'text'];
+
+const getEnhancedI18nData =
+    (
+        originalData: TranslatableStringFunction,
+        interpolationFunction: AdditionalSectionLabelOptionFct,
+        widgetName: string
+    ): TranslatableStringFunction =>
+        (t: TFunction, interview: UserInterviewAttributes, path: string): string => {
+        // Compute the additional options by running the
+        // interpolation function
+            const additionalOptions = interpolationFunction({
+                interview,
+                t,
+                path
+            });
+
+            // Enhance the `t` function to add the additional options to the received options
+            const enhancedT = ((...args: any[]) => {
+            // No argument passed, this is not supported
+                if (args.length === 0) {
+                    console.warn('Trying to display a label/text without parameters for ', widgetName);
+                    return (t as any)();
+                }
+                // More than 2 arguments or second argument is a default value string, not supported
+                if (args.length > 2 || typeof args[1] === 'string') {
+                    console.warn(
+                        '`t` function call with default value not supported for label/text with additional options, only calls with key and options as second arguments are supported for widget ',
+                        widgetName
+                    );
+                    return (t as any)(...args);
+                }
+                const [key, options] = args;
+                // Call the original `t` function with additional options passed
+                return (t as any)(key, { ...(options || {}), ...additionalOptions });
+            }) as TFunction;
+            // Call the original label function with the enhanced `t` function that
+            // will add the options
+            return originalData(enhancedT, interview, path);
+        };
+
+/**
+ * Internal build time function that changes the label function to add the
+ * additional interpolation options to the label call.
+ *
+ * @param widgetConfigs The widget configs on which to applyt he additional
+ * label options
+ * @param additionalLabelOptionFunctions Object with the functions that will add
+ * the interpolation keys to label. The key is the name of the widget and the
+ * value is the function.
+ * @param resolveContext A function that will resolve proper context to pass as
+ * argument to the label option functions.
+ * @returns The updated widget configs, with label functions enhanced to support
+ * additional keys
+ */
+export const applySectionAdditionalLabelOptions = (
+    widgetConfigs: Record<string, WidgetConfig>,
+    additionalLabelOptionFunctions: { [widgetName: string]: AdditionalSectionLabelOptionFct } | undefined
+): Record<string, WidgetConfig> => {
+    // Return the widget configs if there are no functions available
+    if (!additionalLabelOptionFunctions) {
+        return widgetConfigs;
+    }
+
+    return Object.fromEntries(
+        Object.entries(widgetConfigs).map(([widgetName, widgetConfig]) => {
+            const interpolationFunction = additionalLabelOptionFunctions[widgetName];
+            // If there is no interpolation function, return the original widget
+            if (!interpolationFunction) {
+                return [widgetName, widgetConfig];
+            }
+
+            let updatedWidgetConfig: WidgetConfig = widgetConfig;
+            let hasChanged = false;
+            for (const fieldName of widgetI18nField) {
+                const originalField = (widgetConfig as any)[fieldName];
+                // If the original label is not a function, do not change the
+                // label
+                if (typeof originalField === 'function') {
+                    hasChanged = true;
+                    updatedWidgetConfig = {
+                        ...updatedWidgetConfig,
+                        [fieldName]: getEnhancedI18nData(
+                            originalField as TranslatableStringFunction,
+                            interpolationFunction,
+                            widgetName
+                        )
+                    };
+                }
+            }
+
+            return hasChanged ? [widgetName, updatedWidgetConfig] : [widgetName, widgetConfig];
+        })
+    );
+};

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/sectionSegment.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/sectionSegment.test.ts
@@ -24,7 +24,7 @@ jest.mock('uuid', () => ({
     v4: jest.fn().mockReturnValue('newTripId')
 }));
 const mockUuidv4 = uuidv4 as jest.MockedFunction<typeof uuidv4>;
-const segmentSectionConfig = {
+const segmentSectionConfig: SegmentSectionConfiguration = {
     type: 'segments' as const,
     enabled: true
 };
@@ -129,6 +129,30 @@ describe('SegmentsSectionFactory#getWidgetConfigs', () => {
             expect(maskFunctions(widgetConfig)).toEqual(maskFunctions(expected));
         });
     });
+
+    test('should attach additional label options for segment widgets when configured', () => {
+            const sectionConfigWithLabelOptions = _cloneDeep(segmentSectionConfig);
+            const mockedAdditionalLabelFct = jest.fn();
+            sectionConfigWithLabelOptions.additionalLabelOptionFunctions = {
+                segmentMode: mockedAdditionalLabelFct.mockReturnValue({ extraOption: 'extraValue' })
+            };
+    
+            const widgetConfigs = new SegmentsSectionFactory(
+                sectionConfigWithLabelOptions,
+                widgetFactoryOptions
+            ).getWidgetConfigs();
+            const segmentModeConfig = widgetConfigs.segmentMode;
+            expect(segmentModeConfig).toBeDefined();
+            const mockedT = jest.fn();
+            const path = 'household.persons.personId1.journeys.journeyId1.trips.tripId1P1';
+            ((segmentModeConfig as any).label as any)(mockedT, interviewAttributesForTestCases, path);
+            expect(mockedT).toHaveBeenCalledWith(['customSurvey:segments:ModeSpecify', 'segments:ModeSpecify'], { extraOption: 'extraValue' });
+            expect(mockedAdditionalLabelFct).toHaveBeenCalledWith({
+                interview: interviewAttributesForTestCases,
+                t: mockedT,
+                path
+            })
+        });
 
     test('should not return extra widgets', () => {
         const widgetConfigs = new SegmentsSectionFactory(segmentSectionConfig, widgetFactoryOptions).getWidgetConfigs();

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/sectionSegments.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/sectionSegments.ts
@@ -11,6 +11,7 @@ import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { removeGroupedObjects, addGroupedObjects } from '../../../../utils/helpers';
 import * as odHelpers from '../../../odSurvey/helpers';
 import { SectionConfig, SegmentSectionConfiguration, Trip, WidgetConfig } from '../../types';
+import { applySectionAdditionalLabelOptions } from '../common/applyAdditionalLabelOptions';
 import { initializeSegmentSectionHelpers } from './helpers';
 import { SectionConfigFactory, WidgetFactoryOptions } from '../types';
 import { getPersonsTripsTitleWidgetConfig } from './widgetPersonTripsTitle';
@@ -182,13 +183,18 @@ export class SegmentsSectionFactory implements SectionConfigFactory {
         this._sectionConfig = this.getSegmentsSectionConfig();
         const switchPersonsWidget = new SwitchPersonWidgetsFactory(this.options);
         const personTripsGroup = new PersonTripsGroupConfigFactory(this.sectionConfig, this.options);
-        this._widgets = {
+        const widgetConfigs: Record<string, WidgetConfig> = {
             ...switchPersonsWidget.getWidgetConfigs(),
             personTripsTitle: getPersonsTripsTitleWidgetConfig(this.options),
             ...personTripsGroup.getWidgetConfigs(),
             personVisitedPlacesMap: getPersonVisitedPlacesMapConfig(this.options),
             buttonConfirmNextSection: getButtonValidateAndGotoNextSection('survey:ConfirmAndContinue', this.options)
         };
+
+        this._widgets = applySectionAdditionalLabelOptions(
+            widgetConfigs,
+            this.sectionConfig.additionalLabelOptionFunctions
+        );
     }
 
     getSectionConfig(): SectionConfig {

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/sectionVisitedPlaces.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/sectionVisitedPlaces.test.ts
@@ -132,7 +132,31 @@ describe('VisitedPlacesSectionFactory#getWidgetConfigs', () => {
 			).getWidgetConfigs();
 			expect(maskFunctions(widgetConfigs[widgetName])).toEqual(maskFunctions(expected));
 		});
-	});
+    });
+
+    test('should attach additional label options for visited place widgets when configured', () => {
+        const sectionConfigWithLabelOptions = _cloneDeep(visitedPlacesSectionConfig);
+        const mockedAdditionalLabelFct = jest.fn();
+        sectionConfigWithLabelOptions.additionalLabelOptionFunctions = {
+            visitedPlaceActivity: mockedAdditionalLabelFct.mockReturnValue({ extraOption: 'extraValue' })
+        };
+
+        const widgetConfigs = new VisitedPlacesSectionFactory(
+            sectionConfigWithLabelOptions,
+            widgetFactoryOptions
+        ).getWidgetConfigs();
+        const visitedPlaceActivityConfig = widgetConfigs.visitedPlaceActivity;
+        expect(visitedPlaceActivityConfig).toBeDefined();
+        const mockedT = jest.fn();
+        const path = 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1';
+        ((visitedPlaceActivityConfig as any).label as any)(mockedT, interviewAttributesForTestCases, path);
+        expect(mockedT).toHaveBeenCalledWith('visitedPlaces:Activity', { extraOption: 'extraValue' });
+        expect(mockedAdditionalLabelFct).toHaveBeenCalledWith({
+            interview: interviewAttributesForTestCases,
+            t: mockedT,
+            path
+        })
+    });
 
 	test('should not return extra widgets', () => {
 		const widgetConfigs = new VisitedPlacesSectionFactory(visitedPlacesSectionConfig, widgetFactoryOptions).getWidgetConfigs();

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/sectionVisitedPlaces.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/sectionVisitedPlaces.ts
@@ -27,6 +27,7 @@ import { getButtonConfirmGotoNextSectionWidgetConfig } from './buttonConfirmGoto
 import { tripDiarySectionVisibleConditional } from '../tripDiary/tripDiaryHelpers';
 import { Activity, ActivityCategory } from '../../../odSurvey/types';
 import { initializeVisitedPlaceSectionHelpers } from './helpers';
+import { applySectionAdditionalLabelOptions } from '../common/applyAdditionalLabelOptions';
 
 export class VisitedPlacesSectionFactory implements SectionConfigFactory {
     private _sectionConfig: SectionConfig | undefined = undefined;
@@ -200,16 +201,19 @@ export class VisitedPlacesSectionFactory implements SectionConfigFactory {
         const personVisitedPlacesGroup = new PersonVisitedPlacesGroupConfigFactory(this.sectionConfig, this.options);
 
         // Prepare the widgets for this section
-        this._widgets = {
-            ...switchPersonsWidget.getWidgetConfigs(),
-            personVisitedPlacesTitle: getPersonVisitedPlacesTitleWidgetConfig(this.sectionConfig, this.options),
-            ...personVisitedPlacesGroup.getWidgetConfigs(),
-            personVisitedPlacesMap: getPersonVisitedPlacesMapConfig(this.options),
-            buttonVisitedPlacesConfirmNextSection: getButtonConfirmGotoNextSectionWidgetConfig(
-                this.sectionConfig,
-                this.options
-            )
-        };
+        this._widgets = applySectionAdditionalLabelOptions(
+            {
+                ...switchPersonsWidget.getWidgetConfigs(),
+                personVisitedPlacesTitle: getPersonVisitedPlacesTitleWidgetConfig(this.sectionConfig, this.options),
+                ...personVisitedPlacesGroup.getWidgetConfigs(),
+                personVisitedPlacesMap: getPersonVisitedPlacesMapConfig(this.options),
+                buttonVisitedPlacesConfirmNextSection: getButtonConfirmGotoNextSectionWidgetConfig(
+                    this.sectionConfig,
+                    this.options
+                )
+            },
+            this.sectionConfig.additionalLabelOptionFunctions
+        );
     }
 
     getSectionConfig(): SectionConfig {

--- a/packages/evolution-common/src/services/questionnaire/types/SectionConfig.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/SectionConfig.ts
@@ -7,6 +7,7 @@
 // Contains types for the questionnaire sections configuration
 
 import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
+import type { TFunction } from 'i18next';
 import {
     I18nData,
     StartAddGroupedObjects,
@@ -481,6 +482,19 @@ export type SurveyWidgets = {
 };
 
 /**
+ * The type of the function to implement to add additional interpolation keys to
+ * a section widget label or text. The function receives the interview, the
+ * original `t` function for translation, the current person, journey and the
+ * current section-specific context object (for example `VisitedPlace` or
+ * `Trip`).
+ */
+export type AdditionalSectionLabelOptionFct = (args: {
+    interview: UserInterviewAttributes;
+    t: TFunction;
+    path: string;
+}) => Record<string, unknown>;
+
+/**
  * Configuration for the segments section of the questionnaire
  */
 export type SegmentSectionConfiguration = {
@@ -545,6 +559,18 @@ export type SegmentSectionConfiguration = {
         | { type: 'point' }
         | { type: 'fromCollection'; featureCollection: GeoJSON.FeatureCollection<GeoJSON.Point> }
     ))[];
+    /**
+     * Maps a widget name to a function run when the label is displayed to allow
+     * to define additional options to pass to the label function. These
+     * functions return a key/value pair where the key can be interpolated in
+     * the translated string for a maximum flexibility. Most widget's label
+     * already support gender context, the person's `nickname` and the `count`
+     * for adressing the person as you or by nickname. By specifying a function
+     * here, any additional interpolation key can be added to the string.
+     */
+    additionalLabelOptionFunctions?: {
+        [widgetName: string]: AdditionalSectionLabelOptionFct;
+    };
 };
 
 /**
@@ -615,6 +641,18 @@ export type VisitedPlacesSectionConfiguration = {
      * that can be removed and others that cannot, etc.
      */
     additionalVisitedPlacesWidgetNames?: string[];
+    /**
+     * Maps a widget name to a function run when the label is displayed to allow
+     * to define additional options to pass to the label function. These
+     * functions return a key/value pair where the key can be interpolated in
+     * the translated string for a maximum flexibility. Most widget's label
+     * already support gender context, the person's `nickname` and the `count`
+     * for adressing the person as you or by nickname. By specifying a function
+     * here, any additional interpolation key can be added to the string.
+     */
+    additionalLabelOptionFunctions?: {
+        [widgetName: string]: AdditionalSectionLabelOptionFct;
+    };
 };
 
 /**


### PR DESCRIPTION
fixes #1665

Add a `additionalLabelOptionFunctions` property to the `SegmentSectionConfiguration` and `VisitedPlaceSectionConfiguration`. These property take an object which maps a widget name to a function that returns interpolation key data that will be added to the `t` function call to translate the strings, effectively allowing additional interpolation keys to be added dynamically in questionnaires in widget labels.

An `applySectionAdditionalLabelOptions` function replaces the `label` or `text` calls of widgets by a function that calls the addition label option function for that widget and adds those interpolation keys in the actual `t` function call. It does so by passing a enhanced `t` function that catches the original call from the label/text function and adds the keys to it before calling the original `t` function.

Add tests for these methods.

Note that this works only if the original label/text properties of the widget configuration are functions, not for the other types covered by `I18nData`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Section labels can now use extra translation options, allowing more dynamic text in supported questionnaire widgets.
  * Added support for per-widget label customization in segment and visited-place sections.

* **Bug Fixes**
  * Existing widget labels and text fields now keep their current behavior when no extra options are configured.
  * Only widgets with configured extra label options are updated, preserving other widget settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->