### PR TITLE
admin: let reviewers invalidate a person's trip diary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Generator section conditionals**: The `Sections` Excel sheet supports optional `enable_conditional` and `completion_conditional` columns. Set them to a conditional name from the `Conditionals` sheet (generated as `conditionals.<name>`) or to a custom conditional whose name ends with `CustomConditional` (generated as `customConditionals.<name>`). When omitted, the generator keeps the previous defaults (`true` or `isSectionCompleted` with the previous or current section as appropriate). (fixes [#997](https://github.com/chairemobilite/evolution/issues/997)).
 - **Generator selective script generation**: The generator now accepts a `--only` command-line argument to generate only specified scripts (e.g., widgets, conditionals, labels) instead of everything (fixes [#1601](https://github.com/chairemobilite/evolution/issues/1601))
 - **Experimental** Add a `selectFeature` input type that takes a geojson point feature collection and sorts them in a select widget by proximity to a reference geography in the survey (fixes [#1604](https://github.com/chairemobilite/evolution/issues/1604))
+- Validation: reviewers can invalidate a person's whole trip diary from the review column. The diary is then excluded from the trips/visited places export (the person's other answers are kept). Stored as `tripDiaryValid` on the person in the corrected response (fixes [#1675](https://github.com/chairemobilite/evolution/issues/1675)).
 
 ### Changed
 

--- a/locales/en/admin.json
+++ b/locales/en/admin.json
@@ -127,7 +127,10 @@
     },
     "interviewMember": {
         "Keep": "Keep",
-        "Discard": "Discard"
+        "Discard": "Discard",
+        "InvalidateTripDiary": "Invalidate trip diary",
+        "RevalidateTripDiary": "Make trip diary valid",
+        "TripDiaryInvalidMessage": "Trip diary invalidated and ignored in the export"
     },
     "AllAudits": "All Audits",
     "auditLevels": {

--- a/locales/fr/admin.json
+++ b/locales/fr/admin.json
@@ -127,7 +127,10 @@
     },
     "interviewMember": {
         "Keep": "Garder",
-        "Discard": "Écarter"
+        "Discard": "Écarter",
+        "InvalidateTripDiary": "Invalider le carnet de déplacements",
+        "RevalidateTripDiary": "Rendre le carnet de déplacements valide",
+        "TripDiaryInvalidMessage": "Carnet de déplacements invalidé et ignoré dans l'export"
     },
     "AllAudits": "Tous les audits",
     "auditLevels": {

--- a/packages/evolution-backend/src/services/adminExport/__tests__/exportAllToCsvByObject.test.ts
+++ b/packages/evolution-backend/src/services/adminExport/__tests__/exportAllToCsvByObject.test.ts
@@ -436,4 +436,76 @@ describe('exportAllToCsvBySurveyObject', () => {
 
     });
 
+    test('Skips the trip diary of persons whose tripDiaryValid is false, keeping their attributes', async () => {
+        const person1Uuid = uuidV4();
+        const person2Uuid = uuidV4();
+        const journey1Uuid = uuidV4();
+        const journey2Uuid = uuidV4();
+        const visitedPlace1Uuid = uuidV4();
+        const visitedPlace2Uuid = uuidV4();
+        const interviewData = {
+            id: 1,
+            uuid: uuidV4(),
+            'updated_at': '2024-10-11 09:02:00',
+            is_valid: true,
+            is_completed: true,
+            is_validated: null,
+            is_questionable: null,
+            response: {
+                household: {
+                    size: 2,
+                    persons: {
+                        [person1Uuid]: {
+                            _uuid: person1Uuid,
+                            age: 30,
+                            journeys: {
+                                [journey1Uuid]: {
+                                    _uuid: journey1Uuid,
+                                    visitedPlaces: { [visitedPlace1Uuid]: { _uuid: visitedPlace1Uuid, name: 'Place 1' } }
+                                }
+                            }
+                        },
+                        // Person 2's trip diary was invalidated by the reviewer
+                        [person2Uuid]: {
+                            _uuid: person2Uuid,
+                            age: 25,
+                            tripDiaryValid: false,
+                            journeys: {
+                                [journey2Uuid]: {
+                                    _uuid: journey2Uuid,
+                                    visitedPlaces: { [visitedPlace2Uuid]: { _uuid: visitedPlace2Uuid, name: 'Place 2' } }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            corrected_response_available: true
+        };
+
+        // Add the interview to the stream twice, for the paths and the export
+        mockGetInterviewsStream.mockReturnValueOnce(new ObjectReadableMock([interviewData]) as any);
+        mockGetInterviewsStream.mockReturnValueOnce(new ObjectReadableMock([interviewData]) as any);
+
+        await exportAllToCsvBySurveyObjectTask({ responseType: 'correctedIfAvailable' });
+
+        // Both persons are still exported, including the invalidated one (with its tripDiaryValid flag)
+        const personsCsvFileName = Object.keys(fileStreams).find((filename) => filename.endsWith('corrected_household_persons_test.csv'));
+        const personsRows = await getCsvFileRows(fileStreams[personsCsvFileName as string].data);
+        expect(personsRows.map((row) => row._uuid).sort()).toEqual([person1Uuid, person2Uuid].sort());
+        const person2Row = personsRows.find((row) => row._uuid === person2Uuid);
+        expect(person2Row.age).toEqual(String(interviewData.response.household.persons[person2Uuid].age));
+        expect(person2Row.tripDiaryValid).toEqual('false');
+
+        // Only the valid person's journey is exported
+        const journeysCsvFileName = Object.keys(fileStreams).find((filename) => filename.endsWith('corrected_household_persons_journeys_test.csv'));
+        const journeysRows = await getCsvFileRows(fileStreams[journeysCsvFileName as string].data);
+        expect(journeysRows.map((row) => row._uuid)).toEqual([journey1Uuid]);
+
+        // Only the valid person's visited place is exported
+        const visitedPlacesCsvFileName = Object.keys(fileStreams).find((filename) => filename.endsWith('corrected_household_persons_journeys_visitedPlaces_test.csv'));
+        const visitedPlacesRows = await getCsvFileRows(fileStreams[visitedPlacesCsvFileName as string].data);
+        expect(visitedPlacesRows.map((row) => row._uuid)).toEqual([visitedPlace1Uuid]);
+    });
+
 });

--- a/packages/evolution-backend/src/services/adminExport/exportAllToCsvBySurveyObject.ts
+++ b/packages/evolution-backend/src/services/adminExport/exportAllToCsvBySurveyObject.ts
@@ -196,6 +196,35 @@ const getLastUuidFromPath = function (path) {
     return undefined;
 };
 
+/**
+ * Whether a response path belongs to the trip diary of a given person, i.e. the
+ * person's journeys (and legacy visited places stored directly on the person).
+ * Used to exclude these paths from the export when the reviewer invalidated the
+ * person's trip diary. The person's own attributes (age, gender, etc.) are kept.
+ * @param path The response path (with real uuids)
+ * @param personUuid The uuid of the person whose trip diary should be excluded
+ * @returns Whether the path is part of that person's trip diary
+ */
+const isPersonTripDiaryPath = function (path: string, personUuid: string): boolean {
+    const prefix = `household.persons.${personUuid}.`;
+    if (!path.startsWith(prefix)) {
+        return false;
+    }
+    const suffix = path.substring(prefix.length);
+    return suffix.startsWith('journeys.') || suffix.startsWith('visitedPlaces.');
+};
+
+/**
+ * Collect the uuids of the persons whose trip diary was invalidated by a
+ * reviewer (`tripDiaryValid === false`).
+ * @param response The interview response (corrected response when available)
+ * @returns The uuids of the persons whose trip diary is invalid
+ */
+const getInvalidTripDiaryPersonUuids = function (response: any): string[] {
+    const persons = response?.household?.persons || {};
+    return Object.keys(persons).filter((personUuid) => persons[personUuid]?.tripDiaryValid === false);
+};
+
 const getInterviewStream = (options: ExportOptions) =>
     interviewsDbQueries.getInterviewsStream({
         filters: {},
@@ -436,6 +465,9 @@ export const exportAllToCsvBySurveyObjectTask = async function (
                 const exportedInterviewDataBySurveyObjectPath = _cloneDeep(exportedDataBySurveyObjectPath);
 
                 const interviewPaths = getPaths('', response, undefined);
+                // Persons whose trip diary was invalidated by a reviewer: their
+                // journeys/visited places are excluded from the export below.
+                const invalidTripDiaryPersonUuids = getInvalidTripDiaryPersonUuids(response);
                 const objectsBySurveyObjectPath = {
                     interview: exportedInterviewDataBySurveyObjectPath.interview
                 };
@@ -451,6 +483,14 @@ export const exportAllToCsvBySurveyObjectTask = async function (
 
                 for (let j = 0, countJ = interviewPaths.length; j < countJ; j++) {
                     const path = interviewPaths[j];
+                    // Skip the trip diary (journeys/visited places) of persons the
+                    // reviewer invalidated, while keeping their other attributes.
+                    if (
+                        invalidTripDiaryPersonUuids.length > 0 &&
+                        invalidTripDiaryPersonUuids.some((personUuid) => isPersonTripDiaryPath(path, personUuid))
+                    ) {
+                        continue;
+                    }
                     const pathUuid = getLastUuidFromPath(path);
                     const pathWithoutUuids = removeUuidsFromPath(path);
                     let foundObjectPath = false;

--- a/packages/evolution-common/src/services/baseObjects/Person.ts
+++ b/packages/evolution-common/src/services/baseObjects/Person.ts
@@ -38,6 +38,7 @@ export const personAttributes = [
     '_sequence',
     '_color',
     '_keepDiscard',
+    'tripDiaryValid',
     'age',
     'ageGroup',
     'gender',
@@ -84,6 +85,7 @@ export const personAttributesWithComposedAttributes = [
 export const nonStringAttributes = [
     '_weights',
     '_isValid',
+    'tripDiaryValid',
     '_uuid',
     ...completableAttributeNames,
     '_sequence',
@@ -106,6 +108,10 @@ export type PersonAttributes = {
     _sequence?: Optional<number>;
     _color?: Optional<string>; // used for reviewing to color each person's trips on map
     _keepDiscard?: Optional<string>; // 'Keep' or 'Discard'
+    // Set by the reviewer to invalidate the whole trip diary of the person:
+    // `false` means the trip diary is invalid (excluded from trips/places export),
+    // `undefined` (or `true`) means it is valid.
+    tripDiaryValid?: Optional<boolean>;
     age?: Optional<PAttr.Age>;
     ageGroup?: Optional<PAttr.AgeGroup>; // generated, do not use as a widget
     gender?: Optional<PAttr.Gender>;
@@ -270,6 +276,14 @@ export class Person extends SurveyObject {
 
     set _keepDiscard(value: Optional<string>) {
         this._attributes._keepDiscard = value;
+    }
+
+    get tripDiaryValid(): Optional<boolean> {
+        return this._attributes.tripDiaryValid;
+    }
+
+    set tripDiaryValid(value: Optional<boolean>) {
+        this._attributes.tripDiaryValid = value;
     }
 
     get age(): Optional<PAttr.Age> {
@@ -879,6 +893,9 @@ export class Person extends SurveyObject {
 
         // Validate _isValid:
         errors.push(...ParamsValidatorUtils.isBoolean('_isValid', dirtyParams._isValid, displayName));
+
+        // Validate tripDiaryValid (reviewer flag invalidating the person's trip diary):
+        errors.push(...ParamsValidatorUtils.isBoolean('tripDiaryValid', dirtyParams.tripDiaryValid, displayName));
 
         errors.push(...SurveyObject.validateCompletableParams(dirtyParams, displayName));
 

--- a/packages/evolution-frontend/src/components/admin/validations/InterviewStats.tsx
+++ b/packages/evolution-frontend/src/components/admin/validations/InterviewStats.tsx
@@ -54,6 +54,18 @@ const InterviewStats = (props: InterviewStatsProps) => {
         props.startUpdateInterview({ valuesByPath });
     };
 
+    // Invalidate (false) or revalidate (undefined) the person's whole trip diary
+    const invalidateTripDiary = ({
+        tripDiaryValid,
+        personId
+    }: {
+        tripDiaryValid: boolean | undefined;
+        personId: string;
+    }) => {
+        const valuesByPath = { [`response.household.persons.${personId}.tripDiaryValid`]: tripDiaryValid };
+        props.startUpdateInterview({ valuesByPath });
+    };
+
     // Use unserialized objects - show error if not available
     const surveyObjects = props.surveyObjectsAndAudits;
 
@@ -181,6 +193,7 @@ const InterviewStats = (props: InterviewStatsProps) => {
                             selectPlace={props.selectPlace}
                             selectTrip={props.selectTrip}
                             keepDiscard={keepDiscard}
+                            invalidateTripDiary={invalidateTripDiary}
                             showAuditErrorCode={props.prefs?.showAuditErrorCode}
                         />
                     );

--- a/packages/evolution-frontend/src/components/admin/validations/InvalidateTripDiary.tsx
+++ b/packages/evolution-frontend/src/components/admin/validations/InvalidateTripDiary.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faBan } from '@fortawesome/free-solid-svg-icons/faBan';
+import { faCheck } from '@fortawesome/free-solid-svg-icons/faCheck';
+
+type InvalidateTripDiaryProps = {
+    /** Current validity of the person's trip diary; `false` means invalidated, `undefined`/`true` means valid */
+    tripDiaryValid: boolean | undefined;
+    personId: string;
+    /** Called with the new validity value: `false` when invalidated, `undefined` when cleared */
+    onChange: (data: { tripDiaryValid: boolean | undefined; personId: string }) => void;
+};
+
+/**
+ * Single toggle button used by the reviewer to invalidate a person's whole trip
+ * diary. When valid, it shows a red "ban" icon and invalidates the diary on click
+ * (`tripDiaryValid = false`); when invalid, it shows a green check icon and clears
+ * the flag on click (`tripDiaryValid = undefined`, i.e. valid again).
+ * @param props.tripDiaryValid Current validity (`false` = invalid, else valid)
+ * @param props.personId The uuid of the person whose trip diary is toggled
+ * @param props.onChange Called with the new validity value and the person id
+ */
+const InvalidateTripDiary: React.FC<InvalidateTripDiaryProps> = ({ tripDiaryValid, personId, onChange }) => {
+    const { t } = useTranslation('admin');
+    const isInvalid = tripDiaryValid === false;
+
+    const onClick = () => {
+        onChange({ tripDiaryValid: isInvalid ? undefined : false, personId });
+    };
+
+    return (
+        <button
+            className={`_member-trip-diary-invalidate ${isInvalid ? '_green' : '_red'}`}
+            type="button"
+            onClick={onClick}
+            title={
+                isInvalid
+                    ? t('admin:interviewMember:RevalidateTripDiary')
+                    : t('admin:interviewMember:InvalidateTripDiary')
+            }
+        >
+            <FontAwesomeIcon icon={isInvalid ? faCheck : faBan} />
+        </button>
+    );
+};
+
+export default InvalidateTripDiary;

--- a/packages/evolution-frontend/src/components/admin/widgets/PersonPanel.tsx
+++ b/packages/evolution-frontend/src/components/admin/widgets/PersonPanel.tsx
@@ -29,6 +29,7 @@ import { Segment } from 'evolution-common/lib/services/baseObjects/Segment';
 import { AuditForObject } from 'evolution-common/lib/services/audits/types';
 import { VisitedPlaceDecorator } from '../../../services/surveyObjectDecorators/VisitedPlaceDecorator';
 import KeepDiscard from '../validations/KeepDiscard';
+import InvalidateTripDiary from '../validations/InvalidateTripDiary';
 import AuditDisplay from '../AuditDisplay';
 
 export interface PersonPanelProps {
@@ -42,6 +43,7 @@ export interface PersonPanelProps {
     selectPlace: (path: string | undefined) => void;
     selectTrip: (uuid: string | undefined) => void;
     keepDiscard: (params: { choice: string; personId: string }) => void;
+    invalidateTripDiary: (params: { tripDiaryValid: boolean | undefined; personId: string }) => void;
     showAuditErrorCode?: boolean;
 }
 
@@ -56,9 +58,26 @@ export const PersonPanel = ({
     selectPlace,
     selectTrip,
     keepDiscard,
+    invalidateTripDiary,
     showAuditErrorCode
 }: PersonPanelProps) => {
     const { t } = useTranslation(['admin']);
+
+    // Track the trip diary validity locally so the box updates immediately on
+    // click (the deserialized person object is only refreshed on a new fetch)
+    const [tripDiaryValid, setTripDiaryValid] = React.useState(person.tripDiaryValid);
+    React.useEffect(() => {
+        setTripDiaryValid(person.tripDiaryValid);
+    }, [person.tripDiaryValid]);
+
+    const onInvalidateTripDiary = (data: { tripDiaryValid: boolean | undefined; personId: string }) => {
+        setTripDiaryValid(data.tripDiaryValid);
+        invalidateTripDiary(data);
+    };
+
+    // Only offer to invalidate the trip diary when the person has a non-empty
+    // journey, i.e. at least one visited place or trip that the export would drop
+    const hasTripDiary = (journey?.visitedPlaces?.length || 0) > 0 || (journey?.trips?.length || 0) > 0;
 
     // Handle visited places
     const visitedPlacesStats: JSX.Element[] = [];
@@ -283,10 +302,23 @@ export const PersonPanel = ({
                 </span>
             )}
             {audits && audits.length > 0 && <AuditDisplay audits={audits} showAuditErrorCode={showAuditErrorCode} />}
-            {visitedPlacesStats.length > 0 && <br />}
-            {visitedPlacesStats}
-            {tripsStats.length > 0 && <br />}
-            {tripsStats}
+            {hasTripDiary && (
+                <div className={`_trip-diary-box${tripDiaryValid === false ? ' _invalid' : ''}`}>
+                    <InvalidateTripDiary
+                        personId={personId}
+                        tripDiaryValid={tripDiaryValid}
+                        onChange={onInvalidateTripDiary}
+                    />
+                    {tripDiaryValid === false && (
+                        <p className="_red _oblique _small _trip-diary-invalid-message">
+                            {t('admin:interviewMember:TripDiaryInvalidMessage')}
+                        </p>
+                    )}
+                    {visitedPlacesStats}
+                    {tripsStats.length > 0 && <br />}
+                    {tripsStats}
+                </div>
+            )}
         </details>
     );
 };

--- a/packages/evolution-frontend/src/styles/survey/_admin.scss
+++ b/packages/evolution-frontend/src/styles/survey/_admin.scss
@@ -47,6 +47,43 @@
             }
         }
     }
+
+    // Boxed trip diary (visited places + trips) with the invalidate button in its
+    // top-right corner. Button colors are shared with the top toolbar via the
+    // _red / _active-background utilities.
+    ._trip-diary-box {
+        position: relative;
+        margin-top: 0.5rem;
+        padding: 0.5rem;
+        border: 1px solid rgba(0, 0, 0, 0.2);
+        border-radius: 4px;
+
+        // Highlight the box in red when the reviewer invalidated the trip diary
+        &._invalid {
+            background-color: rgba(settings.$red, 0.05);
+            border-color: rgba(settings.$red, 0.3);
+        }
+
+        ._trip-diary-invalid-message {
+            // Leave room for the invalidate button in the top-right corner
+            margin: 0 2rem 0.5rem 0;
+        }
+
+        ._member-trip-diary-invalidate {
+            position: absolute;
+            top: 0.25rem;
+            right: 0.25rem;
+            padding: 0.15rem 0.4rem;
+            background: none;
+            border: none;
+            cursor: pointer;
+
+            // Let the button's native title (tooltip) show on hover over the icon
+            svg {
+                pointer-events: none;
+            }
+        }
+    }
 }
 
 .admin-widget-container._full-width {


### PR DESCRIPTION
## Summary

Adds a way for reviewers to validate/invalidate a single person's whole trip diary from the admin review column, and to exclude an invalidated diary from the trips/visited places export (fixes #1675).

- **Review UI**: the trip diary (visited places + trips) is now boxed in `PersonPanel`. A single icon button sits in the box's top-right corner:
  - valid → red `ban` icon, click invalidates the diary;
  - invalid → green `check` icon, click revalidates (clears the flag);
  - when invalidated, the box turns red (border/background, same red as the toolbar) and shows a red oblique message "Trip diary invalidated and ignored in the export".
  - The button only shows when the person actually has a non-empty trip diary (at least one visited place or trip).
- **Data model**: stored as `tripDiaryValid` on the person in the corrected response (`false` = invalid, `undefined`/`true` = valid). Added to `Person` base object (attribute, type, getter/setter, boolean validation).
- **Export**: `exportAllToCsvBySurveyObject` skips the journeys/visited places of persons whose `tripDiaryValid === false`, while keeping their socio-demographic attributes and non-trip-diary answers.

## Test plan

- [x] `Person.test.ts`: new `tripDiaryValid` boolean validation covered by the parametric attribute tests.
- [x] `exportAllToCsvByObject.test.ts`: new test asserts an invalidated person's journey/visited place are excluded from the export while the person row (incl. `tripDiaryValid`) is kept.
- [x] Frontend + common type-check pass.
- [x] Manually tested in the demo survey admin: toggle, box highlight, message, and corrected-response export exclusion.

code by Claude Opus 4.8, reviewed by @kaligrafy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a way to mark a person’s trip diary as invalid or restore it from the admin review view.
  * Trip diary status is now shown more clearly with updated messaging and visual cues.
* **Bug Fixes**
  * Invalid trip diaries are excluded from trip and visited-place exports, while the person’s other information remains exported.
  * Exported data now preserves the trip diary validity status for review and auditing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->