### PR TITLE
audits: add HH_M_AtLeastOnePersonWithDisability check

### DIFF
--- a/locales/en/audits.json
+++ b/locales/en/audits.json
@@ -16,6 +16,7 @@
     "HH_L_InvalidPersonSequences": "At least one person sequence is invalid",
     "HH_L_CarNumberVehiclesCountMismatch": "Car number and vehicles count mismatch",
     "HH_M_Home": "Home is missing",
+    "HH_M_AtLeastOnePersonWithDisability": "At least one person with disability is missing",
 
     "HM_I_preGeographyAndHomeGeographyTooFarApartError": "Pre-filled and declared home geographies are far apart",
     "HM_I_preGeographyAndHomeGeographyTooFarApartWarning": "Pre-filled and declared home geographies are a bit far apart",

--- a/locales/fr/audits.json
+++ b/locales/fr/audits.json
@@ -16,6 +16,7 @@
     "HH_L_InvalidPersonSequences": "Le numéro de séquence d'au moins une personne est invalide",
     "HH_L_CarNumberVehiclesCountMismatch": "Le nombre de véhicules automobiles et le nombre de véhicules déclarés ne correspondent pas",
     "HH_M_Home": "Le domicile est manquant",
+    "HH_M_AtLeastOnePersonWithDisability": "La présence d'au moins une personne avec un handicap est manquante",
 
     "HM_I_preGeographyAndHomeGeographyTooFarApartError": "Les géographies pré-remplie et déclarée du domicile sont éloignées",
     "HM_I_preGeographyAndHomeGeographyTooFarApartWarning": "Les géographies pré-remplie et déclarée du domicile sont un peu éloignées",

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/HouseholdAuditChecks.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/HouseholdAuditChecks.ts
@@ -196,6 +196,32 @@ export const householdAuditChecks: { [errorCode: string]: HouseholdAuditCheckFun
     },
 
     /**
+     * Check if atLeastOnePersonWithDisability is missing for multi-person households.
+     * For single-person households, disability is asked per person instead.
+     * @param context - HouseholdAuditCheckContext
+     * @returns AuditForObject
+     */
+    HH_M_AtLeastOnePersonWithDisability: (context: HouseholdAuditCheckContext): AuditForObject | undefined => {
+        const { household } = context;
+        const size = household.size;
+        const atLeastOnePersonWithDisability = household.atLeastOnePersonWithDisability;
+
+        if (size !== undefined && size > 1 && atLeastOnePersonWithDisability === undefined) {
+            return {
+                objectType: 'household',
+                objectUuid: household._uuid!,
+                errorCode: 'HH_M_AtLeastOnePersonWithDisability',
+                version: 1,
+                level: 'error',
+                message: 'At least one person with disability is missing',
+                ignore: false
+            };
+        }
+
+        return undefined; // No audit needed
+    },
+
+    /**
      * Check if car number and vehicles count mismatch
      * validate car number is equal to vehicles count
      * Only check if household has vehicles and car number is defined

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/household/HH_M_AtLeastOnePersonWithDisability.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/household/HH_M_AtLeastOnePersonWithDisability.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { v4 as uuidV4 } from 'uuid';
+import { householdAuditChecks } from '../../HouseholdAuditChecks';
+import { createContextWithHouseholdAndHome } from './testHelper';
+
+describe('HH_M_AtLeastOnePersonWithDisability audit check', () => {
+    const validHouseholdUuid = uuidV4();
+    const validHomeUuid = uuidV4();
+
+    // [title, size, atLeastOnePersonWithDisability, shouldError]
+    const cases: [string, number | undefined, string | undefined, boolean][] = [
+        ['missing when size > 1', 3, undefined, true],
+        ['defined when size > 1 does not error', 3, 'yes', false],
+        ['defined as no when size > 1 does not error', 2, 'no', false],
+        ['single-person household does not require the field', 1, undefined, false],
+        ['undefined size does not error', undefined, undefined, false],
+        ['size 0 does not error (size validity is HH_I_Size)', 0, undefined, false]
+    ];
+
+    it.each(cases)('%s', (_title, size, atLeastOnePersonWithDisability, shouldError) => {
+        const context = createContextWithHouseholdAndHome(
+            { size, atLeastOnePersonWithDisability },
+            undefined,
+            validHouseholdUuid,
+            validHomeUuid
+        );
+
+        const result = householdAuditChecks.HH_M_AtLeastOnePersonWithDisability(context);
+
+        if (shouldError) {
+            expect(result).toMatchObject({
+                objectType: 'household',
+                objectUuid: validHouseholdUuid,
+                errorCode: 'HH_M_AtLeastOnePersonWithDisability',
+                version: 1,
+                level: 'error',
+                message: 'At least one person with disability is missing',
+                ignore: false
+            });
+        } else {
+            expect(result).toBeUndefined();
+        }
+    });
+});


### PR DESCRIPTION
## Summary

Porte `H_M_atLeastOnePersonWithDisability` d'od_mtl_2023 : erreur si `atLeastOnePersonWithDisability` est manquant pour un ménage de plus d'une personne (`size > 1`). Pour un ménage à une personne, le handicap est demandé au niveau personne (`hasDisability`), pas au niveau ménage.

## Test plan

- [x] Tests paramétriques `HH_M_AtLeastOnePersonWithDisability.test.ts`
- [x] `AuditLocales` (en/fr)