### PR TITLE
audits: add HH_L_InvalidPersonSequences check

### DIFF
--- a/locales/en/audits.json
+++ b/locales/en/audits.json
@@ -13,6 +13,7 @@
     "HH_M_CarNumber": "Car number is missing",
     "HH_I_CarNumber": "Car number is out of range (should be an integer between 0 and 13)",
     "HH_L_SizeMembersCountMismatch": "Size and members count mismatch",
+    "HH_L_InvalidPersonSequences": "At least one person sequence is invalid",
     "HH_L_CarNumberVehiclesCountMismatch": "Car number and vehicles count mismatch",
     "HH_M_Home": "Home is missing",
 

--- a/locales/fr/audits.json
+++ b/locales/fr/audits.json
@@ -13,6 +13,7 @@
     "HH_M_CarNumber": "Le nombre de véhicules automobiles est manquant",
     "HH_I_CarNumber": "Le nombre de véhicules automobiles est en dehors de la plage autorisée (devrait être un entier entre 0 et 13)",
     "HH_L_SizeMembersCountMismatch": "La taille du ménage et le nombre de personnes ne correspondent pas",
+    "HH_L_InvalidPersonSequences": "Le numéro de séquence d'au moins une personne est invalide",
     "HH_L_CarNumberVehiclesCountMismatch": "Le nombre de véhicules automobiles et le nombre de véhicules déclarés ne correspondent pas",
     "HH_M_Home": "Le domicile est manquant",
 

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/HouseholdAuditChecks.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/HouseholdAuditChecks.ts
@@ -164,6 +164,38 @@ export const householdAuditChecks: { [errorCode: string]: HouseholdAuditCheckFun
     },
 
     /**
+     * Check that each household member _sequence matches its index (1..n).
+     * PersonFactory already sorts members by _sequence; this verifies the
+     * resulting order and that sequences form a contiguous 1..n range.
+     * @param context - HouseholdAuditCheckContext
+     * @returns AuditForObject
+     */
+    HH_L_InvalidPersonSequences: (context: HouseholdAuditCheckContext): AuditForObject | undefined => {
+        const { household } = context;
+        const members = household.members;
+
+        if (!members || members.length === 0) {
+            return undefined;
+        }
+
+        for (let i = 0; i < members.length; i++) {
+            if (members[i].attributes._sequence !== i + 1) {
+                return {
+                    objectType: 'household',
+                    objectUuid: household._uuid!,
+                    errorCode: 'HH_L_InvalidPersonSequences',
+                    version: 1,
+                    level: 'error',
+                    message: 'At least one person sequence is invalid',
+                    ignore: false
+                };
+            }
+        }
+
+        return undefined; // No audit needed
+    },
+
+    /**
      * Check if car number and vehicles count mismatch
      * validate car number is equal to vehicles count
      * Only check if household has vehicles and car number is defined

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/household/HH_L_InvalidPersonSequences.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/household/HH_L_InvalidPersonSequences.test.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { v4 as uuidV4 } from 'uuid';
+import { householdAuditChecks } from '../../HouseholdAuditChecks';
+import { createContextWithHouseholdAndHome } from './testHelper';
+import { Person } from 'evolution-common/lib/services/baseObjects/Person';
+import { SurveyObjectsRegistry } from 'evolution-common/lib/services/baseObjects/SurveyObjectsRegistry';
+
+describe('HH_L_InvalidPersonSequences audit check', () => {
+    const validHouseholdUuid = uuidV4();
+    const validHomeUuid = uuidV4();
+    const surveyObjectsRegistry = new SurveyObjectsRegistry();
+
+    const makeMember = (sequence: number | undefined) =>
+        new Person({ _uuid: uuidV4(), _sequence: sequence }, surveyObjectsRegistry);
+
+    /** Build members as PersonFactory would after sorting by _sequence */
+    const makeMembersAfterFactory = (sequences: (number | undefined)[]) =>
+        [...sequences]
+            .sort((a, b) => (a ?? 0) - (b ?? 0))
+            .map((sequence) => makeMember(sequence));
+
+    // [title, sequences, shouldError, simulateFactorySort]
+    const cases: [string, (number | undefined)[], boolean, boolean][] = [
+        ['valid sequences 1..3', [1, 2, 3], false, true],
+        ['single person with sequence 1', [1], false, true],
+        ['members not sorted by sequence', [3, 1, 2], true, false],
+        ['gap in sequences', [1, 3], true, true],
+        ['sequences not starting at 1', [2, 3], true, true],
+        ['duplicate sequences', [1, 1], true, true],
+        ['missing sequence', [undefined], true, true],
+        ['mixed valid and missing sequence', [1, undefined], true, true]
+    ];
+
+    it.each(cases)('%s', (_title, sequences, shouldError, simulateFactorySort) => {
+        const members = simulateFactorySort ? makeMembersAfterFactory(sequences) : sequences.map((s) => makeMember(s));
+        const context = createContextWithHouseholdAndHome(
+            { members },
+            undefined,
+            validHouseholdUuid,
+            validHomeUuid
+        );
+
+        const result = householdAuditChecks.HH_L_InvalidPersonSequences(context);
+
+        if (shouldError) {
+            expect(result).toMatchObject({
+                objectType: 'household',
+                objectUuid: validHouseholdUuid,
+                errorCode: 'HH_L_InvalidPersonSequences',
+                version: 1,
+                level: 'error',
+                message: 'At least one person sequence is invalid',
+                ignore: false
+            });
+        } else {
+            expect(result).toBeUndefined();
+        }
+    });
+
+    it('should pass when members is undefined', () => {
+        const context = createContextWithHouseholdAndHome(
+            { members: undefined },
+            undefined,
+            validHouseholdUuid,
+            validHomeUuid
+        );
+
+        expect(householdAuditChecks.HH_L_InvalidPersonSequences(context)).toBeUndefined();
+    });
+
+    it('should pass when members is empty', () => {
+        const context = createContextWithHouseholdAndHome(
+            { members: [] },
+            undefined,
+            validHouseholdUuid,
+            validHomeUuid
+        );
+
+        expect(householdAuditChecks.HH_L_InvalidPersonSequences(context)).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## Summary

Porte `H_L_invalidPersonSequences` d'od_mtl_2023 : erreur si `members[i]._sequence !== i + 1`. `PersonFactory` trie déjà les membres par `_sequence` — ce check valide l'ordre résultant et une plage contiguë 1..n (gaps, doublons, séquences manquantes, ou tableau non trié).

## Test plan

- [x] Tests paramétriques `HH_L_InvalidPersonSequences.test.ts` (incl. membres non triés → erreur)
- [x] `AuditLocales` (en/fr)