### PR TITLE
accessCodeFormatter: get the configured access code globally

### DIFF
--- a/packages/evolution-common/src/utils/__tests__/formatters.test.ts
+++ b/packages/evolution-common/src/utils/__tests__/formatters.test.ts
@@ -10,7 +10,7 @@ import { getAccessCodeFormat } from '../../services/accessCode/accessCodeFormats
 
 describe('helper', () => {
   describe('accessCodeFormatter', () => {
-    test.each([
+    describe.each([
       // Test case format: [description, format name, input, expected output]
       // Dashes are inserted eagerly as soon as a group is complete, letters are upper-cased.
       ['8 digits formats as 0000-0000', '0000-0000', '12345678', '1234-5678'],
@@ -31,7 +31,19 @@ describe('helper', () => {
       ['letters then digits ABC-000-000', 'ABC-000-000', 'abc123456', 'ABC-123-456'],
       ['mixed ABC-000-000 with typed dashes', 'ABC-000-000', 'abc-123-456', 'ABC-123-456'],
     ])('%s: %s => %s', (_, formatName, input, expected) => {
-      expect(accessCodeFormatter(input, getAccessCodeFormat(formatName as any))).toBe(expected);
+      test('function call with formatter parameter', () => {
+        expect(accessCodeFormatter(input, getAccessCodeFormat(formatName as any))).toBe(expected);
+      });
+
+      test('using the project configured format as default', async() => {
+        await jest.isolateModulesAsync(async () => {
+          const { default: projectConfig } = await import('../../config/project.config');
+          projectConfig.accessCodeFormat = formatName as any;
+          const { accessCodeFormatter } = await import('../formatters');
+
+          expect(accessCodeFormatter(input)).toBe(expected);
+        });
+      })
     });
   });
 

--- a/packages/evolution-common/src/utils/formatters.ts
+++ b/packages/evolution-common/src/utils/formatters.ts
@@ -5,12 +5,14 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 
+import projectConfig from '../config/project.config';
 import {
     type AccessCodeFormat,
     getAccessCodeFormat,
     normalizeAccessCode
 } from '../services/accessCode/accessCodeFormats';
 
+const accessCodeFormat = getAccessCodeFormat(projectConfig.accessCodeFormat);
 /**
  * Format an access code while typing, following the provided format. For
  * example, `'0000-0000'` produces `1234-5678` and `'ABC-000-000'` produces
@@ -19,10 +21,11 @@ import {
  * dropped and dashes are inserted at group boundaries.
  *
  * @param input The input to format
- * @param format The access code format describing the successive groups
+ * @param [format] The access code format describing the successive groups.
+ * Defaults to the configured access code
  * @returns The formatted access code
  */
-export const accessCodeFormatter = (input: string, format: AccessCodeFormat): string =>
+export const accessCodeFormatter = (input: string, format: AccessCodeFormat = accessCodeFormat): string =>
     normalizeAccessCode(input, format);
 
 /**


### PR DESCRIPTION
fixes #1684

Make the `accessCodeFormatter`'s second argument optional, which defaults to the configured access code format. This makes the signature compatible to use directly in widget's `inputFilter` property, allowing the generator to generate widgets using this function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Access code formatting now automatically uses the project’s configured default format when no format is provided.
  * Formatter behavior is clearer in the documentation, with the default setting now reflected in the API notes.

* **Tests**
  * Expanded formatter coverage to verify the default formatting behavior and updated test structure for readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->