### PR TITLE
audits: add HH_F_AtLeastOneTransitSegmentInHousehold check

### DIFF
--- a/locales/en/audits.json
+++ b/locales/en/audits.json
@@ -16,6 +16,7 @@
     "HH_L_SizeMembersCountMismatch": "Size and members count mismatch",
     "HH_L_InvalidPersonSequences": "At least one person sequence is invalid",
     "HH_L_CarNumberVehiclesCountMismatch": "Car number and vehicles count mismatch",
+    "HH_F_AtLeastOneTransitSegmentInHousehold": "At least one transit trip in household",
     "HH_M_Home": "Home is missing",
     "HH_M_AtLeastOnePersonWithDisability": "At least one person with disability is missing",
 

--- a/locales/fr/audits.json
+++ b/locales/fr/audits.json
@@ -16,6 +16,7 @@
     "HH_L_SizeMembersCountMismatch": "La taille du ménage et le nombre de personnes ne correspondent pas",
     "HH_L_InvalidPersonSequences": "Le numéro de séquence d'au moins une personne est invalide",
     "HH_L_CarNumberVehiclesCountMismatch": "Le nombre de véhicules automobiles et le nombre de véhicules déclarés ne correspondent pas",
+    "HH_F_AtLeastOneTransitSegmentInHousehold": "Au moins un déplacement transport collectif dans le ménage",
     "HH_M_Home": "Le domicile est manquant",
     "HH_M_AtLeastOnePersonWithDisability": "La présence d'au moins une personne avec un handicap est manquante",
 

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/HouseholdAuditChecks.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/HouseholdAuditChecks.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, Polytechnique Montreal and contributors
+ * Copyright Polytechnique Montreal and contributors
  *
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
@@ -263,6 +263,33 @@ export const householdAuditChecks: { [errorCode: string]: HouseholdAuditCheckFun
                 version: 1,
                 level: 'warning',
                 message: 'Car number per potential driving license holder > 3',
+                ignore: false
+            };
+        }
+
+        return undefined; // No audit needed
+    },
+
+    /**
+     * Info flag when the household has at least one transit segment in any trip.
+     * @param context - HouseholdAuditCheckContext
+     * @returns AuditForObject
+     */
+    HH_F_AtLeastOneTransitSegmentInHousehold: (context: HouseholdAuditCheckContext): AuditForObject | undefined => {
+        const { household } = context;
+
+        const hasTransitSegment = (household.members ?? []).some((person) =>
+            (person.journeys ?? []).some((journey) => (journey.trips ?? []).some((trip) => trip.hasTransit()))
+        );
+
+        if (hasTransitSegment) {
+            return {
+                objectType: 'household',
+                objectUuid: household.uuid!,
+                errorCode: 'HH_F_AtLeastOneTransitSegmentInHousehold',
+                version: 1,
+                level: 'info',
+                message: 'At least one transit trip in household',
                 ignore: false
             };
         }

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/household/HH_F_AtLeastOneTransitSegmentInHousehold.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/household/HH_F_AtLeastOneTransitSegmentInHousehold.test.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { v4 as uuidV4 } from 'uuid';
+import { householdAuditChecks } from '../../HouseholdAuditChecks';
+import { createContextWithHouseholdAndHome } from './testHelper';
+import { Person } from 'evolution-common/lib/services/baseObjects/Person';
+import { Journey } from 'evolution-common/lib/services/baseObjects/Journey';
+import { Trip } from 'evolution-common/lib/services/baseObjects/Trip';
+import { Segment } from 'evolution-common/lib/services/baseObjects/Segment';
+import { Mode } from 'evolution-common/lib/services/baseObjects/attributeTypes/SegmentAttributes';
+import { SurveyObjectsRegistry } from 'evolution-common/lib/services/baseObjects/SurveyObjectsRegistry';
+
+describe('HH_F_AtLeastOneTransitSegmentInHousehold audit check', () => {
+    const validHouseholdUuid = uuidV4();
+    const validHomeUuid = uuidV4();
+    const surveyObjectsRegistry = new SurveyObjectsRegistry();
+
+    const expectedInfoAudit = {
+        objectType: 'household',
+        objectUuid: validHouseholdUuid,
+        errorCode: 'HH_F_AtLeastOneTransitSegmentInHousehold',
+        version: 1,
+        level: 'info',
+        message: 'At least one transit trip in household',
+        ignore: false
+    };
+
+    /**
+     * A household member with one journey, one trip and one segment using
+     * the given mode. Used as the fully-populated starting point; individual
+     * tests then remove one link of the chain to check it is handled.
+     */
+    const makePersonWithSegmentMode = (mode: Mode): Person => {
+        const trip = new Trip({ _uuid: uuidV4() }, surveyObjectsRegistry);
+        trip.segments = [new Segment({ _uuid: uuidV4(), mode }, surveyObjectsRegistry)];
+
+        const journey = new Journey({ _uuid: uuidV4() }, surveyObjectsRegistry);
+        journey.trips = [trip];
+
+        const person = new Person({ _uuid: uuidV4() }, surveyObjectsRegistry);
+        person.journeys = [journey];
+        return person;
+    };
+
+    const runCheck = (members: Person[] | undefined) => {
+        const context = createContextWithHouseholdAndHome({ members }, undefined, validHouseholdUuid, validHomeUuid);
+        return householdAuditChecks.HH_F_AtLeastOneTransitSegmentInHousehold(context);
+    };
+
+    it('flags a household with a transit segment', () => {
+        const result = runCheck([makePersonWithSegmentMode('transitBus')]);
+        expect(result).toMatchObject(expectedInfoAudit);
+    });
+
+    it('does not flag a household with only non-transit segments', () => {
+        const result = runCheck([makePersonWithSegmentMode('walk'), makePersonWithSegmentMode('carDriver')]);
+        expect(result).toBeUndefined();
+    });
+
+    it.each([
+        ['members is undefined', undefined],
+        ['members is empty', []]
+    ] as [string, Person[] | undefined][])('does not flag when %s', (_title, members) => {
+        expect(runCheck(members)).toBeUndefined();
+    });
+
+    it('does not flag when a member has no journeys', () => {
+        const person = makePersonWithSegmentMode('transitBus');
+        person.journeys = undefined;
+        expect(runCheck([person])).toBeUndefined();
+    });
+
+    it('does not flag when a journey has no trips', () => {
+        const person = makePersonWithSegmentMode('transitBus');
+        (person.journeys as Journey[])[0].trips = undefined;
+        expect(runCheck([person])).toBeUndefined();
+    });
+
+    it('does not flag when a trip has no segments', () => {
+        const person = makePersonWithSegmentMode('transitBus');
+        (person.journeys as Journey[])[0].trips![0].segments = undefined;
+        expect(runCheck([person])).toBeUndefined();
+    });
+});

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/household/HH_F_AtLeastOneTransitSegmentInHousehold.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/household/HH_F_AtLeastOneTransitSegmentInHousehold.test.ts
@@ -47,18 +47,25 @@ describe('HH_F_AtLeastOneTransitSegmentInHousehold audit check', () => {
         return person;
     };
 
-    const runCheck = (members: Person[] | undefined) => {
+    /**
+     * Builds a household audit context for the given members and runs the
+     * HH_F_AtLeastOneTransitSegmentInHousehold check against it.
+     */
+    const runAtLeastOneTransitSegmentCheck = (members: Person[] | undefined) => {
         const context = createContextWithHouseholdAndHome({ members }, undefined, validHouseholdUuid, validHomeUuid);
         return householdAuditChecks.HH_F_AtLeastOneTransitSegmentInHousehold(context);
     };
 
     it('flags a household with a transit segment', () => {
-        const result = runCheck([makePersonWithSegmentMode('transitBus')]);
+        const result = runAtLeastOneTransitSegmentCheck([makePersonWithSegmentMode('transitBus')]);
         expect(result).toMatchObject(expectedInfoAudit);
     });
 
     it('does not flag a household with only non-transit segments', () => {
-        const result = runCheck([makePersonWithSegmentMode('walk'), makePersonWithSegmentMode('carDriver')]);
+        const result = runAtLeastOneTransitSegmentCheck([
+            makePersonWithSegmentMode('walk'),
+            makePersonWithSegmentMode('carDriver')
+        ]);
         expect(result).toBeUndefined();
     });
 
@@ -66,24 +73,24 @@ describe('HH_F_AtLeastOneTransitSegmentInHousehold audit check', () => {
         ['members is undefined', undefined],
         ['members is empty', []]
     ] as [string, Person[] | undefined][])('does not flag when %s', (_title, members) => {
-        expect(runCheck(members)).toBeUndefined();
+        expect(runAtLeastOneTransitSegmentCheck(members)).toBeUndefined();
     });
 
     it('does not flag when a member has no journeys', () => {
         const person = makePersonWithSegmentMode('transitBus');
         person.journeys = undefined;
-        expect(runCheck([person])).toBeUndefined();
+        expect(runAtLeastOneTransitSegmentCheck([person])).toBeUndefined();
     });
 
     it('does not flag when a journey has no trips', () => {
         const person = makePersonWithSegmentMode('transitBus');
         (person.journeys as Journey[])[0].trips = undefined;
-        expect(runCheck([person])).toBeUndefined();
+        expect(runAtLeastOneTransitSegmentCheck([person])).toBeUndefined();
     });
 
     it('does not flag when a trip has no segments', () => {
         const person = makePersonWithSegmentMode('transitBus');
         (person.journeys as Journey[])[0].trips![0].segments = undefined;
-        expect(runCheck([person])).toBeUndefined();
+        expect(runAtLeastOneTransitSegmentCheck([person])).toBeUndefined();
     });
 });

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/household/testHelper.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/household/testHelper.ts
@@ -16,6 +16,9 @@ import { createMockHome } from '../home/testHelper';
 export const createMockHousehold = (overrides: Partial<Household> = {}, validUuid = uuidV4()) => {
     return {
         _uuid: validUuid,
+        get uuid() {
+            return this._uuid;
+        },
         size: 3,
         ...overrides
     } as Household;


### PR DESCRIPTION
## Summary
- Port `H_F_atLeastOneTransitSegmentInHousehold` from od_mtl_2023 as `HH_F_AtLeastOneTransitSegmentInHousehold` (version 1)
- Info-level flag when any household trip has a transit segment (`trip.hasTransit()`)
- EN/FR locale strings and parametric unit tests (transit vs non-transit, empty chains)

## Test plan
- [x] `yarn jest packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/household/HH_F_AtLeastOneTransitSegmentInHousehold.test.ts`
- [x] `yarn jest packages/evolution-backend/src/services/audits/__tests__/AuditLocales.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new household audit that flags when at least one trip includes a transit segment.
  * Added English and French message text for the new audit.
* **Tests**
  * Added coverage for transit vs. non-transit scenarios, including cases with missing or empty intermediate household data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->