### PR TITLE
segments: Add a modePre to mode mapping

### DIFF
--- a/packages/evolution-common/src/services/odSurvey/types.ts
+++ b/packages/evolution-common/src/services/odSurvey/types.ts
@@ -82,7 +82,7 @@ export const modeValues = [
 
 export type Mode = (typeof modeValues)[number];
 
-export const modePreValues = [
+export const defaultModePreValues = [
     'carDriver',
     'carPassenger',
     'walk',
@@ -98,12 +98,11 @@ export const modePreValues = [
     'dontKnow',
     'preferNotToAnswer'
 ] as const;
-export type ModePre = (typeof modePreValues)[number];
 
 /**
  * Map each mode to the mode categories under which they should appear
  */
-export const modeToModePreMap: { [mode in Mode]: ModePre[] } = {
+export const defaultModeToModePreMap: { [mode in Mode]: string[] } = {
     walk: ['walk'],
     bicycle: ['bicycle'],
     bicyclePassenger: ['bicycle'],
@@ -152,7 +151,7 @@ export const modeToModePreMap: { [mode in Mode]: ModePre[] } = {
  * Map each mode category to the modes that belong to it, it is the reverse of
  * the modeToModePreMap
  */
-export const modePreToModeMap: { [modePre in ModePre]: Mode[] } = Object.entries(modeToModePreMap).reduce(
+export const defaultModePreToModeMap: { [modePre: string]: Mode[] } = Object.entries(defaultModeToModePreMap).reduce(
     (acc, [mode, modePres]) => {
         modePres.forEach((modePre) => {
             if (!acc[modePre]) {
@@ -162,10 +161,10 @@ export const modePreToModeMap: { [modePre in ModePre]: Mode[] } = Object.entries
         });
         return acc;
     },
-    modePreValues.reduce((acc, modePre) => {
+    defaultModePreValues.reduce((acc, modePre) => {
         acc[modePre] = [];
         return acc;
-    }, {}) as { [key in ModePre]: Mode[] }
+    }, {}) as { [modePre: string]: Mode[] }
 );
 
 export const activityCategoryValues = [

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/helpers.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/helpers.test.ts
@@ -11,7 +11,7 @@ import { interviewAttributesForTestCases, setActiveSurveyObjects } from '../../.
 import { getResponse, setResponse } from '../../../../../utils/helpers';
 import * as helpers from '../helpers';
 import type { Journey, Person, Segment, UserInterviewAttributes } from '../../../types';
-import { modeValues, Mode } from '../../../../odSurvey/types';
+import { modeValues, Mode, defaultModePreToModeMap } from '../../../../odSurvey/types';
 
 describe('getPreviousTripSingleSegment', () => {
 
@@ -546,8 +546,13 @@ describe('Mode/modePre filtering based on configuration', () => {
     });
 
     test('getFilteredModesPre should only include categories with available modes', () => {
+        const segmentConfig = {
+            type: 'segments' as const,
+            enabled: true,
+            modesIncludeOnly: ['walk', 'bicycle', 'bicycleElectric'] as Mode[]
+        };
         const availableModes = ['walk', 'bicycle', 'bicycleElectric'] as Mode[];
-        const filteredModesPre = helpers.getFilteredModesPre(availableModes);
+        const filteredModesPre = helpers.getFilteredModesPre(segmentConfig, availableModes);
 
         // Should include walk and bicycle categories
         expect(filteredModesPre).toContain('walk');
@@ -560,8 +565,13 @@ describe('Mode/modePre filtering based on configuration', () => {
     });
 
     test('getFilteredModesPre should include transit when any transit mode is available', () => {
+        const segmentConfig = {
+            type: 'segments' as const,
+            enabled: true,
+            modesIncludeOnly: ['transitBus', 'walk'] as Mode[]
+        };
         const availableModes = ['transitBus', 'walk'] as Mode[];
-        const filteredModesPre = helpers.getFilteredModesPre(availableModes);
+        const filteredModesPre = helpers.getFilteredModesPre(segmentConfig, availableModes);
 
         // Should include transit because transitBus is available
         expect(filteredModesPre).toContain('transit');
@@ -571,8 +581,13 @@ describe('Mode/modePre filtering based on configuration', () => {
     });
 
     test('getFilteredModesPre should handle modes that belong to multiple categories', () => {
+        const segmentConfig = {
+            type: 'segments' as const,
+            enabled: true,
+            modesIncludeOnly: ['wheelchair', 'mobilityScooter'] as Mode[]
+        };
         const availableModes = ['wheelchair', 'mobilityScooter'] as Mode[];
-        const filteredModesPre = helpers.getFilteredModesPre(availableModes);
+        const filteredModesPre = helpers.getFilteredModesPre(segmentConfig, availableModes);
 
         // wheelchair and mobilityScooter belong to both 'walk' and 'other'
         expect(filteredModesPre).toContain('walk');
@@ -581,6 +596,125 @@ describe('Mode/modePre filtering based on configuration', () => {
         expect(filteredModesPre).not.toContain('carDriver');
         expect(filteredModesPre.length).toEqual(2);
     });
+
+    test('getFilteredModesPre should use the modeCategoryToModeMap when available', () => {
+        const segmentConfig = {
+            type: 'segments' as const,
+            enabled: true,
+            modesIncludeOnly: ['wheelchair', 'mobilityScooter'] as Mode[],
+            modeCategoryToModeMap: {
+                active: {
+                    modes: ['walk', 'bicycle'] as Mode[]
+                },
+                personal: {
+                    modes: ['carDriver', 'carPassenger'] as Mode[],
+                    label: 'segments:myLabel'
+                },
+                public: {
+                    modes: ['transitRRT', 'transitHSR'] as Mode[],
+                    icon: 'transitRRT' as Mode,
+                },
+                other: {
+                    modes: ['plane', 'transitBus'] as Mode[]
+                }
+            }
+        };
+        const availableModes = ['walk', 'bicycle', 'transitRRT', 'transitHSR', 'plane', 'carDriver', 'carPassenger'] as Mode[];
+        const filteredModesPre = helpers.getFilteredModesPre(segmentConfig, availableModes);
+
+        expect(filteredModesPre).toEqual(['active', 'personal', 'public', 'other']);
+    });
+
+    test('getFilteredModesPre should use the modeCategoryToModeMap when available, returning only categories with modes', () => {
+        const segmentConfig = {
+            type: 'segments' as const,
+            enabled: true,
+            modesIncludeOnly: ['wheelchair', 'mobilityScooter'] as Mode[],
+            modeCategoryToModeMap: {
+                active: {
+                    modes: ['walk', 'bicycle'] as Mode[]
+                },
+                personal: {
+                    modes: ['carDriver', 'carPassenger'] as Mode[],
+                    label: 'segments:myLabel'
+                },
+                public: {
+                    modes: ['transitRRT', 'transitHSR'] as Mode[],
+                    icon: 'transitRRT' as Mode,
+                },
+                other: {
+                    modes: ['plane', 'transitBus'] as Mode[]
+                }
+            }
+        };
+        // Should include only active and personal
+        const availableModes = ['walk', 'bicycle', 'carDriver', 'carPassenger'] as Mode[];
+        const filteredModesPre = helpers.getFilteredModesPre(segmentConfig, availableModes);
+
+        expect(filteredModesPre).toEqual(['active', 'personal']);
+    });
+
+    test('getFilteredModesPre should throw error when modes are missing from modeCategoryToModeMap', () => {
+        const segmentConfig = {
+            type: 'segments' as const,
+            enabled: true,
+            modesIncludeOnly: ['wheelchair', 'mobilityScooter'] as Mode[],
+            modeCategoryToModeMap: {
+                active: {
+                    modes: ['walk', 'bicycle'] as Mode[]
+                },
+                personal: {
+                    modes: ['carDriver', 'carPassenger'] as Mode[],
+                    label: 'segments:myLabel'
+                },
+                public: {
+                    modes: ['transitRRT', 'transitHSR'] as Mode[],
+                    icon: 'transitRRT' as Mode,
+                },
+                other: {
+                    modes: ['plane', 'transitBus'] as Mode[]
+                }
+            }
+        };
+        // 'dontKnow' is in no category
+        const availableModes = ['walk', 'bicycle', 'carDriver', 'carPassenger', 'dontKnow'] as Mode[];
+
+        expect(() => helpers.getFilteredModesPre(segmentConfig, availableModes)).toThrow('modeCategoryToModeMap: some modes are not part of any mapping: dontKnow');
+    });
+
+    test('getModePreToModeMap should return default if no modeCategoryToModeMap', () => {
+        const segmentConfig = {
+            type: 'segments' as const,
+            enabled: true,
+            modesIncludeOnly: ['wheelchair', 'mobilityScooter'] as Mode[],
+        };
+        expect(helpers.getModePreToModeMap(segmentConfig)).toEqual(defaultModePreToModeMap);
+    });
+
+    test('getModePreToModeMap should return mapping from modeCategoryToModeMap', () => {
+        const segmentConfig = {
+            type: 'segments' as const,
+            enabled: true,
+            modesIncludeOnly: ['wheelchair', 'mobilityScooter'] as Mode[],
+            modeCategoryToModeMap: {
+                active: {
+                    modes: ['walk', 'bicycle'] as Mode[]
+                },
+                public: {
+                    modes: ['transitRRT', 'transitHSR', 'transitBus'] as Mode[],
+                    icon: 'transitRRT' as Mode,
+                },
+                other: {
+                    modes: ['plane', 'transitBus', 'walk'] as Mode[]
+                }
+            }
+        };
+        expect(helpers.getModePreToModeMap(segmentConfig)).toEqual({
+            active: ['walk', 'bicycle'],
+            public: ['transitRRT', 'transitHSR', 'transitBus'],
+            other: ['plane', 'transitBus', 'walk']
+        });
+    })
 });
 
 describe('getSegmentPreviousLocation and getSegmentNextLocation', () => {

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetSegmentMode.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetSegmentMode.test.ts
@@ -7,7 +7,7 @@
 import _upperFirst from 'lodash/upperFirst';
 import _cloneDeep from 'lodash/cloneDeep';
 import each from 'jest-each';
-import { InputRadioType, QuestionWidgetConfig, RadioChoiceType } from '../../../../questionnaire/types';
+import { InputRadioType, QuestionWidgetConfig, RadioChoiceType, SegmentSectionConfiguration } from '../../../../questionnaire/types';
 import { getModeWidgetConfig } from '../widgetSegmentMode';
 import { interviewAttributesForTestCases, widgetFactoryOptions } from '../../../../../tests/surveys';
 import { setResponse, translateString } from '../../../../../utils/helpers';
@@ -140,6 +140,47 @@ describe('Mode choices conditionals', () => {
             expect(mockedHhMayHaveDisability).not.toHaveBeenCalled();
         }
     });
+
+    describe('Test modePre conditional when a modeCategoryToModeMap is provided', () => {
+        const configuration: SegmentSectionConfiguration = {
+            ...segmentSectionConfig,
+            modesIncludeOnly: [ 'walk', 'bicycle', 'transitBus', 'carDriver', 'carPassenger', 'plane', 'dontKnow' ] as Mode[],
+            modeCategoryToModeMap: {
+                walking: { // Will use the fallback icon
+                    modes: ['walk'] as Mode[],
+                    label: `segments:mode:Walk`
+                },
+                bicycle: {
+                    modes: ['bicycle'] as Mode[]
+                },
+                transit: { // Should use icon from transit
+                    modes: ['transitBus', 'plane'] as Mode[],
+                    icon: 'transitBus' as Mode
+                },
+                carDriver: { // Should use conditional for carDriver
+                    modes: ['carDriver', 'carPassenger' ] as Mode[]
+                },
+                dontKnow: {
+                    modes: ['dontKnow'] as Mode[]
+                }
+            }
+        }
+        const widgetConfig = getModeWidgetConfig(configuration, widgetFactoryOptions) as QuestionWidgetConfig & InputRadioType;
+        const choices = widgetConfig.choices as RadioChoiceType[];
+
+        const modePres = ['walking', 'bicycle', 'transit', 'carDriver', 'dontKnow'];
+
+        each(
+            modePres.flatMap((modePre) => configuration.modesIncludeOnly!.map((mode) => [mode, modePre, (configuration.modeCategoryToModeMap as any)[modePre].modes.includes(mode as any)]))
+        ).test('Test modePre conditional for mode %s with modePre %s: %s', (choiceValue, modePreValue, expected) => {
+            // Find the right choice choice
+            const modeChoice = choices.find((choice) => choice.value === choiceValue);
+            expect(modeChoice).toBeDefined();
+            setResponse(interview, 'household.persons.personId1.journeys.journeyId1.trips.tripId1P1.segments.segmentId1P1T1.modePre', modePreValue);
+            const modeResult = modeChoice?.conditional?.(interview, 'household.persons.personId1.journeys.journeyId1.trips.tripId1P1.segments.segmentId1P1T1.mode');
+            expect(modeResult).toEqual(expected);
+        });
+    })
 
 });
 

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetSegmentMode.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetSegmentMode.test.ts
@@ -10,9 +10,9 @@ import each from 'jest-each';
 import { InputRadioType, QuestionWidgetConfig, RadioChoiceType } from '../../../../questionnaire/types';
 import { getModeWidgetConfig } from '../widgetSegmentMode';
 import { interviewAttributesForTestCases, widgetFactoryOptions } from '../../../../../tests/surveys';
-import { getResponse, setResponse, translateString } from '../../../../../utils/helpers';
+import { setResponse, translateString } from '../../../../../utils/helpers';
 import * as surveyHelper from '../../../../odSurvey/helpers';
-import { Mode, ModePre, modePreToModeMap, modeToModePreMap, modeValues } from '../../../../odSurvey/types';
+import { Mode, defaultModePreToModeMap, defaultModeToModePreMap, modeValues } from '../../../../odSurvey/types';
 import { shouldShowSameAsReverseTripQuestion, getPreviousTripSingleSegment } from '../helpers';
 import { modeToIconMapping } from '../modeIconMapping';
 
@@ -85,7 +85,7 @@ describe('Mode choices conditionals', () => {
     // modePreToModeMap to get the values, but filter out the modes that have
     // specific conditionals and that will be tested separately
     each(
-        modeValues.filter((mode) => !['wheelchair', 'mobilityScooter', 'paratransit'].includes(mode)).flatMap((mode) => Object.keys(modePreToModeMap).map((modePre) => [mode, modePre, modeToModePreMap[mode].includes(modePre as any)]))
+        modeValues.filter((mode) => !['wheelchair', 'mobilityScooter', 'paratransit'].includes(mode)).flatMap((mode) => Object.keys(defaultModePreToModeMap).map((modePre) => [mode, modePre, defaultModeToModePreMap[mode].includes(modePre as any)]))
     ).test('Test modePre conditional for mode %s with modePre %s: %s', (choiceValue, modePreValue, expected) => {
         // Find the right choice choice
         const modeChoice = choices.find((choice) => choice.value === choiceValue);
@@ -97,7 +97,7 @@ describe('Mode choices conditionals', () => {
 
     // Test specific conditional for modes, where person may have disability
     each(
-        ['wheelchair' as Mode, 'mobilityScooter' as Mode].flatMap((mode: Mode) => Object.keys(modePreToModeMap).flatMap((modePre) => [[true, mode, modePre, modeToModePreMap[mode].includes(modePre as ModePre)], [false, mode, modePre, modeToModePreMap[mode].includes(modePre as ModePre)]]))
+        ['wheelchair' as Mode, 'mobilityScooter' as Mode].flatMap((mode: Mode) => Object.keys(defaultModePreToModeMap).flatMap((modePre) => [[true, mode, modePre, defaultModeToModePreMap[mode].includes(modePre)], [false, mode, modePre, defaultModeToModePreMap[mode].includes(modePre)]]))
     ).test('Test modePre with person may have disability (%s) conditional for mode %s with modePre %s: %s', (personMayHaveDisability, choiceValue, modePreValue, expectedIfTrue) => {
         // Spy on the personMayHaveDisability function
         if (expectedIfTrue) {
@@ -120,7 +120,7 @@ describe('Mode choices conditionals', () => {
 
     // Test specific conditional for modes, where they may be disabilities in the household
     each(
-        ['paratransit' as Mode].flatMap((mode: Mode) => Object.keys(modePreToModeMap).flatMap((modePre) => [[true, mode, modePre, modeToModePreMap[mode].includes(modePre as ModePre)], [false, mode, modePre, modeToModePreMap[mode].includes(modePre as ModePre)]]))
+        ['paratransit' as Mode].flatMap((mode: Mode) => Object.keys(defaultModePreToModeMap).flatMap((modePre) => [[true, mode, modePre, defaultModeToModePreMap[mode].includes(modePre)], [false, mode, modePre, defaultModeToModePreMap[mode].includes(modePre)]]))
     ).test('Test modePre with hh may have disability (%s) conditional for mode %s with modePre %s: %s', (hhMayHaveDisability, choiceValue, modePreValue, expectedIfTrue) => {
         // Spy on the householdMayHaveDisability function
         if (expectedIfTrue) {

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetSegmentModePre.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetSegmentModePre.test.ts
@@ -109,6 +109,88 @@ describe('getModePreWidgetConfig', () => {
             conditional: expect.any(Function)
         });
     });
+
+    it('should return the correct widget config with a modeCategoryToModeMap configuration', () => {
+
+        const options = {
+            ...widgetFactoryOptions,
+            context: jest.fn()
+        };
+
+        const bicycleConditional = jest.fn();
+
+        const configuration = {
+            ...segmentSectionConfig,
+            modesIncludeOnly: [ 'walk', 'bicycle', 'transitBus', 'carDriver', 'carPassenger', 'plane', 'dontKnow' ] as Mode[],
+            modeCategoryToModeMap: {
+                walking: { // Will use the fallback icon
+                    modes: ['walk'] as Mode[],
+                    label: `segments:mode:Walk`
+                },
+                bicycle: { // Should have thsi conditional
+                    modes: ['bicycle'] as Mode[],
+                    conditional: bicycleConditional
+                },
+                transit: { // Should use icon from transit
+                    modes: ['transitBus', 'plane'] as Mode[],
+                    icon: 'transitBus' as Mode
+                },
+                carDriver: { // Should use conditional for carDriver
+                    modes: ['carDriver', 'carPassenger' ] as Mode[]
+                },
+                dontKnow: {
+                    modes: ['dontKnow'] as Mode[]
+                }
+            }
+        }
+
+        const widgetConfig = getModePreWidgetConfig(configuration, options);
+
+        expect(widgetConfig).toEqual({
+            type: 'question',
+            path: 'modePre',
+            inputType: 'radio',
+            twoColumns: false,
+            datatype: 'string',
+            iconSize: '2.25em',
+            columns: 2,
+            label: expect.any(Function),
+            choices: expect.arrayContaining([
+                expect.objectContaining({
+                    value: 'walking',
+                    label: expect.any(Function),
+                    conditional: undefined,
+                    iconPath: '/dist/icons/modes/other/air_balloon.svg'
+                }),
+                expect.objectContaining({
+                    value: 'bicycle',
+                    label: expect.any(Function),
+                    conditional: bicycleConditional,
+                    iconPath: '/dist/icons/modes/bicycle/bicycle_with_rider.svg'
+                }),
+                expect.objectContaining({
+                    value: 'transit',
+                    label: expect.any(Function),
+                    conditional: undefined,
+                    iconPath: '/dist/icons/modes/bus/bus_city.svg'
+                }),
+                expect.objectContaining({
+                    value: 'carDriver',
+                    label: expect.any(Function),
+                    conditional: expect.any(Function),
+                    iconPath: '/dist/icons/modes/car/car_driver_without_passenger.svg'
+                }),
+                expect.objectContaining({
+                    value: 'dontKnow',
+                    label: expect.any(Function),
+                    conditional: undefined,
+                    iconPath: '/dist/icons/modes/other/question_mark.svg'
+                })
+            ]),
+            validations: expect.any(Function),
+            conditional: expect.any(Function)
+        });
+    });
 });
 
 describe('Mode choices conditionals', () => {
@@ -215,6 +297,74 @@ describe('Mode choices conditionals', () => {
 
 });
 
+describe('Mode choices conditionals, from configurable map', () => {
+    // Include carDriver, to use the default conditional, transitBus, without condition and plane, with a condition
+    const otherConditional = jest.fn()
+    const configuration = {
+        ...segmentSectionConfig,
+        modesIncludeOnly: [ 'transitBus', 'carDriver', 'plane' ] as Mode[],
+        modeCategoryToModeMap: {
+            carDriver: { // Should use default conditional
+                modes: ['carDriver'] as Mode[]
+            },
+            transit: { // Should not have a conditional
+                modes: ['transitBus', 'plane'] as Mode[],
+            },
+            other: { // Should use conditional this conditional
+                modes: ['plane'] as Mode[],
+                conditional: otherConditional
+            }
+        }
+    }
+    const widgetConfig = getModePreWidgetConfig(configuration, widgetFactoryOptions) as QuestionWidgetConfig & InputRadioType;
+    const choices = widgetConfig.choices as RadioChoiceType[];
+
+    test('configured mode carDriver should use default conditional if the category has a conditional', () => {
+        // Prepare test data with active person/journey/trip
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        interview.response._activePersonId = 'personId1';
+        interview.response._activeJourneyId = 'journeyId1';
+        interview.response._activeTripId = 'tripId1P1';
+
+        // Find the carDriver choice
+        const carDriverChoice = choices.find((choice) => choice.value === 'carDriver');
+        expect(carDriverChoice).toBeDefined();
+        expect(carDriverChoice?.conditional).toEqual(expect.any(Function));
+        const carDriverResult = carDriverChoice?.conditional?.(interview, 'household.persons.personId1.journeys.journeyId1.trips.tripId1P1.segments.segmentId1P1T1.modePre');
+        expect(carDriverResult).toEqual(true);
+    });
+
+    test('configured mode transit should not have a conditional', () => {
+        // Prepare test data with active person/journey/trip
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        interview.response._activePersonId = 'personId2';
+        interview.response._activeJourneyId = 'journeyId2';
+        interview.response._activeTripId = 'tripId1P2';
+
+        // Find the transit choice
+        const transitChoice = choices.find((choice) => choice.value === 'transit');
+        expect(transitChoice).toBeDefined();
+        expect(transitChoice?.conditional).toBeUndefined();
+    });
+
+    test('configured mode other should use provided conditional', () => {
+        // Prepare test data with active person/journey/trip
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        interview.response._activePersonId = 'personId3';
+        interview.response._activeJourneyId = 'journeyId3';
+        interview.response._activeTripId = 'tripId1P3';
+
+        // Find the other choice
+        const otherChoice = choices.find((choice) => choice.value === 'other');
+        expect(otherChoice).toBeDefined();
+        expect(otherChoice?.conditional).toBeDefined();
+        otherConditional.mockReturnValue(true);
+        const otherResult = otherChoice?.conditional?.(interview, 'household.persons.personId3.journeys.journeyId3.trips.tripId1P2.segments.segmentId1P3T1.modePre');
+        expect(otherResult).toEqual(true);
+        expect(otherConditional).toHaveBeenCalledWith(interview, 'household.persons.personId3.journeys.journeyId3.trips.tripId1P2.segments.segmentId1P3T1.modePre')
+    });
+});
+
 describe('Mode choices labels', () => {
     // Prepare test data with active person/journey/trip
     const interview = _cloneDeep(interviewAttributesForTestCases);
@@ -251,6 +401,41 @@ describe('Mode choices labels', () => {
         translateString(choice?.label, { t: mockedT } as any, interview, 'path');
         expect(mockedT).toHaveBeenCalledWith('segments:modePre:WalkOrMobilityHelp');
     });
+
+    describe('should return the right label for configured mode category mapping', () => {
+        // Add labels to a simple choice mapping
+        const configuration = {
+            ...segmentSectionConfig,
+            modesIncludeOnly: [ 'transitBus', 'carDriver' ] as Mode[],
+            modeCategoryToModeMap: {
+                category1: { // Should use provided label
+                    modes: ['carDriver'] as Mode[],
+                    label: 'myLabel'
+                },
+                category2: { // Should append the category2 
+                    modes: ['transitBus'] as Mode[],
+                }
+            }
+        }
+        const widgetConfig = getModePreWidgetConfig(configuration, widgetFactoryOptions) as QuestionWidgetConfig & InputRadioType;
+        const choices = widgetConfig.choices as RadioChoiceType[];
+
+        test('should use provided label if available', () => {
+            const mockedT = jest.fn();
+            const choice = choices.find((choice) => choice.value === 'category1');
+            expect(choice).toBeDefined();
+            translateString(choice?.label, { t: mockedT } as any, interview, 'path');
+            expect(mockedT).toHaveBeenCalledWith('myLabel');
+        });
+
+        test('should fallback to adding the category to default namespace if not provided', () => {
+            const mockedT = jest.fn();
+            const choice = choices.find((choice) => choice.value === 'category2');
+            expect(choice).toBeDefined();
+            translateString(choice?.label, { t: mockedT } as any, interview, 'path');
+            expect(mockedT).toHaveBeenCalledWith('segments:modePre:Category2');
+        });
+    })
 
 });
 

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/helpers.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/helpers.ts
@@ -8,7 +8,7 @@
 import _isEqual from 'lodash/isEqual';
 import { isFeature, isPoint } from 'geojson-validation';
 import * as odHelpers from '../../../odSurvey/helpers';
-import { simpleModes, Mode, ModePre, modeValues, modePreValues, modeToModePreMap } from '../../../odSurvey/types';
+import { simpleModes, Mode, modeValues, defaultModePreValues, defaultModeToModePreMap } from '../../../odSurvey/types';
 import type { Optional } from '../../../../types/Optional.type';
 import type {
     Journey,
@@ -193,17 +193,17 @@ export const getFilteredModes = (segmentConfig: SegmentSectionConfiguration): Mo
  * Filter the available mode categories (modePre) based on the filtered modes.
  * Only keep modePre values that have at least one available mode.
  */
-export const getFilteredModesPre = (availableModes: Mode[]): ModePre[] => {
+export const getFilteredModesPre = (availableModes: Mode[]): string[] => {
     // Keep only modePre values that have at least one mode in the availableModes
-    return modePreValues.filter((modePre) => {
+    return defaultModePreValues.filter((modePre) => {
         // Get all modes for this modePre from the reverse map
-        const modesForThisModePre = Object.entries(modeToModePreMap)
+        const modesForThisModePre = Object.entries(defaultModeToModePreMap)
             .filter(([_mode, modePres]) => modePres.includes(modePre))
             .map(([mode, _modePres]) => mode as Mode);
 
         // Check if at least one of these modes is in the availableModes
         return modesForThisModePre.some((mode) => availableModes.includes(mode));
-    }) as ModePre[];
+    });
 };
 
 // Internal interface for various implementations of the segment next/previous

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/helpers.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/helpers.ts
@@ -8,7 +8,14 @@
 import _isEqual from 'lodash/isEqual';
 import { isFeature, isPoint } from 'geojson-validation';
 import * as odHelpers from '../../../odSurvey/helpers';
-import { simpleModes, Mode, modeValues, defaultModePreValues, defaultModeToModePreMap } from '../../../odSurvey/types';
+import {
+    simpleModes,
+    Mode,
+    modeValues,
+    defaultModePreValues,
+    defaultModeToModePreMap,
+    defaultModePreToModeMap
+} from '../../../odSurvey/types';
 import type { Optional } from '../../../../types/Optional.type';
 import type {
     Journey,
@@ -189,13 +196,9 @@ export const getFilteredModes = (segmentConfig: SegmentSectionConfiguration): Mo
     return modeValues as unknown as Mode[];
 };
 
-/**
- * Filter the available mode categories (modePre) based on the filtered modes.
- * Only keep modePre values that have at least one available mode.
- */
-export const getFilteredModesPre = (availableModes: Mode[]): string[] => {
+const getFilteredModesPreFromDefault = (availableModes: Mode[]) =>
     // Keep only modePre values that have at least one mode in the availableModes
-    return defaultModePreValues.filter((modePre) => {
+    defaultModePreValues.filter((modePre) => {
         // Get all modes for this modePre from the reverse map
         const modesForThisModePre = Object.entries(defaultModeToModePreMap)
             .filter(([_mode, modePres]) => modePres.includes(modePre))
@@ -204,6 +207,51 @@ export const getFilteredModesPre = (availableModes: Mode[]): string[] => {
         // Check if at least one of these modes is in the availableModes
         return modesForThisModePre.some((mode) => availableModes.includes(mode));
     });
+
+const getFilteredModesPreFromConfig = (
+    modeCategoryToModeMap: Exclude<SegmentSectionConfiguration['modeCategoryToModeMap'], undefined>,
+    availableModes: Mode[]
+) => {
+    const modeToModePreMap = Object.entries(modeCategoryToModeMap).reduce((acc, [category, catDesc]) => {
+        catDesc.modes.forEach((mode) => {
+            if (!acc[mode]) {
+                acc[mode] = [];
+            }
+            acc[mode].push(category);
+        });
+        return acc;
+    }, {});
+    // Make sure all available modes are configured in the category mapping
+    const missingModes = availableModes.filter((mode) => !Object.keys(modeToModePreMap).includes(mode));
+    if (missingModes.length > 0) {
+        throw new Error('modeCategoryToModeMap: some modes are not part of any mapping: ' + missingModes.join(', '));
+    }
+    // Return only categories with available modes
+    return Object.keys(modeCategoryToModeMap).filter((category) =>
+        modeCategoryToModeMap[category].modes.some((mode) => availableModes.includes(mode))
+    );
+};
+
+export const getModePreToModeMap = (sectionConfig: SegmentSectionConfiguration) =>
+    sectionConfig.modeCategoryToModeMap === undefined
+        ? defaultModePreToModeMap
+        : Object.entries(sectionConfig.modeCategoryToModeMap).reduce((acc, [category, catDesc]) => {
+            if (catDesc.modes.length > 0) {
+                acc[category] = catDesc.modes;
+            }
+            return acc;
+        }, {});
+
+/**
+ * Filter the available mode categories (modePre) based on the filtered modes.
+ * Only keep modePre values that have at least one available mode.
+ */
+export const getFilteredModesPre = (sectionConfig: SegmentSectionConfiguration, availableModes: Mode[]): string[] => {
+    if (sectionConfig.modeCategoryToModeMap) {
+        return getFilteredModesPreFromConfig(sectionConfig.modeCategoryToModeMap, availableModes);
+    } else {
+        return getFilteredModesPreFromDefault(availableModes);
+    }
 };
 
 // Internal interface for various implementations of the segment next/previous

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/modeIconMapping.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/modeIconMapping.ts
@@ -5,7 +5,7 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 
-import { Mode, ModePre } from '../../../odSurvey/types';
+import { Mode } from '../../../odSurvey/types';
 
 /**
  * Maps modes to their corresponding icon paths
@@ -79,7 +79,7 @@ export const modeToIconMapping: Record<Mode, string> = {
     preferNotToAnswer: '/dist/icons/modes/other/air_balloon.svg'
 };
 
-const modePreToModeIconMapping: Record<ModePre, Mode> = {
+const defaultModePreToModeIconMapping: Record<string, Mode> = {
     walk: 'walk',
     bicycle: 'bicycle',
     paratransit: 'paratransit',
@@ -104,9 +104,13 @@ export const getModeIcon = (mode: Mode): string => {
 
 /**
  * Returns the appropriate icon path for a given mode
+ *
+ * FIXME ModePre is not typed anymore, we need to way for various modePre to
+ * advertise icons and provide the mapping
+ *
  * @param modePre The transportation mode
  * @returns The path to the icon for the mode
  */
-export const getModePreIcon = (modePre: ModePre): string => {
-    return modeToIconMapping[modePreToModeIconMapping[modePre]] || '/dist/icons/modes/other/air_balloon.svg';
+export const getModePreIcon = (modePre: string): string => {
+    return modeToIconMapping[defaultModePreToModeIconMapping[modePre]] || '/dist/icons/modes/other/air_balloon.svg';
 };

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/widgetSegmentMode.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/widgetSegmentMode.ts
@@ -11,7 +11,7 @@ import { getResponse } from '../../../../utils/helpers';
 import { TFunction } from 'i18next';
 import * as odHelpers from '../../../odSurvey/helpers';
 import * as segmentHelpers from './helpers';
-import { Mode, modePreToModeMap } from '../../../odSurvey/types';
+import { Mode, defaultModePreToModeMap } from '../../../odSurvey/types';
 import type { Segment } from '../../types';
 import { getModeIcon } from './modeIconMapping';
 import { WidgetFactoryOptions } from '../types';
@@ -30,7 +30,7 @@ const getModeChoices = (filteredModes: Mode[]) =>
         conditional: function (interview, path) {
             const segment = getResponse(interview, path, null, '../') as Segment;
             if (segment !== null && segment.modePre) {
-                if (!modePreToModeMap[segment.modePre].includes(mode)) {
+                if (!defaultModePreToModeMap[segment.modePre].includes(mode)) {
                     return false;
                 }
             }

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/widgetSegmentMode.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/widgetSegmentMode.ts
@@ -11,7 +11,7 @@ import { getResponse } from '../../../../utils/helpers';
 import { TFunction } from 'i18next';
 import * as odHelpers from '../../../odSurvey/helpers';
 import * as segmentHelpers from './helpers';
-import { Mode, defaultModePreToModeMap } from '../../../odSurvey/types';
+import { Mode } from '../../../odSurvey/types';
 import type { Segment } from '../../types';
 import { getModeIcon } from './modeIconMapping';
 import { WidgetFactoryOptions } from '../types';
@@ -23,14 +23,14 @@ const perModeConditionals: Partial<{ [mode in Mode]: WidgetConditional }> = {
 };
 
 /** TODO Get a segment config in parameter to set the sort order and choices */
-const getModeChoices = (filteredModes: Mode[]) =>
+const getModeChoices = (filteredModes: Mode[], modePreToModeMap: { [modePre: string]: Mode[] }) =>
     filteredModes.map((mode) => ({
         value: mode,
         label: (t: TFunction) => t(`segments:mode:${_upperFirst(mode)}`),
         conditional: function (interview, path) {
             const segment = getResponse(interview, path, null, '../') as Segment;
             if (segment !== null && segment.modePre) {
-                if (!defaultModePreToModeMap[segment.modePre].includes(mode)) {
+                if (!modePreToModeMap[segment.modePre].includes(mode)) {
                     return false;
                 }
             }
@@ -51,7 +51,7 @@ export const getModeWidgetConfig = (
     if (filteredModes.length === 0) {
         throw new Error('No available modes to create mode widget configuration');
     }
-    const segmentModeChoices = getModeChoices(filteredModes);
+    const segmentModeChoices = getModeChoices(filteredModes, segmentHelpers.getModePreToModeMap(sectionConfig));
     return {
         type: 'question',
         path: 'mode',

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/widgetSegmentModePre.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/widgetSegmentModePre.ts
@@ -12,8 +12,8 @@ import type { TFunction } from 'i18next';
 import * as odHelpers from '../../../odSurvey/helpers';
 import config from '../../../../config/project.config';
 import * as segmentHelpers from './helpers';
-import type { Person } from '../../types';
-import { getModePreIcon } from './modeIconMapping';
+import type { ModeCategoryConfiguration, Person } from '../../types';
+import { getModeIcon, getModePreIcon } from './modeIconMapping';
 import { WidgetFactoryOptions } from '../types';
 
 const perModePreLabels: Partial<{ [modePre: string]: I18nData }> = {
@@ -46,16 +46,46 @@ const perModePreConditionals: Partial<{ [modePre: string]: WidgetConditional }> 
     carDriver: canPersonDriveCar
 };
 
+const getDefaultModePreChoice = (modeCategory: string) => ({
+    value: modeCategory,
+    label: perModePreLabels[modeCategory]
+        ? perModePreLabels[modeCategory]
+        : (t: TFunction) => t(`segments:modePre:${_upperFirst(modeCategory)}`),
+    conditional: perModePreConditionals[modeCategory],
+    iconPath: getModePreIcon(modeCategory)
+});
+
+const getModePreChoiceFromConfig = (modeCategory: string, categoryConfiguration: ModeCategoryConfiguration) => ({
+    value: modeCategory,
+    label:
+        categoryConfiguration.label === undefined && perModePreLabels[modeCategory]
+            ? perModePreLabels[modeCategory]
+            : (t: TFunction) =>
+                t(
+                    categoryConfiguration.label === undefined
+                        ? `segments:modePre:${_upperFirst(modeCategory)}`
+                        : categoryConfiguration.label
+                ),
+    // FIXME Additionally, a conditional should make sure some of the choices
+    // are available, as we do not know anymore that they are in the case of a
+    // mapping. To do so, widgetSegmentMode and widgetSegmentModePre should go
+    // together in a shared widget factory, so they can share their choices and
+    // lists.
+    conditional: categoryConfiguration.conditional ?? perModePreConditionals[modeCategory] ?? undefined,
+    iconPath: getModeIcon(categoryConfiguration.icon ?? (modeCategory as any))
+});
+
 /** TODO Get a segment config in parameter to set the sort order and choices */
-const getModePreChoices = (filteredModesPre: string[]) =>
-    filteredModesPre.map((mode) => ({
-        value: mode,
-        label: perModePreLabels[mode]
-            ? perModePreLabels[mode]
-            : (t: TFunction) => t(`segments:modePre:${_upperFirst(mode)}`),
-        conditional: perModePreConditionals[mode] !== undefined ? perModePreConditionals[mode] : undefined,
-        iconPath: getModePreIcon(mode)
-    }));
+const getModePreChoices = (
+    filteredModesPre: string[],
+    modeCategoryToModeMap: SegmentSectionConfiguration['modeCategoryToModeMap']
+) => {
+    return filteredModesPre.map((modePre) =>
+        modeCategoryToModeMap?.[modePre] !== undefined
+            ? getModePreChoiceFromConfig(modePre, modeCategoryToModeMap[modePre])
+            : getDefaultModePreChoice(modePre)
+    );
+};
 
 export const getModePreWidgetConfig = (
     sectionConfig: SegmentSectionConfiguration,
@@ -67,8 +97,8 @@ export const getModePreWidgetConfig = (
     if (filteredModes.length === 0) {
         throw new Error('No available modes to create modePre widget configuration');
     }
-    const filteredModesPre = segmentHelpers.getFilteredModesPre(filteredModes);
-    const choices = getModePreChoices(filteredModesPre);
+    const filteredModesPre = segmentHelpers.getFilteredModesPre(sectionConfig, filteredModes);
+    const choices = getModePreChoices(filteredModesPre, sectionConfig.modeCategoryToModeMap);
 
     return {
         type: 'question',

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/widgetSegmentModePre.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/widgetSegmentModePre.ts
@@ -12,12 +12,11 @@ import type { TFunction } from 'i18next';
 import * as odHelpers from '../../../odSurvey/helpers';
 import config from '../../../../config/project.config';
 import * as segmentHelpers from './helpers';
-import type { ModePre } from '../../../odSurvey/types';
 import type { Person } from '../../types';
 import { getModePreIcon } from './modeIconMapping';
 import { WidgetFactoryOptions } from '../types';
 
-const perModePreLabels: Partial<{ [mode in ModePre]: I18nData }> = {
+const perModePreLabels: Partial<{ [modePre: string]: I18nData }> = {
     walk: (t: TFunction, interview) => {
         const person = odHelpers.getActivePerson({ interview });
         const personMayHaveDisability = person && odHelpers.personMayHaveDisability({ person: person as Person });
@@ -42,13 +41,13 @@ const canPersonDriveCar: WidgetConditional = (interview) => {
     return drivingLicenseOwnership === 'yes';
 };
 
-const perModePreConditionals: Partial<{ [mode in ModePre]: WidgetConditional }> = {
+const perModePreConditionals: Partial<{ [modePre: string]: WidgetConditional }> = {
     paratransit: segmentHelpers.conditionalHhMayHaveDisability,
     carDriver: canPersonDriveCar
 };
 
 /** TODO Get a segment config in parameter to set the sort order and choices */
-const getModePreChoices = (filteredModesPre: ModePre[]) =>
+const getModePreChoices = (filteredModesPre: string[]) =>
     filteredModesPre.map((mode) => ({
         value: mode,
         label: perModePreLabels[mode]

--- a/packages/evolution-common/src/services/questionnaire/types/Data.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/Data.ts
@@ -14,7 +14,7 @@ import { Optional } from '../../../types/Optional.type';
 import { SegmentAttributes } from '../../baseObjects/Segment';
 import { HouseholdAttributes } from '../../baseObjects/Household';
 import { NavigationSection } from './NavigationTypes';
-import type { Activity, ActivityCategory, Mode, ModePre } from '../../odSurvey/types';
+import type { Activity, ActivityCategory, Mode } from '../../odSurvey/types';
 import { YesNoDontKnow } from '../../baseObjects/attributeTypes/GenericAttributes';
 
 export type ParsingFunction<T> = (interview: UserInterviewAttributes, path: string, user?: CliUser) => T;
@@ -259,7 +259,14 @@ export type Trip = TripAttributes &
 export type Segment = Omit<SegmentAttributes, 'mode'> &
     QuestionnaireObjectWithUuidAndSequence & {
         _isNew: boolean;
-        modePre?: ModePre;
+        /**
+         * A questionnaire-time value used to group modes under certain
+         * categories.
+         */
+        modePre?: string;
+        /**
+         * The mode of transport used during this segment
+         */
         mode?: Mode;
         sameModeAsReverseTrip?: boolean;
         hasNextMode?: boolean;

--- a/packages/evolution-common/src/services/questionnaire/types/SectionConfig.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/SectionConfig.ts
@@ -495,6 +495,31 @@ export type AdditionalSectionLabelOptionFct = (args: {
 }) => Record<string, unknown>;
 
 /**
+ * Configures a mode category
+ */
+export type ModeCategoryConfiguration = {
+    /**
+     * the array of modes under this mode category
+     * */
+    modes: Mode[];
+    /**
+     * the name of the mode whose icon to use to represent this category. If not
+     * set, the category name will be used.
+     */
+    icon?: Mode;
+    /**
+     * the translatable label to feed to the translation function to
+     * name this mode. If not set, it will be
+     * `segments:modePre:CapitalizedMode`.
+     */
+    label?: string;
+    /**
+     * specific conditional function for this category
+     */
+    conditional?: WidgetConditional;
+};
+
+/**
  * Configuration for the segments section of the questionnaire
  */
 export type SegmentSectionConfiguration = {
@@ -518,6 +543,20 @@ export type SegmentSectionConfiguration = {
      * the modePre and mode questions.
      */
     modesExclude?: Mode[];
+    /**
+     * Provide a mode category to modes mapping, to override the default modePre
+     * <-> mode categorization. If provided, the keys from this map will be the
+     * choices for the mode category question, while the values will be the
+     * choices for the mode question when this modePre is selected. There can be
+     * multiple modes in a modePre and a mode can be in various modePre. Note
+     * that, if set, all modes included need to be in at least one modePre.
+     *
+     * If not set, the available modePre fall back to the
+     * {@link defaultModePreValues} and default mapping.
+     */
+    modeCategoryToModeMap?: {
+        [modePre: string]: ModeCategoryConfiguration;
+    };
     /**
      * Names of additional widgets to include in the segment group of the
      * section besides the default ones (modePre, mode, etc). The widgets need


### PR DESCRIPTION
* Update type of `ModePre` to `string`, as it is only a esthetic field and a categorization. Unlike the `Mode` which really needs to be of a certain type

*  add a `modeCategoryToModeMap` section configuration option

fixes #1658

This option allows questionnaire to override the category to mode
mapping. The mapping is a key/value pair where the key is the mode
category and the mapping is an object, defining the modes and details
for this category. It has `modes` with a list of modes under this
category. Other properties are optional and include:

- icon: which represents the mode from which to borrow the icon for the
  category. If not provided, it will take the category name as mode
- label: which provides the translation key to use in the label
  function, the key must include the namespace. If not provided, it will
  be the `segments:modePre:<Category>`.
- conditional: A conditional function that defines when to show this
  category

Segment helpers, as well as the mode and modePre widgets are updated to
use this mapping if available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Segment questionnaires can now use custom mode categories, with configurable labels, icons, and conditions.
  * Mode filtering and display now adapt to the selected configuration instead of relying on fixed defaults.

* **Bug Fixes**
  * Improved handling of mode/category mappings so unavailable options are filtered out correctly.
  * Added fallback behavior for missing icons and labels to keep the UI consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->