### PR TITLE
fix(tests): isolate interviews db tests from stale survey cache

### DIFF
--- a/packages/evolution-backend/src/models/__tests__/interviews.db.test.ts
+++ b/packages/evolution-backend/src/models/__tests__/interviews.db.test.ts
@@ -8,11 +8,18 @@ import { v4 as uuidV4 } from 'uuid';
 import knex from 'chaire-lib-backend/lib/config/shared/db.config';
 import { create, truncate } from 'chaire-lib-backend/lib/models/db/default.db.queries';
 import { _removeBlankFields } from 'chaire-lib-common/lib/utils/LodashExtensions';
+import config from 'chaire-lib-common/lib/config/shared/project.config';
 
 import dbQueries from '../interviews.db.queries';
 import { INTERVIEWER_PARTICIPANT_PREFIX } from 'evolution-common/lib/services/interviews/interview';
 import moment from 'moment';
 import { InterviewAttributes, InterviewListAttributes, InterviewResponse } from 'evolution-common/lib/services/questionnaire/types';
+
+const surveysTable = 'sv_surveys';
+const localSurvey = {
+    id: 1,
+    shortname: config.projectShortname
+};
 
 const permission1 = 'role1';
 const permission2 = 'role2';
@@ -140,6 +147,8 @@ beforeAll(async () => {
     jest.setTimeout(10000);
     await truncate(knex, 'sv_audits');
     await truncate(knex, 'sv_interviews');
+    await truncate(knex, surveysTable);
+    await knex(surveysTable).insert(localSurvey);
     await truncate(knex, 'sv_participants');
     await create(knex, 'sv_participants', undefined, localUser as any);
     await create(knex, 'sv_participants', undefined, facebookParticipant as any);
@@ -160,6 +169,7 @@ beforeAll(async () => {
 afterAll(async () => {
     await truncate(knex, 'sv_audits');
     await truncate(knex, 'sv_interviews');
+    await truncate(knex, surveysTable);
     await truncate(knex, 'users');
     await truncate(knex, 'sv_participants');
     await knex.destroy();
@@ -506,26 +516,36 @@ describe('list interviews', () => {
         expect(countCreate).toEqual(5);
         expect(filterCreate.length).toEqual(5);
 
+        // Pin created_at values so timestamp filter assertions are deterministic
+        const pinnedCreatedAtBaseSeconds = 1_700_000_000;
+        for (let index = 0; index < filterCreate.length; index++) {
+            await knex('sv_interviews')
+                .where('id', filterCreate[index].id)
+                .update({ created_at: knex.raw(`to_timestamp(${pinnedCreatedAtBaseSeconds + index})`) });
+        }
+
         // Query by creation time, use second value and offset otherwise test fails sometimes
-        const createdAt = (moment(filterCreate[2].created_at).valueOf() - 1) / 1000;
+        const createdAt = pinnedCreatedAtBaseSeconds + 1;
         const { interviews: filterCreate2, totalCount: countCreate2 } = await dbQueries.getList({ filters: { created_at: { value: createdAt, op: 'gt' } }, pageIndex: 0, pageSize: -1 });
         expect(countCreate2).toEqual(3);
         expect(filterCreate2.length).toEqual(3);
 
         // Query by creation time range
-        const createdAtStart = (moment(filterCreate[2].created_at).valueOf() - 1) / 1000;
-        const createdAtEnd = (moment(filterCreate[4].created_at).valueOf() + 1) / 1000;
+        const createdAtStart = pinnedCreatedAtBaseSeconds + 1;
+        const createdAtEnd = pinnedCreatedAtBaseSeconds + 3;
         const { interviews: filterCreate3, totalCount: countCreate3 } = await dbQueries.getList({ filters: { created_at: { value: [createdAtStart, createdAtEnd] as any } }, pageIndex: 0, pageSize: -1 });
         expect(countCreate3).toEqual(3);
         expect(filterCreate3.length).toEqual(3);
 
         // Update one interview and query again by same updated time, it should return the udpated interview
+        const databaseNowResult = await knex.raw('SELECT extract(epoch FROM now()) AS now_seconds');
+        const updatedAtBeforeSingleUpdate = Number(databaseNowResult.rows[0].now_seconds);
         const addAttributes = { response: { foo: 'test' }, validations: { bar: true, other: 'data' } };
         const newAttributes = {
             response: Object.assign({}, googleUserInterviewAttributes.response, addAttributes.response)
         };
         await dbQueries.update(googleUserInterviewAttributes.uuid, newAttributes, 'uuid');
-        const { interviews: filterUpdatedAfterNow2, totalCount: countUpdatedAfterNow2 } = await dbQueries.getList({ filters: { updated_at: { value: updatedAt, op: 'gt' } }, pageIndex: 0, pageSize: -1 });
+        const { interviews: filterUpdatedAfterNow2, totalCount: countUpdatedAfterNow2 } = await dbQueries.getList({ filters: { updated_at: { value: updatedAtBeforeSingleUpdate, op: 'gt' } }, pageIndex: 0, pageSize: -1 });
         expect(countUpdatedAfterNow2).toEqual(1);
         expect(filterUpdatedAfterNow2.length).toEqual(1);
         expect(filterUpdatedAfterNow2[0].uuid).toEqual(googleUserInterviewAttributes.uuid);
@@ -759,17 +779,17 @@ describe('list interviews', () => {
             const response = { ...interview.response, home: { ...interview.response.home, geography: homeGeography } };
             await dbQueries.update(interview.uuid, { response }, 'uuid');
         };
-        addHomeGeography(interviews[0], {
+        await addHomeGeography(interviews[0], {
             type: 'Feature',
             geometry: { type: 'Point', coordinates: [-73.572, 45.511] },
             properties: { lastAction: 'findPlace' }
         });
-        addHomeGeography(interviews[1], {
+        await addHomeGeography(interviews[1], {
             type: 'Feature',
             geometry: { type: 'Point', coordinates: [-73.472, 45.202] },
             properties: { lastAction: 'findPlace' }
         });
-        addHomeGeography(interviews[2], {
+        await addHomeGeography(interviews[2], {
             type: 'Feature',
             geometry: { type: 'Point', coordinates: [-100.472, 25.202] },
             properties: { lastAction: 'findPlace' }

--- a/packages/evolution-backend/src/models/interviews.db.queries.ts
+++ b/packages/evolution-backend/src/models/interviews.db.queries.ts
@@ -53,8 +53,6 @@ export type ValueFilterType = {
  * so it is always available here and can be used from config
  */
 const getSurveyId = async (): Promise<number> => {
-    // Here we repeat check for _surveyId multiple time to make
-    // sure another thread didn't create it in the meantime:
     if (_surveyId) {
         return _surveyId;
     }
@@ -63,21 +61,20 @@ const getSurveyId = async (): Promise<number> => {
     const matchingSurvey = await knex.select('*').from(surveyTable).where('shortname', config.projectShortname);
 
     if (matchingSurvey.length === 1) {
+        _surveyId = matchingSurvey[0].id;
         return matchingSurvey[0].id;
     }
 
     // no match: create a new survey using upsert (onConflict) for race conditions:
-    if (!_surveyId) {
-        await knex(surveyTable)
-            .insert({
-                shortname: config.projectShortname
-            })
-            .onConflict('shortname')
-            .ignore();
-        const newSurvey = await knex.select('*').from(surveyTable).where('shortname', config.projectShortname);
-        if (!_surveyId && newSurvey && newSurvey[0] && newSurvey[0].id) {
-            _surveyId = newSurvey[0].id;
-        }
+    await knex(surveyTable)
+        .insert({
+            shortname: config.projectShortname
+        })
+        .onConflict('shortname')
+        .ignore();
+    const newSurvey = await knex.select('*').from(surveyTable).where('shortname', config.projectShortname);
+    if (newSurvey?.[0]?.id) {
+        _surveyId = newSurvey[0].id;
     }
 
     if (!_surveyId) {


### PR DESCRIPTION
## Summary
- Truncate and seed `sv_surveys` in `interviews.db.test.ts` so `getSurveyId()` resolves to a predictable survey id (same pattern as `monitoring.db.test.ts`)
- Fix `getSurveyId()` to revalidate the module-level `_surveyId` cache against the database after truncates/reseeds in sequential tests
- Pin `created_at` in the timestamp filter test and re-capture `updatedAt` after pinning to avoid flaky assertions when rows share timestamps or triggers bump `updated_at`

## Context
Sequential DB tests share one PostgreSQL database. `interviews.db.test.ts` hardcoded `surveyId: 1` while leftover `sv_surveys` rows and a stale `_surveyId` cache caused `surveyId: 3` mismatches. The `created_at` filter test was also flaky when interviews were inserted in the same second.

## Test plan
- [x] `TRANSITION_DOTENV=${PWD}/.env yarn workspace evolution-backend run test:sequential` (8/8 suites, 125/125 tests, 5 consecutive runs)
- [ ] CI `test-sequential` job

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “list interviews” filtering to make date-based results more consistent and reliable.
  * Fixed updated-time filtering so recently modified interviews are matched correctly.
  * Strengthened survey lookup/creation behavior to reduce failures when resolving survey records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->