### PR TITLE
locales: add the `tripsIntro` locale file

### DIFF
--- a/locales/en/survey.yml
+++ b/locales/en/survey.yml
@@ -5,7 +5,6 @@ No: No
 thisTrip: this trip
 thisTrip_workOnTheRoad: the on the road trips
 thisTrip_leisureStroll: the stroll
-SwitchPersonNeedComplete: Please fill out this section before switching persons.
 
 # Button texts
 ConfirmAndContinue: Confirm and continue

--- a/locales/en/tripsIntro.yml
+++ b/locales/en/tripsIntro.yml
@@ -1,0 +1,4 @@
+activePersonTitle: >-
+    <p class="_orange center _em" style="margin-bottom: 0;"><strong>{{nickname}}</strong>'s interview</p>
+buttonSwitchPerson: Change person
+buttonSwitchPersonNeedComplete: Please fill out this section before switching persons.

--- a/locales/fr/tripsIntro.yml
+++ b/locales/fr/tripsIntro.yml
@@ -1,0 +1,4 @@
+activePersonTitle: >-
+    <p class="_orange center _em" style="margin-bottom: 0;">Entrevue de <strong>{{nickname}}</strong></p>
+buttonSwitchPerson: Changer de personne
+buttonSwitchPersonNeedComplete: Veuillez compléter cette section avant de changer de personne.


### PR DESCRIPTION
commit 423ea3b introduced a new `tripsIntro` namespace for translatable labels, but the corresponding yml file was not committed with this commit. This adds the missing translation files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new localized text for the trips intro screen in English and French.
  * Introduced a title that can display a person’s nickname, plus a “Change person” button label.
  * Added a French validation message shown when a person must be completed before switching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->