### PR TITLE
ui tests: detect object from the response too

### DIFF
--- a/packages/evolution-frontend/tests/ui-testing/testHelpers.ts
+++ b/packages/evolution-frontend/tests/ui-testing/testHelpers.ts
@@ -166,6 +166,31 @@ export const initializeTestPage = async (
             surveyObjectDetector.detectSurveyObjects(data);
         }
     });
+    // Also listen to responses in case the server returns new object data in
+    // the response (the server update callback may update the interview server
+    // side and send updated data to the client)
+    page.on('response', async (response) => {
+        try {
+            // Listen to the response of the `survey/updateInterview` endpoint
+            if (!response.url().includes('survey/updateInterview')) {
+                return;
+            }
+            const text = await response.text();
+            if (!text) {
+                return;
+            }
+            const parsed = JSON.parse(text);
+            // The server response may contain an `updatedValuesByPath` property
+            // which contains the updated values
+            const valuesByPath = parsed && parsed['updatedValuesByPath'];
+            if (valuesByPath !== undefined && Object.keys(valuesByPath).length > 0) {
+                // Detect the survey objects in the updated values by path
+                surveyObjectDetector.detectSurveyObjects(valuesByPath);
+            }
+        } catch (error) {
+            console.error(`Error while parsing survey/updateInterview response: ${error}`);
+        }
+    });
     return page;
 };
 


### PR DESCRIPTION
fixes #1711

The server update callback flow may fill objects on the server and send them back to the client. The UI tests should also listen to those responses to detect survey objects to make sure they don't miss the server created ones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved UI test handling for survey updates by detecting updated survey data from captured network responses.
  * Added safer response parsing (with error logging) so test execution continues even if response payloads are malformed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->