### PR TITLE
audits: add I_M_ContactEmailButWouldLikeToParticipateInOtherSurveys check

### DIFF
--- a/locales/en/audits.json
+++ b/locales/en/audits.json
@@ -6,6 +6,7 @@
     "I_M_AccessCode": "Access code is missing",
     "I_I_InvalidAccessCodeFormat": "Access code format is invalid",
     "I_I_ContactEmail": "Contact email is invalid",
+    "I_M_ContactEmailButWouldLikeToParticipateInOtherSurveys": "Contact email is missing but respondent would like to participate in other surveys",
     "I_I_HelpContactEmail": "Help contact email is invalid",
 
     "HH_I_Size": "Household size is out of range (should be an integer between 1 and 18)",

--- a/locales/fr/audits.json
+++ b/locales/fr/audits.json
@@ -6,6 +6,7 @@
     "I_M_AccessCode": "Le code d'accès est manquant",
     "I_I_InvalidAccessCodeFormat": "Le format du code d'accès est invalide",
     "I_I_ContactEmail": "Le courriel de contact est invalide",
+    "I_M_ContactEmailButWouldLikeToParticipateInOtherSurveys": "Le courriel de contact est manquant, mais la personne répondante aimerait participer à d'autres enquêtes",
     "I_I_HelpContactEmail": "Le courriel de contact d'aide est invalide",
 
     "HH_I_Size": "La taille du ménage est en dehors de la plage autorisée (devrait être un entier entre 1 et 18)",

--- a/packages/evolution-backend/src/services/audits/auditChecks/README.md
+++ b/packages/evolution-backend/src/services/audits/auditChecks/README.md
@@ -299,7 +299,7 @@ That's it. Run `yarn workspace evolution-backend test` and open the PR.
 
 Grep before adding to avoid duplicates. Current standard checks, grouped by object:
 
-- **Interview** (`InterviewAuditChecks.ts`): `I_M_Languages`, `I_M_StartedAt`, `I_I_StartedAtBeforeSurveyStartDate`, `I_I_StartedAtAfterSurveyEndDate`, `I_M_AccessCode`, `I_I_InvalidAccessCodeFormat`, `I_I_ContactEmail`, `I_I_HelpContactEmail`.
+- **Interview** (`InterviewAuditChecks.ts`): `I_M_Languages`, `I_M_StartedAt`, `I_I_StartedAtBeforeSurveyStartDate`, `I_I_StartedAtAfterSurveyEndDate`, `I_M_AccessCode`, `I_I_InvalidAccessCodeFormat`, `I_I_ContactEmail`, `I_M_ContactEmailButWouldLikeToParticipateInOtherSurveys`, `I_I_HelpContactEmail`.
 - **Household**: `HH_M_Size`, `HH_I_Size`, `HH_M_Home`, `HH_L_SizeMembersCountMismatch`, `HH_M_CarNumber`, `HH_I_CarNumber`, `HH_L_CarNumberVehiclesCountMismatch`.
 - **Home**: `HM_M_Geography`, `HM_I_Geography`, `HM_I_preGeographyAndHomeGeographyTooFarApartError`, `HM_I_preGeographyAndHomeGeographyTooFarApartWarning`, `HM_I_geographyNotInSurveyTerritory`.
 - **Person**: `P_M_Age`.

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/InterviewAuditChecks.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/InterviewAuditChecks.ts
@@ -207,6 +207,29 @@ export const interviewAuditChecks: { [errorCode: string]: InterviewAuditCheckFun
     },
 
     /**
+     * Check if contact email is missing while the respondent would like to participate in other surveys
+     * @param context - InterviewAuditCheckContext
+     * @returns {AuditForObject | undefined}
+     */
+    I_M_ContactEmailButWouldLikeToParticipateInOtherSurveys: (
+        context: InterviewAuditCheckContext
+    ): AuditForObject | undefined => {
+        const { interview } = context;
+        if (interview.wouldLikeToParticipateInOtherSurveys === true && _isBlank(interview.contactEmail)) {
+            return {
+                objectType: 'interview',
+                objectUuid: interview.uuid!,
+                errorCode: 'I_M_ContactEmailButWouldLikeToParticipateInOtherSurveys',
+                version: 1,
+                level: 'error',
+                message: 'Contact email is missing but respondent would like to participate in other surveys',
+                ignore: false
+            };
+        }
+        return undefined;
+    },
+
+    /**
      * Check if interview help contact email is invalid
      * @param context - InterviewAuditCheckContext
      * @returns {AuditForObject | undefined}

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/interview/I_M_ContactEmailButWouldLikeToParticipateInOtherSurveys.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/interview/I_M_ContactEmailButWouldLikeToParticipateInOtherSurveys.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { v4 as uuidV4 } from 'uuid';
+import type { InterviewAuditCheckContext } from '../../../AuditCheckContexts';
+import { interviewAuditChecks } from '../../InterviewAuditChecks';
+import { createMockInterview } from './testHelper';
+
+describe('I_M_ContactEmailButWouldLikeToParticipateInOtherSurveys audit check', () => {
+    const validUuid = uuidV4();
+
+    it.each([
+        {
+            description: 'would like to participate in other surveys and contact email present',
+            wouldLikeToParticipateInOtherSurveys: true,
+            contactEmail: 'contact@example.com',
+            expectError: false
+        },
+        {
+            description: 'would not like to participate in other surveys and contact email missing',
+            wouldLikeToParticipateInOtherSurveys: false,
+            contactEmail: undefined,
+            expectError: false
+        },
+        {
+            description: 'would not like to participate in other surveys and contact email present',
+            wouldLikeToParticipateInOtherSurveys: false,
+            contactEmail: 'contact@example.com',
+            expectError: false
+        },
+        {
+            description: 'wouldLikeToParticipateInOtherSurveys is undefined and contact email missing',
+            wouldLikeToParticipateInOtherSurveys: undefined,
+            contactEmail: undefined,
+            expectError: false
+        },
+        {
+            description: 'would like to participate in other surveys and contact email is empty string',
+            wouldLikeToParticipateInOtherSurveys: true,
+            contactEmail: '',
+            expectError: true
+        },
+        {
+            description: 'would like to participate in other surveys and contact email is undefined',
+            wouldLikeToParticipateInOtherSurveys: true,
+            contactEmail: undefined,
+            expectError: true
+        }
+    ])('$description', ({ wouldLikeToParticipateInOtherSurveys, contactEmail, expectError }) => {
+        const interview = createMockInterview({ wouldLikeToParticipateInOtherSurveys, contactEmail }, validUuid);
+        const context: InterviewAuditCheckContext = { interview };
+
+        const result = interviewAuditChecks.I_M_ContactEmailButWouldLikeToParticipateInOtherSurveys(context);
+
+        if (!expectError) {
+            expect(result).toBeUndefined();
+        } else {
+            expect(result).toEqual({
+                objectType: 'interview',
+                objectUuid: validUuid,
+                errorCode: 'I_M_ContactEmailButWouldLikeToParticipateInOtherSurveys',
+                version: 1,
+                level: 'error',
+                message: 'Contact email is missing but respondent would like to participate in other surveys',
+                ignore: false
+            });
+        }
+    });
+});


### PR DESCRIPTION
## Summary

- Adds a new interview audit check, `I_M_ContactEmailButWouldLikeToParticipateInOtherSurveys`, which flags an interview when the respondent would like to participate in other surveys (`wouldLikeToParticipateInOtherSurveys`) but did not provide a `contactEmail`.
- This ports od_mtl_2023's v1 check `I_M_ContactEmailButAcceptedToBeContacted` (dropped in v2 with no replacement) using core `Interview` attributes that already exist (`wouldLikeToParticipateInOtherSurveys`, `contactEmail`), so no new attribute or config is needed.
- Email format itself is intentionally out of scope here — it's already covered separately by the existing `I_I_ContactEmail` check.

## Test plan

- [x] New unit test `I_M_ContactEmailButWouldLikeToParticipateInOtherSurveys.test.ts` (parametric `it.each`), covering: opted-in + email present (pass), not opted-in + missing email (pass), opted-in + empty string email (fail), opted-in + undefined email (fail).
- [x] `yarn workspace evolution-backend test -- auditChecks/checks/__tests__/interview` — all 105 tests pass.
- [x] `yarn lint` — no new errors/warnings introduced.
- [x] `yarn format` — applied.
- [x] Added `en`/`fr` translations in `locales/*/audits.json`.
- [x] No `CHANGELOG.md` entry (individual audit checks aren't tracked there).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an audit warning when respondents want to participate in other surveys but have not provided a contact email.
  - Added English and French translations for the new audit message.

- **Documentation**
  - Updated audit-check authoring guidance and inventory examples.

- **Tests**
  - Added coverage for valid, missing, and empty contact email scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->