### PR TITLE
docs(audits): explain why audit checks duplicate real-time validation

### DIFF
--- a/packages/evolution-backend/src/services/audits/README.md
+++ b/packages/evolution-backend/src/services/audits/README.md
@@ -2,6 +2,8 @@
 
 An **audit** is a post-submission validation run over an interview. Each failing or matching audit check produces an `AuditForObject` record persisted in `sv_audits` database table and surfaced to reviewers in the admin app. Audits do *not* block the respondent while they fill the questionnaire — that is [real-time validation](../../../../../docs/nomenclature.md), a separate system.
 
+Audits must validate the interview data on its own merits, never assuming it was already validated in real time: a respondent can leave a field invalid after passing through it once, or edit the stored data directly (e.g. via browser dev tools), bypassing the frontend entirely. This is why most real-time validations are intentionally duplicated as audit checks — see [`auditChecks/README.md`](auditChecks/README.md#1-what-is-an-audit-check) for details.
+
 Each check declares a `level` (defaults to `error` if omitted):
 
 - **`error`** — must be reviewed; may lead to correction or rejection of the interview.

--- a/packages/evolution-backend/src/services/audits/auditChecks/README.md
+++ b/packages/evolution-backend/src/services/audits/auditChecks/README.md
@@ -26,6 +26,8 @@ An audit check must validate the data it is given regardless of whether that dat
 
 Because the server can never trust that stored data went through real-time validation, most checks in `evolution-common/src/services/widgets/validations` (frontend/real-time) have a corresponding audit check here that re-validates the same rule against the data as it actually sits in the database. When adding a real-time validation, check whether it needs an audit-check counterpart too, and vice versa.
 
+> **TODO**: Once survey objects are unified between frontend and backend and persisted in the database as separate columns per attribute (rather than as a single JSON response blob), most audit checks could be reused directly as real-time validations too, removing the current duplication between the two systems.
+
 **Rule of thumb**:
 
 

--- a/packages/evolution-backend/src/services/audits/auditChecks/README.md
+++ b/packages/evolution-backend/src/services/audits/auditChecks/README.md
@@ -17,6 +17,15 @@ In Evolution, an **audit check** is a post-submission validation run over a comp
 
 Checks do *not* run while the respondent fills the questionnaire — that is **real-time validation**, a separate system (see [`docs/nomenclature.md`](../../../../../../docs/nomenclature.md)). If your rule needs to prevent a respondent from moving forward, it is a real-time validation, not an audit.
 
+### Why audits duplicate real-time validation
+
+An audit check must validate the data it is given regardless of whether that data was ever seen by real-time validation. It cannot assume a field is valid just because the respondent passed through it once, because:
+
+- A respondent can go back to a previously-completed field, clear it or type an invalid value (e.g. an invalid email), then leave the interview without fixing the error shown in red by real-time validation. The invalid value stays saved.
+- A respondent (or anyone with access to the browser) can edit the interview's stored data directly — e.g. through the Redux dev tools — completely bypassing real-time validation.
+
+Because the server can never trust that stored data went through real-time validation, most checks in `evolution-common/src/services/widgets/validations` (frontend/real-time) have a corresponding audit check here that re-validates the same rule against the data as it actually sits in the database. When adding a real-time validation, check whether it needs an audit-check counterpart too, and vice versa.
+
 **Rule of thumb**:
 
 

--- a/packages/evolution-backend/src/services/audits/auditChecks/README.md
+++ b/packages/evolution-backend/src/services/audits/auditChecks/README.md
@@ -26,8 +26,6 @@ An audit check must validate the data it is given regardless of whether that dat
 
 Because the server can never trust that stored data went through real-time validation, most checks in `evolution-common/src/services/widgets/validations` (frontend/real-time) have a corresponding audit check here that re-validates the same rule against the data as it actually sits in the database. When adding a real-time validation, check whether it needs an audit-check counterpart too, and vice versa.
 
-> **TODO**: Once survey objects are unified between frontend and backend and persisted in the database as separate columns per attribute (rather than as a single JSON response blob), most audit checks could be reused directly as real-time validations too, removing the current duplication between the two systems.
-
 **Rule of thumb**:
 
 


### PR DESCRIPTION
## Summary

- Clarifies in the audit READMEs that audit checks must validate interview data on its own merits, never assuming it was already validated in real time on the frontend.
- Explains the two concrete reasons this matters: a respondent can leave a field invalid after passing through it (without correcting the red error shown in the frontend) and abandon the interview, or edit the stored interview data directly (e.g. via browser dev tools), bypassing real-time validation entirely.
- Short version added to `packages/evolution-backend/src/services/audits/README.md`; more complete version with the two scenarios added to `packages/evolution-backend/src/services/audits/auditChecks/README.md`, linked from the short one.

No code changes — documentation only.

## Test plan

- [ ] Review rendered markdown for the two README files
- [ ] Confirm the cross-link anchor (`auditChecks/README.md#1-what-is-an-audit-check`) resolves correctly on GitHub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that audit checks independently re-validate stored interview data.
  * Documented scenarios where data may change or bypass real-time validation.
  * Added guidance to create corresponding audit checks for new real-time validations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->