### PR TITLE
docs(audits): simplify audit-check guide (drop CHANGELOG step and stale inventory list)

### DIFF
--- a/packages/evolution-backend/src/services/audits/auditChecks/README.md
+++ b/packages/evolution-backend/src/services/audits/auditChecks/README.md
@@ -140,7 +140,7 @@ Put it in **standard** otherwise. All current extended maps are empty (`{}`) —
 
 ---
 
-## 4. The 6-step checklist
+## 4. The 5-step checklist
 
 Follow these in order. Every step is mandatory unless marked optional.
 
@@ -154,8 +154,7 @@ Follow these in order. Every step is mandatory unless marked optional.
    yarn lint && yarn format
    ```
 
-5. **Add a CHANGELOG entry** under `Added` in the `Unreleased` section of `CHANGELOG.md`, listing the new `errorCode`.
-6. **Open a small PR**. One check per commit when practical. If you add several related checks, split by object type.
+5. **Open a small PR**. One check per commit when practical. If you add several related checks, split by object type. No `CHANGELOG.md` entry — individual audit checks are not tracked there, there are too many of them.
 
 Optional but encouraged:
 
@@ -284,14 +283,7 @@ describe('P_I_AgeOutOfRange', () => {
 
 Parametric tests are preferred here — all cases share a table. If a case needs more setup, drop it out of `it.each` into its own `it(...)`.
 
-### 6.4 CHANGELOG
-
-```md
-### Added
-- Audit check `P_I_AgeOutOfRange`: flags persons with age outside 0–120.
-```
-
-That's it. Run `yarn workspace evolution-backend test` and open the PR.
+That's it. Run `yarn workspace evolution-backend test` and open the PR. No `CHANGELOG.md` entry needed (see §4).
 
 ---
 

--- a/packages/evolution-backend/src/services/audits/auditChecks/README.md
+++ b/packages/evolution-backend/src/services/audits/auditChecks/README.md
@@ -140,7 +140,7 @@ Put it in **standard** otherwise. All current extended maps are empty (`{}`) —
 
 ---
 
-## 4. The 5-step checklist
+## 4. The checklist
 
 Follow these in order. Every step is mandatory unless marked optional.
 
@@ -283,19 +283,17 @@ describe('P_I_AgeOutOfRange', () => {
 
 Parametric tests are preferred here — all cases share a table. If a case needs more setup, drop it out of `it.each` into its own `it(...)`.
 
-That's it. Run `yarn workspace evolution-backend test` and open the PR. No `CHANGELOG.md` entry needed (see §4).
+That's it. Run `yarn workspace evolution-backend test` and open the PR.
 
 ---
 
 ## 7. Inventory of current checks (read before adding)
 
 Grep before adding to avoid duplicates. Checks live in `<Object>AuditChecks.ts`
-and `<Object>ExtendedAuditChecks.ts` under
-[`./checks/`](./checks/), one file per survey object type (see the table in
-§3.1). To list all current checks:
+and `<Object>ExtendedAuditChecks.ts` under [`./checks/`](./checks/), one file per survey object type (see the table in §3.1). To list all current checks:
 
 ```bash
-rg -n "^\s+[IHMPJVTS]{1,2}_[MIL]_[A-Za-z]+:" \
+grep -rEn "^[[:space:]]+[IHMPJVTS]{1,2}_[MIL]_[A-Za-z]+:" \
   packages/evolution-backend/src/services/audits/auditChecks/checks
 ```
 

--- a/packages/evolution-backend/src/services/audits/auditChecks/README.md
+++ b/packages/evolution-backend/src/services/audits/auditChecks/README.md
@@ -289,20 +289,10 @@ That's it. Run `yarn workspace evolution-backend test` and open the PR. No `CHAN
 
 ## 7. Inventory of current checks (read before adding)
 
-Grep before adding to avoid duplicates. Current standard checks, grouped by object:
-
-- **Interview** (`InterviewAuditChecks.ts`): `I_M_Languages`, `I_M_StartedAt`, `I_I_StartedAtBeforeSurveyStartDate`, `I_I_StartedAtAfterSurveyEndDate`, `I_M_AccessCode`, `I_I_InvalidAccessCodeFormat`, `I_I_ContactEmail`, `I_M_ContactEmailButWouldLikeToParticipateInOtherSurveys`, `I_I_HelpContactEmail`.
-- **Household**: `HH_M_Size`, `HH_I_Size`, `HH_M_Home`, `HH_L_SizeMembersCountMismatch`, `HH_M_CarNumber`, `HH_I_CarNumber`, `HH_L_CarNumberVehiclesCountMismatch`.
-- **Home**: `HM_M_Geography`, `HM_I_Geography`, `HM_I_preGeographyAndHomeGeographyTooFarApartError`, `HM_I_preGeographyAndHomeGeographyTooFarApartWarning`, `HM_I_geographyNotInSurveyTerritory`.
-- **Person**: `P_M_Age`.
-- **Journey**: `J_M_StartDate`.
-- **VisitedPlace**: `VP_M_Geography`, `VP_I_Geography`.
-- **Trip**: `T_M_Segments`.
-- **Segment**: `S_M_Mode`.
-
-Extended maps are all currently empty.
-
-This inventory ages fast — regenerate it from the source files if in doubt:
+Grep before adding to avoid duplicates. Checks live in `<Object>AuditChecks.ts`
+and `<Object>ExtendedAuditChecks.ts` under
+[`./checks/`](./checks/), one file per survey object type (see the table in
+§3.1). To list all current checks:
 
 ```bash
 rg -n "^\s+[IHMPJVTS]{1,2}_[MIL]_[A-Za-z]+:" \


### PR DESCRIPTION
## Summary

Split out of #1723 per [@greenscientist's review comment](https://github.com/chairemobilite/evolution/pull/1723#issuecomment) — these two commits are unrelated to the `I_M_ContactEmailButWouldLikeToParticipateInOtherSurveys` audit check added there.

- Drop the "add a CHANGELOG entry" step from the audit-check authoring guide: individual audit checks are not tracked in `CHANGELOG.md`, there are too many of them.
- Remove the manually maintained per-object inventory list of current checks from the guide (it duplicates the source files and was already flagged as aging fast). Point to the `checks/` folder and the existing `rg` command instead.

No code changes — documentation only (`packages/evolution-backend/src/services/audits/auditChecks/README.md`).

## Test plan

- [ ] Review rendered markdown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the audit check contribution guide to reflect a shorter mandatory checklist (now referencing “4. The checklist” and “5. Open a small PR”).
  * Clarified that adding an audit check does not require a `CHANGELOG.md` entry.
  * Enhanced the worked example with an “Inventory of current checks” section and guidance to review existing checks first to avoid duplicates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->