### PR TITLE
fix(surveyObjects): stabilize household/home uuid across reconstructions

### DIFF
--- a/packages/evolution-backend/src/services/surveyObjects/SurveyObjectsFactory.ts
+++ b/packages/evolution-backend/src/services/surveyObjects/SurveyObjectsFactory.ts
@@ -125,7 +125,13 @@ export class SurveyObjectsFactory {
 
         // Only try to create home if we have home attributes
         if (homeAttributes) {
-            const homeResult = Home.create(homeAttributes as { [key: string]: unknown }, surveyObjectsRegistry);
+            // Home is a singleton per interview and its corrected_response never stores an
+            // explicit _uuid. Default it to the interview uuid so it stays stable across
+            // reconstructions (matches the review API's existence check for singleton objects).
+            const homeResult = Home.create(
+                { _uuid: interviewAttributes.uuid, ...homeAttributes } as { [key: string]: unknown },
+                surveyObjectsRegistry
+            );
             if (isOk(homeResult)) {
                 surveyObjectsWithErrors.home = homeResult.result;
             } else {
@@ -145,8 +151,13 @@ export class SurveyObjectsFactory {
 
         // Only try to create household if we have household attributes
         if (householdAttributes) {
+            // Household is a singleton per interview and its corrected_response never stores
+            // an explicit _uuid. Default it to the interview uuid so it stays stable across
+            // reconstructions (matches the review API's existence check for singleton objects).
             const householdResult = Household.create(
-                _omit(householdAttributes, ['persons']) as { [key: string]: unknown },
+                { _uuid: interviewAttributes.uuid, ..._omit(householdAttributes, ['persons']) } as {
+                    [key: string]: unknown;
+                },
                 surveyObjectsRegistry
             );
             if (isOk(householdResult)) {

--- a/packages/evolution-backend/src/services/surveyObjects/__tests__/SurveyObjectsFactory.test.ts
+++ b/packages/evolution-backend/src/services/surveyObjects/__tests__/SurveyObjectsFactory.test.ts
@@ -194,6 +194,66 @@ describe('SurveyObjectsFactory', () => {
             expect(mockedPopulateJourneysForPerson).not.toHaveBeenCalled();
         });
 
+        it('should default home _uuid to the interview uuid when not explicitly set', async () => {
+            interviewAttributes.corrected_response!.home = {
+                geography: { type: 'Point', coordinates: [-73.5, 45.5] }
+            } as any;
+
+            mockedCreateInterviewObject.mockReturnValue(createOk({} as any));
+            (MockedHome.create as jest.Mock).mockReturnValue(createOk({} as any));
+            (MockedHousehold.create as jest.Mock).mockReturnValue(createOk({ members: [] } as any));
+
+            await factory.createAllObjectsWithErrors(interviewAttributes);
+
+            expect(MockedHome.create).toHaveBeenCalledWith(
+                expect.objectContaining({ _uuid: 'interview-uuid' }),
+                expect.any(SurveyObjectsRegistry)
+            );
+        });
+
+        it('should keep an explicit home _uuid over the interview uuid default', async () => {
+            mockedCreateInterviewObject.mockReturnValue(createOk({} as any));
+            (MockedHome.create as jest.Mock).mockReturnValue(createOk({} as any));
+            (MockedHousehold.create as jest.Mock).mockReturnValue(createOk({ members: [] } as any));
+
+            await factory.createAllObjectsWithErrors(interviewAttributes);
+
+            // Fixture's home already has an explicit `_uuid: 'home-uuid'`, which must win.
+            expect(MockedHome.create).toHaveBeenCalledWith(
+                expect.objectContaining({ _uuid: 'home-uuid' }),
+                expect.any(SurveyObjectsRegistry)
+            );
+        });
+
+        it('should default household _uuid to the interview uuid when not explicitly set', async () => {
+            interviewAttributes.corrected_response!.household = { size: 2 } as any;
+
+            mockedCreateInterviewObject.mockReturnValue(createOk({} as any));
+            (MockedHome.create as jest.Mock).mockReturnValue(createOk({} as any));
+            (MockedHousehold.create as jest.Mock).mockReturnValue(createOk({ members: [] } as any));
+
+            await factory.createAllObjectsWithErrors(interviewAttributes);
+
+            expect(MockedHousehold.create).toHaveBeenCalledWith(
+                expect.objectContaining({ _uuid: 'interview-uuid' }),
+                expect.any(SurveyObjectsRegistry)
+            );
+        });
+
+        it('should keep an explicit household _uuid over the interview uuid default', async () => {
+            mockedCreateInterviewObject.mockReturnValue(createOk({} as any));
+            (MockedHome.create as jest.Mock).mockReturnValue(createOk({} as any));
+            (MockedHousehold.create as jest.Mock).mockReturnValue(createOk({ members: [] } as any));
+
+            await factory.createAllObjectsWithErrors(interviewAttributes);
+
+            // Fixture's household already has an explicit `_uuid: 'household-uuid'`, which must win.
+            expect(MockedHousehold.create).toHaveBeenCalledWith(
+                expect.objectContaining({ _uuid: 'household-uuid' }),
+                expect.any(SurveyObjectsRegistry)
+            );
+        });
+
         it('should handle missing home attributes', async () => {
             interviewAttributes.corrected_response!.home = undefined;
 


### PR DESCRIPTION
## Résumé
`Household` et `Home` sont des objets singleton (un par interview), et leur `corrected_response` ne stocke jamais de `_uuid` explicite. Sans cela, `Uuidable` générait un UUID aléatoire à chaque reconstruction de ces objets par `SurveyObjectsFactory` (donc à chaque chargement de page admin), rendant `household._uuid`/`home._uuid` instables.

Conséquence concrète découverte via l'admin d'un projet dérivé : les boutons d'approbation/rejet de review (`POST /api/review/decision/:interviewId`) pour `household`/`home` échouaient systématiquement avec une erreur 404 `Survey object does not exist in interview`, pour n'importe quel utilisateur (permissions non impliquées). En cause : le frontend envoie l'uuid généré côté objet, alors que `surveyObjectExistsInInterview`/`singletonObjectMatchesUuid` compare contre l'`interview.uuid` en fallback quand `_uuid` est absent de `corrected_response` — un fallback qui ne matchait jamais puisque l'uuid envoyé était aléatoire, pas l'uuid de l'interview.

## Changement
Dans `SurveyObjectsFactory.ts`, `_uuid` par défaut = `interview.uuid` pour `household`/`home` quand absent des attributs, avant l'appel à `Household.create`/`Home.create`. Un `_uuid` explicite déjà présent dans `corrected_response` reste prioritaire.

## Plan de test
- [x] Tests unitaires ajoutés dans `SurveyObjectsFactory.test.ts` (défaut à l'uuid de l'interview + priorité à un `_uuid` explicite, pour `household` et `home`)
- [x] Suite complète `evolution-backend` (surveyObjects, audits, reviews, routes de validation) : 59 suites, 588 tests passés