### PR TITLE
AuditCheck: I_M_AssignedDate - missing assigned date

### DIFF
--- a/locales/en/audits.json
+++ b/locales/en/audits.json
@@ -4,6 +4,7 @@
     "I_I_StartedAtBeforeSurveyStartDate": "Interview start time is before survey start date",
     "I_I_StartedAtAfterSurveyEndDate": "Interview start time is after survey end date",
     "I_M_AccessCode": "Access code is missing",
+    "I_M_AssignedDate": "Assigned date is missing",
     "I_I_InvalidAccessCodeFormat": "Access code format is invalid",
     "I_I_ContactEmail": "Contact email is invalid",
     "I_M_ContactEmailButWouldLikeToParticipateInOtherSurveys": "Contact email is missing but respondent would like to participate in other surveys",

--- a/locales/fr/audits.json
+++ b/locales/fr/audits.json
@@ -4,6 +4,7 @@
     "I_I_StartedAtBeforeSurveyStartDate": "Le début de l'entrevue est avant la date de début de l'enquête",
     "I_I_StartedAtAfterSurveyEndDate": "Le début de l'entrevue est après la date de fin de l'enquête",
     "I_M_AccessCode": "Le code d'accès est manquant",
+    "I_M_AssignedDate": "La date assignée est manquante",
     "I_I_InvalidAccessCodeFormat": "Le format du code d'accès est invalide",
     "I_I_ContactEmail": "Le courriel de contact est invalide",
     "I_M_ContactEmailButWouldLikeToParticipateInOtherSurveys": "Le courriel de contact est manquant, mais la personne répondante aimerait participer à d'autres enquêtes",

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/InterviewAuditChecks.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/InterviewAuditChecks.ts
@@ -249,7 +249,29 @@ export const interviewAuditChecks: { [errorCode: string]: InterviewAuditCheckFun
             };
         }
         return undefined;
-    }
+    },
 
     // TODO: validate phone number formats and normalize. The format should be defined in the survey config (by country).
+
+    /**
+     * Check if interview assigned date is missing (if required)
+     * @param context - InterviewAuditCheckContext
+     * @returns {AuditForObject | undefined}
+     */
+    I_M_AssignedDate: (context: InterviewAuditCheckContext): AuditForObject | undefined => {
+        const { interview } = context;
+        const assignedDate = interview.assignedDate;
+        if (fieldIsRequired('interview', 'assignedDate') && _isBlank(assignedDate)) {
+            return {
+                objectType: 'interview',
+                objectUuid: interview.uuid!,
+                errorCode: 'I_M_AssignedDate',
+                version: 1,
+                level: 'error',
+                message: 'Assigned date is missing',
+                ignore: false
+            };
+        }
+        return undefined;
+    }
 };

--- a/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/interview/I_M_AssignedDate.test.ts
+++ b/packages/evolution-backend/src/services/audits/auditChecks/checks/__tests__/interview/I_M_AssignedDate.test.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import _cloneDeep from 'lodash/cloneDeep';
+import { v4 as uuidV4 } from 'uuid';
+import projectConfig from 'evolution-common/lib/config/project.config';
+import type { Interview } from 'evolution-common/lib/services/baseObjects/interview/Interview';
+import type { InterviewAuditCheckContext } from '../../../AuditCheckContexts';
+import { interviewAuditChecks } from '../../InterviewAuditChecks';
+import { createMockInterview } from './testHelper';
+
+/**
+ * Override interview required fields for the current test.
+ * @param fields - Field names required on the interview object for this test
+ */
+const setInterviewRequiredFields = (fields: string[]): void => {
+    projectConfig.requiredFieldsBySurveyObject = {
+        ...projectConfig.requiredFieldsBySurveyObject,
+        interview: fields
+    };
+};
+
+describe('I_M_AssignedDate audit check', () => {
+    const validUuid = uuidV4();
+    let originalRequiredFieldsBySurveyObject: typeof projectConfig.requiredFieldsBySurveyObject;
+
+    beforeAll(() => {
+        originalRequiredFieldsBySurveyObject = _cloneDeep(projectConfig.requiredFieldsBySurveyObject);
+    });
+
+    afterEach(() => {
+        projectConfig.requiredFieldsBySurveyObject = _cloneDeep(originalRequiredFieldsBySurveyObject);
+    });
+
+    describe('audit should pass when', () => {
+        it.each([
+            {
+                description: 'assigned date is required and present',
+                assignedDate: '2023-05-01',
+                isRequired: true
+            },
+            {
+                description: 'assigned date is not required and present',
+                assignedDate: '2023-05-01',
+                isRequired: false
+            },
+            {
+                description: 'assigned date is not required and missing',
+                assignedDate: undefined,
+                isRequired: false
+            },
+            {
+                description: 'assigned date is not required and null',
+                assignedDate: null,
+                isRequired: false
+            },
+            {
+                description: 'assigned date is not required and empty string',
+                assignedDate: '',
+                isRequired: false
+            }
+        ])('$description', ({ assignedDate, isRequired }) => {
+            setInterviewRequiredFields(isRequired ? ['assignedDate'] : []);
+
+            const interview = createMockInterview({ assignedDate } as Partial<Interview>);
+            const context: InterviewAuditCheckContext = { interview };
+
+            const result = interviewAuditChecks.I_M_AssignedDate(context);
+
+            expect(result).toBeUndefined();
+        });
+    });
+
+    describe('audit should fail when assigned date is required', () => {
+        it.each([
+            {
+                description: 'assigned date is undefined',
+                assignedDate: undefined
+            },
+            {
+                description: 'assigned date is empty string',
+                assignedDate: ''
+            },
+            {
+                description: 'assigned date is whitespace only',
+                assignedDate: '   '
+            }
+        ])('$description', ({ assignedDate }) => {
+            setInterviewRequiredFields(['assignedDate']);
+
+            const interview = createMockInterview({ assignedDate } as Partial<Interview>, validUuid);
+            const context: InterviewAuditCheckContext = { interview };
+
+            const result = interviewAuditChecks.I_M_AssignedDate(context);
+
+            expect(result).toEqual({
+                objectType: 'interview',
+                objectUuid: validUuid,
+                errorCode: 'I_M_AssignedDate',
+                version: 1,
+                level: 'error',
+                message: 'Assigned date is missing',
+                ignore: false
+            });
+        });
+    });
+});


### PR DESCRIPTION
If the assigned date is required per survey configuration (requiredFieldsBySurveyObject['interview'].includes('assignedDate')), this audit check will return an error if the assigned date is missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added interview validation to flag a missing assigned date when the field is required.
  * Added English and French alert messages for this validation.
* **Bug Fixes**
  * Empty, undefined, and whitespace-only assigned dates are now correctly flagged when required.
  * Optional assigned dates continue to pass validation when blank.
* **Tests**
  * Added automated coverage for required and optional assigned-date scenarios, including expected pass and fail outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->