### PR TITLE
Enable automatic retry of stalled coderabbit reviews

### DIFF
--- a/.github/workflows/coderabbit-retry.yml
+++ b/.github/workflows/coderabbit-retry.yml
@@ -1,0 +1,14 @@
+# Atttempt retry on stalled coderabbit review
+# See file in Transition repo
+
+on:
+  schedule:
+    # Every 3 hours, offset from Transition
+    - cron: '20 4-11/3 * * *'
+  workflow_dispatch:
+
+
+jobs:
+  retry:
+    name: Process rate-limited reviews
+    uses: chairemobilite/transition/.github/workflows/coderabbit-retry.yml@main


### PR DESCRIPTION
Reuse the workflow in the Transition repo.

This is an exact copy of what was added in trRouting We use the same timing as trRouting with a small offset, the probabilityy of the same people contributing to both trRouting and evolution is low