### PR TITLE
Fix permission for coderabbit retry workflow

### DIFF
--- a/.github/workflows/coderabbit-retry.yml
+++ b/.github/workflows/coderabbit-retry.yml
@@ -11,4 +11,8 @@ on:
 jobs:
   retry:
     name: Process rate-limited reviews
+    permissions:
+      pull-requests: write
+      contents: read
     uses: chairemobilite/transition/.github/workflows/coderabbit-retry.yml@main
+    secrets: inherit


### PR DESCRIPTION
Was tested on the TrRouting repo and seem to work better

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of automated pull request review retry workflows by explicitly configuring the required access permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->