### PR TITLE
widget: add path and `containsHtml` to widgetTripSegmentIntro

### DIFF
--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetTripSegmentsIntro.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetTripSegmentsIntro.test.ts
@@ -23,7 +23,9 @@ describe('getTripSegmentsIntro', () => {
 
         expect(widgetConfig).toEqual({
             type: 'text',
-            text: expect.any(Function)
+            text: expect.any(Function),
+            containsHtml: true,
+            path: 'segmentIntro'
         });
     });
 });

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/widgetTripSegmentsIntro.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/widgetTripSegmentsIntro.ts
@@ -12,6 +12,8 @@ import { WidgetFactoryOptions } from '../types';
 
 export const getTripSegmentsIntro = (_options: WidgetFactoryOptions): TextWidgetConfig => ({
     type: 'text',
+    path: 'segmentIntro',
+    containsHtml: true,
     text: (t: TFunction, interview) => {
         const person = odHelpers.getPerson({ interview });
         const journey = odHelpers.getActiveJourney({ interview, person });


### PR DESCRIPTION
fixes #1715

The path allows functions like conditionals and labels to access the current context of the group (the trip)

`containsHtml` allows to add html characters in the labels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trip segment introduction content now supports HTML formatting.
  * Added a dedicated path for the trip segment introduction widget.

* **Tests**
  * Updated coverage to verify HTML support and widget path configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->