### PR TITLE
ui test: add possibility to use otherPerson in paths

### DIFF
--- a/packages/evolution-frontend/tests/ui-testing/SurveyObjectDetectors.ts
+++ b/packages/evolution-frontend/tests/ui-testing/SurveyObjectDetectors.ts
@@ -84,6 +84,20 @@ export class SurveyObjectDetector {
         return newString;
     }
 
+    // Replace ${otherPerson[n]} with the actual person ID of another household member.
+    private replaceWithOtherPersonId(str: string): string {
+        let newString = str;
+        const otherPersonRegex = /\$\{otherPerson\[(\d+)\]\}/g;
+        const otherPersonIds = this.personIds.filter((personId) => personId !== this.activePersonId);
+
+        newString = str.replace(otherPersonRegex, (match, indexStr) => {
+            const index = Number(indexStr);
+            return otherPersonIds[index] ?? match;
+        });
+
+        return newString;
+    }
+
     // Replace ${tripDiary[n]} with the actual trip diary ID, or optional fields like ${tripDiary[n].personId}, ${tripDiary[n].journeyId}, ${tripDiary[n].visitedPlace[index]}
     private replaceWithTripDiaryData(str: string): string {
         let newString = str;
@@ -140,6 +154,7 @@ export class SurveyObjectDetector {
     public replaceWithIds(str: string): string {
         let newString = this.replaceWithPersonId(str);
         newString = this.replaceWithVehicleId(newString);
+        newString = this.replaceWithOtherPersonId(newString);
         newString = this.replaceWithActiveObjectId(newString, this.activePersonStr, this.activePersonId);
         newString = this.replaceWithActiveObjectId(newString, this.activeVehicleStr, this.activeVehicleId);
         newString = this.replaceWithActiveObjectId(newString, this.activeJourneyStr, this.activeJourneyId);


### PR DESCRIPTION
fixes #1716

In UI tests, placeholders can use the `${otherPerson[n]}` syntax to replace with the value of a person ID that is not the currently active person. This is useful for questions where other household members are listed as answers, for example, who answers for a given household member to select another person than the current one.

This has been tested with the od_mtl UI tests