### PR TITLE
tripDiary: support entering on the road work place when usual places are inlined

### DIFF
--- a/locales/en/visitedPlaces.yml
+++ b/locales/en/visitedPlaces.yml
@@ -83,6 +83,7 @@ visitedPlaceNameExample_worship: >-
     Sholem
 visitedPlaceNameExample_secondaryHome: Secondary home or cottage address
 visitedPlaceNameExample_schoolNotStudent: language centre, Tecnic driving school
+visitedPlacePreviousWorkPlaceName: Name or address of the usual work place
 activityNameIsRequiredError: Description is required.
 visitedPlaceGeography: >-
     Please locate this place on the map<br /><span class="_pale _oblique">Pan,
@@ -94,6 +95,12 @@ locationIsRequiredError: Location is required.
 locationIsNotPreciseError: >-
     Location is not precise enough. Please use the + zoom and drag the icon
     marker to confirm the precise location.
+visitedPlacePreviousWorkPlaceGeography: >-
+    Please locate on the map the usual work place<br /><span class="_pale _oblique">Pan,
+    zoom and click on map. Once a pin icon has been dropped, you will be able to
+    drag the icon to specify a more precise location. You can also search for a
+    place using its name or address with the button below.</span>
+workPlaceLocationIsRequiredError: Usual work place location is required.
 ConfirmDeleteVisitedPlace: Do you confirm that you want to remove this location?
 dayScheduleFor: Day schedule for <strong>{{nickname}}</strong>
 dayScheduleFor_one: Your day schedule

--- a/locales/fr/visitedPlaces.yml
+++ b/locales/fr/visitedPlaces.yml
@@ -81,6 +81,7 @@ visitedPlaceNameExample_service: Coiffure Dans le Vent, Caisse Desjardins de Lim
 visitedPlaceNameExample_worship: Église Saint-Nicéphore, Mosquée de la Capitale, Synagogue Maison Chabad
 visitedPlaceNameExample_secondaryHome: Adresse de la résidence secondaire ou du chalet
 visitedPlaceNameExample_schoolNotStudent: Institut Linguistique, École de conduite Tecnic
+visitedPlacePreviousWorkPlaceName: Nom ou adresse du lieu habituel de travail
 activityNameIsRequiredError: La description est requise.
 visitedPlaceGeography: >-
     Veuillez positionner le lieu sur la carte<br /><span class="_pale
@@ -94,6 +95,13 @@ locationIsNotPreciseError: >-
     Le positionnement du lieu n'est pas assez précis. Utilisez le zoom + pour
     vous rapprocher davantage, puis précisez la localisation en déplaçant
     l'icône.
+visitedPlacePreviousWorkPlaceGeography: >-
+    Veuillez positionner sur la carte le lieu habituel de travail<br /><span class="_pale
+    _oblique">Naviguez, zoomez, et cliquez sur la carte pour localiser le lieu.
+    Une fois localisé, vous pourrez déplacer le point pour davantage de
+    précision. Vous pouvez également chercher le lieu en utilisant le nom ou
+    l'adresse avec le bouton ci-dessous.</span>
+workPlaceLocationIsRequiredError: Le positionnement du lieu de travail habituel est requis.
 ConfirmDeleteVisitedPlace: Confirmez-vous que vous voulez retirer ce lieu?
 dayScheduleFor: Horaire de la journée de <strong>{{nickname}}</strong>
 dayScheduleFor_one: Votre horaire de la journée

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/buttonsVisitedPlace.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/buttonsVisitedPlace.test.ts
@@ -216,6 +216,134 @@ describe('buttonSaveVisitedPlace widget', () => {
                 },
                 expectedActiveVisitedPlaceId: null
             }, {
+                title: 'inserts two places for workOnTheRoad with workUsual departure and workUsual arrival, inlining usual places',
+                path: 'household.persons.personId1.journeys.journeyId1.visitedPlaces.otherPlace2P1',
+                activeVisitedPlaceId: 'otherPlace2P1',
+                setup: (interview: typeof interviewAttributesForTestCases) => {
+                    const journey = getJourney(interview);
+                    const visitedPlace = journey.visitedPlaces!.otherPlace2P1;
+                    visitedPlace.activity = 'workOnTheRoad';
+                    visitedPlace.activityCategory = 'work';
+                    visitedPlace.onTheRoadPreviousPlaceActivity = 'workUsual';
+                    visitedPlace.onTheRoadNextPlaceCategory = 'wentToUsualWorkPlace';
+                    visitedPlace._previousWorkPlace = {
+                        name: 'Previous on the road work place',
+                        geography: { type: 'Feature', geometry: { type: 'Point', coordinates: [73, 45] }, properties: { lastAction: 'findPlace' } }
+                    };
+                    visitedPlace.arrivalTime = 9 * 60 * 60;
+                    visitedPlace.departureTime = 17 * 60 * 60;
+                    visitedPlace._previousArrivalTime = 8 * 60 * 60;
+                },
+                expectedInsertedPlaces: [
+                    {
+                        insertSequence: 5,
+                        newVisitedPlace: {
+                            activity: 'workUsual',
+                            activityCategory: 'work',
+                            nextPlaceCategory: 'visitedAnotherPlace',
+                            arrivalTime: 8 * 60 * 60,
+                            departureTime: 9 * 60 * 60,
+                            name: 'Previous on the road work place',
+                            geography: { type: 'Feature', geometry: { type: 'Point', coordinates: [73, 45] }, properties: { lastAction: 'findPlace' } }
+                        }
+                    },
+                    {
+                        insertSequence: 7,
+                        newVisitedPlace: {
+                            activity: 'workUsual',
+                            activityCategory: 'work',
+                            arrivalTime: 17 * 60 * 60
+                        }
+                    }
+                ],
+                expectedFirstUpdateValuesByPath: {
+                    'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.otherPlace2P1._isNew': false
+                },
+                expectedActiveVisitedPlaceId: null,
+                widgetConfig: new ButtonsVisitedPlaceConfigFactory(
+                    { ...visitedPlacesSectionConfig, inlineUsualPlacesEntry: true },
+                    widgetFactoryOptions
+                ).getWidgetConfigs().buttonSaveVisitedPlace as ButtonWidgetConfig
+            }, {
+                title: 'inserts two places for workOnTheRoad with workUsual departure and workUsual arrival',
+                path: 'household.persons.personId1.journeys.journeyId1.visitedPlaces.otherPlace2P1',
+                activeVisitedPlaceId: 'otherPlace2P1',
+                setup: (interview: typeof interviewAttributesForTestCases) => {
+                    const journey = getJourney(interview);
+                    const visitedPlace = journey.visitedPlaces!.otherPlace2P1;
+                    visitedPlace.activity = 'workOnTheRoad';
+                    visitedPlace.activityCategory = 'work';
+                    visitedPlace.onTheRoadPreviousPlaceActivity = 'workUsual';
+                    visitedPlace.onTheRoadNextPlaceCategory = 'wentToUsualWorkPlace';
+                    visitedPlace.arrivalTime = 9 * 60 * 60;
+                    visitedPlace.departureTime = 17 * 60 * 60;
+                    visitedPlace._previousArrivalTime = 8 * 60 * 60;
+                },
+                expectedInsertedPlaces: [
+                    {
+                        insertSequence: 5,
+                        newVisitedPlace: {
+                            activity: 'workUsual',
+                            activityCategory: 'work',
+                            nextPlaceCategory: 'visitedAnotherPlace',
+                            arrivalTime: 8 * 60 * 60,
+                            departureTime: 9 * 60 * 60
+                        }
+                    },
+                    {
+                        insertSequence: 7,
+                        newVisitedPlace: {
+                            activity: 'workUsual',
+                            activityCategory: 'work',
+                            arrivalTime: 17 * 60 * 60
+                        }
+                    }
+                ],
+                expectedFirstUpdateValuesByPath: {
+                    'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.otherPlace2P1._isNew': false
+                },
+                expectedActiveVisitedPlaceId: null
+            }, {
+                title: 'do not change previous place for workOnTheRoad with workUsual if previous place is already workUsual, with inline',
+                path: 'household.persons.personId1.journeys.journeyId1.visitedPlaces.otherPlace2P1',
+                activeVisitedPlaceId: 'otherPlace2P1',
+                setup: (interview: typeof interviewAttributesForTestCases) => {
+                    const journey = getJourney(interview);
+                    // Ensure the previous place is a workUsual, its geography and name should be used for previous work place of current place
+                    const previousPlace = journey.visitedPlaces!.otherPlaceP1;
+                    previousPlace.activity = 'workUsual';
+                    previousPlace.activityCategory = 'work';
+                    const visitedPlace = journey.visitedPlaces!.otherPlace2P1;
+                    visitedPlace.activity = 'workOnTheRoad';
+                    visitedPlace.activityCategory = 'work';
+                    visitedPlace.onTheRoadPreviousPlaceActivity = 'workUsual';
+                    visitedPlace.onTheRoadNextPlaceCategory = 'wentToUsualWorkPlace';
+                    visitedPlace._previousWorkPlace = {
+                        name: previousPlace.name,
+                        geography: previousPlace.geography
+                    },
+                    visitedPlace.arrivalTime = 9 * 60 * 60;
+                    visitedPlace.departureTime = 17 * 60 * 60;
+                },
+                expectedInsertedPlaces: [
+                    {
+                        insertSequence: 6,
+                        newVisitedPlace: {
+                            activity: 'workUsual',
+                            activityCategory: 'work',
+                            arrivalTime: 17 * 60 * 60
+                        }
+                    }
+                ],
+                expectedFirstUpdateValuesByPath: {
+                    'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.otherPlace2P1._isNew': false
+                },
+                expectedActiveVisitedPlaceId: null,
+                widgetConfig: new ButtonsVisitedPlaceConfigFactory(
+                    { ...visitedPlacesSectionConfig, inlineUsualPlacesEntry: true },
+                    widgetFactoryOptions
+                ).getWidgetConfigs().buttonSaveVisitedPlace as ButtonWidgetConfig
+            }, {
                 title: 'set previous departure time when editing the second place of the day, and stay until next day',
                 path: 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1',
                 activeVisitedPlaceId: 'workPlace1P1',
@@ -295,7 +423,8 @@ describe('buttonSaveVisitedPlace widget', () => {
                 }
             });
 
-            await widgetConfig.saveCallback?.(
+            const effectiveWidgetConfig = testCase.widgetConfig ?? widgetConfig;
+            await effectiveWidgetConfig.saveCallback?.(
                 {
                     startAddGroupedObjects,
                     startUpdateInterview

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/groupPersonVisitedPlaces.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/groupPersonVisitedPlaces.test.ts
@@ -18,6 +18,7 @@ import { VisitedPlaceShortcutWidgetFactory } from '../widgetsVisitedPlaceShortcu
 import { ButtonsVisitedPlaceConfigFactory } from '../buttonsVisitedPlace';
 import { VisitedPlaceTimeWidgetFactory } from '../widgetsTime';
 import { VisitedPlaceOnTheRoadWidgetFactory } from '../widgetsOnTheRoadSpecifics';
+import { PreviousWorkPlaceGeographyWidgetFactory } from '../widgetsPreviousWorkplaceGeography';
 
 const visitedPlacesSectionConfig: VisitedPlacesSectionConfiguration = {
     type: 'visitedPlaces',
@@ -25,6 +26,8 @@ const visitedPlacesSectionConfig: VisitedPlacesSectionConfiguration = {
     tripDiaryMinTimeOfDay: 4 * 60 * 60, // 4h in seconds
     tripDiaryMaxTimeOfDay: 28 * 60 * 60
 };
+
+const expectedWidgetCount = 18;
 
 describe('PersonVisitedPlacesGroupConfigFactory widgets', () => {
     test.each([
@@ -60,7 +63,7 @@ describe('PersonVisitedPlacesGroupConfigFactory widgets', () => {
             visitedPlacesSectionConfig,
             widgetFactoryOptions
         ).getWidgetConfigs();
-        expect(Object.keys(widgetConfigs)).toHaveLength(18);
+        expect(Object.keys(widgetConfigs)).toHaveLength(expectedWidgetCount);
     });
 
     test.each([
@@ -396,4 +399,83 @@ describe('PersonVisitedPlacesGroupConfigFactory personVisitedPlaces GroupConfig 
             ]
         });
     });
+});
+
+describe('PersonVisitedPlacesGroupConfigFactory widgets, with inlining usual places', () => {
+    const visitedPlacesWithInlineSectionConfig: VisitedPlacesSectionConfiguration = {
+        type: 'visitedPlaces',
+        enabled: true,
+        inlineUsualPlacesEntry: true,
+        tripDiaryMinTimeOfDay: 4 * 60 * 60, // 4h in seconds
+        tripDiaryMaxTimeOfDay: 28 * 60 * 60
+    };
+
+    test.each([
+        'personVisitedPlaces',
+        'visitedPlaceActivityCategory',
+        'visitedPlaceActivity',
+        'visitedPlaceOnTheRoadPreviousPlaceActivity',
+        'visitedPlacePreviousWorkPlaceName',
+        'visitedPlacePreviousWorkPlaceGeography',
+        'visitedPlaceAlreadyVisited',
+        'visitedPlaceShortcut',
+        'visitedPlaceName',
+        'visitedPlaceGeography',
+        'visitedPlaceOnTheRoadNextPlaceCategory',
+        'visitedPlaceNextPlaceCategory',
+        'buttonSaveVisitedPlace',
+        'buttonCancelVisitedPlace',
+        'buttonDeleteVisitedPlace',
+        'visitedPlaceArrivalTime',
+        'visitedPlacePreviousDepartureTime',
+        'visitedPlacePreviousArrivalTime',
+        'visitedPlacePreviousPreviousDepartureTime',
+        'visitedPlaceDepartureTime'
+    ])('should have a widget named %s', (widgetName) => {
+        const widgetConfigs = new PersonVisitedPlacesGroupConfigFactory(
+            visitedPlacesWithInlineSectionConfig,
+            widgetFactoryOptions
+        ).getWidgetConfigs();
+        const widgetNames = Object.keys(widgetConfigs);
+        expect(widgetNames).toContain(widgetName);
+    });
+
+    test('should not return extra widgets', () => {
+        const widgetConfigs = new PersonVisitedPlacesGroupConfigFactory(
+            visitedPlacesWithInlineSectionConfig,
+            widgetFactoryOptions
+        ).getWidgetConfigs();
+        expect(Object.keys(widgetConfigs)).toHaveLength(expectedWidgetCount + 2);
+    });
+
+    test.each([
+        {
+            widgetName: 'visitedPlacePreviousWorkPlaceName',
+            expected: (config: VisitedPlacesSectionConfiguration) =>
+                new PreviousWorkPlaceGeographyWidgetFactory(config, widgetFactoryOptions).getWidgetConfigs().visitedPlacePreviousWorkPlaceName
+        },
+        {
+            widgetName: 'visitedPlacePreviousWorkPlaceGeography',
+            expected: (config: VisitedPlacesSectionConfiguration) =>
+                new PreviousWorkPlaceGeographyWidgetFactory(config, widgetFactoryOptions).getWidgetConfigs()
+                    .visitedPlacePreviousWorkPlaceGeography
+        }
+    ])(
+        'should return the correct widget config for $widgetName',
+        ({
+            widgetName,
+            expected
+        }: {
+            widgetName: string;
+            expected: (config: VisitedPlacesSectionConfiguration) => WidgetConfig;
+        }) => {
+            const widgetConfigs = new PersonVisitedPlacesGroupConfigFactory(
+                visitedPlacesWithInlineSectionConfig,
+                widgetFactoryOptions
+            ).getWidgetConfigs();
+            const widgetConfig = widgetConfigs[widgetName];
+            const expectedWidgetConfig = expected(visitedPlacesWithInlineSectionConfig);
+            expect(maskFunctions(widgetConfig)).toEqual(maskFunctions(expectedWidgetConfig));
+        }
+    );
 });

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetsPreviousWorkplaceGeography.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetsPreviousWorkplaceGeography.test.ts
@@ -1,0 +1,454 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import _cloneDeep from 'lodash/cloneDeep';
+import i18n from 'i18next';
+import config from '../../../../../config/project.config';
+import { interviewAttributesForTestCases, setActiveSurveyObjects, widgetFactoryOptions } from '../../../../../tests/surveys';
+import { setResponse, translateString } from '../../../../../utils/helpers';
+import { InputMapFindPlaceType, InputStringType, QuestionWidgetConfig } from '../../../types';
+import { homeGeographyCoordinates, shoppingPlace1P2Coordinates } from '../../../../../tests/surveys/testCasesInterview';
+import { PreviousWorkPlaceGeographyWidgetFactory } from '../widgetsPreviousWorkplaceGeography';
+import { getActivityMarkerIcon } from '../activityIconMapping';
+import { initializeVisitedPlaceSectionHelpers } from '../helpers';
+
+const visitedPlacesSectionConfig = {
+    type: 'visitedPlaces' as const,
+    enabled: true,
+    inlineUsualPlacesEntry: true,
+    tripDiaryMinTimeOfDay: 4 * 60 * 60,
+    tripDiaryMaxTimeOfDay: 28 * 60 * 60
+};
+
+beforeAll(() => {
+    // initialize the visited place section helpers with the inline version
+    initializeVisitedPlaceSectionHelpers(visitedPlacesSectionConfig);
+});
+
+describe('PreviousWorkPlaceGeographyWidgetFactory', () => {
+    test('should return expected location widgets configuration', () => {
+        const widgetConfig = new PreviousWorkPlaceGeographyWidgetFactory(
+            visitedPlacesSectionConfig,
+            widgetFactoryOptions
+        ).getWidgetConfigs();
+
+        expect(Object.keys(widgetConfig).sort()).toEqual(['visitedPlacePreviousWorkPlaceGeography', 'visitedPlacePreviousWorkPlaceName']);
+
+        const nameWidget = widgetConfig.visitedPlacePreviousWorkPlaceName as QuestionWidgetConfig & InputStringType;
+        expect(nameWidget.path).toBe('_previousWorkPlace.name');
+        expect(nameWidget.conditional).toEqual(expect.any(Function));
+        expect(nameWidget.validations).toEqual(expect.any(Function));
+
+        const geographyWidget = widgetConfig.visitedPlacePreviousWorkPlaceGeography as QuestionWidgetConfig & InputMapFindPlaceType;
+        expect(geographyWidget.path).toBe('_previousWorkPlace.geography');
+        expect(geographyWidget.conditional).toEqual(expect.any(Function));
+        expect(geographyWidget.validations).toEqual(expect.any(Function));
+    });
+});
+
+describe('visitedPlacePreviousWorkPlaceName widget', () => {
+    const widgetConfig = new PreviousWorkPlaceGeographyWidgetFactory(
+        visitedPlacesSectionConfig,
+        widgetFactoryOptions
+    ).getWidgetConfigs()['visitedPlacePreviousWorkPlaceName'] as QuestionWidgetConfig & InputStringType;
+
+    beforeEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    describe('label', () => {
+        test('should include example help text when i18n key exists', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const mockedT = jest.fn().mockImplementation((key: string) => key);
+            jest.spyOn(i18n, 'exists').mockReturnValue(true);
+
+            const result = translateString(
+                widgetConfig.label,
+                { t: mockedT } as any,
+                interview,
+                'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.name'
+            );
+
+            expect(result).toContain('visitedPlaces:visitedPlacePreviousWorkPlaceName');
+            expect(result).toContain('survey:forExampleAbbreviation');
+            expect(result).toContain('visitedPlaces:visitedPlaceNameExample');
+            expect(mockedT).toHaveBeenCalledWith('visitedPlaces:visitedPlacePreviousWorkPlaceName');
+            expect(mockedT).toHaveBeenCalledWith('survey:forExampleAbbreviation');
+            expect(mockedT).toHaveBeenCalledWith('visitedPlaces:visitedPlaceNameExample', {
+                context: 'workUsual_onTheRoadOften'
+            });
+        });
+    });
+    
+    describe('conditional', () => {
+        test('should return false when usual places are not inlined', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const widgetFactory = new PreviousWorkPlaceGeographyWidgetFactory(
+                { ...visitedPlacesSectionConfig, inlineUsualPlacesEntry: false },
+                widgetFactoryOptions
+            );
+            const conditional = widgetFactory.getWidgetConfigs()['visitedPlacePreviousWorkPlaceName'].conditional as any;
+
+            expect(conditional(interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1._previousWorkPlace.name')).toBe(false);
+        });
+
+        test('should return false when the previous on-the-road activity is not workUsual', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const conditional = widgetConfig.conditional as any;
+            setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'newPlace' });
+            interview.response.household!.persons!.personId1!.journeys!.journeyId1.visitedPlaces!.newPlace = {
+                _uuid: 'newPlace',
+                _sequence: 6,
+                activity: 'workOnTheRoad',
+                onTheRoadPreviousPlaceActivity: 'home'
+            };
+
+            expect(
+                conditional(
+                    interview,
+                    'household.persons.personId1.journeys.journeyId1.visitedPlaces.newPlace._previousWorkPlace.name'
+                )
+            ).toBe(false);
+        });
+
+        test('should show the widget when the usual work place is not yet defined', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const conditional = widgetConfig.conditional as any;
+            // Set the new place
+            setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'newPlace' });
+            interview.response.household!.persons!.personId1!.journeys!.journeyId1.visitedPlaces!.newPlace = {
+                _uuid: 'newPlace',
+                _sequence: 6,
+                activity: 'workOnTheRoad',
+                onTheRoadPreviousPlaceActivity: 'workUsual'
+            };
+            // Change activity of workPlace1P1 to be not 'workUsual'
+            interview.response.household!.persons!.personId1!.journeys!.journeyId1.visitedPlaces!.workPlace1P1.activity = 'workNotUsual';
+
+            expect(
+                conditional(
+                    interview,
+                    'household.persons.personId1.journeys.journeyId1.visitedPlaces.newPlace._previousWorkPlace.name'
+                )
+            ).toEqual(true);
+        });
+
+        test('should hide the widget and use the usual work place name when it is already defined', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const conditional = widgetConfig.conditional as any;
+            // Set the new place
+            setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'newPlace' });
+            interview.response.household!.persons!.personId1!.journeys!.journeyId1.visitedPlaces!.newPlace = {
+                _uuid: 'newPlace',
+                _sequence: 6,
+                activity: 'workOnTheRoad',
+                onTheRoadPreviousPlaceActivity: 'workUsual'
+            };
+
+            // workPlace1P1 is a workUsual
+            expect(
+                conditional(
+                    interview,
+                    'household.persons.personId1.journeys.journeyId1.visitedPlaces.newPlace._previousWorkPlace.name'
+                )
+            ).toEqual([false, interview.response.household!.persons!.personId1!.journeys!.journeyId1.visitedPlaces!.workPlace1P1.name]);
+        });
+    });
+
+    describe('validations', () => {
+        const validations = widgetConfig.validations as any;
+
+        test('should require a non-blank value', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            
+            const validationResult = validations(undefined, null, interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.newPlace._previousWorkPlace.name');
+            expect(validationResult[0].validation).toBe(true);
+        });
+    });
+});
+
+describe('visitedPlacePreviousWorkPlaceGeography widget', () => {
+    const widgetConfig = new PreviousWorkPlaceGeographyWidgetFactory(
+        visitedPlacesSectionConfig,
+        widgetFactoryOptions
+    ).getWidgetConfigs()['visitedPlacePreviousWorkPlaceGeography'] as QuestionWidgetConfig & InputMapFindPlaceType;
+
+    beforeEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    describe('label', () => {
+        test('should use the right translation key for the label', () => {
+            const mockedT = jest.fn();
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+
+            translateString(widgetConfig.label, { t: mockedT } as any, interview, 'path');
+            expect(mockedT).toHaveBeenCalledWith('visitedPlaces:visitedPlacePreviousWorkPlaceGeography');
+        });
+
+        test('should use the right translation key for geocoding refresh', () => {
+            const mockedT = jest.fn();
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+
+            translateString(widgetConfig.refreshGeocodingLabel, { t: mockedT } as any, interview, 'path');
+            expect(mockedT).toHaveBeenCalledWith('visitedPlaces:refreshGeocodingButton');
+        });
+    });
+
+    test('should return marker icon for workUsual', () => {
+        const icon = widgetConfig.icon;
+
+        expect(icon).toEqual({
+            url: getActivityMarkerIcon('workUsual'),
+            size: [70, 70]
+        });
+    });
+
+    describe('defaultCenter', () => {
+        test('should use the previous visited place geography when available', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            setActiveSurveyObjects(interview, { personId: 'personId2', journeyId: 'journeyId2', visitedPlaceId: 'otherWorkPlace1P2' });
+            const expectedCoordinates = shoppingPlace1P2Coordinates;
+
+            expect(
+                (widgetConfig.defaultCenter as any)(
+                    interview,
+                    'household.persons.personId2.journeys.journeyId2.visitedPlaces.otherWorkPlace1P2.geography'
+                )
+            ).toEqual({ lat: expectedCoordinates[1], lon: expectedCoordinates[0] });
+        });
+
+        test('should fall back to home geography when no previous visited place exists', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const expectedCoordinates = homeGeographyCoordinates;
+            delete interview.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!.homePlace1P1;
+            setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'homePlace1P1' });
+
+            expect(
+                (widgetConfig.defaultCenter as any)(
+                    interview,
+                    'household.persons.personId1.journeys.journeyId1.visitedPlaces.homePlace1P1.geography'
+                )
+            ).toEqual({ lat: expectedCoordinates[1], lon: expectedCoordinates[0] });
+        });
+
+        test('should return the default map center when no home geography is available', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            setResponse(interview, 'home.geography.geometry.coordinates', undefined);
+            setResponse(interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.homePlace1P1.geography', undefined);
+            setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'homePlace1P1' });
+
+            expect(
+                (widgetConfig.defaultCenter as any)(
+                    interview,
+                    'household.persons.personId1.journeys.journeyId1.visitedPlaces.homePlace1P1.geography'
+                )
+            ).toEqual(config.mapDefaultCenter);
+        });
+    });
+
+    describe('conditional', () => {
+        test('should return false when usual places are not inlined', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const widgetFactory = new PreviousWorkPlaceGeographyWidgetFactory(
+                { ...visitedPlacesSectionConfig, inlineUsualPlacesEntry: false },
+                widgetFactoryOptions
+            );
+            const conditional = widgetFactory.getWidgetConfigs()['visitedPlacePreviousWorkPlaceGeography'].conditional as any;
+
+            expect(conditional(interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1._previousWorkPlace.name')).toBe(false);
+        });
+
+        test('should return false when the previous on-the-road activity is not workUsual', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const conditional = widgetConfig.conditional as any;
+            setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'newPlace' });
+            interview.response.household!.persons!.personId1!.journeys!.journeyId1.visitedPlaces!.newPlace = {
+                _uuid: 'newPlace',
+                _sequence: 6,
+                activity: 'workOnTheRoad',
+                onTheRoadPreviousPlaceActivity: 'home'
+            };
+
+            expect(
+                conditional(
+                    interview,
+                    'household.persons.personId1.journeys.journeyId1.visitedPlaces.newPlace._previousWorkPlace.geography'
+                )
+            ).toBe(false);
+        });
+
+        test('should show the widget when the usual work place is not yet defined', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const conditional = widgetConfig.conditional as any;
+            // Set the new place
+            setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'newPlace' });
+            interview.response.household!.persons!.personId1!.journeys!.journeyId1.visitedPlaces!.newPlace = {
+                _uuid: 'newPlace',
+                _sequence: 6,
+                activity: 'workOnTheRoad',
+                onTheRoadPreviousPlaceActivity: 'workUsual'
+            };
+            // Change activity of workPlace1P1 to be not 'workUsual'
+            interview.response.household!.persons!.personId1!.journeys!.journeyId1.visitedPlaces!.workPlace1P1.activity = 'workNotUsual';
+
+            expect(
+                conditional(
+                    interview,
+                    'household.persons.personId1.journeys.journeyId1.visitedPlaces.newPlace._previousWorkPlace.geography'
+                )
+            ).toEqual(true);
+        });
+
+        test('should hide the widget and use the usual work place name when it is already defined', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const conditional = widgetConfig.conditional as any;
+            // Set the new place
+            setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'newPlace' });
+            interview.response.household!.persons!.personId1!.journeys!.journeyId1.visitedPlaces!.newPlace = {
+                _uuid: 'newPlace',
+                _sequence: 6,
+                activity: 'workOnTheRoad',
+                onTheRoadPreviousPlaceActivity: 'workUsual'
+            };
+
+            // workPlace1P1 is a workUsual
+            expect(
+                conditional(
+                    interview,
+                    'household.persons.personId1.journeys.journeyId1.visitedPlaces.newPlace._previousWorkPlace.geography'
+                )
+            ).toEqual([false, interview.response.household!.persons!.personId1!.journeys!.journeyId1.visitedPlaces!.workPlace1P1.geography]);
+        });
+
+    });
+
+    describe('validations', () => {
+        const validations = widgetConfig.validations!;
+        const mockedT = jest.fn().mockImplementation((key: string) => key);
+
+        beforeEach(() => {
+            jest.clearAllMocks();
+        });
+
+        test('should require a geography value', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const path =
+                'household.persons.personId1.journeys.journeyId1.visitedPlaces.otherPlaceP1._previousWorkPlace.geography';
+            const validationResult = validations(undefined, null, interview, path);
+
+            expect(validationResult[0].validation).toBe(true);
+            expect(translateString(validationResult[0].errorMessage, { t: mockedT } as any, interview, path)).toBe('visitedPlaces:workPlaceLocationIsRequiredError');
+        });
+
+        test('should accept geography value', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const validationResult = validations(interview.response.household!.persons!.personId1!.journeys!.journeyId1.visitedPlaces!.workPlace1P1.geography, null, interview, 'path');
+
+            expect(validationResult[0].validation).toBe(false);
+        });
+
+        test('should flag imprecise location when mapClicked and zoom is below 15', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const path =
+                'household.persons.personId1.journeys.journeyId1.visitedPlaces.otherPlaceP1._previousWorkPlace.geography';
+            // Set geography at zoom 14 with mapClicked action
+            const geography = {
+                type: 'Feature',
+                geometry: { type: 'Point', coordinates: [-73.62, 45.54] },
+                properties: { lastAction: 'mapClicked', zoom: 14 }
+            };
+            setResponse(interview, path, geography);
+            setResponse(interview, path.replace('._previousWorkPlace.geography', '.activity'), 'workOnTheRoad');
+
+            const validationResult = validations!(geography, null, interview, path);
+            expect(validationResult[1].validation).toBe(true);
+            expect(translateString(validationResult[1].errorMessage, { t: mockedT } as any, interview, path)).toBe('visitedPlaces:locationIsNotPreciseError');
+        });
+
+        test('should flag imprecise location when markerDragged and zoom is below 15', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const path =
+                'household.persons.personId1.journeys.journeyId1.visitedPlaces.otherPlaceP1._previousWorkPlace.geography';
+            const geography = {
+                type: 'Feature',
+                geometry: { type: 'Point', coordinates: [-73.62, 45.54] },
+                properties: { lastAction: 'markerDragged', zoom: 10 }
+            };
+            setResponse(interview, path, geography);
+            setResponse(interview, path.replace('._previousWorkPlace.geography', '.activity'), 'workOnTheRoad');
+
+            const validationResult = validations!(geography, null, interview, path);
+            expect(validationResult[1].validation).toBe(true);
+            expect(translateString(validationResult[1].errorMessage, { t: mockedT } as any, interview, path)).toBe('visitedPlaces:locationIsNotPreciseError');
+        });
+
+        test('should not flag zoom precision error when zoom is 15 or more', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const path =
+                'household.persons.personId1.journeys.journeyId1.visitedPlaces.otherPlaceP1._previousWorkPlace.geography';
+            const geography = {
+                type: 'Feature',
+                geometry: { type: 'Point', coordinates: [-73.62, 45.54] },
+                properties: { lastAction: 'mapClicked', zoom: 15 }
+            };
+            setResponse(interview, path, geography);
+            setResponse(interview, path.replace('._previousWorkPlace.geography', '.activity'), 'workOnTheRoad');
+
+            const validationResult = validations!(geography, null, interview, path);
+            expect(validationResult[1].validation).toBe(false);
+        });
+
+        test('should flag geocoding imprecision and pass geocoding text to translation', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const path =
+                'household.persons.personId1.journeys.journeyId1.visitedPlaces.otherPlaceP1._previousWorkPlace.geography';
+            const geography = {
+                type: 'Feature',
+                geometry: { type: 'Point', coordinates: [-73.62, 45.54] },
+                properties: {
+                    isGeocodingImprecise: true,
+                    geocodingQueryString: 'Main street'
+                }
+            };
+            setResponse(interview, path, geography);
+
+            const validationResult = validations!(geography, null, interview, path);
+            expect(validationResult[2].validation).toBe(true);
+
+            
+            translateString(validationResult[2].errorMessage, { t: mockedT } as any, interview, path);
+            expect(mockedT).toHaveBeenCalledWith('survey:geography.geocodingStringImpreciseError', {
+                geocodingTextInput: 'Main street',
+                interpolation: { escapeValue: true }
+            });
+        });
+
+        test('should pass empty geocoding text when not available', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const path =
+                'household.persons.personId1.journeys.journeyId1.visitedPlaces.otherPlaceP1._previousWorkPlace.geography';
+            const geography = {
+                type: 'Feature',
+                geometry: { type: 'Point', coordinates: [-73.62, 45.54] },
+                properties: {
+                    isGeocodingImprecise: true
+                }
+            };
+            setResponse(interview, path, geography);
+
+            const validationResult = validations!(geography, null, interview, path);
+
+            const mockedT = jest.fn();
+            translateString(validationResult[2].errorMessage, { t: mockedT } as any, interview, path);
+            expect(mockedT).toHaveBeenCalledWith('survey:geography.geocodingStringImpreciseError', {
+                geocodingTextInput: '',
+                interpolation: { escapeValue: true }
+            });
+        });
+    });
+});

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/buttonsVisitedPlace.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/buttonsVisitedPlace.ts
@@ -147,16 +147,25 @@ export class ButtonsVisitedPlaceConfigFactory implements WidgetConfigFactory {
             currentVisitedPlace.onTheRoadPreviousPlaceActivity === 'workUsual' &&
             (!previousVisitedPlace || previousVisitedPlace.activity !== 'workUsual')
         ) {
-            return {
-                activity: 'workUsual',
-                activityCategory: 'work',
-                nextPlaceCategory: 'visitedAnotherPlace',
+            const usualWorkPlace = {
+                activity: 'workUsual' as const,
+                activityCategory: 'work' as const,
+                nextPlaceCategory: 'visitedAnotherPlace' as const,
                 arrivalTime: currentVisitedPlace._previousArrivalTime
                     ? currentVisitedPlace._previousArrivalTime
                     : undefined,
                 departureTime:
                     currentVisitedPlace.activity === 'workOnTheRoad' ? currentVisitedPlace.arrivalTime : undefined
-            };
+            } as VisitedPlace;
+            // If usual places are inlined, see if we need to add the name and geography too
+            if (
+                this.sectionConfig.inlineUsualPlacesEntry === true &&
+                currentVisitedPlace._previousWorkPlace !== undefined
+            ) {
+                usualWorkPlace.name = currentVisitedPlace._previousWorkPlace.name;
+                usualWorkPlace.geography = currentVisitedPlace._previousWorkPlace.geography;
+            }
+            return usualWorkPlace;
         }
         return undefined;
     };

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/groupPersonVisitedPlaces.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/groupPersonVisitedPlaces.ts
@@ -18,6 +18,7 @@ import { VisitedPlaceShortcutWidgetFactory } from './widgetsVisitedPlaceShortcut
 import { ButtonsVisitedPlaceConfigFactory } from './buttonsVisitedPlace';
 import { VisitedPlaceTimeWidgetFactory } from './widgetsTime';
 import { VisitedPlaceOnTheRoadWidgetFactory } from './widgetsOnTheRoadSpecifics';
+import { PreviousWorkPlaceGeographyWidgetFactory } from './widgetsPreviousWorkplaceGeography';
 
 /**
  * Widget config factory for the person visited places group. It represents the
@@ -39,6 +40,11 @@ export class PersonVisitedPlacesGroupConfigFactory implements WidgetConfigFactor
         // could be listed in the additional widgets to control their order, but
         // if not there, we should add them at the right place.
         const allWidgetNames = [...additionalWidgetNames];
+        // Add the previous work place name and geography to the group if inlineUsualPlacesEntry is true
+        const onTheRoadPreviousWorkPlaceNames =
+            this.sectionConfig.inlineUsualPlacesEntry === true
+                ? ['visitedPlacePreviousWorkPlaceGeography', 'visitedPlacePreviousWorkPlaceName']
+                : [];
         // Add the geography, shortcuts and activity widgets at the beginning of the groups, listed in reverse order of appearance to unshift them in the right order
         // FIXME Allow to fine-tune where to put the additional widgets if a survey needs a question to be asked between the builtin ones
         const widgetsAtTheBeginning = [
@@ -50,6 +56,8 @@ export class PersonVisitedPlacesGroupConfigFactory implements WidgetConfigFactor
             'visitedPlaceName',
             'visitedPlaceShortcut',
             'visitedPlaceAlreadyVisited',
+            // Add previous work place location if usual places are inlined
+            ...onTheRoadPreviousWorkPlaceNames,
             'visitedPlaceOnTheRoadPreviousPlaceActivity',
             'visitedPlaceActivity',
             'visitedPlaceActivityCategory'
@@ -130,6 +138,10 @@ export class PersonVisitedPlacesGroupConfigFactory implements WidgetConfigFactor
         const buttonsWidgetFactory = new ButtonsVisitedPlaceConfigFactory(this.sectionConfig, this.options);
         const visitedPlaceTimeWidgetFactory = new VisitedPlaceTimeWidgetFactory(this.sectionConfig, this.options);
         const onTheRoadWidgetFactory = new VisitedPlaceOnTheRoadWidgetFactory(this.sectionConfig, this.options);
+        const onTheRoadPreviousWorkPlaceWidgets =
+            this.sectionConfig.inlineUsualPlacesEntry === true
+                ? new PreviousWorkPlaceGeographyWidgetFactory(this.sectionConfig, this.options).getWidgetConfigs()
+                : {};
         return {
             personVisitedPlaces: this.getVisitedPlacesGroupConfig(),
             visitedPlaceActivityCategory: getActivityCategoryWidgetConfig(this.sectionConfig, this.options),
@@ -139,6 +151,7 @@ export class PersonVisitedPlacesGroupConfigFactory implements WidgetConfigFactor
             visitedPlaceNextPlaceCategory: getNextPlaceCategoryWidgetConfig(this.sectionConfig, this.options),
             ...visitedPlaceTimeWidgetFactory.getWidgetConfigs(),
             ...onTheRoadWidgetFactory.getWidgetConfigs(),
+            ...onTheRoadPreviousWorkPlaceWidgets,
             ...buttonsWidgetFactory.getWidgetConfigs()
         };
     };

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetsPreviousWorkplaceGeography.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetsPreviousWorkplaceGeography.ts
@@ -1,0 +1,181 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import _get from 'lodash/get';
+import _cloneDeep from 'lodash/cloneDeep';
+import i18n, { type TFunction } from 'i18next';
+import config from '../../../../config/project.config';
+import type { QuestionWidgetConfig, VisitedPlacesSectionConfiguration, WidgetConditional } from '../../types';
+import { type LocationWithNameWidgetOptions, LocationWithNameWidgetsFactory } from '../common/widgetsLocation';
+import type { WidgetConfigFactory, WidgetFactoryOptions } from '../types';
+import * as odHelpers from '../../../odSurvey/helpers';
+import { getResponse } from '../../../../utils/helpers';
+import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
+import * as visitedPlacesHelpers from './helpers';
+import { getActivityMarkerIcon } from './activityIconMapping';
+import { requiredValidation } from '../../../widgets/validations/validations';
+
+// This is the minimum zoom required to avoid placement errors when selecting an
+// exact location at a micro scale.
+//
+// FIXME We need to decide where to put it though, not here: in the
+// questionnaire configuration itself, to fine-tune for different fields (they
+// may not all require the same level of precision)? in the project
+// configuration for all geographies? It should also be possible to configure it
+// for specific visited place use cases depending on the desired scale (long
+// distance surveys, where we may want a more macro scale may accept a lower
+// zoom level)
+const visitedPlacesMapClickDragDefaultZoom = 15;
+
+/**
+ * Widget factory that creates a pair of widgets for the previous work place
+ * location. These widgets are used only in the case where the usual places are
+ * inlined in the trip diary, for `onTheRoad` activities with departure from a
+ * usual work place that is not defined yet.
+ */
+export class PreviousWorkPlaceGeographyWidgetFactory implements WidgetConfigFactory {
+    private readonly mayDisplayTheseWidgets: boolean;
+
+    constructor(
+        private sectionConfig: VisitedPlacesSectionConfiguration,
+        private options: WidgetFactoryOptions
+    ) {
+        this.mayDisplayTheseWidgets = sectionConfig.inlineUsualPlacesEntry === true;
+    }
+
+    private previousWorkPlaceConditional: (field: 'name' | 'geography') => WidgetConditional =
+        (field: 'name' | 'geography') => (interview, path) => {
+            // Display if usual places are inlined, if the `visitedPlaceOnTheRoadPreviousPlaceActivity` is 'workUsual' and the person has no usual work place set (if the person has a place defined already, take its value)
+            if (!this.mayDisplayTheseWidgets) {
+                return false;
+            }
+
+            const visitedPlaceContext = odHelpers.getVisitedPlaceContextFromPath({ interview, path });
+            if (visitedPlaceContext === null) {
+                throw new Error(
+                    `PreviousWorkPlaceGeographyWidgetFactory: cannot find visited place context for path ${path}`
+                );
+            }
+            const { visitedPlace } = visitedPlaceContext;
+            // Previous on the road activity is not workUsual, do not display
+            if (visitedPlace.onTheRoadPreviousPlaceActivity !== 'workUsual') {
+                return false;
+            }
+
+            // See if there is a workplace already set. Use this as default value if so, otherwise, display
+            const { usualPlace } = visitedPlacesHelpers.getPersonUsualWorkPlace(interview, path);
+            // Place not set, display it
+            if (usualPlace === null) {
+                return true;
+            }
+            // Place set, hide if the property to display is set, with default value
+            const usualPlaceValue = usualPlace[field];
+            return [usualPlaceValue === undefined, usualPlaceValue];
+        };
+
+    private getNameWidgetConfiguration = (): LocationWithNameWidgetOptions['nameWidget'] => ({
+        containsHtml: true,
+        label: (t: TFunction) => {
+            const key = 'visitedPlaces:visitedPlaceNameExample';
+
+            const helpText = i18n.exists(key)
+                ? `<span class="_pale _oblique">(${t('survey:forExampleAbbreviation')}: ${t(key, { context: 'workUsual_onTheRoadOften' })})</span>`
+                : '';
+            return t('visitedPlaces:visitedPlacePreviousWorkPlaceName') + ' ' + helpText;
+        },
+        conditional: this.previousWorkPlaceConditional('name'),
+        validations: requiredValidation
+    });
+
+    private getGeographyWidgetConfiguration = (): LocationWithNameWidgetOptions['geographyWidget'] => ({
+        containsHtml: true,
+        label: (t: TFunction) => t('visitedPlaces:visitedPlacePreviousWorkPlaceGeography'),
+        refreshGeocodingLabel: (t: TFunction) => t('visitedPlaces:refreshGeocodingButton'),
+        icon: {
+            url: getActivityMarkerIcon('workUsual'),
+            size: [70, 70]
+        },
+        defaultCenter: function (interview, path) {
+            // Center on the previous visited place geography if it exists, otherwise center on home geography, otherwise use the default center
+            const visitedPlaceContext = odHelpers.getVisitedPlaceContextFromPath({ interview, path });
+            const previousVisitedPlace = visitedPlaceContext
+                ? odHelpers.getPreviousVisitedPlace({
+                    journey: visitedPlaceContext.journey,
+                    visitedPlaceId: visitedPlaceContext.visitedPlace._uuid
+                })
+                : undefined;
+            if (previousVisitedPlace) {
+                const person = odHelpers.getActivePerson({ interview });
+                const geography = person
+                    ? odHelpers.getVisitedPlaceGeography({ visitedPlace: previousVisitedPlace, interview, person })
+                    : undefined;
+                if (geography) {
+                    const coordinates = _get(geography, 'geometry.coordinates', null);
+                    if (coordinates) {
+                        return {
+                            lat: coordinates[1],
+                            lon: coordinates[0]
+                        };
+                    }
+                }
+            }
+            const homeCoordinates = getResponse(interview, 'home.geography.geometry.coordinates', null) as
+                | null
+                | [number, number];
+            return homeCoordinates
+                ? {
+                    lat: homeCoordinates[1],
+                    lon: homeCoordinates[0]
+                }
+                : config.mapDefaultCenter;
+        },
+        validations: (value) => {
+            const geography = value as GeoJSON.Feature<GeoJSON.Point> | null | undefined;
+            const geocodingTextInput = geography ? geography.properties?.geocodingQueryString : undefined;
+            const validations: any[] = [
+                {
+                    validation: _isBlank(value),
+                    errorMessage: (t: TFunction) => t('visitedPlaces:workPlaceLocationIsRequiredError')
+                },
+                {
+                    validation:
+                        geography &&
+                        geography.properties?.lastAction &&
+                        (geography.properties.lastAction === 'mapClicked' ||
+                            geography.properties.lastAction === 'markerDragged') &&
+                        geography.properties.zoom < visitedPlacesMapClickDragDefaultZoom,
+                    errorMessage: (t: TFunction) => t('visitedPlaces:locationIsNotPreciseError')
+                },
+                // TODO Should an inaccessible zone validation here when we support it from survey configuration
+                {
+                    validation: geography && geography.properties?.isGeocodingImprecise,
+                    errorMessage: (t: TFunction) =>
+                        t('survey:geography.geocodingStringImpreciseError', {
+                            geocodingTextInput: geocodingTextInput || '',
+                            interpolation: { escapeValue: true }
+                        })
+                }
+            ];
+            return validations;
+        },
+        conditional: this.previousWorkPlaceConditional('geography')
+    });
+
+    getWidgetConfigs = (): Record<string, QuestionWidgetConfig> => {
+        // Will generate a _previousWorkPlaceName and
+        // _previousWorkPlaceGeography widget with the appropriate
+        // configuration, where paths are within the visited place group
+        const locationWidgetFactory = new LocationWithNameWidgetsFactory({
+            widgetNamePrefix: 'visitedPlacePreviousWorkPlace',
+            path: '_previousWorkPlace',
+            nameWidget: this.getNameWidgetConfiguration(),
+            geographyWidget: this.getGeographyWidgetConfiguration()
+        });
+
+        return locationWidgetFactory.getWidgetConfigs();
+    };
+}

--- a/packages/evolution-common/src/services/questionnaire/types/Data.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/Data.ts
@@ -237,6 +237,12 @@ export type VisitedPlace = QuestionnaireObjectWithUuidAndSequence &
          */
         _previousDepartureTime?: number;
         /**
+         * Temporary field to store the name and geography of the previous usual
+         * work place for on the road activities with departure at work place
+         * and usual places inlined and not set.
+         */
+        _previousWorkPlace?: NamedPlace;
+        /**
          * The category of the next place. The 'wentToUsualWorkPlace' category is
          * used for workOnTheRoad trips. It is imputed by values entered by
          * participant


### PR DESCRIPTION
fixes #1552

Add 2 widgets, only when the `inlineUsualPlacesEntry` is `true`, to the visited places group: `visitedPlacePreviousWorkPlaceName` and `visitedPlacePreviousWorkPlaceGeography`. These widgets allow to enter the previous work place geography, when not available, to populate the previous place that will be added upon saving the place.

The widgets are not available if the `inlineUsualPlacesEntry` is `false`.

See individual commits for more details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added inline support for capturing a previous usual workplace name and its map location within relevant visited-place questions.
  - Included on-screen map instructions plus required-field and map precision validations, with improved feedback for missing or imprecise locations.
  - Automatically selects the best available starting point for map positioning (from the most relevant prior/home data).
- **Bug Fixes**
  - Preserves previous workplace name and geography when usual workplaces are included for on-the-road work entries, preventing accidental overwrites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->