### PR TITLE
feat(paradata): record build ids in interview paradata

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -62,6 +62,8 @@ jobs:
         with:
           context: .
           push: true
+          build-args: |
+            BUILD_ID=${{ github.sha }}
           tags: ${{ steps.branch-meta.outputs.tags }}
           labels: ${{ steps.branch-meta.outputs.labels }}
           cache-from: type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,11 @@
 FROM node:24-trixie
 WORKDIR /app
 
+# Git commit hash stamped into interview paradata (github.sha in CI). No default: when
+# unset, resolveAppBuildId falls back to the local git revision, then to 'dev'.
+ARG BUILD_ID
+ENV BUILD_ID=$BUILD_ID
+
 # TODO split package.json copy and yarn install to have some intermediary images
 COPY . /app
 RUN yarn install

--- a/packages/evolution-backend/src/api/__tests__/survey.validation.routes.test.ts
+++ b/packages/evolution-backend/src/api/__tests__/survey.validation.routes.test.ts
@@ -78,6 +78,11 @@ jest.mock('../../services/audits/SurveyObjectsAndAuditsFactory', () => ({
     }
 }));
 
+jest.mock('../../services/paradata/backendBuildIds', () => ({
+    persistReviewBackendBuildId: jest.fn().mockResolvedValue(undefined),
+    getReviewBackendBuildIdsValuesByPath: jest.fn(() => ({}))
+}));
+
 // survey.validation.routes reads reviewableSurveyObjects from evolution-common project.config
 // (survey config.js), not backend config/projectConfig (server-only overlay without that field).
 jest.mock('evolution-common/lib/config/project.config', () => ({

--- a/packages/evolution-backend/src/api/survey.common.routes.ts
+++ b/packages/evolution-backend/src/api/survey.common.routes.ts
@@ -19,6 +19,7 @@ import { logClientSide } from '../services/logging/messageLogging';
 import { updateInterview } from '../services/interviews/interview';
 import { getParadataLoggingFunction } from '../services/logging/paradataLogging';
 import { handleUserActionSideEffect } from '../services/interviews/interviewUtils';
+import { getParticipantBackendBuildIdsValuesByPath } from '../services/paradata/backendBuildIds';
 
 /**
  * Add the common survey routes to the router
@@ -75,6 +76,13 @@ export default (router: Router, authorizationMiddleware, loggingMiddleware: Inte
                     if (userAction) {
                         handleUserActionSideEffect(interview, valuesByPath, userAction);
                     }
+                    // Stamp participant response build id here (not in updateInterview).
+                    // Admin corrected_response updates use REVIEW_BACKEND_BUILD_IDS_PATH instead
+                    // and never touch response._backendBuildIds.
+                    Object.assign(
+                        valuesByPath,
+                        getParticipantBackendBuildIdsValuesByPath(interview.response?._backendBuildIds)
+                    );
                     const retInterview = await updateInterview(interview, {
                         logUpdate: getParadataLoggingFunction({
                             interviewId: interview.id,

--- a/packages/evolution-backend/src/api/survey.validation.routes.ts
+++ b/packages/evolution-backend/src/api/survey.validation.routes.ts
@@ -15,7 +15,11 @@ import { updateInterview, copyResponseToCorrectedResponse } from '../services/in
 import { VALID_OPERATORS } from '../models/interviews.db.queries';
 import interviewUserIsAuthorized, { isUserAllowed } from '../services/auth/userAuthorization';
 import serverProjectConfig from '../config/projectConfig';
-import { handleUserActionSideEffect, mapResponseToCorrectedResponse } from '../services/interviews/interviewUtils';
+import {
+    handleUserActionSideEffect,
+    mapResponseToCorrectedResponse,
+    mapCorrectedResponseToResponse
+} from '../services/interviews/interviewUtils';
 import { UserAttributes } from 'chaire-lib-backend/lib/services/users/user';
 import { logUserAccessesMiddleware } from '../services/logging/queryLoggingMiddleware';
 import { _booleish, _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
@@ -31,6 +35,10 @@ import { getParadataLoggingFunction } from '../services/logging/paradataLogging'
 import { BatchAuditService } from '../services/audits/BatchAuditService';
 import { ReviewDecisionService } from '../services/reviews/ReviewDecisionService';
 import { CANNOT_FORCE_APPROVE_WITHOUT_CONFLICT_ERROR_CODE } from '../services/reviews/reviewDecisionErrors';
+import {
+    getReviewBackendBuildIdsValuesByPath,
+    persistReviewBackendBuildId
+} from '../services/paradata/backendBuildIds';
 import type { ReviewDecisionValue, ReviewDecisions } from 'evolution-common/lib/services/reviews/types';
 import { hasErrors } from 'evolution-common/lib/types/Result.type';
 import TrError from 'chaire-lib-common/lib/utils/TrError';
@@ -74,19 +82,24 @@ const handleReviewMutationRouteError = (res: Response, error: unknown, logMessag
 };
 
 /**
- * Runs a review mutation and returns the standard success JSON payload.
+ * Runs a review mutation, stamps the admin backend build id on the interview (best-effort, see
+ * persistReviewBackendBuildId), and returns the standard success JSON payload. The build id is
+ * persisted only after a successful mutation, so failed mutations leave the interview untouched.
  * @param res - Express response
  * @param logMessage - Route-specific message prefix for server logs
+ * @param interview - Interview to stamp with the current admin backend build id
  * @param mutate - ReviewDecisionService call for the route
  * @returns HTTP response with review decisions or a mutation error
  */
 const respondWithReviewMutationResult = async (
     res: Response,
     logMessage: string,
+    interview: InterviewAttributes,
     mutate: () => Promise<ReviewDecisions>
 ): Promise<Response> => {
     try {
         const reviewDecisions = await mutate();
+        await persistReviewBackendBuildId(interview);
         return res.status(200).json({ status: 'success', reviewDecisions });
     } catch (error) {
         return handleReviewMutationRouteError(res, error, logMessage);
@@ -190,6 +203,9 @@ router.get(
                             interview,
                             runExtendedAuditChecks
                         );
+                    // Record which admin backend build served this interview for review. Like the
+                    // corrected_response copy above, this persists to the database on a GET route.
+                    await persistReviewBackendBuildId(interview);
 
                     // TODO Here, the response field should not make it to frontend. But make sure there are no side effect in the frontend, where the _response is used or checked.
                     const { response, corrected_response, ...rest } = interview;
@@ -248,6 +264,9 @@ router.get(
                     if (_isBlank(interview.corrected_response)) {
                         await copyResponseToCorrectedResponse(interview);
                     }
+                    // Record which admin backend build served this interview for correction. Like
+                    // the corrected_response copy above, this persists to the database on a GET route.
+                    await persistReviewBackendBuildId(interview);
 
                     // Make sure the original response does not make it to the frontend
                     const { response: _response, corrected_response, ...rest } = interview;
@@ -305,6 +324,10 @@ router.post(
                     unsetPaths,
                     userAction
                 } = mapResponseToCorrectedResponse(valuesByPath, origUnsetPaths, content.userAction);
+                const reviewBackendBuildIdsPatch = getReviewBackendBuildIdsValuesByPath(
+                    interview.corrected_response?._reviewBackendBuildIds
+                );
+                Object.assign(mappedValuesByPath, reviewBackendBuildIdsPatch);
 
                 const canConfirm = isUserAllowed(req.user as UserAttributes, interview, ['confirm']);
                 const fieldsToUpdate: (keyof InterviewAttributes)[] = [
@@ -328,18 +351,22 @@ router.post(
                     fieldsToUpdate: canConfirm ? [...fieldsToUpdate, 'is_validated'] : fieldsToUpdate,
                     logData: { adminValidation: true }
                 });
+                const updatedValuesByPath = mapCorrectedResponseToResponse({
+                    ...retInterview.serverValuesByPath,
+                    ...reviewBackendBuildIdsPatch
+                });
                 if (retInterview.serverValidations === true) {
                     return res.status(200).json({
                         status: 'success',
                         interviewId: retInterview.interviewId,
-                        updatedValuesByPath: retInterview.serverValuesByPath
+                        updatedValuesByPath
                     });
                 }
                 return res.status(200).json({
                     status: 'invalid',
                     interviewId: retInterview.interviewId,
                     messages: retInterview.serverValidations,
-                    updatedValuesByPath: retInterview.serverValuesByPath
+                    updatedValuesByPath
                 });
             }
             return res.status(200).json({ status: 'failed', interviewId: null });
@@ -462,7 +489,7 @@ router.post(
         }
         const { interview, user, objectType, objectUuid } = getReviewObjectContext(res);
 
-        return respondWithReviewMutationResult(res, 'error setting review for interview:', () =>
+        return respondWithReviewMutationResult(res, 'error setting review for interview:', interview, () =>
             ReviewDecisionService.setReviewDecision(interview.id, user.id, {
                 objectType,
                 objectUuid,
@@ -486,7 +513,7 @@ router.post(
         }
         const { interview, user, objectType, objectUuid } = getReviewObjectContext(res);
 
-        return respondWithReviewMutationResult(res, 'error requesting re-review for interview:', () =>
+        return respondWithReviewMutationResult(res, 'error requesting re-review for interview:', interview, () =>
             ReviewDecisionService.requestReReview(interview.id, user.id, {
                 objectType,
                 objectUuid,
@@ -504,7 +531,7 @@ router.post(
     async (req: Request, res: Response) => {
         const { interview, user, objectType, objectUuid } = getReviewObjectContext(res);
 
-        return respondWithReviewMutationResult(res, 'error clearing review for interview:', () =>
+        return respondWithReviewMutationResult(res, 'error clearing review for interview:', interview, () =>
             ReviewDecisionService.clearReviewDecision(interview.id, user.id, {
                 objectType,
                 objectUuid
@@ -521,7 +548,7 @@ router.post(
     async (req: Request, res: Response) => {
         const { interview, user, objectType, objectUuid } = getReviewObjectContext(res);
 
-        return respondWithReviewMutationResult(res, 'error clearing force approve for interview:', () =>
+        return respondWithReviewMutationResult(res, 'error clearing force approve for interview:', interview, () =>
             ReviewDecisionService.clearForceApprove(interview.id, user.id, {
                 objectType,
                 objectUuid
@@ -543,7 +570,7 @@ router.post(
         }
         const { interview, user, objectType, objectUuid } = getReviewObjectContext(res);
 
-        return respondWithReviewMutationResult(res, 'error force-approving object for interview:', () =>
+        return respondWithReviewMutationResult(res, 'error force-approving object for interview:', interview, () =>
             ReviewDecisionService.setForceApprove(interview.id, user.id, {
                 objectType,
                 objectUuid,

--- a/packages/evolution-backend/src/apps/admin/index.ts
+++ b/packages/evolution-backend/src/apps/admin/index.ts
@@ -15,12 +15,14 @@ import { hideBin } from 'yargs/helpers';
 import { registerTranslationDir } from 'chaire-lib-backend/lib/config/i18next';
 import express, { Express } from 'express';
 import { setupServerApp } from './serverApp';
+import { initializeBackendBuildId } from '../../config/buildId';
 
 const argv = yargs(hideBin(process.argv)).parseSync();
 
 const useSSL = typeof argv.ssl === 'boolean' ? argv.ssl : false;
 const port = argv.port ? parseInt(argv.port as string) : useSSL ? 8443 : 8080;
 
+initializeBackendBuildId();
 console.log(`starting server for project ${config.projectShortname} with port ${port}`);
 
 process.on('uncaughtException', (err: Error) => {

--- a/packages/evolution-backend/src/apps/participant/index.ts
+++ b/packages/evolution-backend/src/apps/participant/index.ts
@@ -15,12 +15,14 @@ import { hideBin } from 'yargs/helpers';
 import { registerTranslationDir } from 'chaire-lib-backend/lib/config/i18next';
 import express from 'express';
 import { setupServerApp } from './serverApp';
+import { initializeBackendBuildId } from '../../config/buildId';
 
 const argv = yargs(hideBin(process.argv)).parseSync();
 
 const useSSL = typeof argv.ssl === 'boolean' ? argv.ssl : false;
 const port = argv.port ? parseInt(argv.port as string) : useSSL ? 8443 : 8080;
 
+initializeBackendBuildId();
 console.log(`starting server for project ${config.projectShortname} with port ${port}`);
 
 process.on('uncaughtException', (err) => {

--- a/packages/evolution-backend/src/config/__tests__/buildId.test.ts
+++ b/packages/evolution-backend/src/config/__tests__/buildId.test.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+// The backend build id must be resolved once at server startup and stay immutable for the
+// lifetime of the process: the paradata stamping logic (appendBuildIdIfChanged) relies on it,
+// otherwise a changing value would append spurious entries to the build id histories.
+describe('buildId', () => {
+    beforeEach(() => {
+        // The cache is a module-level variable; reset the module registry so the dynamic
+        // import below gets a fresh, uninitialized module regardless of other tests.
+        jest.resetModules();
+    });
+
+    it('should resolve the backend build id from the environment and cache it', async () => {
+        const { initializeBackendBuildId, getBackendBuildId } = await import('../buildId');
+
+        // Resolved from the BUILD_ID environment variable (highest priority in resolveAppBuildId)
+        expect(initializeBackendBuildId({ BUILD_ID: 'cached-build-id' } as NodeJS.ProcessEnv)).toBe('cached-build-id');
+        // Subsequent calls return the cached value, even with a different environment
+        expect(initializeBackendBuildId({ BUILD_ID: 'other-build-id' } as NodeJS.ProcessEnv)).toBe('cached-build-id');
+        // The getter used by the stamping code reads the cache without re-resolving
+        expect(getBackendBuildId()).toBe('cached-build-id');
+    });
+});

--- a/packages/evolution-backend/src/config/__tests__/resolveBuildId.test.ts
+++ b/packages/evolution-backend/src/config/__tests__/resolveBuildId.test.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { execSync } from 'child_process';
+import { resolveAppBuildId, resolveGitBuildId } from '../resolveBuildId';
+
+jest.mock('child_process', () => ({
+    execSync: jest.fn()
+}));
+
+const mockExecSync = execSync as jest.MockedFunction<typeof execSync>;
+
+describe('resolveBuildId', () => {
+    beforeEach(() => {
+        mockExecSync.mockReset();
+    });
+
+    describe('resolveGitBuildId', () => {
+        it('should return the git commit hash', () => {
+            mockExecSync.mockReturnValue('git-sha\n');
+
+            expect(resolveGitBuildId()).toBe('git-sha');
+        });
+    });
+
+    describe('resolveAppBuildId', () => {
+        it('should prefer the BUILD_ID env value over git', () => {
+            mockExecSync.mockReturnValue('git-sha\n');
+
+            expect(resolveAppBuildId({ BUILD_ID: 'env-sha' } as NodeJS.ProcessEnv)).toBe('env-sha');
+            expect(mockExecSync).not.toHaveBeenCalled();
+        });
+
+        it('should fall back to git when BUILD_ID is not set', () => {
+            mockExecSync.mockReturnValue('git-sha\n');
+
+            expect(resolveAppBuildId({} as NodeJS.ProcessEnv)).toBe('git-sha');
+        });
+
+        it('should fall back to dev when BUILD_ID and git are unavailable', () => {
+            mockExecSync.mockImplementation(() => {
+                throw new Error('git not available');
+            });
+
+            expect(resolveAppBuildId({} as NodeJS.ProcessEnv)).toBe('dev');
+        });
+    });
+});

--- a/packages/evolution-backend/src/config/buildId.ts
+++ b/packages/evolution-backend/src/config/buildId.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { resolveAppBuildId } from './resolveBuildId';
+
+let backendBuildId: string | undefined;
+
+/**
+ * Initialize and cache the backend commit hash at startup.
+ * @param env environment variables object
+ */
+export const initializeBackendBuildId = (env: NodeJS.ProcessEnv = process.env): string => {
+    if (!backendBuildId) {
+        backendBuildId = resolveAppBuildId(env);
+        console.info(`Evolution backend build id: ${backendBuildId}`);
+    }
+    return backendBuildId;
+};
+
+/**
+ * Return the cached backend commit hash.
+ */
+export const getBackendBuildId = (): string => {
+    return backendBuildId ?? initializeBackendBuildId();
+};

--- a/packages/evolution-backend/src/config/resolveBuildId.ts
+++ b/packages/evolution-backend/src/config/resolveBuildId.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+/*
+ * Build ids stored in the interview paradata are git commit hashes of the *deployed repository*.
+ * For a survey deployment, this is the survey project's repository, not evolution's: the survey
+ * repository references evolution as a git submodule, so its commit hash is enough to recover the
+ * exact evolution version (`git submodule status` at that commit).
+ */
+
+import { execSync } from 'child_process';
+
+/** Environment variable holding the git commit hash of the current deployment (`github.sha` in CI). */
+export const BUILD_ID_ENV_KEY = 'BUILD_ID';
+
+/**
+ * Resolve the current git commit hash from the local repository.
+ */
+export const resolveGitBuildId = (): string | undefined => {
+    try {
+        return execSync('git rev-parse HEAD', {
+            encoding: 'utf8',
+            stdio: ['ignore', 'pipe', 'ignore']
+        }).trim();
+    } catch {
+        return undefined;
+    }
+};
+
+/**
+ * Resolve the deployment commit hash from the `BUILD_ID` environment variable, falling back to the
+ * local git repository, then to `'dev'` (local dev without git). Read at backend startup.
+ * @param env environment variables object
+ */
+export const resolveAppBuildId = (env: NodeJS.ProcessEnv = process.env): string => {
+    return env[BUILD_ID_ENV_KEY] || resolveGitBuildId() || 'dev';
+};

--- a/packages/evolution-backend/src/services/interviews/__tests__/InterviewUtils.test.ts
+++ b/packages/evolution-backend/src/services/interviews/__tests__/InterviewUtils.test.ts
@@ -5,7 +5,7 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import _cloneDeep from 'lodash/cloneDeep';
-import { mapResponseToCorrectedResponse, handleUserActionSideEffect } from '../interviewUtils';
+import { mapResponseToCorrectedResponse, mapCorrectedResponseToResponse, handleUserActionSideEffect } from '../interviewUtils';
 import moment from 'moment';
 
 // Mock moment.unix to return a consistent value for testing
@@ -58,6 +58,22 @@ describe('mapResponseToCorrectedResponse', () => {
             'response2': 'notToBeModified'
         });
         expect(updatedUnsetPaths).toEqual(['corrected_response.accessCode', 'response2', 'response2.notToBeModified']);
+    });
+});
+
+describe('mapCorrectedResponseToResponse', () => {
+    test('maps corrected_response paths to response paths', () => {
+        const valuesByPath = {
+            'corrected_response._reviewBackendBuildIds': [{ buildId: 'abc', startTimestamp: 1 }],
+            'corrected_response.household.size': 2,
+            'validations.accessCode': false
+        };
+
+        expect(mapCorrectedResponseToResponse(valuesByPath)).toEqual({
+            'response._reviewBackendBuildIds': [{ buildId: 'abc', startTimestamp: 1 }],
+            'response.household.size': 2,
+            'validations.accessCode': false
+        });
     });
 });
 

--- a/packages/evolution-backend/src/services/interviews/__tests__/interview.test.ts
+++ b/packages/evolution-backend/src/services/interviews/__tests__/interview.test.ts
@@ -681,8 +681,8 @@ describe('Update Interview', () => {
         const testAttributes = _cloneDeep(interviewAttributes);
         const scriptInjectionString = '<div onmouseover="(function(){alert(\'XSS vulnerability detected\')})()">Hover over me</div>';
         const sanitizedValue = 'Hover over me';
-        const arrayResponse = [scriptInjectionString, { name: scriptInjectionString}, 42];
-        const sanitizedArray = [sanitizedValue, { name: sanitizedValue}, 42];
+        const arrayResponse = [scriptInjectionString, { name: scriptInjectionString }, 42];
+        const sanitizedArray = [sanitizedValue, { name: sanitizedValue }, 42];
 
         // Execute interview update
         const { interviewId, serverValuesByPath, serverValidations } = await updateInterview(testAttributes, { valuesByPath: { 'response.foo': arrayResponse } });

--- a/packages/evolution-backend/src/services/interviews/__tests__/interviews.test.ts
+++ b/packages/evolution-backend/src/services/interviews/__tests__/interviews.test.ts
@@ -15,6 +15,15 @@ import { updateInterview } from '../interview';
 import moment from 'moment';
 import { getParadataLoggingFunction } from '../../logging/paradataLogging';
 
+jest.mock('../../../config/buildId', () => ({
+    getBackendBuildId: jest.fn(() => 'backend-test-build-id')
+}));
+
+const withBackendBuildId = (response: Record<string, unknown>) => ({
+    ...response,
+    _backendBuildIds: [{ buildId: 'backend-test-build-id', startTimestamp: expect.any(Number) }]
+});
+
 jest.mock('../../../models/interviews.db.queries', () => ({
     findByResponse: jest.fn(),
     getInterviewByUuid: jest.fn(),
@@ -207,7 +216,7 @@ describe('Create interviews', () => {
         expect(mockDbCreate).toHaveBeenCalledTimes(1);
         expect(mockDbCreate).toHaveBeenCalledWith({
             participant_id: participantId,
-            response: { _startedAt: expect.anything() },
+            response: withBackendBuildId({ _startedAt: expect.anything() }),
             is_active: true,
             validations: {}
         }, 'uuid');
@@ -228,7 +237,7 @@ describe('Create interviews', () => {
         expect(mockDbCreate).toHaveBeenCalledTimes(1);
         expect(mockDbCreate).toHaveBeenCalledWith({
             participant_id: participantId,
-            response: { ...response, _startedAt: expect.anything() },
+            response: withBackendBuildId({ ...response, _startedAt: expect.anything() }),
             is_active: true,
             validations: {}
         }, 'uuid');
@@ -236,7 +245,36 @@ describe('Create interviews', () => {
         expect(mockDbGetByUuid).toHaveBeenCalledTimes(1);
         expect(mockDbGetByUuid).toHaveBeenCalledWith(newInterview.uuid);
         expect(mockInterviewUpdate).toHaveBeenCalledWith(createdInterview, {
-            valuesByPath: { 'response.foo': response.foo, 'response.fooObj': response.fooObj },
+            valuesByPath: {
+                'response.foo': response.foo,
+                'response.fooObj': response.fooObj,
+                'response._startedAt': expect.anything(),
+                'response._backendBuildIds': [{ buildId: 'backend-test-build-id', startTimestamp: expect.any(Number) }]
+            },
+            fieldsToUpdate: ['response']
+        });
+    });
+
+    test('should persist appended backend build id history in follow-up update', async () => {
+        mockDbGetByUuid.mockImplementationOnce(async () => createdInterview);
+        const priorBackendBuildIds = [{ buildId: 'old-backend-sha', startTimestamp: 1632929461 }];
+        const response = {
+            foo: 'bar',
+            _backendBuildIds: priorBackendBuildIds
+        };
+
+        const newInterview = await Interviews.createInterviewForUser(participantId, response);
+
+        expect(newInterview).toEqual({ uuid: expect.anything() });
+        expect(mockInterviewUpdate).toHaveBeenCalledWith(createdInterview, {
+            valuesByPath: {
+                'response.foo': 'bar',
+                'response._startedAt': expect.anything(),
+                'response._backendBuildIds': [
+                    { buildId: 'old-backend-sha', startTimestamp: 1632929461, endTimestamp: expect.any(Number) },
+                    { buildId: 'backend-test-build-id', startTimestamp: expect.any(Number) }
+                ]
+            },
             fieldsToUpdate: ['response']
         });
     });
@@ -247,7 +285,7 @@ describe('Create interviews', () => {
         expect(mockDbCreate).toHaveBeenCalledTimes(1);
         expect(mockDbCreate).toHaveBeenCalledWith({
             participant_id: participantId,
-            response: { _startedAt: expect.anything() },
+            response: withBackendBuildId({ _startedAt: expect.anything() }),
             is_active: true,
             validations: {}
         }, 'participant_id');
@@ -263,11 +301,15 @@ describe('Create interviews', () => {
         expect(mockDbCreate).toHaveBeenCalledTimes(1);
         expect(mockDbCreate).toHaveBeenCalledWith({
             participant_id: participantId,
-            response: { _startedAt: expect.anything() },
+            response: withBackendBuildId({ _startedAt: expect.anything() }),
             is_active: true,
             validations: {}
         }, returningFields);
-        expect(newInterview).toEqual({ participant_id: participantId, uuid: expect.anything(), response: { _startedAt: expect.anything() } });
+        expect(newInterview).toEqual({
+            participant_id: participantId,
+            uuid: expect.anything(),
+            response: withBackendBuildId({ _startedAt: expect.anything() })
+        });
         expect(mockDbGetByUuid).not.toHaveBeenCalled();
         expect(mockInterviewUpdate).not.toHaveBeenCalled();
 
@@ -286,7 +328,7 @@ describe('Create interviews', () => {
         expect(mockDbCreate).toHaveBeenCalledTimes(1);
         expect(mockDbCreate).toHaveBeenCalledWith({
             participant_id: participantId,
-            response: { _startedAt: expect.anything(), initial: 'value' },
+            response: withBackendBuildId({ _startedAt: expect.anything(), initial: 'value' }),
             is_active: true,
             validations: {}
         }, 'uuid');
@@ -297,7 +339,11 @@ describe('Create interviews', () => {
         expect(mockGetParadataLogFunction).toHaveBeenCalledWith({ interviewId: createdInterview!.id, userId });
         expect(mockInterviewUpdate).toHaveBeenCalledWith(createdInterview, {
             logUpdate: logFunction,
-            valuesByPath: { 'response.initial': 'value' },
+            valuesByPath: {
+                'response.initial': 'value',
+                'response._startedAt': expect.anything(),
+                'response._backendBuildIds': [{ buildId: 'backend-test-build-id', startTimestamp: expect.any(Number) }]
+            },
             fieldsToUpdate: ['response']
         });
     });

--- a/packages/evolution-backend/src/services/interviews/interview.ts
+++ b/packages/evolution-backend/src/services/interviews/interview.ts
@@ -154,10 +154,11 @@ export const updateInterview = async (
         ? updateValuesByPathWithUserAction(options.valuesByPath, options.userAction)
         : options.valuesByPath;
 
+    const fieldsToUpdate = options.fieldsToUpdate || ['response', 'validations'];
+
     // Sanitize all string fields in the valuesByPath, as they may contain javascript injection
     const sanitizedValuesByPath = sanitizeInterviewData(_cloneDeep(allValuesByPath));
 
-    const fieldsToUpdate = options.fieldsToUpdate || ['response', 'validations'];
     const logData = options.logData || {};
     const serverValidations = await serverValidate(
         interview,
@@ -244,7 +245,9 @@ export const updateInterview = async (
         // won't be required anymore.
         serverValuesByPath:
             sanitizedValuesByPath['response._sections._actions'] !== undefined
-                ? Object.assign({}, serverValuesByPath, { 'response._sections': interview.response._sections })
+                ? Object.assign({}, serverValuesByPath, {
+                    'response._sections': interview.response._sections
+                })
                 : serverValuesByPath,
         redirectUrl
     };

--- a/packages/evolution-backend/src/services/interviews/interviewUtils.ts
+++ b/packages/evolution-backend/src/services/interviews/interviewUtils.ts
@@ -43,6 +43,21 @@ export const mapResponseToCorrectedResponse = (
     return { valuesByPath: updatedValuesByPath, unsetPaths: updatedUnsetPaths, userAction: updatedUserAction };
 };
 
+/** Map corrected_response paths to response paths for admin client responses. */
+export const mapCorrectedResponseToResponse = (valuesByPath: {
+    [key: string]: unknown;
+}): { [key: string]: unknown } => {
+    const updatedValuesByPath: { [key: string]: unknown } = {};
+    Object.keys(valuesByPath).forEach((key) => {
+        const newKey =
+            key.startsWith('corrected_response.') || key === 'corrected_response'
+                ? key.replace('corrected_response', 'response')
+                : key;
+        updatedValuesByPath[newKey] = valuesByPath[key];
+    });
+    return updatedValuesByPath;
+};
+
 /**
  * Augment the valuesByPath with user action specific data, as some user actions
  * may require updating some additional fields in the interview response, like

--- a/packages/evolution-backend/src/services/interviews/interviews.ts
+++ b/packages/evolution-backend/src/services/interviews/interviews.ts
@@ -25,6 +25,7 @@ import {
     UserInterviewAttributes
 } from 'evolution-common/lib/services/questionnaire/types';
 import { getParadataLoggingFunction } from '../logging/paradataLogging';
+import { appendCurrentBackendBuildIdIfChanged } from '../paradata/backendBuildIds';
 
 export type FilterType = string | string[] | ValueFilterType;
 
@@ -108,6 +109,10 @@ export default class Interviews {
         if (response._startedAt === undefined) {
             response._startedAt = moment().unix();
         }
+        const updatedBackendBuildIds = appendCurrentBackendBuildIdIfChanged(response._backendBuildIds);
+        if (updatedBackendBuildIds) {
+            response._backendBuildIds = updatedBackendBuildIds;
+        }
         const interview = await interviewsDbQueries.create(
             { participant_id: participantId, response, is_active: true, validations: {} },
             returning
@@ -115,14 +120,14 @@ export default class Interviews {
         if (!interview.uuid || Object.keys(initialResponse).length === 0) {
             return interview as InterviewAttributes;
         }
-        // update interview with initial response so that server updates are run on the initial response
+        // update interview with modified response so that server updates are run on the persisted values
         const userInterview = await Interviews.getInterviewByUuid(interview.uuid);
         if (userInterview === undefined) {
             throw 'Interview just created was not found!';
         }
         const valuesByPath = {};
-        Object.keys(initialResponse).forEach((key) => {
-            valuesByPath[`response.${key}`] = initialResponse[key];
+        Object.keys(response).forEach((key) => {
+            valuesByPath[`response.${key}`] = response[key];
         });
         await updateInterview(userInterview, {
             logUpdate: getParadataLoggingFunction({ interviewId: userInterview.id, userId: creatingUserId }),

--- a/packages/evolution-backend/src/services/paradata/__tests__/backendBuildIds.test.ts
+++ b/packages/evolution-backend/src/services/paradata/__tests__/backendBuildIds.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import {
+    applyReviewBackendBuildIdToInterview,
+    getBuildIdsValuesByPath,
+    getParticipantBackendBuildIdsValuesByPath,
+    getReviewBackendBuildIdsValuesByPath,
+    PARTICIPANT_BACKEND_BUILD_IDS_PATH,
+    persistReviewBackendBuildId,
+    REVIEW_BACKEND_BUILD_IDS_PATH
+} from '../backendBuildIds';
+import interviewsDbQueries from '../../../models/interviews.db.queries';
+
+jest.mock('../../../config/buildId', () => ({
+    getBackendBuildId: jest.fn(() => 'backend-sha')
+}));
+
+jest.mock('../../../models/interviews.db.queries', () => ({
+    __esModule: true,
+    default: {
+        update: jest.fn()
+    }
+}));
+const mockDbUpdate = interviewsDbQueries.update as jest.MockedFunction<typeof interviewsDbQueries.update>;
+
+describe.each([
+    [
+        'participant response',
+        PARTICIPANT_BACKEND_BUILD_IDS_PATH,
+        getParticipantBackendBuildIdsValuesByPath
+    ],
+    [
+        'review corrected_response',
+        REVIEW_BACKEND_BUILD_IDS_PATH,
+        getReviewBackendBuildIdsValuesByPath
+    ]
+] as const)('getBuildIdsValuesByPath (%s)', (_label, path, getValuesByPath) => {
+    it('should append build ids when the build id changed', () => {
+        // Setup: no build id history yet (undefined). The running backend deployment
+        // (mocked as 'backend-sha') has never been recorded on this field.
+        expect(getValuesByPath(undefined)).toEqual({
+            [path]: [expect.objectContaining({ buildId: 'backend-sha', startTimestamp: expect.any(Number) })]
+        });
+    });
+
+    it('should return an empty patch when the build id did not change', () => {
+        // Setup: the last recorded entry already matches the current backend deployment.
+        // appendBuildIdIfChanged has nothing new to append, so the route should not
+        // add this path to valuesByPath.
+        expect(getValuesByPath([{ buildId: 'backend-sha', startTimestamp: 1632929461 }])).toEqual({});
+    });
+});
+
+describe('getBuildIdsValuesByPath', () => {
+    it('should work for any response field path', () => {
+        expect(getBuildIdsValuesByPath('response._customBuildIds', undefined)).toEqual({
+            'response._customBuildIds': [
+                expect.objectContaining({ buildId: 'backend-sha', startTimestamp: expect.any(Number) })
+            ]
+        });
+    });
+});
+
+describe('review backend build id persistence', () => {
+    it('should append review backend build ids on corrected_response', () => {
+        const interview = {
+            uuid: 'interview-uuid',
+            corrected_response: {}
+        } as any;
+
+        expect(applyReviewBackendBuildIdToInterview(interview)).toBe(true);
+        expect(interview.corrected_response._reviewBackendBuildIds).toEqual([
+            expect.objectContaining({ buildId: 'backend-sha', startTimestamp: expect.any(Number) })
+        ]);
+    });
+
+    it('should not throw when persisting the build id fails', async () => {
+        mockDbUpdate.mockRejectedValueOnce(new Error('db unavailable'));
+        const interview = {
+            uuid: 'interview-uuid',
+            corrected_response: {}
+        } as any;
+
+        await expect(persistReviewBackendBuildId(interview)).resolves.toBeUndefined();
+        expect(mockDbUpdate).toHaveBeenCalled();
+    });
+});

--- a/packages/evolution-backend/src/services/paradata/backendBuildIds.ts
+++ b/packages/evolution-backend/src/services/paradata/backendBuildIds.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import type { BuildId } from 'evolution-common/lib/services/baseObjects/attributeTypes/InterviewParadataAttributes';
+import type { InterviewAttributes } from 'evolution-common/lib/services/questionnaire/types';
+import { appendBuildIdIfChanged } from 'evolution-common/lib/services/paradata/appendBuildIdIfChanged';
+import { getBackendBuildId } from '../../config/buildId';
+import interviewsDbQueries from '../../models/interviews.db.queries';
+
+export const PARTICIPANT_BACKEND_BUILD_IDS_PATH = 'response._backendBuildIds';
+export const REVIEW_BACKEND_BUILD_IDS_PATH = 'corrected_response._reviewBackendBuildIds';
+
+/**
+ * Append the current backend build id when it changed.
+ * @param existingBuildIds current build id history
+ */
+export const appendCurrentBackendBuildIdIfChanged = (existingBuildIds: BuildId[] | undefined): BuildId[] | undefined =>
+    appendBuildIdIfChanged(existingBuildIds, getBackendBuildId());
+
+/**
+ * Build a valuesByPath patch for a build id history field.
+ * @param path dot-separated path to the build id array on the interview
+ * @param existingBuildIds current build id history
+ */
+export const getBuildIdsValuesByPath = (
+    path: string,
+    existingBuildIds: BuildId[] | undefined
+): { [path: string]: BuildId[] } => {
+    const updatedBuildIds = appendCurrentBackendBuildIdIfChanged(existingBuildIds);
+    if (!updatedBuildIds) {
+        return {};
+    }
+
+    return { [path]: updatedBuildIds };
+};
+
+/** @param existingBackendBuildIds current backend build id history on response */
+export const getParticipantBackendBuildIdsValuesByPath = (
+    existingBackendBuildIds: BuildId[] | undefined
+): { [path: string]: BuildId[] } =>
+    getBuildIdsValuesByPath(PARTICIPANT_BACKEND_BUILD_IDS_PATH, existingBackendBuildIds);
+
+/** @param existingReviewBackendBuildIds current review backend build id history on corrected_response */
+export const getReviewBackendBuildIdsValuesByPath = (
+    existingReviewBackendBuildIds: BuildId[] | undefined
+): { [path: string]: BuildId[] } =>
+    getBuildIdsValuesByPath(REVIEW_BACKEND_BUILD_IDS_PATH, existingReviewBackendBuildIds);
+
+/**
+ * Append the current admin backend build id to corrected_response when it changed.
+ * @param interview interview with corrected_response to update in memory
+ * @returns true when corrected_response was updated
+ */
+export const applyReviewBackendBuildIdToInterview = (interview: InterviewAttributes): boolean => {
+    const updatedReviewBackendBuildIds = appendCurrentBackendBuildIdIfChanged(
+        interview.corrected_response?._reviewBackendBuildIds
+    );
+    if (!updatedReviewBackendBuildIds) {
+        return false;
+    }
+
+    interview.corrected_response = interview.corrected_response || {};
+    interview.corrected_response._reviewBackendBuildIds = updatedReviewBackendBuildIds;
+    return true;
+};
+
+/**
+ * Persist review backend build id history on corrected_response when it changed.
+ * Best-effort: the stamp is traceability paradata, so persistence failures are logged and never
+ * thrown, to avoid failing an otherwise successful request (a missed stamp will be recorded on
+ * the next review access anyway).
+ * @param interview interview to update
+ */
+export const persistReviewBackendBuildId = async (interview: InterviewAttributes): Promise<void> => {
+    if (!applyReviewBackendBuildIdToInterview(interview)) {
+        return;
+    }
+
+    try {
+        await interviewsDbQueries.update(interview.uuid, { corrected_response: interview.corrected_response });
+    } catch (error) {
+        console.error(`Failed to persist review backend build id for interview ${interview.uuid}:`, error);
+    }
+};

--- a/packages/evolution-common/src/services/baseObjects/attributeTypes/InterviewParadataAttributes.ts
+++ b/packages/evolution-common/src/services/baseObjects/attributeTypes/InterviewParadataAttributes.ts
@@ -63,3 +63,8 @@ export type SectionMetadata = {
 export type Language = {
     language?: string; // ISO 639-1 two letters language code
 } & StartEndTimestampable;
+
+export type BuildId = {
+    /** Git commit hash of the frontend, backend, or review server build. */
+    buildId: string;
+} & StartEndTimestampable;

--- a/packages/evolution-common/src/services/baseObjects/interview/Interview.ts
+++ b/packages/evolution-common/src/services/baseObjects/interview/Interview.ts
@@ -215,6 +215,9 @@ export class Interview extends Uuidable {
                 '_language', // TODO: remove this once we have migrated all interviews to the new paradata structure
                 '_languages', // TODO: remove this once we have migrated all interviews to the new paradata structure
                 '_browser', // TODO use an array instead of a single browser in survey
+                '_frontendBuildIds',
+                '_backendBuildIds',
+                '_reviewBackendBuildIds',
                 '_startedAt',
                 '_updatedAt',
                 '_completedAt',
@@ -519,7 +522,10 @@ export class Interview extends Uuidable {
             completedAt: dirtyParams._completedAt,
             source: dirtyParams._source,
             personsRandomSequence: dirtyParams._personRandomSequence, // TODO: rename to personsRandomSequence in survey
-            sections: dirtyParams._sections
+            sections: dirtyParams._sections,
+            frontendBuildIds: dirtyParams._frontendBuildIds,
+            backendBuildIds: dirtyParams._backendBuildIds,
+            reviewBackendBuildIds: dirtyParams._reviewBackendBuildIds
         };
     }
 }

--- a/packages/evolution-common/src/services/baseObjects/interview/InterviewParadata.ts
+++ b/packages/evolution-common/src/services/baseObjects/interview/InterviewParadata.ts
@@ -6,7 +6,7 @@
  */
 
 import { Optional } from '../../../types/Optional.type';
-import { Language, Browser, SectionMetadata } from '../attributeTypes/InterviewParadataAttributes';
+import { Language, Browser, SectionMetadata, BuildId } from '../attributeTypes/InterviewParadataAttributes';
 import { ConstructorUtils } from '../../../utils/ConstructorUtils';
 import { SurveyObjectUnserializer } from '../SurveyObjectUnserializer';
 import { ParamsValidatorUtils } from '../../../utils/ParamsValidatorUtils';
@@ -27,7 +27,10 @@ const interviewParadataAttributes = [
 
     'languages',
     'browsers',
-    'sections'
+    'sections',
+    'frontendBuildIds',
+    'backendBuildIds',
+    'reviewBackendBuildIds'
 ];
 
 const interviewParadataAttributesWithComposedAttributes = [...interviewParadataAttributes];
@@ -52,6 +55,13 @@ export type InterviewParadataAttributes = {
     */
     languages?: Language[]; // two-letter ISO 639-1 code
     browsers?: Browser[];
+
+    // Each time a new frontend build id is detected, we add a new BuildId object with timestamps in response._frontendBuildIds.
+    frontendBuildIds?: BuildId[];
+    // Each time a new backend build id is detected, we add a new BuildId object with timestamps in response._backendBuildIds.
+    backendBuildIds?: BuildId[];
+    // Each time a new admin backend build id is detected during review, we add a new BuildId object with timestamps in corrected_response._reviewBackendBuildIds.
+    reviewBackendBuildIds?: BuildId[];
 
     // each time a section is opened, we add a new SectionMetadata object with timestamps
     // TODO: move this to a Log/Paradata class? and update interview reponse to the new SectionMetadata format
@@ -91,6 +101,9 @@ export class InterviewParadata {
         'personsRandomSequence',
         'languages', // TODO: automatically select the most used language during the interview (longest duration)
         'browsers', // TODO: only some of this metadata should be exported, like the device and/or os and/or browser name
+        'frontendBuildIds',
+        'backendBuildIds',
+        'reviewBackendBuildIds',
         'sections'
     ];
 
@@ -166,6 +179,30 @@ export class InterviewParadata {
 
     set browsers(value: Optional<Browser[]>) {
         this._attributes.browsers = value || [];
+    }
+
+    get frontendBuildIds(): Optional<BuildId[]> {
+        return this._attributes.frontendBuildIds || [];
+    }
+
+    set frontendBuildIds(value: Optional<BuildId[]>) {
+        this._attributes.frontendBuildIds = value || [];
+    }
+
+    get backendBuildIds(): Optional<BuildId[]> {
+        return this._attributes.backendBuildIds || [];
+    }
+
+    set backendBuildIds(value: Optional<BuildId[]>) {
+        this._attributes.backendBuildIds = value || [];
+    }
+
+    get reviewBackendBuildIds(): Optional<BuildId[]> {
+        return this._attributes.reviewBackendBuildIds || [];
+    }
+
+    set reviewBackendBuildIds(value: Optional<BuildId[]>) {
+        this._attributes.reviewBackendBuildIds = value || [];
     }
 
     get sections(): Optional<SectionMetadata> {
@@ -353,6 +390,52 @@ export class InterviewParadata {
 
         errors.push(...ParamsValidatorUtils.isRecord('sections', dirtyParams.sections, displayName));
         // TODO: validate the section metadata object when we will have implemented the format
+
+        const buildIdsAttributes = ['frontendBuildIds', 'backendBuildIds', 'reviewBackendBuildIds'] as const;
+        for (const buildIdsAttribute of buildIdsAttributes) {
+            errors.push(
+                ...ParamsValidatorUtils.isArray(buildIdsAttribute, dirtyParams[buildIdsAttribute], displayName)
+            );
+            const buildIds = dirtyParams[buildIdsAttribute];
+            if (buildIds && Array.isArray(buildIds)) {
+                for (let i = 0; i < buildIds.length; i++) {
+                    const buildId = buildIds[i];
+                    const buildIdPath = `${buildIdsAttribute}.[${i}]`;
+                    errors.push(...ParamsValidatorUtils.isRecord(buildIdPath, buildId, displayName, false));
+                    if (!buildId || typeof buildId !== 'object' || Array.isArray(buildId)) {
+                        continue;
+                    }
+                    errors.push(
+                        ...ParamsValidatorUtils.isRequired(`${buildIdPath}.buildId`, buildId.buildId, displayName)
+                    );
+                    errors.push(
+                        ...ParamsValidatorUtils.isString(`${buildIdPath}.buildId`, buildId.buildId, displayName)
+                    );
+                    errors.push(
+                        ...ParamsValidatorUtils.isRequired(
+                            `${buildIdPath}.startTimestamp`,
+                            buildId.startTimestamp,
+                            displayName
+                        )
+                    );
+                    errors.push(
+                        ...ParamsValidatorUtils.isPositiveInteger(
+                            `${buildIdPath}.startTimestamp`,
+                            buildId.startTimestamp,
+                            displayName
+                        )
+                    );
+                    errors.push(
+                        ...ParamsValidatorUtils.isPositiveInteger(
+                            `${buildIdPath}.endTimestamp`,
+                            buildId.endTimestamp,
+                            displayName
+                        )
+                    );
+                }
+            }
+        }
+
         return errors;
     };
 }

--- a/packages/evolution-common/src/services/baseObjects/interview/__tests__/Interview.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/interview/__tests__/Interview.test.ts
@@ -426,6 +426,30 @@ describe('Interview', () => {
             expect(result.source).toBeUndefined();
             expect(result.personsRandomSequence).toBeUndefined();
             expect(result.sections).toBeUndefined();
+            expect(result.frontendBuildIds).toBeUndefined();
+            expect(result.backendBuildIds).toBeUndefined();
+        });
+
+        it('should extract frontend and backend build ids from dirty params', () => {
+            const dirtyParams = {
+                _frontendBuildIds: [{ buildId: 'frontend-sha', startTimestamp: 1632929461 }],
+                _backendBuildIds: [{ buildId: 'backend-sha', startTimestamp: 1632929462 }]
+            };
+
+            const result = Interview.extractDirtyParadataParams(dirtyParams);
+
+            expect(result.frontendBuildIds).toEqual(dirtyParams._frontendBuildIds);
+            expect(result.backendBuildIds).toEqual(dirtyParams._backendBuildIds);
+        });
+
+        it('should extract review backend build ids from dirty params', () => {
+            const dirtyParams = {
+                _reviewBackendBuildIds: [{ buildId: 'review-backend-sha', startTimestamp: 1632929463 }]
+            };
+
+            const result = Interview.extractDirtyParadataParams(dirtyParams);
+
+            expect(result.reviewBackendBuildIds).toEqual(dirtyParams._reviewBackendBuildIds);
         });
     });
 
@@ -494,6 +518,29 @@ describe('Interview', () => {
                 expect(interview.paradata?.browsers?.[0].browser?.name).toBe('Firefox');
                 expect(interview.paradata?.personsRandomSequence).toEqual(['uuid1', 'uuid2']);
                 expect(interview.paradata?.sections?.home).toBeDefined();
+            }
+        });
+
+        it('should map build ids to paradata only, not custom attributes', () => {
+            const validParams = {
+                _uuid: uuidV4(),
+                accessCode: 'ABC123',
+                assignedDate: '2023-09-30',
+                _frontendBuildIds: [{ buildId: 'frontend-sha', startTimestamp: 1632929461 }],
+                _backendBuildIds: [{ buildId: 'backend-sha', startTimestamp: 1632929462 }],
+                _reviewBackendBuildIds: [{ buildId: 'review-backend-sha', startTimestamp: 1632929463 }]
+            };
+
+            const result = create(validParams, { id: 123, participant_id: 456 } as RawInterviewAttributes, registry);
+            expect(isOk(result)).toBe(true);
+            if (isOk(result)) {
+                const interview = unwrap(result) as Interview;
+                expect(interview.paradata?.frontendBuildIds).toEqual(validParams._frontendBuildIds);
+                expect(interview.paradata?.backendBuildIds).toEqual(validParams._backendBuildIds);
+                expect(interview.paradata?.reviewBackendBuildIds).toEqual(validParams._reviewBackendBuildIds);
+                expect(interview.customAttributes._frontendBuildIds).toBeUndefined();
+                expect(interview.customAttributes._backendBuildIds).toBeUndefined();
+                expect(interview.customAttributes._reviewBackendBuildIds).toBeUndefined();
             }
         });
 

--- a/packages/evolution-common/src/services/baseObjects/interview/__tests__/InterviewParadata.validateParams.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/interview/__tests__/InterviewParadata.validateParams.test.ts
@@ -246,4 +246,58 @@ describe('InterviewParadata - InterviewParadata.validateParams', () => {
         });
     });
 
+    describe('Build ids validation', () => {
+        it('should validate valid build ids', () => {
+            const params = {
+                frontendBuildIds: [{ buildId: 'abc123', startTimestamp: 1632929461 }],
+                backendBuildIds: [{ buildId: 'def456', startTimestamp: 1632929462, endTimestamp: 1632930461 }],
+                reviewBackendBuildIds: [{ buildId: 'ghi789', startTimestamp: 1632929463 }]
+            };
+            expect(InterviewParadata.validateParams(params)).toHaveLength(0);
+        });
+
+        it('should return errors for null build id entries without throwing', () => {
+            const params = {
+                frontendBuildIds: [null, { buildId: 'abc123', startTimestamp: 1632929461 }]
+            };
+            const errors = InterviewParadata.validateParams(params);
+            expect(errors.some((e) => e.message.includes('frontendBuildIds.[0]'))).toBe(true);
+            expect(errors.some((e) => e.message.includes('frontendBuildIds.[1]'))).toBe(false);
+        });
+
+        it('should return an error for build id entries without a buildId', () => {
+            const params = {
+                frontendBuildIds: [{ startTimestamp: 1632929461 }]
+            };
+            const errors = InterviewParadata.validateParams(params);
+            expect(errors.some((e) => e.message.includes('frontendBuildIds.[0].buildId is required'))).toBe(true);
+        });
+
+        it('should return an error for build id entries without a startTimestamp', () => {
+            const params = {
+                frontendBuildIds: [{ buildId: 'abc123' }]
+            };
+            const errors = InterviewParadata.validateParams(params);
+            expect(errors.some((e) => e.message.includes('frontendBuildIds.[0].startTimestamp is required'))).toBe(
+                true
+            );
+        });
+
+        it('should allow build id entries without an endTimestamp', () => {
+            const params = {
+                frontendBuildIds: [{ buildId: 'abc123', startTimestamp: 1632929461 }]
+            };
+            expect(InterviewParadata.validateParams(params)).toHaveLength(0);
+        });
+
+        it('should return errors for malformed build id entries without throwing', () => {
+            const params = {
+                backendBuildIds: ['not-an-object', { buildId: 123, startTimestamp: 1632929461 }]
+            };
+            const errors = InterviewParadata.validateParams(params);
+            expect(errors.some((e) => e.message.includes('backendBuildIds.[0]'))).toBe(true);
+            expect(errors.some((e) => e.message.includes('backendBuildIds.[1].buildId'))).toBe(true);
+        });
+    });
+
 });

--- a/packages/evolution-common/src/services/paradata/__tests__/appendBuildIdIfChanged.test.ts
+++ b/packages/evolution-common/src/services/paradata/__tests__/appendBuildIdIfChanged.test.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { appendBuildIdIfChanged } from '../appendBuildIdIfChanged';
+
+describe('appendBuildIdIfChanged', () => {
+    it('should append a new build id with timestamp', () => {
+        expect(appendBuildIdIfChanged([], 'abc123', 1632929461)).toEqual([
+            { buildId: 'abc123', startTimestamp: 1632929461 }
+        ]);
+    });
+
+    it('should return undefined when the build id did not change', () => {
+        expect(
+            appendBuildIdIfChanged([{ buildId: 'abc123', startTimestamp: 1632929461 }], 'abc123', 1632930461)
+        ).toBeUndefined();
+    });
+
+    it('should append when the build id changed and close the previous entry', () => {
+        expect(
+            appendBuildIdIfChanged([{ buildId: 'abc123', startTimestamp: 1632929461 }], 'def456', 1632930461)
+        ).toEqual([
+            { buildId: 'abc123', startTimestamp: 1632929461, endTimestamp: 1632930461 },
+            { buildId: 'def456', startTimestamp: 1632930461 }
+        ]);
+    });
+});

--- a/packages/evolution-common/src/services/paradata/appendBuildIdIfChanged.ts
+++ b/packages/evolution-common/src/services/paradata/appendBuildIdIfChanged.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import type { BuildId } from '../baseObjects/attributeTypes/InterviewParadataAttributes';
+
+/**
+ * Append a build id to the history when it differs from the last entry.
+ * @param existingBuildIds the current build id history
+ * @param newBuildId git commit hash to append
+ * @param startTimestamp unix epoch timestamp in seconds
+ * @returns the updated history, or `undefined` when nothing changed
+ */
+export const appendBuildIdIfChanged = (
+    existingBuildIds: BuildId[] | undefined,
+    newBuildId: string | undefined,
+    startTimestamp: number = Math.floor(Date.now() / 1000)
+): BuildId[] | undefined => {
+    if (!newBuildId) {
+        return undefined;
+    }
+
+    const lastBuildId = existingBuildIds?.[existingBuildIds.length - 1]?.buildId ?? null;
+    if (lastBuildId === newBuildId) {
+        return undefined;
+    }
+
+    const updatedBuildIds = [...(existingBuildIds ?? [])];
+    if (updatedBuildIds.length > 0) {
+        const lastIndex = updatedBuildIds.length - 1;
+        updatedBuildIds[lastIndex] = {
+            ...updatedBuildIds[lastIndex],
+            endTimestamp: startTimestamp
+        };
+    }
+
+    return [...updatedBuildIds, { buildId: newBuildId, startTimestamp }];
+};

--- a/packages/evolution-common/src/services/questionnaire/types/Data.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/Data.ts
@@ -13,6 +13,7 @@ import { TripAttributes } from '../../baseObjects/Trip';
 import { Optional } from '../../../types/Optional.type';
 import { SegmentAttributes } from '../../baseObjects/Segment';
 import { HouseholdAttributes } from '../../baseObjects/Household';
+import type { BuildId } from '../../baseObjects/attributeTypes/InterviewParadataAttributes';
 import { NavigationSection } from './NavigationTypes';
 import type { Activity, ActivityCategory, Mode } from '../../odSurvey/types';
 import { YesNoDontKnow } from '../../baseObjects/attributeTypes/GenericAttributes';
@@ -321,6 +322,10 @@ export type InterviewResponse = {
     _startedAt?: number;
     _updatedAt?: number;
     _language?: string;
+    /** Git commit hashes of frontend bundles that touched this interview. */
+    _frontendBuildIds?: BuildId[];
+    /** Git commit hashes of backend builds that touched this interview. */
+    _backendBuildIds?: BuildId[];
     _isCompleted?: boolean;
     _completedAt?: number;
 
@@ -349,6 +354,8 @@ export type InterviewResponse = {
 export type CorrectedResponse = InterviewResponse & {
     _correctedResponseCopiedAt?: number;
     _validationComment?: string;
+    /** Git commit hashes of admin backend builds that touched this review. */
+    _reviewBackendBuildIds?: BuildId[];
 };
 
 export interface InterviewAudits {

--- a/packages/evolution-frontend/src/actions/Survey.ts
+++ b/packages/evolution-frontend/src/actions/Survey.ts
@@ -52,6 +52,7 @@ import { AuthAction } from 'chaire-lib-frontend/lib/store/auth';
 import { LoadingStateAction } from '../store/loadingState';
 import { RootState } from '../store/configureStore';
 import { createNavigationService } from 'evolution-common/lib/services/questionnaire/sections/NavigationService';
+import { appendBuildIdIfChanged } from 'evolution-common/lib/services/paradata/appendBuildIdIfChanged';
 
 /**
  * Class used to manage a queue of asynchronous update functions, to ensure they
@@ -799,6 +800,16 @@ export const startSetInterview = (
                     if (_isBlank(previousLanguage) || previousLanguage !== currentLanguage) {
                         valuesByPath['response._language'] = currentLanguage;
                     }
+
+                    const buildId = process.env.BUILD_ID;
+                    const updatedFrontendBuildIds = appendBuildIdIfChanged(
+                        _get(interview, 'response._frontendBuildIds', undefined),
+                        buildId && buildId !== '' ? buildId : undefined
+                    );
+                    if (updatedFrontendBuildIds) {
+                        valuesByPath['response._frontendBuildIds'] = updatedFrontendBuildIds;
+                    }
+
                     // Set the interview in the state first
                     dispatch(setInterviewState(interview));
 

--- a/packages/evolution-frontend/src/actions/SurveyAdmin.ts
+++ b/packages/evolution-frontend/src/actions/SurveyAdmin.ts
@@ -183,6 +183,14 @@ const updateSurveyCorrectedInterview = async (
         if (response.status === 200) {
             const body = await response.json();
             if (body.status === 'success' && body.interviewId === updatedInterview.uuid) {
+                if (body.updatedValuesByPath && Object.keys(body.updatedValuesByPath).length > 0) {
+                    // Server-assigned values (e.g. _reviewBackendBuildIds paradata or server
+                    // update callback results) are applied in place without re-running section
+                    // preparation. Widget state referencing these values, if any, is refreshed by
+                    // the next interaction, which is sufficient for the admin correction UI.
+                    updateInterviewData(updatedInterview, { valuesByPath: body.updatedValuesByPath });
+                }
+
                 dispatch(updateInterviewState(_cloneDeep(updatedInterview), {}, updatedValuesByPath['_all'] === true));
                 if (typeof callback === 'function') {
                     callback(updatedInterview);

--- a/packages/evolution-frontend/src/actions/__tests__/Survey.test.ts
+++ b/packages/evolution-frontend/src/actions/__tests__/Survey.test.ts
@@ -1482,6 +1482,7 @@ describe('startSetInterview', () => {
     const initialAppConfigSections = _cloneDeep(applicationConfiguration.sections);
     let startNavigateSpy;
     const startNavigateMock = jest.fn();
+    const originalBuildId = process.env.BUILD_ID;
 
     beforeAll(() => {
         startNavigateSpy = jest.spyOn(SurveyActions, 'startNavigate').mockReturnValue(startNavigateMock);
@@ -1494,11 +1495,20 @@ describe('startSetInterview', () => {
         applicationConfiguration.sections = initialAppConfigSections;
     });
 
+    afterEach(() => {
+        if (originalBuildId === undefined) {
+            delete process.env.BUILD_ID;
+        } else {
+            process.env.BUILD_ID = originalBuildId;
+        }
+    });
+
     test('No prefilled response', async () => {
 
         // Prepare mock and test data
         const returnedInterview = _cloneDeep(interviewAttributes);
         jsonFetchResolve.mockResolvedValue({ status: 'success', interview: returnedInterview });
+        process.env.BUILD_ID = 'frontend-build-id';
 
         // Do the actual test
         const dispatchFct = SurveyActions.startSetInterview();
@@ -1519,7 +1529,13 @@ describe('startSetInterview', () => {
         expect(SurveyActions.startNavigate).toHaveBeenCalledWith({
             requestedSection: undefined,
             valuesByPath: {
-                'response._browser': expect.anything()
+                'response._browser': expect.anything(),
+                'response._frontendBuildIds': [
+                    expect.objectContaining({
+                        buildId: 'frontend-build-id',
+                        startTimestamp: expect.any(Number)
+                    })
+                ]
             }
         });
     });

--- a/packages/evolution-frontend/src/actions/__tests__/SurveyAdmin.test.ts
+++ b/packages/evolution-frontend/src/actions/__tests__/SurveyAdmin.test.ts
@@ -5,6 +5,7 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import { v4 as uuidV4 } from 'uuid';
+import _cloneDeep from 'lodash/cloneDeep';
 import type { ReviewDecisions } from 'evolution-common/lib/services/reviews/types';
 import {
     startSubmitObjectReview,

--- a/packages/evolution-frontend/src/config/__tests__/resolveBuildId.test.ts
+++ b/packages/evolution-frontend/src/config/__tests__/resolveBuildId.test.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { resolveAppBuildId } from '../resolveBuildId';
+
+describe('resolveBuildId', () => {
+    describe('resolveAppBuildId', () => {
+        it('should return the BUILD_ID env value when set', () => {
+            expect(resolveAppBuildId({ BUILD_ID: 'env-sha' } as NodeJS.ProcessEnv)).toBe('env-sha');
+        });
+
+        it('should fall back to dev when BUILD_ID is not set', () => {
+            expect(resolveAppBuildId({} as NodeJS.ProcessEnv)).toBe('dev');
+        });
+    });
+});

--- a/packages/evolution-frontend/src/config/resolveBuildId.ts
+++ b/packages/evolution-frontend/src/config/resolveBuildId.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+/*
+ * Build ids stored in the interview paradata are git commit hashes of the *deployed repository*.
+ * For a survey deployment, this is the survey project's repository, not evolution's: the survey
+ * repository references evolution as a git submodule, so its commit hash is enough to recover the
+ * exact evolution version (`git submodule status` at that commit).
+ */
+
+/** Environment variable holding the git commit hash of the current deployment (`github.sha` in CI). */
+export const BUILD_ID_ENV_KEY = 'BUILD_ID';
+
+/**
+ * Resolve the deployment commit hash baked into the frontend bundle at webpack build time.
+ * The frontend cannot run git commands; `BUILD_ID` must be set in the build environment.
+ * @param env environment variables object
+ */
+export const resolveAppBuildId = (env: NodeJS.ProcessEnv = process.env): string => {
+    return env[BUILD_ID_ENV_KEY] || 'dev';
+};

--- a/packages/evolution-frontend/src/utils/dev/webpackCommon.ts
+++ b/packages/evolution-frontend/src/utils/dev/webpackCommon.ts
@@ -20,6 +20,7 @@ import HtmlWebpackPlugin from 'html-webpack-plugin';
 import { CleanWebpackPlugin } from 'clean-webpack-plugin';
 // eslint-disable-next-line n/no-unpublished-import
 import CompressionPlugin from 'compression-webpack-plugin';
+import { resolveAppBuildId } from '../../config/resolveBuildId';
 
 export type ParticipantWebpackConfigParams = CommonWebpackConfigParams & {
     /** The path to the participant app's entry file */
@@ -73,6 +74,13 @@ const stringifyEnvValues = (envs: Record<string, unknown>) => {
     return Object.fromEntries(Object.entries(envs).map(([key, value]) => [key, JSON.stringify(value)]));
 };
 
+const getDefaultBuildEnvs = (): Record<string, string> => {
+    return {
+        // Git commit hash baked into the frontend bundle (github.sha in CI)
+        BUILD_ID: resolveAppBuildId(process.env)
+    };
+};
+
 export const createCommonWebpackConfig = (params: WebpackGenerationConfigParams): Configuration => {
     const currentNodeEnv = params.env.NODE_ENV || process.env.NODE_ENV;
     const isProduction = currentNodeEnv === 'production';
@@ -111,7 +119,7 @@ export const createCommonWebpackConfig = (params: WebpackGenerationConfigParams)
             IS_TESTING: JSON.stringify(currentNodeEnv === 'test'),
             GOOGLE_API_KEY: JSON.stringify(process.env.GOOGLE_API_KEY),
             GOOGLE_MAP_ID: JSON.stringify(process.env.GOOGLE_MAP_ID),
-            ...stringifyEnvValues(params.extraEnvs)
+            ...stringifyEnvValues({ ...params.extraEnvs, ...getDefaultBuildEnvs() })
         },
         __CONFIG__: JSON.stringify({
             ...params.config


### PR DESCRIPTION
Stamp the deployment git commit hash (BUILD_ID env, github.sha in CI, or local git HEAD) in the interview paradata to track questionnaire and validation changes across respondents:

- response._frontendBuildIds: frontend bundle that loaded the interview
- response._backendBuildIds: backend builds that created/updated the participant response
- corrected_response._reviewBackendBuildIds: admin backend builds that opened or edited the interview for review

A new entry is appended only when the hash changes. Build id stamping is best-effort and never fails an otherwise successful request.

closes #1750

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added build identification across frontend, backend, and review services.
  * Interview records now capture build histories with start and end timestamps.
  * Build metadata is preserved during interview creation, updates, corrections, reviews, and validation.
  * Deployment identifiers can be supplied during container builds, with development fallbacks when unavailable.
* **Bug Fixes**
  * Corrected interview updates now consistently apply server-provided values.
  * Build-history persistence failures no longer interrupt successful interview operations.
* **Tests**
  * Expanded coverage for build identification, validation, tracking, and persistence scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->