### PR TITLE
generator: support multiple parentheses per conditional cell

### DIFF
--- a/packages/evolution-common/src/services/widgets/conditionals/__tests__/checkConditionals.test.ts
+++ b/packages/evolution-common/src/services/widgets/conditionals/__tests__/checkConditionals.test.ts
@@ -562,6 +562,33 @@ const testCases: Array<{
         expected: [true, null]
     },
     {
+        testTitle: '_isNumber1 === 1 && (_isNumber1 === 0 || (_isNumber1 === 1 && _isNumber1 === 1)), should return true.',
+        conditionals: [
+            {
+                path: '_isNumber1',
+                comparisonOperator: '===',
+                value: 1
+            },
+            { path: '_isNumber1', comparisonOperator: '===', value: 0, logicalOperator: '&&', parentheses: '(' },
+            { path: '_isNumber1', comparisonOperator: '===', value: 1, logicalOperator: '||', parentheses: '(' },
+            { path: '_isNumber1', comparisonOperator: '===', value: 1, logicalOperator: '&&', parentheses: '))' }
+        ],
+        expected: [true, null]
+    },
+    {
+        testTitle: '_isNumber1 === 1 && ((_isNumber1 === 0 || _isNumber1 === 1)), should return true.',
+        conditionals: [
+            {
+                path: '_isNumber1',
+                comparisonOperator: '===',
+                value: 1
+            },
+            { path: '_isNumber1', comparisonOperator: '===', value: 0, logicalOperator: '&&', parentheses: '((' },
+            { path: '_isNumber1', comparisonOperator: '===', value: 1, logicalOperator: '||', parentheses: '))' }
+        ],
+        expected: [true, null]
+    },
+    {
         testTitle: '_isNumber1 === 1 || (_isNumber1 === 0 && _isNumber1 === 1), should return true.',
         conditionals: [
             {
@@ -679,6 +706,34 @@ const testCases: Array<{
         ],
         expectedErrorMessage:
             'checkConditionals: Unbalanced parentheses (closing without opening) in conditionals',
+        expected: null
+    },
+    {
+        testTitle: 'invalid parentheses characters throw before evaluation',
+        conditionals: [
+            {
+                path: '_isNumber1',
+                comparisonOperator: '===',
+                value: 1,
+                parentheses: '(x'
+            }
+        ],
+        expectedErrorMessage:
+            "checkConditionals: Invalid parentheses in conditionals (index=0): must contain only '(' and ')' characters",
+        expected: null
+    },
+    {
+        testTitle: 'invalid parentheses order throws instead of reordering',
+        conditionals: [
+            {
+                path: '_isNumber1',
+                comparisonOperator: '===',
+                value: 1,
+                parentheses: ')('
+            }
+        ],
+        expectedErrorMessage:
+            'checkConditionals: Invalid parentheses in conditionals (index=0): closing parenthesis must not appear before an opening parenthesis in the same value',
         expected: null
     }
 ];

--- a/packages/evolution-common/src/services/widgets/conditionals/checkConditionals.ts
+++ b/packages/evolution-common/src/services/widgets/conditionals/checkConditionals.ts
@@ -11,7 +11,7 @@ type PathType = string;
 type ComparisonOperatorsType = '===' | '!==' | '>' | '<' | '>=' | '<=';
 type ValueType = string | number | boolean | null;
 type logicalOperatorsType = '&&' | '||';
-type ParenthesesType = '(' | ')';
+type ParenthesesType = string;
 type SingleConditionalsType = {
     logicalOperator?: logicalOperatorsType;
     path: PathType;
@@ -20,6 +20,41 @@ type SingleConditionalsType = {
     parentheses?: ParenthesesType;
 };
 type ConditionalsType = SingleConditionalsType[];
+
+const validateParenthesesCell = (parentheses: string | undefined, index: number): void => {
+    if (parentheses === undefined || parentheses === '') {
+        return;
+    }
+    if (!/^[()]*$/.test(parentheses)) {
+        throw new Error(
+            `checkConditionals: Invalid parentheses in conditionals (index=${index}): must contain only '(' and ')' characters`
+        );
+    }
+    let seenClosing = false;
+    for (const char of parentheses) {
+        if (char === ')') {
+            seenClosing = true;
+        } else if (seenClosing) {
+            throw new Error(
+                `checkConditionals: Invalid parentheses in conditionals (index=${index}): closing parenthesis must not appear before an opening parenthesis in the same value`
+            );
+        }
+    }
+};
+
+const splitParentheses = (parentheses?: string): { opening: string; closing: string } => {
+    if (!parentheses) {
+        return { opening: '', closing: '' };
+    }
+    let splitIndex = 0;
+    while (splitIndex < parentheses.length && parentheses[splitIndex] === '(') {
+        splitIndex += 1;
+    }
+    return {
+        opening: parentheses.slice(0, splitIndex),
+        closing: parentheses.slice(splitIndex)
+    };
+};
 
 /**
  * Evaluates a list of conditionals against an interview response.
@@ -54,16 +89,20 @@ export const checkConditionals = ({
         // Extract components of the conditional
         const { logicalOperator, path, comparisonOperator, value, parentheses } = conditional;
 
+        validateParenthesesCell(parentheses, index);
+
         // Parentheses must be well-formed: you can't close before opening, and all opened '(' must be closed.
-        if (parentheses === '(') {
-            parenthesesBalance += 1;
-        } else if (parentheses === ')') {
-            parenthesesBalance -= 1;
-            if (parenthesesBalance < 0) {
-                parenthesesInvalid = true;
-                throw new Error(
-                    `checkConditionals: Unbalanced parentheses (closing without opening) in conditionals (index=${index})`
-                );
+        for (const char of parentheses ?? '') {
+            if (char === '(') {
+                parenthesesBalance += 1;
+            } else if (char === ')') {
+                parenthesesBalance -= 1;
+                if (parenthesesBalance < 0) {
+                    parenthesesInvalid = true;
+                    throw new Error(
+                        `checkConditionals: Unbalanced parentheses (closing without opening) in conditionals (index=${index})`
+                    );
+                }
             }
         }
 
@@ -165,8 +204,7 @@ export const checkConditionals = ({
             conditionMet = false;
         }
 
-        const parenthesesStart = parentheses === '(' ? '(' : ''; // Add an opening parentheses if necessary
-        const parenthesesEnd = parentheses === ')' ? ')' : ''; // Add a closing parentheses if necessary
+        const { opening: parenthesesStart, closing: parenthesesEnd } = splitParentheses(parentheses);
 
         if (index === 0) {
             // For the first condition, initialize the result

--- a/packages/evolution-generator/src/scripts/conditionals_generator.py
+++ b/packages/evolution-generator/src/scripts/conditionals_generator.py
@@ -23,6 +23,21 @@ from helpers.generator_helpers import (
 )
 
 
+def split_parentheses_cell(value: str | None) -> tuple[str, str]:
+    """
+    Split a parentheses cell into opening and closing prefix/suffix strings.
+
+    @param value Parentheses cell from the Conditionals sheet
+    @returns Tuple of opening parentheses followed by closing parentheses
+    """
+    if not value:
+        return "", ""
+    split_index = 0
+    while split_index < len(value) and value[split_index] == "(":
+        split_index += 1
+    return value[:split_index], value[split_index:]
+
+
 @dataclass(frozen=True)
 class _ColumnSpec:
     """Spec for one column: controls expected headers, required fields, and value constraints."""
@@ -70,7 +85,7 @@ class ConditionalsGenerator:
         _ColumnSpec(
             name="parentheses",
             required=False,
-            allowed_values=frozenset({"(", ")", None}),
+            allowed_types=(str,),
         ),
         _ColumnSpec(
             name="value_when_hidden",
@@ -270,6 +285,16 @@ class ConditionalsGenerator:
                         f"must be one of {sorted(spec.allowed_values - {None})!r} or empty, got {repr(cell_value)}"
                     )
 
+        parentheses_value = self._empty_to_none(row_dict.get("parentheses"))
+        if isinstance(parentheses_value, str) and not self._is_valid_parentheses_cell(
+            parentheses_value
+        ):
+            issues.append(
+                f"{prefix}Invalid parentheses in row {row_number}: "
+                "must contain only '(' and ')' characters with openings before closings, "
+                f"or be empty, got {parentheses_value!r}"
+            )
+
         # Validate that the path contains only one expansion token
         raw_path = row_dict.get("path")
         if (
@@ -367,17 +392,29 @@ class ConditionalsGenerator:
             start_row_number = group_rows[0][0] if group_rows else 0
             bad_negative = False
             for rn, paren in group:
-                if paren == "(":
-                    balance += 1
-                elif paren == ")":
-                    balance -= 1
-                    if balance < 0:
-                        self._validation_errors.append(
-                            f"{prefix}Unbalanced parentheses for conditional_name '{name}' in row {rn}: "
-                            "too many ')' (closing parenthesis without matching opening)."
-                        )
-                        bad_negative = True
-                        break
+                if isinstance(paren, str) and not self._is_valid_parentheses_cell(
+                    paren
+                ):
+                    self._validation_errors.append(
+                        f"{prefix}Invalid parentheses for conditional_name '{name}' in row {rn}: "
+                        "closing parenthesis must not appear before an opening parenthesis in the same cell."
+                    )
+                    bad_negative = True
+                    break
+                for char in paren or "":
+                    if char == "(":
+                        balance += 1
+                    elif char == ")":
+                        balance -= 1
+                        if balance < 0:
+                            self._validation_errors.append(
+                                f"{prefix}Unbalanced parentheses for conditional_name '{name}' in row {rn}: "
+                                "too many ')' (closing parenthesis without matching opening)."
+                            )
+                            bad_negative = True
+                            break
+                if bad_negative:
+                    break
             if bad_negative:
                 continue
             if balance != 0:
@@ -436,6 +473,19 @@ class ConditionalsGenerator:
     def _empty_to_none(value) -> str | None:
         """Treat empty string as None for optional Excel cells (e.g. logical_operator, parentheses)."""
         return None if value == "" else value
+
+    @staticmethod
+    def _is_valid_parentheses_cell(value: str) -> bool:
+        """Return whether a cell uses only parentheses with openings before closings."""
+        if not all(char in ("(", ")") for char in value):
+            return False
+        seen_closing = False
+        for char in value:
+            if char == ")":
+                seen_closing = True
+            elif seen_closing:
+                return False
+        return True
 
     @staticmethod
     def _path_expansion_tokens_found(

--- a/packages/evolution-generator/src/scripts/generate_questionnaire_dictionary.py
+++ b/packages/evolution-generator/src/scripts/generate_questionnaire_dictionary.py
@@ -8,6 +8,7 @@ import os
 import csv
 from typing import Literal
 from helpers.generator_helpers import get_data_from_excel, clean_text
+from scripts.conditionals_generator import split_parentheses_cell
 
 
 # Function to generate questionnaire_test for each section
@@ -368,10 +369,10 @@ def process_conditionals(conditionals_rows, conditionals_headers, sections):
         conditional_string = f"{transformed_path} {comparison_operator} {value}"
 
         # Add parentheses if they exist, and place them around the conditional string depending on the parentheses
-        if parentheses == "(":
-            conditional_string = f"{parentheses}{conditional_string}"
-        elif parentheses == ")":
-            conditional_string = f"{conditional_string}{parentheses}"
+        opening_parentheses, closing_parentheses = split_parentheses_cell(parentheses)
+        conditional_string = (
+            f"{opening_parentheses}{conditional_string}{closing_parentheses}"
+        )
 
         # Add logical operator if it exists
         if logical_operator:

--- a/packages/evolution-generator/src/tests/test_conditionals_generator.py
+++ b/packages/evolution-generator/src/tests/test_conditionals_generator.py
@@ -8,7 +8,7 @@ import datetime
 from collections import defaultdict
 import pytest  # pyright: ignore[reportMissingImports]
 
-from scripts.conditionals_generator import ConditionalsGenerator
+from scripts.conditionals_generator import ConditionalsGenerator, split_parentheses_cell
 from scripts.generate_survey import check_excel_integrity
 from helpers.generator_helpers import create_mocked_excel_data, delete_file_if_exists
 
@@ -738,12 +738,47 @@ class TestValidateConditionalsRow:
         ]
 
     def test_invalid_parentheses_raises(self):
-        """parentheses must be '(', ')', or empty."""
+        """parentheses must contain only valid opening/closing characters in order."""
         assert self.checker._validate_conditionals_row(
-            self._row(parentheses="(("), self.ROW_NUMBER
+            self._row(parentheses="(x"), self.ROW_NUMBER
         ) == [
-            "Error in Conditionals sheet - Invalid parentheses in row 2: "
-            "must be one of ['(', ')'] or empty, got '(('"
+            (
+                "Error in Conditionals sheet - Invalid parentheses in row 2: "
+                "must contain only '(' and ')' characters with openings before closings, "
+                "or be empty, got '(x'"
+            )
+        ]
+
+    def test_invalid_parentheses_order_raises(self):
+        """A closing parenthesis cannot appear before a later opening in the same cell."""
+        assert self.checker._validate_conditionals_row(
+            self._row(parentheses=")("), self.ROW_NUMBER
+        ) == [
+            (
+                "Error in Conditionals sheet - Invalid parentheses in row 2: "
+                "must contain only '(' and ')' characters with openings before closings, "
+                "or be empty, got ')('"
+            )
+        ]
+
+    def test_multi_parentheses_are_valid(self):
+        """Multiple parentheses in one cell are allowed when balanced across the conditional."""
+        assert (
+            self.checker._validate_conditionals_row(
+                self._row(parentheses="))"), self.ROW_NUMBER
+            )
+            == []
+        )
+
+    def test_non_string_parentheses_reports_type_error_only(self):
+        """Non-string parentheses values use the generic type validation message."""
+        assert self.checker._validate_conditionals_row(
+            self._row(parentheses=1), self.ROW_NUMBER
+        ) == [
+            (
+                "Error in Conditionals sheet - Invalid parentheses in row 2: "
+                "must be one of types (str), got int with value 1"
+            )
         ]
 
     def test_invalid_value_type_raises(self):
@@ -758,12 +793,19 @@ class TestValidateConditionalsRow:
     def test_same_row_can_report_two_validation_issues(self):
         """When all required cells are present, every invalid optional/column is reported."""
         issues = self.checker._collect_row_validation_issues(
-            self._row(logical_operator="OR", parentheses="(("),
+            self._row(logical_operator="OR", parentheses="(x"),
             self.ROW_NUMBER,
         )
         assert len(issues) == 2
         assert any("logical_operator" in msg for msg in issues)
         assert any("parentheses" in msg for msg in issues)
+
+
+class TestSplitParenthesesCell:
+    def test_splits_openings_then_closings_in_order(self):
+        assert split_parentheses_cell("()") == ("(", ")")
+        assert split_parentheses_cell("))") == ("", "))")
+        assert split_parentheses_cell("((") == ("((", "")
 
 
 class TestValidateConditionalsParenthesesBalance:
@@ -797,6 +839,30 @@ class TestValidateConditionalsParenthesesBalance:
         ]
         self.checker._validate_conditionals_parentheses_balance(row_data)
         assert self.checker._validation_errors == []
+
+    def test_balanced_with_multiple_closing_parentheses_on_one_row(self):
+        """Nested groups may close with multiple ')' in the same cell."""
+        row_data = [
+            (2, self._row("cond1", "(")),
+            (3, self._row("cond1", "(")),
+            (4, self._row("cond1", "))")),
+        ]
+        self.checker._validate_conditionals_parentheses_balance(row_data)
+        assert self.checker._validation_errors == []
+
+    def test_invalid_parentheses_order_in_balance_check(self):
+        """Per-cell order is validated even when group balance could mask the rewrite."""
+        row_data = [
+            (2, self._row("cond1", "(")),
+            (3, self._row("cond1", ")(")),
+        ]
+        self.checker._validate_conditionals_parentheses_balance(row_data)
+        assert self.checker._validation_errors == [
+            (
+                "Error in Conditionals sheet - Invalid parentheses for conditional_name 'cond1' in row 3: "
+                "closing parenthesis must not appear before an opening parenthesis in the same cell."
+            )
+        ]
 
     def test_unbalanced_too_many_closing_raises(self):
         """')' without matching '(' appends the expected message."""

--- a/packages/evolution-generator/src/tests/test_generate_questionnaire_dictionary.py
+++ b/packages/evolution-generator/src/tests/test_generate_questionnaire_dictionary.py
@@ -1,0 +1,136 @@
+# Copyright, Polytechnique Montreal and contributors
+# This file is licensed under the MIT License.
+# License text available at https://opensource.org/licenses/MIT
+
+from scripts.generate_questionnaire_dictionary import process_conditionals
+
+CONDITIONALS_HEADERS = [
+    "conditional_name",
+    "logical_operator",
+    "path",
+    "comparison_operator",
+    "value",
+    "parentheses",
+]
+
+SECTIONS = {
+    "home": {
+        "title": "Home",
+        "abbreviation": "hm_",
+    }
+}
+
+
+class MockCell:
+    def __init__(self, value: object) -> None:
+        self.value = value
+
+
+def conditional_row(**kwargs: object) -> list[MockCell]:
+    values = dict.fromkeys(CONDITIONALS_HEADERS)
+    values.update(kwargs)
+    return [MockCell(values[header]) for header in CONDITIONALS_HEADERS]
+
+
+def conditionals_data_rows(*rows: list[MockCell]) -> list[list[MockCell]]:
+    """process_conditionals skips the first row, like Excel sheet data."""
+    return [[MockCell(header) for header in CONDITIONALS_HEADERS], *rows]
+
+
+class TestProcessConditionals:
+    def test_nested_parentheses_preserve_opening_and_closing_order(self):
+        rows = conditionals_data_rows(
+            conditional_row(
+                conditional_name="cond1",
+                path="home.field1",
+                comparison_operator="===",
+                value=1,
+                parentheses="((",
+            ),
+            conditional_row(
+                conditional_name="cond1",
+                logical_operator="&&",
+                path="home.field2",
+                comparison_operator="===",
+                value=2,
+            ),
+            conditional_row(
+                conditional_name="cond1",
+                logical_operator="||",
+                path="home.field3",
+                comparison_operator="===",
+                value=3,
+                parentheses="(",
+            ),
+            conditional_row(
+                conditional_name="cond1",
+                logical_operator="&&",
+                path="home.field4",
+                comparison_operator="===",
+                value=4,
+                parentheses="))",
+            ),
+        )
+
+        conditionals_map = process_conditionals(rows, CONDITIONALS_HEADERS, SECTIONS)
+
+        assert conditionals_map["cond1"] == (
+            "cond1 : ((hm_field1 === 1 && hm_field2 === 2 "
+            "|| (hm_field3 === 3 && hm_field4 === 4))"
+        )
+
+    def test_empty_parentheses_cell_leaves_conditional_unchanged(self):
+        rows = conditionals_data_rows(
+            conditional_row(
+                conditional_name="cond1",
+                path="home.field1",
+                comparison_operator="===",
+                value=1,
+                parentheses="",
+            )
+        )
+
+        conditionals_map = process_conditionals(rows, CONDITIONALS_HEADERS, SECTIONS)
+
+        assert conditionals_map["cond1"] == "cond1 : hm_field1 === 1"
+
+    def test_opening_only_and_closing_only_parentheses(self):
+        rows = conditionals_data_rows(
+            conditional_row(
+                conditional_name="cond1",
+                path="home.field1",
+                comparison_operator="===",
+                value=1,
+                parentheses="(",
+            ),
+            conditional_row(
+                conditional_name="cond1",
+                logical_operator="||",
+                path="home.field2",
+                comparison_operator="===",
+                value=2,
+                parentheses=")",
+            ),
+        )
+
+        conditionals_map = process_conditionals(rows, CONDITIONALS_HEADERS, SECTIONS)
+
+        assert conditionals_map["cond1"] == (
+            "cond1 : (hm_field1 === 1 || hm_field2 === 2)"
+        )
+
+    def test_invalid_mixed_parentheses_use_prefix_suffix_split_without_validation(self):
+        """Dictionary generation does not validate parentheses; invalid cells pass through."""
+        rows = conditionals_data_rows(
+            conditional_row(
+                conditional_name="cond1",
+                path="home.field1",
+                comparison_operator="===",
+                value=1,
+                parentheses=")(",
+            )
+        )
+
+        conditionals_map = process_conditionals(rows, CONDITIONALS_HEADERS, SECTIONS)
+
+        assert conditionals_map["cond1"] == "cond1 : hm_field1 === 1)("


### PR DESCRIPTION
The Conditionals sheet integrity check only accepted a single '(' or ')' in the parentheses column, which made it impossible to express nested groups like `c1 && (c2 || (c3 && c4))` that need to close two groups on the same row (e.g. '))').

The parentheses cell now accepts any number of parentheses, with openings before closings within a cell (e.g. '((', '))', but not ')(', which would be silently reordered and change the grouping):

- evolution-generator: validate the new format in the row-level check and in the cross-row balance check; extract a public split_parentheses_cell helper reused by the questionnaire dictionary generation.
- evolution-common: checkConditionals validates and evaluates multi-parentheses cells the same way at runtime.

code by Cursor Composer 2.5, validated by coderabbit and Claude 5 Fable Low

closes #1616

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Conditional expressions now support multiple opening and closing parentheses, enabling more complex nested logic.
  - Questionnaire generation preserves nested parentheses when converting conditional rules.
- **Bug Fixes**
  - Invalid characters and incorrectly ordered parentheses are now detected with clearer validation errors.
  - Conditional expressions with multiple closing parentheses are handled correctly.
- **Tests**
  - Expanded coverage for nested expressions, malformed parentheses, validation, and questionnaire generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->