### PR TITLE
admin: group started interviews by day in timezone

### DIFF
--- a/packages/evolution-backend/src/api/admin.routes.ts
+++ b/packages/evolution-backend/src/api/admin.routes.ts
@@ -12,7 +12,6 @@ import path from 'path';
 import { Response, Request } from 'express';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
-import knex from 'chaire-lib-backend/lib/config/shared/db.config';
 import router from 'chaire-lib-backend/lib/api/admin.routes';
 import { addExportRoutes } from './admin/exports.routes';
 import { RespondentBehaviorService } from '../services/paradata/respondentBehavior';
@@ -21,6 +20,7 @@ import {
     getStartedInterviewsCount,
     getCompletedInterviewsCount,
     getInterviewsCompletionRate,
+    getStartedAndCompletedInterviewsByDay,
     getSurveyDifficultyDistribution
 } from '../models/monitoring.db.queries';
 
@@ -267,22 +267,10 @@ router.post('/generator/verify', (req: Request, res: Response) => {
 });
 
 // TODO: add CSV export for this widget.
-// TODO: Move this logic to monitoring.db.queries.ts
 const handleStartedAndCompletedInterviewsByDay = async (res: Response) => {
-    // Get the sum directly from the DB, using the started_at date for grouping
-    const subquery = knex('sv_interviews').select(
-        'id',
-        knex.raw('to_char(created_at, \'YYYY-MM-DD\') as started_at_date'),
-        knex.raw('case when response->>\'_completedAt\' is null then 0 else 1 end as is_completed')
-    );
-    const responses = await knex(subquery.as('resp_data'))
-        .select('started_at_date')
-        .count({ started_at: 'id' })
-        .sum({ is_completed: 'is_completed' })
-        .whereNotNull('started_at_date')
-        .groupBy('started_at_date')
-        .orderBy('started_at_date');
-    if (responses.length <= 0) {
+    // Get the counts by local calendar day directly from the DB
+    const byDay = await getStartedAndCompletedInterviewsByDay();
+    if (byDay.length === 0) {
         return respondOk({
             res,
             result: { dates: [], started: [], completed: [], startedCount: 0, completedCount: 0 }
@@ -290,19 +278,17 @@ const handleStartedAndCompletedInterviewsByDay = async (res: Response) => {
     }
     // Create an array of dates with all dates in range
     const dates: string[] = [];
-    const firstDate = moment(responses[0]['started_at_date']);
-    const lastDate = moment(responses[responses.length - 1]['started_at_date']);
+    const firstDate = moment(byDay[0].date);
+    const lastDate = moment(byDay[byDay.length - 1].date);
     for (let date = firstDate; date.diff(lastDate, 'days') <= 0; date.add(1, 'days')) {
         const dateStr = date.format('YYYY-MM-DD');
         dates.push(dateStr);
     }
     // Process database data into response field
     const dataByDate = {};
-    responses.forEach((dateCount) => (dataByDate[dateCount['started_at_date']] = dateCount));
-    const started = dates.map((date) => (dataByDate[date] !== undefined ? Number(dataByDate[date]['started_at']) : 0));
-    const completed = dates.map((date) =>
-        dataByDate[date] !== undefined ? Number(dataByDate[date]['is_completed']) : 0
-    );
+    byDay.forEach((dayCounts) => (dataByDate[dayCounts.date] = dayCounts));
+    const started = dates.map((date) => (dataByDate[date] !== undefined ? dataByDate[date].started : 0));
+    const completed = dates.map((date) => (dataByDate[date] !== undefined ? dataByDate[date].completed : 0));
     const startedCount = started.reduce((cnt, startedCnt) => cnt + startedCnt, 0);
     const completedCount = completed.reduce((cnt, startedCnt) => cnt + startedCnt, 0);
     return respondOk({ res, result: { dates, started, completed, startedCount, completedCount } });

--- a/packages/evolution-backend/src/models/__tests__/monitoring.db.test.ts
+++ b/packages/evolution-backend/src/models/__tests__/monitoring.db.test.ts
@@ -11,8 +11,23 @@ import {
     getStartedInterviewsCount,
     getCompletedInterviewsCount,
     getInterviewsCompletionRate,
+    getStartedAndCompletedInterviewsByDay,
     getSurveyDifficultyDistribution
 } from '../monitoring.db.queries';
+import each from 'jest-each';
+import projectConfig from 'evolution-common/lib/config/project.config';
+import type { Timezone } from 'evolution-common/lib/utils/DateTimeUtils';
+
+// Fixed timezone so the by-day grouping test is deterministic on any machine.
+// Survey start/end dates are mutated per test (see afterEach reset).
+jest.mock('evolution-common/lib/config/project.config', () => ({
+    __esModule: true,
+    default: {
+        timezone: 'America/Toronto',
+        startDateTimeWithTimezoneOffset: undefined,
+        endDateTimeWithTimezoneOffset: undefined
+    }
+}));
 
 const interviewsTable = 'sv_interviews';
 const participantsTable = 'sv_participants';
@@ -20,7 +35,7 @@ const surveysTable = 'sv_surveys';
 
 // `sv_interviews.participant_id` is NOT NULL and there is a UNIQUE(survey_id, participant_id)
 // constraint, so each interview fixture must reference a distinct participant for a given survey.
-const localParticipants = Array.from({ length: 5 }, (_v, i) => ({
+const localParticipants = Array.from({ length: 7 }, (_v, i) => ({
     id: i + 1,
     email: `test${i + 1}@transition.city`,
     is_valid: true
@@ -32,6 +47,9 @@ const localSurvey = {
     shortname: 'test_survey'
 };
 
+// created_at values are chosen around UTC midnights so the by-day test verifies
+// that grouping follows the survey timezone (America/Toronto, UTC-5 in January)
+// instead of the UTC calendar day.
 const mockInterviews = [
     {
         id: 1,
@@ -40,6 +58,7 @@ const mockInterviews = [
         participant_id: localParticipants[0].id,
         is_valid: true,
         is_completed: true,
+        created_at: '2024-01-02T02:00:00Z', // 2024-01-01 21:00 in Toronto
         response: {
             _completedAt: '2024-01-01T10:00:00Z',
             perceivedBurden: { difficultyRange: 10 }
@@ -52,6 +71,7 @@ const mockInterviews = [
         participant_id: localParticipants[1].id,
         is_valid: true,
         is_completed: true,
+        created_at: '2024-01-01T15:00:00Z', // 2024-01-01 10:00 in Toronto
         response: {
             _completedAt: '2024-01-02T10:00:00Z',
             perceivedBurden: { difficultyRange: 50 }
@@ -64,6 +84,7 @@ const mockInterviews = [
         participant_id: localParticipants[2].id,
         is_valid: true,
         is_completed: false,
+        created_at: '2024-01-03T04:59:00Z', // 2024-01-02 23:59 in Toronto
         response: {
             perceivedBurden: { difficultyRange: 90 }
         }
@@ -75,6 +96,7 @@ const mockInterviews = [
         participant_id: localParticipants[3].id,
         is_valid: true,
         is_completed: true,
+        created_at: '2024-01-03T12:00:00Z', // 2024-01-03 07:00 in Toronto
         response: {
             _completedAt: '2024-01-03T10:00:00Z',
             perceivedBurden: { difficultyRange: null }
@@ -87,7 +109,32 @@ const mockInterviews = [
         participant_id: localParticipants[4].id,
         is_valid: true,
         is_completed: false,
+        created_at: '2024-01-04T00:30:00Z', // 2024-01-03 19:30 in Toronto
         response: {}
+    },
+    // Interviews 6 and 7 are exactly at the survey period boundaries used in the
+    // configured-period tests, to verify that the start/end filtering is inclusive
+    {
+        id: 6,
+        uuid: uuidV4(),
+        survey_id: localSurvey.id,
+        participant_id: localParticipants[5].id,
+        is_valid: true,
+        is_completed: false,
+        created_at: '2024-01-02T05:00:00Z', // exactly 2024-01-02T00:00:00-05:00 (survey start)
+        response: {}
+    },
+    {
+        id: 7,
+        uuid: uuidV4(),
+        survey_id: localSurvey.id,
+        participant_id: localParticipants[6].id,
+        is_valid: true,
+        is_completed: true,
+        created_at: '2024-01-03T04:59:59Z', // exactly 2024-01-02T23:59:59-05:00 (survey end)
+        response: {
+            _completedAt: '2024-01-03T10:00:00Z'
+        }
     }
 ];
 
@@ -128,6 +175,75 @@ describe('monitoring.db.queries with mock data', () => {
         const expectedRate = started > 0 ? Number(((completed / started) * 100).toFixed(1)) : 0;
         const result = await getInterviewsCompletionRate();
         expect(result).toBe(expectedRate);
+    });
+
+    test('getStartedAndCompletedInterviewsByDay groups by day in the survey timezone', async () => {
+        // Interviews 1 and 2 started on 2024-01-01 Toronto time (interview 1 is on
+        // 2024-01-02 in UTC), interviews 3, 6 and 7 on 2024-01-02, interviews 4 and 5 on 2024-01-03
+        const result = await getStartedAndCompletedInterviewsByDay();
+        expect(result).toEqual([
+            { date: '2024-01-01', started: 2, completed: 2 },
+            { date: '2024-01-02', started: 3, completed: 1 },
+            { date: '2024-01-03', started: 2, completed: 1 }
+        ]);
+    });
+
+    test('getStartedAndCompletedInterviewsByDay defaults to UTC when no timezone is configured', async () => {
+        projectConfig.timezone = undefined;
+        try {
+            // Same interviews as above, but grouped by the UTC calendar day: interviews 1
+            // and 7 move to the next UTC day, as does interview 5 (from 2024-01-03 to 2024-01-04)
+            const result = await getStartedAndCompletedInterviewsByDay();
+            expect(result).toEqual([
+                { date: '2024-01-01', started: 1, completed: 1 },
+                { date: '2024-01-02', started: 2, completed: 1 },
+                { date: '2024-01-03', started: 3, completed: 2 },
+                { date: '2024-01-04', started: 1, completed: 0 }
+            ]);
+        } finally {
+            projectConfig.timezone = 'America/Toronto' as Timezone;
+        }
+    });
+
+    describe('getStartedAndCompletedInterviewsByDay with a configured survey period', () => {
+        afterEach(() => {
+            projectConfig.startDateTimeWithTimezoneOffset = undefined;
+            projectConfig.endDateTimeWithTimezoneOffset = undefined;
+        });
+
+        // Interview 6 is exactly at the start instant and interview 7 exactly at the end
+        // instant: both must remain included (the filtering is inclusive on both ends)
+        each([
+            [
+                'interviews before the survey start date are ignored',
+                '2024-01-02T00:00:00-05:00',
+                undefined,
+                [
+                    { date: '2024-01-02', started: 3, completed: 1 },
+                    { date: '2024-01-03', started: 2, completed: 1 }
+                ]
+            ],
+            [
+                'interviews after the survey end date are ignored',
+                undefined,
+                '2024-01-02T23:59:59-05:00',
+                [
+                    { date: '2024-01-01', started: 2, completed: 2 },
+                    { date: '2024-01-02', started: 3, completed: 1 }
+                ]
+            ],
+            [
+                'interviews outside the start/end range are ignored',
+                '2024-01-02T00:00:00-05:00',
+                '2024-01-02T23:59:59-05:00',
+                [{ date: '2024-01-02', started: 3, completed: 1 }]
+            ]
+        ]).test('%s', async (_title, startDateTime, endDateTime, expected) => {
+            projectConfig.startDateTimeWithTimezoneOffset = startDateTime;
+            projectConfig.endDateTimeWithTimezoneOffset = endDateTime;
+            const result = await getStartedAndCompletedInterviewsByDay();
+            expect(result).toEqual(expected);
+        });
     });
 
     test('getSurveyDifficultyDistribution returns correct bins', async () => {

--- a/packages/evolution-backend/src/models/monitoring.db.queries.ts
+++ b/packages/evolution-backend/src/models/monitoring.db.queries.ts
@@ -6,6 +6,8 @@
  */
 import knex from 'chaire-lib-backend/lib/config/shared/db.config';
 import TrError from 'chaire-lib-common/lib/utils/TrError';
+import config from 'evolution-common/lib/config/project.config';
+import { parseISODateToTimestamp } from 'evolution-common/lib/utils/DateTimeUtils';
 
 const interviewsTable = 'sv_interviews';
 
@@ -49,6 +51,51 @@ export const getInterviewsCompletionRate = async (): Promise<number> => {
     } catch (error) {
         console.error('Error fetching interviews completion rate:', error);
         throw new TrError(`cannot get interviews completion rate (knex error: ${error})`, 'MON0003');
+    }
+};
+
+/**
+ * Get the counts of started and completed interviews, grouped by the calendar
+ * day (in the survey's configured timezone) on which the interview started.
+ * Interviews started outside the survey period (`startDateTimeWithTimezoneOffset` /
+ * `endDateTimeWithTimezoneOffset` config options, when set) are ignored.
+ * @returns Array of `{ date: 'YYYY-MM-DD', started, completed }`, ordered by date
+ */
+export const getStartedAndCompletedInterviewsByDay = async (): Promise<
+    Array<{ date: string; started: number; completed: number }>
+> => {
+    try {
+        // created_at is a timestamptz; convert it to the survey's timezone (UTC when not
+        // configured) so the calendar day does not depend on the DB session timezone
+        const subquery = knex(interviewsTable).select(
+            'id',
+            knex.raw('to_char(created_at at time zone ?, \'YYYY-MM-DD\') as started_at_date', [config.timezone ?? 'UTC']),
+            knex.raw('case when response->>\'_completedAt\' is null then 0 else 1 end as is_completed')
+        );
+        // Ignore interviews started outside the survey period, if configured
+        const surveyStartTimestamp = parseISODateToTimestamp(config.startDateTimeWithTimezoneOffset);
+        const surveyEndTimestamp = parseISODateToTimestamp(config.endDateTimeWithTimezoneOffset);
+        if (surveyStartTimestamp !== undefined) {
+            subquery.where('created_at', '>=', new Date(surveyStartTimestamp));
+        }
+        if (surveyEndTimestamp !== undefined) {
+            subquery.where('created_at', '<=', new Date(surveyEndTimestamp));
+        }
+        const rows = await knex(subquery.as('resp_data'))
+            .select('started_at_date')
+            .count({ started_at: 'id' })
+            .sum({ is_completed: 'is_completed' })
+            .whereNotNull('started_at_date')
+            .groupBy('started_at_date')
+            .orderBy('started_at_date');
+        return rows.map((row) => ({
+            date: row['started_at_date'],
+            started: Number(row['started_at']),
+            completed: Number(row['is_completed'])
+        }));
+    } catch (error) {
+        console.error('Error fetching started and completed interviews by day:', error);
+        throw new TrError(`cannot get started and completed interviews by day (knex error: ${error})`, 'MON0005');
     }
 };
 

--- a/packages/evolution-common/src/config/project.config.ts
+++ b/packages/evolution-common/src/config/project.config.ts
@@ -8,7 +8,7 @@ import projectConfig, {
     ProjectConfiguration,
     setProjectConfiguration
 } from 'chaire-lib-common/lib/config/shared/project.config';
-import { ISODateTimeStringWithTimezoneOffset } from '../utils/DateTimeUtils';
+import { ISODateTimeStringWithTimezoneOffset, Timezone } from '../utils/DateTimeUtils';
 import { AuditChecksGroup, SurveyBase, AuditRequiredFieldsBySurveyObject } from '../services/audits/types';
 import type { SurveyObjectName } from '../services/baseObjects/types';
 import { AccessCodeFormatName } from '../services/accessCode/accessCodeFormats';
@@ -47,6 +47,13 @@ export type EvolutionProjectConfiguration = {
      * Provide the timezone offset so we can calculate the correct unix epoch.
      * */
     endDateTimeWithTimezoneOffset?: ISODateTimeStringWithTimezoneOffset;
+    /**
+     * IANA timezone of the survey area (e.g. 'America/Toronto'). Used to
+     * display interview timestamps (e.g. start dates in admin dashboards and
+     * exports) as local calendar dates. When not set, dates are displayed in
+     * UTC (no runtime-dependent default, so servers and browsers always agree).
+     */
+    timezone?: Timezone;
     /** Whether to log database updates. FIXME This should be server-side only
      * */
     logDatabaseUpdates: boolean;
@@ -265,6 +272,7 @@ const defaultConfig = {
     countryCode: 'CA',
     startDateTimeWithTimezoneOffset: undefined,
     endDateTimeWithTimezoneOffset: undefined,
+    timezone: undefined,
     surveyAreaGeojsonPath: undefined,
     hideStartButtonOnHomePage: false,
     introductionTwoParagraph: false,

--- a/packages/evolution-frontend/src/components/admin/validations/InterviewListComponent.tsx
+++ b/packages/evolution-frontend/src/components/admin/validations/InterviewListComponent.tsx
@@ -23,6 +23,7 @@ import { handleHttpOtherResponseCode } from '../../../services/errorManagement/e
 import { Dispatch } from 'redux';
 import { InterviewStatusAttributesBase } from 'evolution-common/lib/services/questionnaire/types';
 import config from 'evolution-common/lib/config/project.config';
+import { dateToIsoWithTimezone } from 'evolution-common/lib/utils/DateTimeUtils';
 import * as Status from 'chaire-lib-common/lib/utils/Status';
 
 interface InterviewListComponentProps {
@@ -242,7 +243,8 @@ const InterviewListComponent: React.FunctionComponent<InterviewListComponentProp
                 accessor: 'created_at',
                 label: t('admin:interviewByDateFilter:title'),
                 Cell: ({ value }: CellArgs) =>
-                    !_isBlank(value) ? new Date(value).toISOString().split('T')[0].replace('/', '-') : '?', // Converts to YYYY-MM-DD format
+                    // Display the date (YYYY-MM-DD) in the survey's timezone instead of UTC
+                    !_isBlank(value) ? dateToIsoWithTimezone(new Date(value), config.timezone) : '?',
                 Filter: InterviewByDateFilter,
                 enableSortBy: true
             },


### PR DESCRIPTION
The monitoring widget grouped interviews by the UTC calendar day (to_char on a timestamptz follows the DB session timezone). Add a typed `timezone` config option (IANA, defaults to the runtime timezone) and use it to group by the local calendar day. Interviews started outside the configured survey period (startDateTimeWithTimezoneOffset / endDateTimeWithTimezoneOffset) are now excluded from the counts. Move the query to monitoring.db.queries.ts as per the existing TODO, with tests around UTC midnight boundaries and survey period limits.

fixes #995

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Monitoring now groups started and completed interviews by the project’s configured timezone.
  - Optional survey start and end dates are respected when calculating daily interview totals.
  - Projects can now define a timezone for date-based reporting.

- **Bug Fixes**
  - Interview creation dates in the admin list now display in the survey timezone instead of UTC.
  - Daily monitoring reports correctly handle timezone boundaries and UTC fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->