### PR TITLE
redux action: set interview state to `undefined` before loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix wrong interview passed to update callback when server updates the interview (fixes [#1700](https://github.com/chairemobilite/evolution/issues/1700))
 - Fix UI tests by getting the objects IDs that come from the server too (fixes [#1711](https://github.com/chairemobilite/evolution/issues/1711))
 - Fix widget preparation to not reset newly set values when the widget becomes visible (fixes [#1361](https://github.com/chairemobilite/evolution/issues/1361))
+- Fix race condition with stale interview updates while a new interview is being fetched (fixes [#1772](https://github.com/chairemobilite/evolution/issues/1772))
 
 ### Security
 

--- a/example/demo_survey/locales/en/survey.json
+++ b/example/demo_survey/locales/en/survey.json
@@ -55,5 +55,6 @@
     "gender": {
         "Custom": "{{nickname}} identifies themselves as",
         "Custom_one": "I identify myself as"
-    }
+    },
+    "Interviewers": "Interviewers"
 }

--- a/example/demo_survey/locales/fr/survey.json
+++ b/example/demo_survey/locales/fr/survey.json
@@ -55,5 +55,6 @@
     "gender": {
         "Custom": "{{nickname}} s'identifie comme",
         "Custom_one": "Je m'identifie comme"
-    }
+    },
+    "Interviewers": "Intervieweurs"
 }

--- a/example/demo_survey/src/admin/app-admin.tsx
+++ b/example/demo_survey/src/admin/app-admin.tsx
@@ -5,12 +5,19 @@ import appConfig, { EvolutionApplicationConfiguration } from 'evolution-frontend
 import { surveySections, widgetsConfig } from '../survey/questionnaire';
 import projectHelpers from '../survey/helper';
 
+// TODO This is a workaround to get the links to the user, until some more complete solution is implemented (see https://github.com/chairemobilite/transition/issues/1516)
+const pages = [
+    ...appConfig.pages,
+    { path: '/interviews', permissions: { Interviews: ['read', 'update'] }, title: 'survey:Interviewers' }
+];
+
 setApplicationConfiguration<EvolutionApplicationConfiguration>({
     sections: surveySections,
     widgets: widgetsConfig as any,
     allowedUrlFields: ['source', 'household.carNumber'],
     projectHelpers: projectHelpers as any,
-    templateMapping: appConfig.templateMapping
+    templateMapping: appConfig.templateMapping,
+    pages
 });
 
 runClientApp();

--- a/packages/evolution-frontend/src/actions/Survey.ts
+++ b/packages/evolution-frontend/src/actions/Survey.ts
@@ -88,6 +88,10 @@ class AsyncDispatchQueue {
 // Exported for the SurveyAdmin action and in case we need to monitor the queue
 export const asyncDispatchQueue = new AsyncDispatchQueue();
 
+// Keep an identifier for the latest interview activation request to avoid race
+// conditions and make sure only the most recent sets the interview
+let latestInterviewSetRequestId = 0;
+
 /**
  * Called whenever an update occurs in interview response or when section is
  * switched to. It will run the validations and side effects for the requested
@@ -764,7 +768,14 @@ export const startSetInterview = (
         dispatch: ThunkDispatch<RootState, unknown, SurveyAction | AuthAction | LoadingStateAction>,
         _getState: () => RootState
     ) => {
+        const requestId = ++latestInterviewSetRequestId;
+
         try {
+            // Make sure to set the interview to `undefined` first, to override
+            // any previous interview and avoid side effects if previous state
+            // remain.
+            dispatch(setInterviewState(undefined));
+
             const browserTechData = bowser.getParser(window.navigator.userAgent).parse();
             // get the interview from the server for the current user (or create one), or with a specific survey uuid
             const response = await fetch(
@@ -773,6 +784,14 @@ export const startSetInterview = (
                     credentials: 'include'
                 }
             );
+
+            // Only the most recent request may commit the result. This prevents
+            // out-of-order responses from overwriting the interview with stale
+            // data.
+            if (requestId !== latestInterviewSetRequestId) {
+                return;
+            }
+
             if (response.status === 200) {
                 const body = await response.json();
                 // Get the interview from the response

--- a/packages/evolution-frontend/src/actions/SurveyAdmin.ts
+++ b/packages/evolution-frontend/src/actions/SurveyAdmin.ts
@@ -44,7 +44,8 @@ import {
     updateInterviewState,
     updateInterviewData,
     startNavigateWithUpdateCallback,
-    asyncDispatchQueue
+    asyncDispatchQueue,
+    setInterviewState
 } from './Survey';
 import { ThunkDispatch } from 'redux-thunk';
 import { RootState } from '../store/configureStore';
@@ -236,6 +237,10 @@ export const startNavigateCorrectedInterview = (
     callback?: Parameters<StartNavigate>[1]
 ) => startNavigateWithUpdateCallback(startUpdateSurveyCorrectedInterview, options, callback);
 
+// Keep an identifier for the latest interview activation request to avoid race
+// conditions and make sure only the most recent sets the interview
+let latestInterviewSetRequestId = 0;
+
 /**
  * Fetch an interview from server and set it for edition in correction mode.
  *
@@ -254,17 +259,31 @@ export const startSetSurveyCorrectedInterview = (
         dispatch: ThunkDispatch<RootState, unknown, SurveyAction | AuthAction | LoadingStateAction>,
         _getState: () => RootState
     ) => {
+        const requestId = ++latestInterviewSetRequestId;
         try {
+            // Make sure to set the interview to `undefined` first, to override
+            // any previous interview and avoid side effects if previous state
+            // remain.
+            dispatch(setInterviewState(undefined));
+
             const response = await fetch(`/api/survey/activeCorrectedInterview/${interviewUuid}`, {
                 credentials: 'include'
             });
+
+            // Only the most recent request may commit the result. This prevents
+            // out-of-order responses from overwriting the interview with stale
+            // data.
+            if (requestId !== latestInterviewSetRequestId) {
+                return;
+            }
+
             if (response.status === 200) {
                 const body = await response.json();
                 if (body.interview) {
                     const interview = body.interview;
 
                     // Set the interview in the state first
-                    dispatch(updateInterviewState(interview));
+                    dispatch(setInterviewState(interview));
 
                     // Then, initialize navigation for the current interview
                     // This will handle all necessary updates internally

--- a/packages/evolution-frontend/src/actions/__tests__/Survey.test.ts
+++ b/packages/evolution-frontend/src/actions/__tests__/Survey.test.ts
@@ -1509,7 +1509,13 @@ describe('startSetInterview', () => {
         expect(fetchRetryMock).toHaveBeenCalledWith('/api/survey/activeInterview', expect.objectContaining({
             credentials: 'include'
         }));
-        expect(mockDispatch).toHaveBeenCalledTimes(2);
+        expect(mockDispatch).toHaveBeenCalledTimes(3);
+        // First called to reset the interview
+        expect(mockDispatch).toHaveBeenNthCalledWith(1, {
+            type: SurveyActionTypes.SET_INTERVIEW,
+            interview: undefined,
+            interviewLoaded: false
+        });
         expect(mockDispatch).toHaveBeenCalledWith({
             type: SurveyActionTypes.SET_INTERVIEW,
             interview: returnedInterview,
@@ -1540,7 +1546,13 @@ describe('startSetInterview', () => {
         expect(fetchRetryMock).toHaveBeenCalledWith('/api/survey/activeInterview', expect.objectContaining({
             credentials: 'include'
         }));
-        expect(mockDispatch).toHaveBeenCalledTimes(2);
+        expect(mockDispatch).toHaveBeenCalledTimes(3);
+        // First called to reset the interview
+        expect(mockDispatch).toHaveBeenNthCalledWith(1, {
+            type: SurveyActionTypes.SET_INTERVIEW,
+            interview: undefined,
+            interviewLoaded: false
+        });
         expect(mockDispatch).toHaveBeenCalledWith({
             type: SurveyActionTypes.SET_INTERVIEW,
             interview: returnedInterview,
@@ -1573,7 +1585,13 @@ describe('startSetInterview', () => {
         expect(fetchRetryMock).toHaveBeenCalledWith('/api/survey/activeInterview', expect.objectContaining({
             credentials: 'include'
         }));
-        expect(mockDispatch).not.toHaveBeenCalled();
+        expect(mockDispatch).toHaveBeenCalledTimes(1);
+        // Interview should be reset in any case
+        expect(mockDispatch).toHaveBeenNthCalledWith(1, {
+            type: SurveyActionTypes.SET_INTERVIEW,
+            interview: undefined,
+            interviewLoaded: false
+        });
         expect(consoleErrorSpy).toHaveBeenCalledWith('Error: Get active interview: no interview was returned, it\'s not supposed to happen');
         expect(SurveyActions.startNavigate).not.toHaveBeenCalled();
     });
@@ -1595,7 +1613,13 @@ describe('startSetInterview', () => {
         expect(fetchRetryMock).toHaveBeenCalledWith(`/api/survey/activeInterview/${uuid}`, expect.objectContaining({
             credentials: 'include'
         }));
-        expect(mockDispatch).toHaveBeenCalledTimes(2);
+        expect(mockDispatch).toHaveBeenCalledTimes(3);
+        // First called to reset the interview
+        expect(mockDispatch).toHaveBeenNthCalledWith(1, {
+            type: SurveyActionTypes.SET_INTERVIEW,
+            interview: undefined,
+            interviewLoaded: false
+        });
         expect(mockDispatch).toHaveBeenCalledWith({
             type: SurveyActionTypes.SET_INTERVIEW,
             interview: returnedInterview,
@@ -1609,6 +1633,65 @@ describe('startSetInterview', () => {
             }
         });
 
+    });
+
+    test('Only the last requested interview should be applied when responses resolve out of order', async () => {
+        // Create the 2 interview to return
+        const firstInterview = _cloneDeep(interviewAttributes);
+        firstInterview.response.section1.q1 = 'first';
+        firstInterview.uuid = uuidV4();
+        const secondInterview = _cloneDeep(interviewAttributes);
+        secondInterview.response.section1.q1 = 'second';
+        secondInterview.uuid = uuidV4();
+
+        // Create promises to use in the fetch, so they can be resolved out of order when the test chooses
+        let resolveFirstFetch!: (value: { status: number; json: () => Promise<{ status: string; interview: UserRuntimeInterviewAttributes }> }) => void;
+        let resolveSecondFetch!: (value: { status: number; json: () => Promise<{ status: string; interview: UserRuntimeInterviewAttributes }> }) => void;
+        const firstFetch = new Promise<{ status: number; json: () => Promise<{ status: string; interview: UserRuntimeInterviewAttributes }> }>((resolve) => {
+            resolveFirstFetch = resolve;
+        });
+        const secondFetch = new Promise<{ status: number; json: () => Promise<{ status: string; interview: UserRuntimeInterviewAttributes }> }>((resolve) => {
+            resolveSecondFetch = resolve;
+        });
+
+        fetchRetryMock.mockImplementationOnce(() => firstFetch).mockImplementationOnce(() => secondFetch);
+
+        // Call the set function twice
+        const firstCall = SurveyActions.startSetInterview('sectionFirst', firstInterview.uuid)(mockDispatch, mockGetState);
+        const secondCall = SurveyActions.startSetInterview('sectionSecond', secondInterview.uuid)(mockDispatch, mockGetState);
+
+        // Resolve second fetch first (should be the one to set the interview)
+        resolveSecondFetch({
+            status: 200,
+            json: async () => ({ status: 'success', interview: secondInterview })
+        });
+        await Promise.resolve();
+        // Resolve first fetch (should be ignored)
+        resolveFirstFetch({
+            status: 200,
+            json: async () => ({ status: 'success', interview: firstInterview })
+        });
+
+        // make sure we wait for the actions to be completed
+        await Promise.all([firstCall, secondCall]);
+
+        expect(SurveyActions.startNavigate).toHaveBeenCalledTimes(1);
+        expect(SurveyActions.startNavigate).toHaveBeenCalledWith({
+            requestedSection: { sectionShortname: 'sectionSecond' },
+            valuesByPath: {
+                'response._browser': expect.anything()
+            }
+        });
+        expect(mockDispatch).toHaveBeenCalledWith({
+            type: SurveyActionTypes.SET_INTERVIEW,
+            interview: secondInterview,
+            interviewLoaded: true
+        });
+        expect(mockDispatch).not.toHaveBeenCalledWith({
+            type: SurveyActionTypes.SET_INTERVIEW,
+            interview: firstInterview,
+            interviewLoaded: true
+        });
     });
 
     test('Invalid response from server', async () => {
@@ -1626,7 +1709,13 @@ describe('startSetInterview', () => {
         expect(fetchRetryMock).toHaveBeenCalledWith('/api/survey/activeInterview', expect.objectContaining({
             credentials: 'include'
         }));
-        expect(mockDispatch).not.toHaveBeenCalled();
+        expect(mockDispatch).toHaveBeenCalledTimes(1);
+        // Interview should be reset in any case
+        expect(mockDispatch).toHaveBeenNthCalledWith(1, {
+            type: SurveyActionTypes.SET_INTERVIEW,
+            interview: undefined,
+            interviewLoaded: false
+        });
         expect(SurveyActions.startNavigate).not.toHaveBeenCalled();
 
     });


### PR DESCRIPTION
fixes #1772

Set the active interview to `undefined` in the global state before loading the active interview, such that no stale interview state remains, which may cause race conditions if the `Survey` components re-renders and updates from the previous state.

Also add the "interviews" page link to the menu, so that allowed users of the demo_survey have access to that page in a clik

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an Interviews page to the administration area with access controls.
  - Added English and French translations for “Interviewers.”

- **Bug Fixes**
  - Improved interview switching by clearing the previous interview before loading another.
  - Prevented outdated interview requests from overwriting newer selections.
  - Ensured corrected interviews replace the current interview state consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->