### PR TITLE
getFormattedDate: use current locale if not received as argument

### DIFF
--- a/packages/evolution-frontend/src/services/display/__tests__/frontendHelper.test.ts
+++ b/packages/evolution-frontend/src/services/display/__tests__/frontendHelper.test.ts
@@ -19,11 +19,13 @@ import {
 } from '../frontendHelper';
 import { interviewAttributesForTestCases } from 'evolution-common/lib/tests/surveys';
 
+const defaultLocale = "en";
 jest.mock('../../../config/i18n.config', () => ({
     t: jest.fn(
         (key, options) =>
             `${key}${options && options.context ? `_${options.context}` : ''}${options && options.count !== undefined ? `_${options.count}` : ''}`
-    )
+    ),
+    language: "en" // Should match current locale, but cannot set before initialization
 }));
 const mockedT = i18n.t as jest.MockedFunction<TFunction>;
 
@@ -76,10 +78,18 @@ describe('getGenderedSuffixes', () => {
 });
 
 describe('getFormattedi18nDate', () => {
-    it('should return formatted date with default locale and without day of week or relative', () => {
+    afterEach(() => {
+        // Reset the default locale
+        i18n.language = defaultLocale
+    });
+
+    it('should return formatted date with current locale and without day of week or relative', () => {
         const date = '2023-10-01';
+        // Change the current locale
+        const newCurrentLocale = 'de';
+        i18n.language = newCurrentLocale;
         const result = getFormattedDate(date);
-        expect(result).toBe(moment(date).format('LL'));
+        expect(result).toBe(moment(date).locale(newCurrentLocale).format('LL'));
     });
 
     it('should return formatted date with specified locale and without day of week', () => {
@@ -92,7 +102,7 @@ describe('getFormattedi18nDate', () => {
     it('should return formatted date with day of week', () => {
         const date = '2023-10-01';
         const result = getFormattedDate(date, { withDayOfWeek: true });
-        expect(result).toBe(moment(date).format('dddd LL'));
+        expect(result).toBe(moment(date).locale(defaultLocale).format('dddd LL'));
     });
 
     it('should return formatted date with relative date (yesterday)', () => {

--- a/packages/evolution-frontend/src/services/display/frontendHelper.ts
+++ b/packages/evolution-frontend/src/services/display/frontendHelper.ts
@@ -71,7 +71,7 @@ export const getGenderedStrings = (person: Person | undefined | null, t: TFuncti
  * @param date The date string, formatted YYYY-MM-DD
  * @param options The options
  * @param {boolean} [options.withRelative=false] Whether to add a relative date (eg. yesterday, day before yesterday)
- * @param {string} [options.locale=undefined] The locale to use or undefined to use the default locale
+ * @param {string} [options.locale=undefined] The locale to use or undefined to use the current locale
  * @param {boolean} [options.withDayOfWeek=false] Whether to add the day of the week
  * @returns
  */
@@ -85,7 +85,8 @@ export const getFormattedDate = (
 ) => {
     const tripsDate = moment(date);
     const format = withDayOfWeek ? 'dddd LL' : 'LL';
-    let formattedTripsDate = locale ? tripsDate.locale(locale).format(format) : tripsDate.format(format);
+    const effectiveLocale = locale !== undefined ? locale : i18n.language;
+    let formattedTripsDate = tripsDate.locale(effectiveLocale).format(format);
     if (withRelative) {
         const today = moment(0, 'HH'); // today
         const numberOfDaysDiff = today.diff(tripsDate, 'days');


### PR DESCRIPTION
fixes #1775

Instead of formatting with arbitrary locale, if the locale is not passed as parameter, the current locale will be used to format the date.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Date formatting now consistently uses the application’s current language when no locale is specified.
  * Updated date-formatting guidance to clarify the default locale behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->