### PR TITLE
widgets: use the plural form of the `journeyDates` placeholder

### DIFF
--- a/locales/en/visitedPlaces.yml
+++ b/locales/en/visitedPlaces.yml
@@ -110,6 +110,12 @@ workPlaceLocationIsRequiredError: Usual work place location is required.
 ConfirmDeleteVisitedPlace: Do you confirm that you want to remove this location?
 dayScheduleFor: Day schedule for <strong>{{nickname}}</strong>
 dayScheduleFor_one: Your day schedule
+personVisitedPlacesTitle_undated: >-
+    Places {{nickname}} went:<br />Chronological order must
+    be respected (i.e. sequence matters).
+personVisitedPlacesTitle_undated_one: >-
+    Places you went:<br />Chronological order must be respected
+    (i.e. sequence matters).
 personVisitedPlacesTitle: >-
     Places {{nickname}} went on {{journeyDates}}:<br />Chronological order must
     be respected (i.e. sequence matters).

--- a/locales/en/visitedPlaces.yml
+++ b/locales/en/visitedPlaces.yml
@@ -111,10 +111,10 @@ ConfirmDeleteVisitedPlace: Do you confirm that you want to remove this location?
 dayScheduleFor: Day schedule for <strong>{{nickname}}</strong>
 dayScheduleFor_one: Your day schedule
 personVisitedPlacesTitle: >-
-    Places {{nickname}} went on {{journeyDate}}:<br />Chronological order must
+    Places {{nickname}} went on {{journeyDates}}:<br />Chronological order must
     be respected (i.e. sequence matters).
 personVisitedPlacesTitle_one: >-
-    Places you went on {{journeyDate}}:<br />Chronological order must be respected
+    Places you went on {{journeyDates}}:<br />Chronological order must be respected
     (i.e. sequence matters).
 visitedPlaceNextPlaceCategory: >-
     After being {{atPlace}}, {{nickname}}…

--- a/locales/fr/visitedPlaces.yml
+++ b/locales/fr/visitedPlaces.yml
@@ -113,22 +113,22 @@ ConfirmDeleteVisitedPlace: Confirmez-vous que vous voulez retirer ce lieu?
 dayScheduleFor: Horaire de la journée de <strong>{{nickname}}</strong>
 dayScheduleFor_one: Votre horaire de la journée
 personVisitedPlacesTitle: >-
-    Lieux où {{nickname}} est allé(e) le {{journeyDate}}:<br />L'ordre
+    Lieux où {{nickname}} est allé(e) le {{journeyDates}}:<br />L'ordre
     chronologique doit être respecté.
 personVisitedPlacesTitle_male: >-
-    Lieux où {{nickname}} est allé le {{journeyDate}}:<br />L'ordre chronologique
+    Lieux où {{nickname}} est allé le {{journeyDates}}:<br />L'ordre chronologique
     doit être respecté.
 personVisitedPlacesTitle_female: >-
-    Lieux où {{nickname}} est allée le {{journeyDate}}:<br />L'ordre chronologique
+    Lieux où {{nickname}} est allée le {{journeyDates}}:<br />L'ordre chronologique
     doit être respecté.
 personVisitedPlacesTitle_one: >-
-    Lieux où vous êtes allé(e) le {{journeyDate}}:<br />L'ordre chronologique doit
+    Lieux où vous êtes allé(e) le {{journeyDates}}:<br />L'ordre chronologique doit
     être respecté.
 personVisitedPlacesTitle_male_one: >-
-    Lieux où vous êtes allé le {{journeyDate}}:<br />L'ordre chronologique doit être
+    Lieux où vous êtes allé le {{journeyDates}}:<br />L'ordre chronologique doit être
     respecté.
 personVisitedPlacesTitle_female_one: >-
-    Lieux où vous êtes allée le {{journeyDate}}:<br />L'ordre chronologique doit
+    Lieux où vous êtes allée le {{journeyDates}}:<br />L'ordre chronologique doit
     être respecté.
 visitedPlaceNextPlaceCategory: >-
     Après avoir été {{atPlace}}, {{nickname}} est…

--- a/packages/evolution-common/src/services/odSurvey/__tests__/helpers.test.ts
+++ b/packages/evolution-common/src/services/odSurvey/__tests__/helpers.test.ts
@@ -1595,6 +1595,60 @@ describe('getJourneys', () => {
     });
 });
 
+describe('formatJourneyDates', () => {
+    const mockGetFormattedDate = jest.fn((date: string, options?: any) => `formatted:${date}`);
+    const mockedJourney: Journey = { _uuid: 'uuid', _sequence: 1 };
+
+    beforeEach(() => {
+        mockGetFormattedDate.mockClear();
+    });
+
+    test('returns null when journey has no startDate', () => {
+        const result = Helpers.formatJourneyDates({
+            journey: mockedJourney,
+            getFormattedDate: mockGetFormattedDate
+        });
+
+        expect(result).toBe(null);
+        expect(mockGetFormattedDate).not.toHaveBeenCalled();
+    });
+
+    test('calls getFormattedDate with journey.startDate and returns the formatted value with undefined parameters', () => {
+        const journey = { ...mockedJourney, startDate: '2026-08-06' } as any;
+
+        const result = Helpers.formatJourneyDates({
+            journey,
+            getFormattedDate: mockGetFormattedDate
+        });
+
+        expect(result).toBe('formatted:2026-08-06');
+        expect(mockGetFormattedDate).toHaveBeenCalledTimes(1);
+        expect(mockGetFormattedDate).toHaveBeenCalledWith('2026-08-06', {
+            withDayOfWeek: undefined,
+            locale: undefined,
+            withRelative: undefined
+        });
+    });
+
+    test('passes through withDayOfWeek, locale and withRelative options', () => {
+        const journey = { startDate: '2026-08-06' } as any;
+
+        Helpers.formatJourneyDates({
+            journey,
+            getFormattedDate: mockGetFormattedDate,
+            withDayOfWeek: true,
+            locale: 'fr',
+            withRelative: true
+        });
+
+        expect(mockGetFormattedDate).toHaveBeenCalledWith('2026-08-06', {
+            withDayOfWeek: true,
+            locale: 'fr',
+            withRelative: true
+        });
+    });
+});
+
 describe('shouldShowTripsAndPlacesSections', () => {
     const baseJourney: Journey = {
         _uuid: 'arbitraryJourney',

--- a/packages/evolution-common/src/services/odSurvey/helpers.ts
+++ b/packages/evolution-common/src/services/odSurvey/helpers.ts
@@ -27,6 +27,7 @@ import config from '../../config/project.config';
 import { loopActivities, usualActivities } from './types';
 import { SchoolType } from '../baseObjects/attributeTypes/PersonAttributes';
 import { secondsSinceMidnightToTimeStr } from 'chaire-lib-common/lib/utils/DateTimeUtils';
+import { WidgetFactoryOptions } from '../questionnaire/sections/types';
 
 // This file contains helper function that retrieves various data from the
 // response field of the interview
@@ -703,6 +704,44 @@ export const getJourneyContextFromPath = ({
         }
     }
     return null;
+};
+
+/**
+ * Format the journey dates as requested
+ *
+ * TODO For now, the formatter only format the start date, so multi-day journeys
+ * will not display a range. It has to be implemented, once fully supported.
+ *
+ * @param {Object} options - The options object.
+ * @param {Journey} options.journey - The journey for which to format the date
+ * @param {string} options.getFormattedDate - The `getFormattedDate` function to
+ * use
+ * @param {boolean} [options.withRelative] Whether to add a relative date (eg.
+ * yesterday, day before yesterday)
+ * @param {string} [options.locale] The locale to use or undefined to use the
+ * default locale
+ * @param {boolean} [options.withDayOfWeek] Whether to add the day of the week
+ * @returns {string} The formatted journey date, or `null` if the journey is
+ * undated.
+ */
+export const formatJourneyDates = ({
+    journey,
+    getFormattedDate,
+    withRelative,
+    locale,
+    withDayOfWeek
+}: {
+    journey: Journey;
+    getFormattedDate: WidgetFactoryOptions['getFormattedDate'];
+    withRelative?: boolean;
+    locale?: string;
+    withDayOfWeek?: boolean;
+}): string | null => {
+    // TODO Support journeys with an end date different than start date
+    const journeyDates = journey.startDate
+        ? getFormattedDate(journey.startDate, { withDayOfWeek, locale, withRelative })
+        : null;
+    return journeyDates;
 };
 
 /**

--- a/packages/evolution-common/src/services/questionnaire/sections/common/__tests__/widgetPersonVisitedPlacesMap.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/common/__tests__/widgetPersonVisitedPlacesMap.test.ts
@@ -77,8 +77,8 @@ describe('personVisitedPlacesMapConfig title', () => {
     test('should call translation with correct parameters if one person household and no journey dates', () => {
         mockedGetJourneyContextFromPath.mockReturnValueOnce({ person: { _uuid: 'person1', _sequence: 1 }, journey: { _uuid: 'journey1', _sequence: 1 } });
         expect(widgetTitle(mockedT, interviewAttributesForTestCases, 'path')).toEqual('translatedString');
-        expect(mockedT).toHaveBeenCalledWith('visitedPlaces:personVisitedPlacesMap', {
-            context: 'undated',
+        expect(mockedT).toHaveBeenCalledWith('visitedPlaces:personVisitedPlacesMap_undated', {
+            context: undefined,
             count: 1,
             nickname: 'translatedString', // Should have called the getPersonIdentificationString function and translated the name
             journeyDates: null

--- a/packages/evolution-common/src/services/questionnaire/sections/common/widgetPersonVisitedPlacesMap.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/common/widgetPersonVisitedPlacesMap.ts
@@ -29,17 +29,22 @@ export const getPersonVisitedPlacesMapConfig = (options: WidgetFactoryOptions): 
                 console.error('Journey context not found for path', path);
                 return '';
             }
-            // FIXME Write a function somewhere to get the journey's or dateToString function, once we move to objects
-            // FIXME2 Plan for a translation string that has a period (undated, dated, period)
-            const journeyDates = journeyContext.journey.startDate
-                ? options.getFormattedDate(journeyContext.journey.startDate)
-                : null;
-            return t('visitedPlaces:personVisitedPlacesMap', {
-                context: journeyDates === null ? 'undated' : undefined,
-                nickname: odHelpers.getPersonIdentificationString({ person: journeyContext.person, t }),
-                journeyDates,
-                count: odHelpers.getCountOrSelfDeclared({ interview, person: journeyContext.person })
+
+            const journeyDates = odHelpers.formatJourneyDates({
+                journey: journeyContext.journey,
+                getFormattedDate: options.getFormattedDate
             });
+            return t(
+                journeyDates === null
+                    ? 'visitedPlaces:personVisitedPlacesMap_undated'
+                    : 'visitedPlaces:personVisitedPlacesMap',
+                {
+                    context: odHelpers.getPersonGenderContext({ person: journeyContext.person }),
+                    nickname: odHelpers.getPersonIdentificationString({ person: journeyContext.person, t }),
+                    journeyDates,
+                    count: odHelpers.getCountOrSelfDeclared({ interview, person: journeyContext.person })
+                }
+            );
         },
         linestringColor: '#0000ff',
         geojsons: (interview, path) => {

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetPersonTripsTitle.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetPersonTripsTitle.test.ts
@@ -30,12 +30,7 @@ describe('getPersonsTripsTitleWidgetConfig', () => {
 
 describe('personsTripsTitleWidgetConfig text', () => {
 
-    const options = {
-        ...widgetFactoryOptions,
-        context: jest.fn().mockImplementation((context: string) => context)
-    };
-
-    const widgetText = getPersonsTripsTitleWidgetConfig(options).text as any;
+    const widgetText = getPersonsTripsTitleWidgetConfig(widgetFactoryOptions).text as any;
     const mockedT = jest.fn().mockReturnValue('translatedString');
    
     test('should call translation with correct parameters if no person/journey context', () => {
@@ -58,13 +53,12 @@ describe('personsTripsTitleWidgetConfig text', () => {
         }
         delete testInterview.response.household!.persons!.personId1.journeys!.journeyId1.startDate;
         expect(widgetText(mockedT, testInterview)).toEqual('translatedString');
-        expect(mockedT).toHaveBeenCalledWith('segments:personTripsTitle', {
-            context: 'undated',
+        expect(mockedT).toHaveBeenCalledWith('segments:personTripsTitle_undated', {
+            context: undefined,
             count: 1,
             nickname: '',
             journeyDates: null
         });
-        expect(options.context).toHaveBeenCalledWith('undated');
     });
 
     test('should call translation with correct parameters if multiple person household and journey with start date', () => {
@@ -82,7 +76,6 @@ describe('personsTripsTitleWidgetConfig text', () => {
             nickname,
             journeyDates: 'formattedDate'
         });
-        expect(options.context).toHaveBeenCalledWith(undefined);
     });
 
 });

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/widgetPersonTripsTitle.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/widgetPersonTripsTitle.ts
@@ -12,7 +12,6 @@ import { UserInterviewAttributes } from '../../types';
 import { WidgetFactoryOptions } from '../types';
 
 export const getPersonsTripsTitleWidgetConfig = (options: WidgetFactoryOptions): TextWidgetConfig => {
-    const getContext = options.context || ((str) => str);
     return {
         type: 'text',
         align: 'left',
@@ -22,11 +21,15 @@ export const getPersonsTripsTitleWidgetConfig = (options: WidgetFactoryOptions):
             if (!person || !journey) {
                 throw new Error('personTripsTitle: Person or Journey not found');
             }
-            // FIXME Write a function somewhere to get the journey's or dateToString function, once we move to objects
-            // FIXME2 Plan for a translation string that has a period (undated, dated, period)
-            const journeyDates = journey.startDate ? options.getFormattedDate(journey.startDate) : null;
-            return t('segments:personTripsTitle', {
-                context: getContext(journeyDates === null ? 'undated' : undefined),
+            // Format journey dates with relative and day of week, for the title
+            const journeyDates = odHelpers.formatJourneyDates({
+                journey: journey,
+                getFormattedDate: options.getFormattedDate,
+                withDayOfWeek: true,
+                withRelative: true
+            });
+            return t(journeyDates === null ? 'segments:personTripsTitle_undated' : 'segments:personTripsTitle', {
+                context: odHelpers.getPersonGenderContext({ person }),
                 nickname: person.nickname ? person.nickname : '',
                 journeyDates,
                 count: odHelpers.getCountOrSelfDeclared({ interview, person })

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetPersonVisitedPlaceTitle.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetPersonVisitedPlaceTitle.test.ts
@@ -47,8 +47,8 @@ describe('personsTripsTitleWidgetConfig text', () => {
     const widgetText = getPersonVisitedPlacesTitleWidgetConfig(visitedPlacesSectionConfig, widgetFactoryOptions).text as any;
     // Mock the translation function to just return the key for easier testing of parameters
     const mockedT = jest.fn().mockImplementation((str: any) => str);
-    // Extract the journey date for use in expected parameters in tests
-    const journeyDate = interviewAttributesForTestCases.response.household!.persons!.personId1.journeys!.journeyId1.startDate;
+    // Extract the journey date(s) for use in expected parameters in tests
+    const journeyDates = interviewAttributesForTestCases.response.household!.persons!.personId1.journeys!.journeyId1.startDate;
    
     test('should throw an error if no active person', () => {
         const testInterview = _cloneDeep(interviewAttributesForTestCases);
@@ -77,10 +77,10 @@ describe('personsTripsTitleWidgetConfig text', () => {
             context: undefined,
             count: 1,
             nickname: 'survey:personWithSequenceAndAge', // Default nickname for person without one
-            journeyDate
+            journeyDates
         });
         expect(widgetFactoryOptions.getFormattedDate).toHaveBeenCalledWith(
-            journeyDate,
+            journeyDates,
             { withDayOfWeek: true, withRelative: true }
         );
     });
@@ -96,10 +96,10 @@ describe('personsTripsTitleWidgetConfig text', () => {
             context: undefined,
             count: 3,
             nickname: 'Jane',
-            journeyDate
+            journeyDates
         });
         expect(widgetFactoryOptions.getFormattedDate).toHaveBeenCalledWith(
-            journeyDate,
+            journeyDates,
             { withDayOfWeek: true, withRelative: true }
         );
     });

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetPersonVisitedPlacesTitle.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetPersonVisitedPlacesTitle.ts
@@ -31,18 +31,25 @@ export const getPersonVisitedPlacesTitleWidgetConfig = (
                 throw new Error('Active journey for person not found in interview response');
             }
 
-            // Format the journey date(s) for context in the title
-            const assignedDay = journey.startDate;
-            const journeyDates = !_isBlank(assignedDay)
-                ? options.getFormattedDate(assignedDay!, { withDayOfWeek: true, withRelative: true })
-                : undefined;
-
-            return t('visitedPlaces:personVisitedPlacesTitle', {
-                nickname: odHelpers.getPersonIdentificationString({ person, t }),
-                context: odHelpers.getPersonGenderContext({ person }),
-                journeyDates,
-                count: odHelpers.getCountOrSelfDeclared({ interview, person })
+            // Format journey dates with relative and day of week, for the title
+            const journeyDates = odHelpers.formatJourneyDates({
+                journey: journey,
+                getFormattedDate: options.getFormattedDate,
+                withDayOfWeek: true,
+                withRelative: true
             });
+
+            return t(
+                journeyDates === null
+                    ? 'visitedPlaces:personVisitedPlacesTitle_undated'
+                    : 'visitedPlaces:personVisitedPlacesTitle',
+                {
+                    nickname: odHelpers.getPersonIdentificationString({ person, t }),
+                    context: odHelpers.getPersonGenderContext({ person }),
+                    journeyDates,
+                    count: odHelpers.getCountOrSelfDeclared({ interview, person })
+                }
+            );
         }
     };
 };

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetPersonVisitedPlacesTitle.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetPersonVisitedPlacesTitle.ts
@@ -31,17 +31,16 @@ export const getPersonVisitedPlacesTitleWidgetConfig = (
                 throw new Error('Active journey for person not found in interview response');
             }
 
-            // Format the journey start date for context in the title
-            // FIXME Update to support multiple days journeys when we support them in builtin questionnaire
+            // Format the journey date(s) for context in the title
             const assignedDay = journey.startDate;
-            const journeyDate = !_isBlank(assignedDay)
+            const journeyDates = !_isBlank(assignedDay)
                 ? options.getFormattedDate(assignedDay!, { withDayOfWeek: true, withRelative: true })
                 : undefined;
 
             return t('visitedPlaces:personVisitedPlacesTitle', {
                 nickname: odHelpers.getPersonIdentificationString({ person, t }),
                 context: odHelpers.getPersonGenderContext({ person }),
-                journeyDate,
+                journeyDates,
                 count: odHelpers.getCountOrSelfDeclared({ interview, person })
             });
         }


### PR DESCRIPTION
fixes #1782

This uniformizes how the `journeyDates` are used in builtin widget
labels, where necessary. It uses the plural form as a journey may have a
start and end date.

Also add and use a helper function to format the journey dates, that will make it easier later to support multi-day journeys


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Journey dates in visited-place and trip titles now display as complete, localized date ranges.
  * Date displays can include relative dates and days of the week where applicable.
  * Undated journeys now use clearer, dedicated labeling.
  * Updated English and French translations to support the new date range wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->