### PR TITLE
fix(generator): parse InputRange numeric cells in questionnaire dicti…

### DIFF
--- a/packages/evolution-generator/src/scripts/generate_questionnaire_dictionary.py
+++ b/packages/evolution-generator/src/scripts/generate_questionnaire_dictionary.py
@@ -10,6 +10,19 @@ from typing import Literal
 from helpers.generator_helpers import get_data_from_excel, clean_text
 
 
+def parse_int_cell_value(value):
+    """Parse an Excel cell value as an integer (handles numeric strings)."""
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        raise TypeError(f"Expected a numeric cell value, got boolean: {value}")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    return int(float(str(value).strip()))
+
+
 # Function to generate questionnaire_test for each section
 def generate_questionnaire_dictionary(
     excel_file_path: str,
@@ -311,9 +324,12 @@ def process_range(ranges_rows, ranges_headers, language):
     ranges_map = {}
     for row in ranges_rows[1:]:
         input_range_name = row[input_range_name_index].value
-        # Ensure min_value is not negative
-        min_value = max(0, row[min_value_index].value)
-        max_value = row[max_value_index].value
+        parsed_min_value = parse_int_cell_value(row[min_value_index].value)
+        # Ensure min_value is not negative, but keep None for incomplete rows
+        min_value = (
+            max(0, parsed_min_value) if parsed_min_value is not None else None
+        )
+        max_value = parse_int_cell_value(row[max_value_index].value)
         label_min = clean_text(row[label_min_index].value)
         label_middle = (
             clean_text(row[label_middle_index].value)

--- a/packages/evolution-generator/src/tests/test_generate_questionnaire_dictionary.py
+++ b/packages/evolution-generator/src/tests/test_generate_questionnaire_dictionary.py
@@ -2,7 +2,13 @@
 # This file is licensed under the MIT License.
 # License text available at https://opensource.org/licenses/MIT
 
-from scripts.generate_questionnaire_dictionary import process_choices
+import pytest
+
+from scripts.generate_questionnaire_dictionary import (
+    parse_int_cell_value,
+    process_choices,
+    process_range,
+)
 
 CHOICES_HEADERS = [
     "choicesName",
@@ -65,3 +71,142 @@ class TestProcessChoices:
         choices_map = process_choices(rows, CHOICES_HEADERS, "en", {})
 
         assert choices_map["yesNo"] == ["yes : Yes", "False : No"]
+
+
+INPUT_RANGE_HEADERS = [
+    "inputRangeName",
+    "labelFrMin",
+    "labelFrMiddle",
+    "labelFrMax",
+    "labelEnMin",
+    "labelEnMiddle",
+    "labelEnMax",
+    "minValue",
+    "maxValue",
+]
+
+
+def input_range_row(**kwargs):
+    values = {header: None for header in INPUT_RANGE_HEADERS}
+    values.update(kwargs)
+    return [MockCell(values[header]) for header in INPUT_RANGE_HEADERS]
+
+
+def input_range_data_rows(*rows):
+    return [[MockCell(header) for header in INPUT_RANGE_HEADERS], *rows]
+
+
+class TestParseIntCellValue:
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (None, None),
+            ("", None),
+            (0, 0),
+            (42, 42),
+            ("-10", -10),
+            (10.0, 10),
+            (99.9, 99),
+        ],
+    )
+    def test_parses_numeric_values(self, value, expected):
+        assert parse_int_cell_value(value) == expected
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_rejects_boolean_values(self, value):
+        with pytest.raises(TypeError, match="boolean"):
+            parse_int_cell_value(value)
+
+
+class TestProcessRange:
+    def test_parses_string_min_and_max_values(self):
+        rows = input_range_data_rows(
+            input_range_row(
+                inputRangeName="helpPopupTestRange",
+                labelEnMin="Very easy",
+                labelEnMiddle="Moderately difficult",
+                labelEnMax="Very difficult",
+                minValue="-10",
+                maxValue="100",
+            )
+        )
+
+        ranges_map = process_range(rows, INPUT_RANGE_HEADERS, "en")
+
+        assert ranges_map["helpPopupTestRange"] == (
+            "0 : Very easy\n50 : Moderately difficult\n100 : Very difficult"
+        )
+
+    @pytest.mark.parametrize(
+        "min_value,max_value",
+        [
+            (None, "100"),
+            ("", "100"),
+            ("0", None),
+            ("0", ""),
+        ],
+    )
+    def test_skips_incomplete_range_rows(self, min_value, max_value):
+        rows = input_range_data_rows(
+            input_range_row(
+                inputRangeName="incompleteRange",
+                labelEnMin="Very easy",
+                labelEnMax="Very difficult",
+                minValue=min_value,
+                maxValue=max_value,
+            )
+        )
+
+        ranges_map = process_range(rows, INPUT_RANGE_HEADERS, "en")
+
+        assert "incompleteRange" not in ranges_map
+
+    @pytest.mark.parametrize(
+        "min_value,max_value,expected_entry",
+        [
+            (
+                2,
+                8,
+                "2 : Low\n8 : High",
+            ),
+            (
+                2.0,
+                8.0,
+                "2 : Low\n8 : High",
+            ),
+            (
+                "-5",
+                "15",
+                "0 : Low\n15 : High",
+            ),
+        ],
+    )
+    def test_parses_integer_and_float_bounds(self, min_value, max_value, expected_entry):
+        rows = input_range_data_rows(
+            input_range_row(
+                inputRangeName="boundedRange",
+                labelEnMin="Low",
+                labelEnMax="High",
+                minValue=min_value,
+                maxValue=max_value,
+            )
+        )
+
+        ranges_map = process_range(rows, INPUT_RANGE_HEADERS, "en")
+
+        assert ranges_map["boundedRange"] == expected_entry
+
+    @pytest.mark.parametrize("min_value", [True, False])
+    def test_rejects_boolean_min_value(self, min_value):
+        rows = input_range_data_rows(
+            input_range_row(
+                inputRangeName="invalidRange",
+                labelEnMin="Low",
+                labelEnMax="High",
+                minValue=min_value,
+                maxValue=10,
+            )
+        )
+
+        with pytest.raises(TypeError, match="boolean"):
+            process_range(rows, INPUT_RANGE_HEADERS, "en")


### PR DESCRIPTION
…onary

Handle string and float min/max values from Excel and skip incomplete InputRange rows without raising when minValue is empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of questionnaire ranges with numeric values, numeric text, and empty cells.
  * Preserved missing minimum values instead of incorrectly assigning defaults.
  * Rejected boolean values where integer ranges are expected.

* **Tests**
  * Expanded coverage for numeric parsing, incomplete ranges, mixed input types, and generated range labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->