### PR TITLE
authorization: fix route middleware call to actually test with interview id

### DIFF
--- a/packages/evolution-backend/src/api/__tests__/survey.validation.routes.test.ts
+++ b/packages/evolution-backend/src/api/__tests__/survey.validation.routes.test.ts
@@ -16,6 +16,7 @@ import { surveyObjectExistsInInterview } from '../../services/surveyObjects/surv
 import { ReviewDecisionService } from '../../services/reviews/ReviewDecisionService';
 import { SurveyObjectsAndAuditsFactory } from '../../services/audits/SurveyObjectsAndAuditsFactory';
 import { CANNOT_FORCE_APPROVE_WITHOUT_CONFLICT_ERROR_CODE } from '../../services/reviews/reviewDecisionErrors';
+import { UserAttributes } from 'chaire-lib-backend/lib/services/users/user';
 
 // Mirrors the real interviewUserIsAuthorized behavior (services/auth/userAuthorization.ts),
 // using the mocked Interviews and the shared isUserAllowed mock so tests can drive
@@ -124,7 +125,8 @@ const mockCreateSurveyObjectsAndSaveAuditsToDb = SurveyObjectsAndAuditsFactory.c
     typeof SurveyObjectsAndAuditsFactory.createSurveyObjectsAndSaveAuditsToDb
 >;
 
-let mockAuthUser: { id: number } | undefined = { id: 3 };
+const defaultUser = { id: 3, is_admin: true, uuid: 'someuuid' };
+let mockAuthUser: UserAttributes | undefined = defaultUser;
 
 const app = express();
 app.use(express.json());
@@ -183,7 +185,7 @@ const runValidationReviewContextFailureTests = ({ path, body }: ValidationReview
 
     beforeEach(() => {
         jest.clearAllMocks();
-        mockAuthUser = { id: 3 };
+        mockAuthUser = { id: 3, uuid: 'someUuid', is_admin: true };
         mockGetInterviewByUuid.mockResolvedValue({
             id: 10,
             uuid: interviewUuid,
@@ -295,7 +297,7 @@ const setupValidationReviewMutationMocks = ({
 }: SetupValidationReviewMutationMocksOptions) => {
     beforeEach(() => {
         jest.clearAllMocks();
-        mockAuthUser = { id: 3 };
+        mockAuthUser = defaultUser;
         mockGetInterviewByUuid.mockResolvedValue({
             id: 10,
             uuid: interviewUuid,
@@ -319,7 +321,7 @@ describe('GET /review/decisions/:interviewId', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
-        mockAuthUser = { id: 3 };
+        mockAuthUser = defaultUser;
         mockIsUserAllowed.mockReturnValue(true);
         mockGetInterviewByUuid.mockResolvedValue({ id: 10, uuid: interviewUuid } as any);
         mockGetReviewDecisions.mockResolvedValue(reviewDecisionsPayload);

--- a/packages/evolution-backend/src/api/__tests__/survey.validation.routes.test.ts
+++ b/packages/evolution-backend/src/api/__tests__/survey.validation.routes.test.ts
@@ -27,12 +27,12 @@ jest.mock('../../services/auth/userAuthorization', () => {
             if (!req.user?.id) {
                 return res.status(401).json({ status: 'Unauthorized' });
             }
-            const interviewId = req.params?.interviewId || req.body?.interviewId;
-            if (!interviewId) {
+            const interviewUuid = req.params?.interviewUuid || req.body?.interviewUuid;
+            if (!interviewUuid) {
                 return next();
             }
             const interview = await require('../../services/interviews/interviews').default.getInterviewByUuid(
-                interviewId
+                interviewUuid
             );
             if (!interview) {
                 return res.status(404).json({ status: 'NotFound' });

--- a/packages/evolution-backend/src/api/helpers/validateReviewObjectMiddleware.ts
+++ b/packages/evolution-backend/src/api/helpers/validateReviewObjectMiddleware.ts
@@ -71,7 +71,7 @@ const validateReviewObjectMiddleware = async (req: Request, res: Response, next:
             return sendError(res, 400, 'Invalid object uuid');
         }
 
-        const interview = await Interviews.getInterviewByUuid(req.params.interviewId);
+        const interview = await Interviews.getInterviewByUuid(req.params.interviewUuid);
         if (!interview) {
             return sendError(res, 404, 'Interview does not exist');
         }

--- a/packages/evolution-backend/src/api/helpers/validateUuidMiddleware.ts
+++ b/packages/evolution-backend/src/api/helpers/validateUuidMiddleware.ts
@@ -16,6 +16,13 @@ const validateUuidMiddleware = (req: Request, res: Response, next: NextFunction)
         console.warn(`Received an invalid interview ID from client: ${interviewUuid}`);
         return res.status(400).json({ status: 'failed', error: 'Invalid interview ID' });
     }
+    if (req.params.interviewId) {
+        // We are using an interview UUID, it should be in the interviewUUID paramemeter. Just log an error if it is not the case, so we notice and fix
+        console.error(
+            'interviewUuid set in the interviewId parameter of the route, the parameter name should be updated to interviewUuid ',
+            req.route.path
+        );
+    }
     next();
 };
 

--- a/packages/evolution-backend/src/api/survey.validation.routes.ts
+++ b/packages/evolution-backend/src/api/survey.validation.routes.ts
@@ -34,6 +34,8 @@ import { CANNOT_FORCE_APPROVE_WITHOUT_CONFLICT_ERROR_CODE } from '../services/re
 import type { ReviewDecisionValue, ReviewDecisions } from 'evolution-common/lib/services/reviews/types';
 import { hasErrors } from 'evolution-common/lib/types/Result.type';
 import TrError from 'chaire-lib-common/lib/utils/TrError';
+import isAuthorized from 'chaire-lib-backend/lib/services/auth/authorization';
+import { InterviewsSubject } from '../services/auth/roleDefinition';
 
 const router = express.Router();
 
@@ -93,7 +95,7 @@ const respondWithReviewMutationResult = async (
     }
 };
 
-router.use(interviewUserIsAuthorized(['validate', 'read']));
+router.use(isAuthorized({ [InterviewsSubject]: ['read', 'validate'] }));
 
 /**
  * Type for the filter parameter accepted by getValidationAuditStats
@@ -159,6 +161,7 @@ const parseOptionalStringBodyField = (
 router.get(
     '/survey/correctInterview/:interviewUuid',
     validateUuidMiddleware,
+    interviewUserIsAuthorized(['validate', 'read']),
     logUserAccessesMiddleware.openingInterview(true),
     async (req: Request, res: Response) => {
         // Extended audit checks: When enabled (extended=true), runs additional audit checks that may
@@ -224,6 +227,7 @@ router.get(
 router.get(
     '/survey/activeCorrectedInterview/:interviewUuid',
     validateUuidMiddleware,
+    interviewUserIsAuthorized(['validate', 'read']),
     logUserAccessesMiddleware.openingInterview(true),
     async (req: Request, res: Response) => {
         if (req.params.interviewUuid) {
@@ -274,6 +278,7 @@ router.get(
 router.post(
     '/survey/updateCorrectedInterview/:interviewUuid',
     validateUuidMiddleware,
+    interviewUserIsAuthorized(['validate', 'read']),
     logUserAccessesMiddleware.updatingInterview(true),
     async (req: Request, res: Response) => {
         try {
@@ -401,23 +406,31 @@ router.post('/validation/auditStats', async (req: Request, res: Response) => {
     }
 });
 
-router.post('/validation/updateAudits/:uuid', async (req, res, _next) => {
-    try {
-        const audits = req.body.audits;
-        const interview = await Interviews.getInterviewByUuid(req.params.uuid);
-        if (!interview) {
-            throw 'Interview does not exist';
-        }
-        await SurveyObjectsAndAuditsFactory.updateAudits(interview.id, audits);
+// FIXME This route is never called. See if it's required. The commit that added
+// it (a45c7b9acf5) states that it was meant to update audits from clients to
+// set the ignore status. Is that right?
+router.post(
+    '/validation/updateAudits/:interviewUuid',
+    validateUuidMiddleware,
+    interviewUserIsAuthorized(['validate']),
+    async (req, res, _next) => {
+        try {
+            const audits = req.body.audits;
+            const interview = await Interviews.getInterviewByUuid(req.params.interviewUuid);
+            if (!interview) {
+                throw 'Interview does not exist';
+            }
+            await SurveyObjectsAndAuditsFactory.updateAudits(interview.id, audits);
 
-        return res.status(200).json({
-            status: 'ok'
-        });
-    } catch (error) {
-        console.error('error updating audits for interview:', error);
-        return res.status(500).json({ status: 'error' });
+            return res.status(200).json({
+                status: 'ok'
+            });
+        } catch (error) {
+            console.error('error updating audits for interview:', error);
+            return res.status(500).json({ status: 'error' });
+        }
     }
-});
+);
 
 // This route fetches the review decisions for an interview, separately from
 // the interview and its audits, so each can be requested/refreshed independently.

--- a/packages/evolution-backend/src/api/survey.validation.routes.ts
+++ b/packages/evolution-backend/src/api/survey.validation.routes.ts
@@ -422,12 +422,12 @@ router.post('/validation/updateAudits/:uuid', async (req, res, _next) => {
 // This route fetches the review decisions for an interview, separately from
 // the interview and its audits, so each can be requested/refreshed independently.
 router.get(
-    '/review/decisions/:interviewId',
+    '/review/decisions/:interviewUuid',
     validateUuidMiddleware,
     interviewUserIsAuthorized(['read']),
     async (req: Request, res: Response) => {
         try {
-            const interview = await Interviews.getInterviewByUuid(req.params.interviewId);
+            const interview = await Interviews.getInterviewByUuid(req.params.interviewUuid);
             if (!interview) {
                 return sendError(res, 404, 'Interview does not exist');
             }
@@ -447,7 +447,7 @@ router.get(
 );
 
 router.post(
-    '/review/decision/:interviewId',
+    '/review/decision/:interviewUuid',
     validateUuidMiddleware,
     interviewUserIsAuthorized(['validate']),
     validateReviewObjectMiddleware,
@@ -474,7 +474,7 @@ router.post(
 );
 
 router.post(
-    '/review/reReview/:interviewId',
+    '/review/reReview/:interviewUuid',
     validateUuidMiddleware,
     interviewUserIsAuthorized(['validate']),
     validateReviewObjectMiddleware,
@@ -497,7 +497,7 @@ router.post(
 );
 
 router.post(
-    '/review/clearDecision/:interviewId',
+    '/review/clearDecision/:interviewUuid',
     validateUuidMiddleware,
     interviewUserIsAuthorized(['validate']),
     validateReviewObjectMiddleware,
@@ -514,7 +514,7 @@ router.post(
 );
 
 router.post(
-    '/review/clearForceApprove/:interviewId',
+    '/review/clearForceApprove/:interviewUuid',
     validateUuidMiddleware,
     interviewUserIsAuthorized(['confirm']),
     validateReviewObjectMiddleware,
@@ -531,7 +531,7 @@ router.post(
 );
 
 router.post(
-    '/review/forceApprove/:interviewId',
+    '/review/forceApprove/:interviewUuid',
     validateUuidMiddleware,
     interviewUserIsAuthorized(['confirm']),
     validateReviewObjectMiddleware,

--- a/packages/evolution-backend/src/services/auth/__tests__/userAuthorization.test.ts
+++ b/packages/evolution-backend/src/services/auth/__tests__/userAuthorization.test.ts
@@ -21,7 +21,7 @@ const mockAdmin = { id: 4, username: 'admin', is_admin: true };
 
 const mockGetInterviewByUuid = Interviews.getInterviewByUuid = jest.fn();
 
-const interviewId = uuidV4();
+const interviewUuid = uuidV4();
 
 beforeEach(() => {
     mockRequest = {};
@@ -35,8 +35,8 @@ beforeEach(() => {
 
 describe('User interview access', () => {
     const defaultPermissions = ['update', 'read'];
-    const defaultGetParams = { params: { interviewId } };
-    const defaultPostParams = { body: { interviewId } };
+    const defaultGetParams = { params: { interviewUuid } };
+    const defaultPostParams = { body: { interviewUuid } };
 
     each([
         ['No authenticated user', undefined, defaultGetParams, defaultPermissions, undefined, 401],
@@ -52,7 +52,7 @@ describe('User interview access', () => {
         ['Get params, Admin user, interview exists', mockAdmin, defaultPostParams, defaultPermissions, true, true],
         ['Get params, Admin user, interview with extra permissions', mockAdmin, defaultPostParams, [...defaultPermissions, 'validate'], true, true],
         ['Post and get params, identical, ok', mockAdmin, { ...defaultPostParams, ...defaultGetParams }, defaultPermissions, true, true],
-        ['Post and get params, not identical, not ok', mockAdmin, { ...defaultGetParams, body: { interviewId: uuidV4() } }, defaultPermissions, true, 400]
+        ['Post and get params, not identical, not ok', mockAdmin, { ...defaultGetParams, body: { interviewUuid: uuidV4() } }, defaultPermissions, true, 400]
     ]).test('%s', async (_title, user, reqParams, requestedPermissions, retUndefined, expectedNextOrCode, is_active = true) => {
         mockRequest.user = user;
         const request = { ...mockRequest, ...reqParams };

--- a/packages/evolution-backend/src/services/auth/userAuthorization.ts
+++ b/packages/evolution-backend/src/services/auth/userAuthorization.ts
@@ -15,7 +15,8 @@ import { InterviewAttributes } from 'evolution-common/lib/services/questionnaire
 export type permissionType = 'read' | 'update' | 'validate' | 'confirm' | 'delete' | 'create';
 
 /**
- * Authorization middleware to authorize a user on an interview
+ * Authorization middleware to authorize a user on an interview, given the
+ * interview UUID
  *
  * @param {{ [key: string ]: string}} permissions An object with the permissions
  * to verify
@@ -29,13 +30,17 @@ const interviewUserIsAuthorized = (permissions: permissionType[]) => {
             return;
         }
         // Get the interview
-        const interviewId = req.params?.interviewId || req.body?.interviewId;
+        const interviewUuid = req.params?.interviewUuid || req.body?.interviewUuid;
         // No interview specified, let the request do what must be done
-        if (!interviewId) {
+        if (!interviewUuid) {
             next();
             return;
         }
-        if (req.params?.interviewId && req.body?.interviewId && req.params.interviewId !== req.body.interviewId) {
+        if (
+            req.params?.interviewUuid &&
+            req.body?.interviewUuid &&
+            req.params.interviewUuid !== req.body.interviewUuid
+        ) {
             // Ambiguous query, 3 interview IDs are specified
             console.error(
                 'Ambiguous query: 2 different interviews have been specified in query string and body. Bailing out'
@@ -45,7 +50,7 @@ const interviewUserIsAuthorized = (permissions: permissionType[]) => {
         }
 
         try {
-            const interview = await Interviews.getInterviewByUuid(interviewId);
+            const interview = await Interviews.getInterviewByUuid(interviewUuid);
             // The interview is not found
             if (!interview) {
                 res.status(404).json({ status: 'NotFound' });


### PR DESCRIPTION
fixes security advisory
[GHSA-rxph-jj5c-wm57](https://github.com/chairemobilite/evolution/security/advisories/GHSA-rxph-jj5c-wm57)

The named parameter on the route is not available yet in middleware used
by `router.use`. If we need to use those parameter in the middleware, it
has to be added at the route level. The middleware at the router level
is replaced with a middleware that validates that the user is authorized
to read and validate interviews as a whole.

authorization: rename `interviewId` parameter to `interviewUuid`

Since an interview has both an ID and a uuid, they should have the
correct naming. the `interviewUserIsAuthorized` function receives an
interview uuid, therefore the parameter is renamed to `interviewUuid`.

Rename the parameter received in review decision routes to match the
`interviewUuid` requirement.

Add a `console.error` in the `validateUuidMiddleware` to warn if the
`interviewId` parameter was used in a route. All routes should be
updated to `interviewUuid`, but if it's not the case, we'll know.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated survey validation and review routes to use interview UUIDs consistently.
  * Improved authorization checks for interview reading, validation, audit updates, and corrections.
  * Added clearer error logging when the legacy interview identifier is used.
  * Added validation for conflicting interview UUIDs supplied in requests.
  * Improved request handling when interview identifiers are missing, invalid, or inconsistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->