### PR TITLE
inputSelectFeature: support additional options and shortcuts

### DIFF
--- a/packages/evolution-common/src/services/questionnaire/types/WidgetConfig.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/WidgetConfig.ts
@@ -213,6 +213,14 @@ export type InputSelectFeatureType = BaseQuestionType & {
     featureCollection: GeoJSON.FeatureCollection<GeoJSON.Point>;
     labelProperty: string;
     referenceGeography: ParsingFunction<GeoJSON.Feature<GeoJSON.Point> | null>;
+    /**
+     * Additional choices to add to the select list, that does not map to a feature
+     */
+    additionalChoices?: ChoiceType[];
+    /**
+     * Choices to add as shortcuts buttons below the select box, to automatically select a given choice.
+     */
+    shortcuts?: ChoiceType[];
 };
 
 export type InputMultiselectType = BaseQuestionType & {

--- a/packages/evolution-frontend/src/components/inputs/InputSelectFeature.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputSelectFeature.tsx
@@ -4,13 +4,16 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import React from 'react';
+import React, { JSX } from 'react';
 import Select, { SelectInstance } from 'react-select';
 import { distance as turfDistance } from '@turf/turf';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { InputSelectFeatureType } from 'evolution-common/lib/services/questionnaire/types';
 import { CommonInputProps } from './CommonInputProps';
+import { useTranslation } from 'react-i18next';
+import { parseBoolean, translateString } from 'evolution-common/lib/utils/helpers';
 
 export type InputSelectFeatureProps = CommonInputProps & {
     value?: string;
@@ -29,15 +32,17 @@ type OptionType = { label: string; value: string };
  * @returns The options to feed to the searchable select, in display order
  */
 const useFeatureOptions = (
-    widgetConfig: InputSelectFeatureType,
+    props: InputSelectFeatureProps,
     referenceGeography: GeoJSON.Feature<GeoJSON.Point> | null
 ): OptionType[] => {
     const referenceGeographyKey = referenceGeography
         ? `${referenceGeography.geometry.type}:${referenceGeography.geometry.coordinates.join(',')}`
         : null;
+    const { i18n } = useTranslation();
 
+    const widgetConfig = props.widgetConfig;
     // Memoized sorted options, to avoid recalculating distances on every render
-    return React.useMemo(() => {
+    const featureOptions = React.useMemo(() => {
         const features = widgetConfig.featureCollection.features as GeoJSON.Feature<GeoJSON.Point>[];
         const sortedFeatures =
             referenceGeography === null
@@ -52,6 +57,64 @@ const useFeatureOptions = (
             label: feature.properties?.[widgetConfig.labelProperty]
         }));
     }, [widgetConfig, referenceGeographyKey]);
+
+    // Add additional options to the list, if any
+    if (widgetConfig.additionalChoices) {
+        const additionalOptions = widgetConfig.additionalChoices
+            .filter(
+                (choice) =>
+                    choice.hidden !== true && parseBoolean(choice.conditional, props.interview, props.path, props.user)
+            )
+            .map((choice) => ({
+                label: translateString(choice.label, i18n, props.interview, props.path, props.user) as string,
+                color: choice.color,
+                value: choice.value
+            }));
+
+        return [...featureOptions, ...additionalOptions];
+    }
+    return featureOptions;
+};
+
+const ShortcutButtons = (
+    props: InputSelectFeatureProps & {
+        availableOptions: OptionType[];
+        onChange: (option: { value: string } | null) => void;
+    }
+) => {
+    const { i18n } = useTranslation();
+    const shortcuts = props.widgetConfig.shortcuts;
+    if (shortcuts === undefined || shortcuts.length === 0) {
+        return null;
+    }
+
+    const selectShortcut = (value: string, e: React.MouseEvent) => {
+        if (e) {
+            e.preventDefault();
+        }
+        props.onChange({ value });
+    };
+
+    const shortcutButtons: JSX.Element[] = [];
+    for (let i = 0, count = shortcuts.length; i < count; i++) {
+        const shortcut = shortcuts[i];
+        // Make sure the corresponding option is available, otherwise don't add the shortcut
+        if (props.availableOptions.findIndex((visiblechoice) => visiblechoice.value === shortcut.value) === -1) {
+            continue;
+        }
+        shortcutButtons.push(
+            <button
+                key={'shortcut' + i}
+                type="button"
+                className={`button shortcut-button${shortcut.color ? ` ${shortcut.color}` : 'blue'}`}
+                onClick={(e) => selectShortcut(shortcut.value, e)}
+            >
+                {shortcut.icon && <FontAwesomeIcon icon={shortcut.icon} className="faIconLeft" />}
+                {translateString(shortcut.label, i18n, props.interview, props.path, props.user)}
+            </button>
+        );
+    }
+    return shortcutButtons;
 };
 
 export const InputSelectFeature = (props: InputSelectFeatureProps) => {
@@ -60,11 +123,11 @@ export const InputSelectFeature = (props: InputSelectFeatureProps) => {
             ? props.widgetConfig.referenceGeography(props.interview, props.path, props.user)
             : null;
 
-    const options = useFeatureOptions(props.widgetConfig, referenceGeography ?? null);
+    const options = useFeatureOptions(props, referenceGeography ?? null);
 
     // react-select returns the selected option (or null when cleared); adapt it to
     // the event-like shape ({ target: { value } }) expected by the survey layer.
-    const onChange = (option: OptionType | null) => {
+    const onChange = (option: { value: string } | null) => {
         props.onValueChange({ target: { value: option ? option.value : null } });
     };
 
@@ -94,6 +157,7 @@ export const InputSelectFeature = (props: InputSelectFeatureProps) => {
                 className="react-select-container"
                 classNamePrefix="react-select"
             />
+            <ShortcutButtons {...props} availableOptions={options} onChange={onChange} />
         </div>
     );
 };

--- a/packages/evolution-frontend/src/components/inputs/__tests__/InputSelectFeature.test.tsx
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/InputSelectFeature.test.tsx
@@ -142,6 +142,79 @@ describe('Render InputSelectFeature with various options', () => {
         expect(refGeographyFct).toHaveBeenCalledWith(interviewAttributes, 'foo.test', userAttributes);
     });
 
+    test('with additional choices and shortcuts', async () => {
+        // Return geography, sorting should be features 4, 2, 1, 3
+        const refGeographyFct = jest
+            .fn()
+            .mockReturnValue({
+                type: 'Feature' as const,
+                geometry: { type: 'Point', coordinates: [2.5, 0] },
+                properties: {}
+            });
+
+        const widgetConfig = {
+            type: 'question' as const,
+            twoColumns: true,
+            path: 'test.foo',
+            inputType: 'selectFeature' as const,
+            featureCollection: testFeatureCollection,
+            labelProperty: 'label',
+            referenceGeography: refGeographyFct,
+            size: 'medium',
+            containsHtml: true,
+            label: {
+                fr: `Texte en français`,
+                en: `English text`
+            },
+            additionalChoices: [
+                {
+                    label: 'Other',
+                    value: 'other'
+                }, {
+                    label: 'DontKnow',
+                    value: 'dontKnow'
+                }, {
+                    // This choice should not be present in the output
+                    label: 'Invisible',
+                    value: 'shouldNotBePresent',
+                    conditional: jest.fn().mockReturnValue(false)
+                }
+            ],
+            shortcuts: [
+                {
+                    label: 'Other',
+                    value: 'other',
+                    color: 'blue'
+                }, {
+                    // This shortcut should not be present
+                    label: 'Invisible',
+                    value: 'shouldNotBePresent',
+                    color: 'red'
+                }
+            ]
+        };
+
+        const user = userEvent.setup();
+        const { container } = render(
+            <InputSelectFeature
+                id={'test'}
+                onValueChange={() => {
+                    /* nothing to do */
+                }}
+                widgetConfig={widgetConfig}
+                value="value"
+                inputRef={React.createRef()}
+                interview={interviewAttributes}
+                user={userAttributes}
+                path="foo.test"
+            />
+        );
+        // Open the menu so the proximity-sorted options (features 4, 2, 1, 3) appear in the snapshot
+        await user.click(screen.getByRole('combobox'));
+        expect(container).toMatchSnapshot();
+        expect(refGeographyFct).toHaveBeenCalledWith(interviewAttributes, 'foo.test', userAttributes);
+    });
+
 });
 
 const widgetConfigWithRef = (refGeographyFct) => ({
@@ -254,5 +327,32 @@ describe('InputSelectFeature searchable behavior', () => {
         await user.click(clearIndicator as Element);
 
         expect(onValueChange).toHaveBeenCalledWith({ target: { value: null } });
+    });
+
+    test('selects the associated choice when a shortcut is clicked', async () => {
+        const user = userEvent.setup();
+        const onValueChange = jest.fn();
+
+        const widgetConfigWithShortcut = {
+            ...widgetConfigWithRef(refGeographyFct),
+            additionalChoices: [{ label: 'Other', value: 'other' }],
+            shortcuts: [{ label: 'Other', value: 'other', color: 'blue' }]
+        };
+
+        render(
+            <InputSelectFeature
+                id={'test'}
+                onValueChange={onValueChange}
+                widgetConfig={widgetConfigWithShortcut}
+                value={undefined}
+                interview={interviewAttributes}
+                user={userAttributes}
+                path="foo.test"
+            />
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Other' }));
+
+        expect(onValueChange).toHaveBeenCalledWith({ target: { value: 'other' } });
     });
 });

--- a/packages/evolution-frontend/src/components/inputs/__tests__/InputSelectFeature.test.tsx
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/InputSelectFeature.test.tsx
@@ -53,45 +53,95 @@ const testFeatureCollection = {
     ]
 };
 
-test('Render InputSelect with normal option type, no sorting', async () => {
-    // Return null for ref geography, features should not be sorted
-    const refGeographyFct = jest.fn().mockReturnValue(null);
+describe('Render InputSelectFeature with various options', () => {
+    test('with normal option type, no sorting', async () => {
+        // Return null for ref geography, features should not be sorted
+        const refGeographyFct = jest.fn().mockReturnValue(null);
 
-    const widgetConfig = {
-        type: 'question' as const,
-        twoColumns: true,
-        path: 'test.foo',
-        inputType: 'selectFeature' as const,
-        featureCollection: testFeatureCollection,
-        labelProperty: 'label',
-        referenceGeography: refGeographyFct,
-        size: 'medium',
-        containsHtml: true,
-        label: {
-            fr: `Texte en français`,
-            en: `English text`
-        }
-    };
+        const widgetConfig = {
+            type: 'question' as const,
+            twoColumns: true,
+            path: 'test.foo',
+            inputType: 'selectFeature' as const,
+            featureCollection: testFeatureCollection,
+            labelProperty: 'label',
+            referenceGeography: refGeographyFct,
+            size: 'medium',
+            containsHtml: true,
+            label: {
+                fr: `Texte en français`,
+                en: `English text`
+            }
+        };
 
-    const user = userEvent.setup();
-    const { container } = render(
-        <InputSelectFeature
-            id={'test'}
-            onValueChange={() => {
-                /* nothing to do */
-            }}
-            widgetConfig={widgetConfig}
-            value="value"
-            inputRef={React.createRef()}
-            interview={interviewAttributes}
-            user={userAttributes}
-            path="foo.test"
-        />
-    );
-    // Open the menu so the options (in collection order) appear in the snapshot
-    await user.click(screen.getByRole('combobox'));
-    expect(container).toMatchSnapshot();
-    expect(refGeographyFct).toHaveBeenCalledWith(interviewAttributes, 'foo.test', userAttributes);
+        const user = userEvent.setup();
+        const { container } = render(
+            <InputSelectFeature
+                id={'test'}
+                onValueChange={() => {
+                    /* nothing to do */
+                }}
+                widgetConfig={widgetConfig}
+                value="value"
+                inputRef={React.createRef()}
+                interview={interviewAttributes}
+                user={userAttributes}
+                path="foo.test"
+            />
+        );
+        // Open the menu so the options (in collection order) appear in the snapshot
+        await user.click(screen.getByRole('combobox'));
+        expect(container).toMatchSnapshot();
+        expect(refGeographyFct).toHaveBeenCalledWith(interviewAttributes, 'foo.test', userAttributes);
+    });
+
+    test('with normal option type, proximity sorting', async () => {
+        // Return geography, sorting should be features 4, 2, 1, 3
+        const refGeographyFct = jest
+            .fn()
+            .mockReturnValue({
+                type: 'Feature' as const,
+                geometry: { type: 'Point', coordinates: [2.5, 0] },
+                properties: {}
+            });
+
+        const widgetConfig = {
+            type: 'question' as const,
+            twoColumns: true,
+            path: 'test.foo',
+            inputType: 'selectFeature' as const,
+            featureCollection: testFeatureCollection,
+            labelProperty: 'label',
+            referenceGeography: refGeographyFct,
+            size: 'medium',
+            containsHtml: true,
+            label: {
+                fr: `Texte en français`,
+                en: `English text`
+            }
+        };
+
+        const user = userEvent.setup();
+        const { container } = render(
+            <InputSelectFeature
+                id={'test'}
+                onValueChange={() => {
+                    /* nothing to do */
+                }}
+                widgetConfig={widgetConfig}
+                value="value"
+                inputRef={React.createRef()}
+                interview={interviewAttributes}
+                user={userAttributes}
+                path="foo.test"
+            />
+        );
+        // Open the menu so the proximity-sorted options (features 4, 2, 1, 3) appear in the snapshot
+        await user.click(screen.getByRole('combobox'));
+        expect(container).toMatchSnapshot();
+        expect(refGeographyFct).toHaveBeenCalledWith(interviewAttributes, 'foo.test', userAttributes);
+    });
+
 });
 
 const widgetConfigWithRef = (refGeographyFct) => ({
@@ -205,51 +255,4 @@ describe('InputSelectFeature searchable behavior', () => {
 
         expect(onValueChange).toHaveBeenCalledWith({ target: { value: null } });
     });
-});
-
-test('Render InputSelect with normal option type, proximity sorting', async () => {
-    // Return geography, sorting should be features 4, 2, 1, 3
-    const refGeographyFct = jest
-        .fn()
-        .mockReturnValue({
-            type: 'Feature' as const,
-            geometry: { type: 'Point', coordinates: [2.5, 0] },
-            properties: {}
-        });
-
-    const widgetConfig = {
-        type: 'question' as const,
-        twoColumns: true,
-        path: 'test.foo',
-        inputType: 'selectFeature' as const,
-        featureCollection: testFeatureCollection,
-        labelProperty: 'label',
-        referenceGeography: refGeographyFct,
-        size: 'medium',
-        containsHtml: true,
-        label: {
-            fr: `Texte en français`,
-            en: `English text`
-        }
-    };
-
-    const user = userEvent.setup();
-    const { container } = render(
-        <InputSelectFeature
-            id={'test'}
-            onValueChange={() => {
-                /* nothing to do */
-            }}
-            widgetConfig={widgetConfig}
-            value="value"
-            inputRef={React.createRef()}
-            interview={interviewAttributes}
-            user={userAttributes}
-            path="foo.test"
-        />
-    );
-    // Open the menu so the proximity-sorted options (features 4, 2, 1, 3) appear in the snapshot
-    await user.click(screen.getByRole('combobox'));
-    expect(container).toMatchSnapshot();
-    expect(refGeographyFct).toHaveBeenCalledWith(interviewAttributes, 'foo.test', userAttributes);
 });

--- a/packages/evolution-frontend/src/components/inputs/__tests__/__snapshots__/InputSelectFeature.test.tsx.snap
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/__snapshots__/InputSelectFeature.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`Render InputSelect with normal option type, no sorting 1`] = `
+exports[`Render InputSelectFeature with various options with normal option type, no sorting 1`] = `
 <div>
   <div
     class="survey-question__input-select-container"
@@ -158,7 +158,7 @@ exports[`Render InputSelect with normal option type, no sorting 1`] = `
 </div>
 `;
 
-exports[`Render InputSelect with normal option type, proximity sorting 1`] = `
+exports[`Render InputSelectFeature with various options with normal option type, proximity sorting 1`] = `
 <div>
   <div
     class="survey-question__input-select-container"
@@ -168,7 +168,7 @@ exports[`Render InputSelect with normal option type, proximity sorting 1`] = `
     >
       <span
         class="css-1f43avz-a11yText-A11yText"
-        id="react-select-7-live-region"
+        id="react-select-3-live-region"
       />
       <span
         aria-atomic="false"
@@ -202,17 +202,17 @@ exports[`Render InputSelect with normal option type, proximity sorting 1`] = `
         >
           <div
             class="react-select__placeholder css-1jqq78o-placeholder"
-            id="react-select-7-placeholder"
+            id="react-select-3-placeholder"
           />
           <div
             class="react-select__input-container css-qbdosj-Input"
             data-value=""
           >
             <input
-              aria-activedescendant="react-select-7-option-0"
+              aria-activedescendant="react-select-3-option-0"
               aria-autocomplete="list"
-              aria-controls="react-select-7-listbox"
-              aria-describedby="react-select-7-placeholder"
+              aria-controls="react-select-3-listbox"
+              aria-describedby="react-select-3-placeholder"
               aria-expanded="true"
               aria-haspopup="true"
               aria-labelledby="test_label"
@@ -261,14 +261,14 @@ exports[`Render InputSelect with normal option type, proximity sorting 1`] = `
         <div
           aria-multiselectable="false"
           class="react-select__menu-list css-1n6sfyn-MenuList"
-          id="react-select-7-listbox"
+          id="react-select-3-listbox"
           role="listbox"
         >
           <div
             aria-disabled="false"
             aria-selected="false"
             class="react-select__option react-select__option--is-focused css-d7l1ni-option"
-            id="react-select-7-option-0"
+            id="react-select-3-option-0"
             role="option"
             tabindex="-1"
           >
@@ -278,7 +278,7 @@ exports[`Render InputSelect with normal option type, proximity sorting 1`] = `
             aria-disabled="false"
             aria-selected="false"
             class="react-select__option css-10wo9uf-option"
-            id="react-select-7-option-1"
+            id="react-select-3-option-1"
             role="option"
             tabindex="-1"
           >
@@ -288,7 +288,7 @@ exports[`Render InputSelect with normal option type, proximity sorting 1`] = `
             aria-disabled="false"
             aria-selected="false"
             class="react-select__option css-10wo9uf-option"
-            id="react-select-7-option-2"
+            id="react-select-3-option-2"
             role="option"
             tabindex="-1"
           >
@@ -298,7 +298,7 @@ exports[`Render InputSelect with normal option type, proximity sorting 1`] = `
             aria-disabled="false"
             aria-selected="false"
             class="react-select__option css-10wo9uf-option"
-            id="react-select-7-option-3"
+            id="react-select-3-option-3"
             role="option"
             tabindex="-1"
           >

--- a/packages/evolution-frontend/src/components/inputs/__tests__/__snapshots__/InputSelectFeature.test.tsx.snap
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/__snapshots__/InputSelectFeature.test.tsx.snap
@@ -1,5 +1,189 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`Render InputSelectFeature with various options with additional choices and shortcuts 1`] = `
+<div>
+  <div
+    class="survey-question__input-select-container"
+  >
+    <div
+      class="react-select-container css-b62m3t-container"
+    >
+      <span
+        class="css-1f43avz-a11yText-A11yText"
+        id="react-select-4-live-region"
+      />
+      <span
+        aria-atomic="false"
+        aria-live="polite"
+        aria-relevant="additions text"
+        class="css-1f43avz-a11yText-A11yText"
+        role="log"
+      >
+        <span
+          id="aria-selection"
+        />
+        <span
+          id="aria-focused"
+        />
+        <span
+          id="aria-results"
+        >
+          6 results available.
+        </span>
+        <span
+          id="aria-guidance"
+        >
+          Use Up and Down to choose options, press Enter to select the currently focused option, press Escape to exit the menu, press Tab to select the option and exit the menu.
+        </span>
+      </span>
+      <div
+        class="react-select__control react-select__control--is-focused react-select__control--menu-is-open css-t3ipsp-control"
+      >
+        <div
+          class="react-select__value-container css-1fdsijx-ValueContainer"
+        >
+          <div
+            class="react-select__placeholder css-1jqq78o-placeholder"
+            id="react-select-4-placeholder"
+          />
+          <div
+            class="react-select__input-container css-qbdosj-Input"
+            data-value=""
+          >
+            <input
+              aria-activedescendant="react-select-4-option-0"
+              aria-autocomplete="list"
+              aria-controls="react-select-4-listbox"
+              aria-describedby="react-select-4-placeholder"
+              aria-expanded="true"
+              aria-haspopup="true"
+              aria-labelledby="test_label"
+              autocapitalize="none"
+              autocomplete="off"
+              autocorrect="off"
+              class="react-select__input"
+              id="test"
+              role="combobox"
+              spellcheck="false"
+              style="color: inherit; background: 0px; opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
+              tabindex="0"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          class="react-select__indicators css-1hb7zxy-IndicatorsContainer"
+        >
+          <span
+            class="react-select__indicator-separator css-1u9des2-indicatorSeparator"
+          />
+          <div
+            aria-hidden="true"
+            class="react-select__indicator react-select__dropdown-indicator css-15lsz6c-indicatorContainer"
+          >
+            <svg
+              aria-hidden="true"
+              class="css-tj5bde-Svg"
+              focusable="false"
+              height="20"
+              viewBox="0 0 20 20"
+              width="20"
+            >
+              <path
+                d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+      <div
+        class="react-select__menu css-1nmdiq5-menu"
+      >
+        <div
+          aria-multiselectable="false"
+          class="react-select__menu-list css-1n6sfyn-MenuList"
+          id="react-select-4-listbox"
+          role="listbox"
+        >
+          <div
+            aria-disabled="false"
+            aria-selected="false"
+            class="react-select__option react-select__option--is-focused css-d7l1ni-option"
+            id="react-select-4-option-0"
+            role="option"
+            tabindex="-1"
+          >
+            Label For Feature 4
+          </div>
+          <div
+            aria-disabled="false"
+            aria-selected="false"
+            class="react-select__option css-10wo9uf-option"
+            id="react-select-4-option-1"
+            role="option"
+            tabindex="-1"
+          >
+            Label For Feature 2
+          </div>
+          <div
+            aria-disabled="false"
+            aria-selected="false"
+            class="react-select__option css-10wo9uf-option"
+            id="react-select-4-option-2"
+            role="option"
+            tabindex="-1"
+          >
+            Label For Feature 1
+          </div>
+          <div
+            aria-disabled="false"
+            aria-selected="false"
+            class="react-select__option css-10wo9uf-option"
+            id="react-select-4-option-3"
+            role="option"
+            tabindex="-1"
+          >
+            Label For Feature 3
+          </div>
+          <div
+            aria-disabled="false"
+            aria-selected="false"
+            class="react-select__option css-10wo9uf-option"
+            id="react-select-4-option-4"
+            role="option"
+            tabindex="-1"
+          >
+            Other
+          </div>
+          <div
+            aria-disabled="false"
+            aria-selected="false"
+            class="react-select__option css-10wo9uf-option"
+            id="react-select-4-option-5"
+            role="option"
+            tabindex="-1"
+          >
+            DontKnow
+          </div>
+        </div>
+      </div>
+      <input
+        name="survey-question__input-select-feature-foo.test"
+        type="hidden"
+        value=""
+      />
+    </div>
+    <button
+      class="button shortcut-button blue"
+      type="button"
+    >
+      Other
+    </button>
+  </div>
+</div>
+`;
+
 exports[`Render InputSelectFeature with various options with normal option type, no sorting 1`] = `
 <div>
   <div


### PR DESCRIPTION
fixes #1793

The `additionalChoices` widget config option allows to specify
additional choices, like 'other', that do not map to one of the features
in parameter.

The `shortcuts` widget config option allows to provide shortcut buttons
to automatically select the given option. Shortcuts are visible only if
the corresponding choice is also visible.

Update the `InputSelectFeature` component to add those features.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Select inputs can now display additional non-feature choices.
  * Added shortcut buttons for quickly selecting commonly used options.
  * Additional choices and shortcuts support translated labels, colors, and conditional availability.
  * Shortcut selections trigger the same value-change behavior as standard options.

* **Tests**
  * Added coverage for option ordering, additional choices, shortcut configurations, and shortcut selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->