### PR TITLE
Fix wrong times in looping activities

### DIFF
--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetsTime.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetsTime.test.ts
@@ -1144,6 +1144,42 @@ describe('visitedPlaceArrivalTime widget', () => {
                 expected: [false, 8 * 60 * 60]
             },
             {
+                title: 'returns [true, null] when workOnTheRoad inserts workUsual before and _previousArrivalTime is set',
+                visitedPlaceId: 'workPlace1P1',
+                setup: (interview: typeof interviewAttributesForTestCases) => {
+                    interview.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!.homePlace1P1.activity = 'home';
+                    interview.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!.homePlace1P1.departureTime = 8 * 60 * 60;
+                    interview.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!.workPlace1P1.activity = 'workOnTheRoad';
+                    interview.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!.workPlace1P1.onTheRoadPreviousPlaceActivity = 'workUsual';
+                    interview.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!.workPlace1P1._previousArrivalTime = 8 * 60 * 60 + 30 * 60;
+                },
+                expected: [true, null]
+            },
+            {
+                title: 'returns [true, null] when workOnTheRoad inserts home before and _previousArrivalTime is set',
+                visitedPlaceId: 'workPlace1P1',
+                setup: (interview: typeof interviewAttributesForTestCases) => {
+                    interview.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!.homePlace1P1.activity = 'shopping';
+                    interview.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!.homePlace1P1.departureTime = 8 * 60 * 60;
+                    interview.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!.workPlace1P1.activity = 'workOnTheRoad';
+                    interview.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!.workPlace1P1.onTheRoadPreviousPlaceActivity = 'home';
+                    interview.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!.workPlace1P1._previousArrivalTime = 8 * 60 * 60 + 30 * 60;
+                },
+                expected: [true, null]
+            },
+            {
+                title: 'returns [false, null] when workOnTheRoad inserts a place before but _previousArrivalTime is blank',
+                visitedPlaceId: 'workPlace1P1',
+                setup: (interview: typeof interviewAttributesForTestCases) => {
+                    interview.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!.homePlace1P1.activity = 'home';
+                    interview.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!.homePlace1P1.departureTime = 8 * 60 * 60;
+                    interview.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!.workPlace1P1.activity = 'workOnTheRoad';
+                    interview.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!.workPlace1P1.onTheRoadPreviousPlaceActivity = 'workUsual';
+                    delete interview.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!.workPlace1P1._previousArrivalTime;
+                },
+                expected: [false, null]
+            },
+            {
                 title: 'returns [true, null] when place is not first and activity is set',
                 visitedPlaceId: 'workPlace1P1',
                 setup: (interview: typeof interviewAttributesForTestCases) => {

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetsTime.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetsTime.ts
@@ -549,13 +549,16 @@ export class VisitedPlaceTimeWidgetFactory implements WidgetConfigFactory {
             ) {
                 return [false, null];
             }
-            // Use to previous departure time if either the current or previous
-            // activity is a loop activity and the departure time is set
+            // Use previous departure time if either the current or previous
+            // activity is a loop activity and the departure time is set, unless a
+            // place will be inserted before (on-the-road start is not the previous
+            // place's departure).
             if (
                 previousVisitedPlace &&
                 (odHelpers.isLoopActivity({ visitedPlace }) ||
                     odHelpers.isLoopActivity({ visitedPlace: previousVisitedPlace })) &&
-                !_isBlank(previousVisitedPlace.departureTime)
+                !_isBlank(previousVisitedPlace.departureTime) &&
+                !previousArrivalTimeIsVisible
             ) {
                 return [false, previousVisitedPlace.departureTime];
             }

--- a/packages/evolution-frontend/src/components/survey/sectionTemplates/TripsAndSegmentsSection.tsx
+++ b/packages/evolution-frontend/src/components/survey/sectionTemplates/TripsAndSegmentsSection.tsx
@@ -135,6 +135,9 @@ export const SegmentsSection: React.FC<SectionProps> = (props: SectionProps) => 
                 journey: currentJourney
             })
             : undefined;
+        // Loop destinations have arrivalTime equal to origin departure; the trip
+        // ends when arriving at the next place after the loop.
+        const tripEndPlace = isDestinationLoopActivity && nextDestination ? nextDestination : destination;
 
         const modeIcons: JSX.Element[] = [];
 
@@ -170,9 +173,9 @@ export const SegmentsSection: React.FC<SectionProps> = (props: SectionProps) => 
                     <FontAwesomeIcon icon={faClock} style={{ marginRight: '0.3rem', marginLeft: '0.6rem' }} />
                     {origin && origin.departureTime && secondsSinceMidnightToTimeStrWithSuffix(origin.departureTime)}
                     <FontAwesomeIcon icon={faArrowRight} style={{ marginRight: '0.3rem', marginLeft: '0.3rem' }} />
-                    {destination &&
-                        destination.arrivalTime &&
-                        secondsSinceMidnightToTimeStrWithSuffix(destination.arrivalTime)}
+                    {tripEndPlace &&
+                        !_isBlank(tripEndPlace.arrivalTime) &&
+                        secondsSinceMidnightToTimeStrWithSuffix(tripEndPlace.arrivalTime!)}
                     {!selectedTripId && props.loadingState === 0 && (
                         <button
                             type="button"

--- a/packages/evolution-frontend/src/components/survey/sectionTemplates/__tests__/TripsAndSegmentsSection.test.tsx
+++ b/packages/evolution-frontend/src/components/survey/sectionTemplates/__tests__/TripsAndSegmentsSection.test.tsx
@@ -239,6 +239,59 @@ describe('SegmentsSection UI display', () => {
             expect(container).toMatchSnapshot();
         });
 
+        test('should display trip end time from next place when destination is a loop activity', () => {
+            const { secondsSinceMidnightToTimeStrWithSuffix } = jest.requireMock(
+                '../../../../services/display/frontendHelper'
+            ) as { secondsSinceMidnightToTimeStrWithSuffix: jest.Mock };
+            secondsSinceMidnightToTimeStrWithSuffix.mockClear();
+
+            // Restaurant (7:50) → leisureStroll (7:50→8:05) → Home (8:05)
+            const testVisitedPlaces = _cloneDeep(visitedPlaces);
+            testVisitedPlaces.place1.departureTime = 7 * 3600 + 50 * 60;
+            testVisitedPlaces.place2.activity = 'leisureStroll';
+            testVisitedPlaces.place2.arrivalTime = 7 * 3600 + 50 * 60;
+            testVisitedPlaces.place2.departureTime = 8 * 3600 + 5 * 60;
+            testVisitedPlaces.place3.activity = 'home';
+            testVisitedPlaces.place3.arrivalTime = 8 * 3600 + 5 * 60;
+
+            mockedGetJourneysArray.mockReturnValueOnce([{ ...journey, visitedPlaces: testVisitedPlaces }]);
+            mockedGetNextVisitedPlace.mockReturnValueOnce(testVisitedPlaces.place3);
+
+            render(
+                <TestContextProvider>
+                    <SegmentsSection {...props} />
+                </TestContextProvider>
+            );
+
+            expect(secondsSinceMidnightToTimeStrWithSuffix).toHaveBeenCalledWith(7 * 3600 + 50 * 60);
+            expect(secondsSinceMidnightToTimeStrWithSuffix).toHaveBeenCalledWith(8 * 3600 + 5 * 60);
+            // End time must be next place arrival (8:05), not loop arrival (= origin departure 7:50)
+            const timeCalls = secondsSinceMidnightToTimeStrWithSuffix.mock.calls.map((call) => call[0]);
+            expect(timeCalls.filter((t) => t === 7 * 3600 + 50 * 60)).toHaveLength(1);
+            expect(timeCalls.filter((t) => t === 8 * 3600 + 5 * 60)).toHaveLength(1);
+        });
+
+        test('should display trip end arrivalTime of 0 (midnight)', () => {
+            const { secondsSinceMidnightToTimeStrWithSuffix } = jest.requireMock(
+                '../../../../services/display/frontendHelper'
+            ) as { secondsSinceMidnightToTimeStrWithSuffix: jest.Mock };
+            secondsSinceMidnightToTimeStrWithSuffix.mockClear();
+
+            const testVisitedPlaces = _cloneDeep(visitedPlaces);
+            testVisitedPlaces.place1.departureTime = 23 * 3600;
+            testVisitedPlaces.place2.arrivalTime = 0;
+
+            mockedGetJourneysArray.mockReturnValueOnce([{ ...journey, visitedPlaces: testVisitedPlaces }]);
+
+            render(
+                <TestContextProvider>
+                    <SegmentsSection {...props} />
+                </TestContextProvider>
+            );
+
+            expect(secondsSinceMidnightToTimeStrWithSuffix).toHaveBeenCalledWith(0);
+        });
+
         test('should render list of trips when loop activity is the first visited place, no trip selected', () => {
             const testVisitedPlaces = _cloneDeep(visitedPlaces);
             testVisitedPlaces.place1.activity = 'workOnTheRoad';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved arrival-time questions for work-on-the-road activities, ensuring required previous arrival details are requested correctly.
  * Corrected displayed trip end times when a trip destination is a loop activity, using the next visited place when available.
  * Preserved midnight arrival times when displaying trip details.
  * Added regression coverage to help prevent related timing display issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->