### PR TITLE
InputMapFindPlace: add a confirm place button (issue 1807)

### DIFF
--- a/example/demo_survey/src/survey/common/geographyValidations.ts
+++ b/example/demo_survey/src/survey/common/geographyValidations.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { TFunction } from 'i18next';
+
+/**
+ * Rejects a geography confirmed from an imprecise geocoding result.
+ * The widget must set `invalidGeocodingResultTypes` so InputMapFindPlace can
+ * flag `properties.isGeocodingImprecise` on confirm (`lastAction: 'findPlace'`).
+ */
+export const getImpreciseGeocodingValidation = (
+    geography: {
+        properties?: {
+            isGeocodingImprecise?: boolean;
+            geocodingQueryString?: string;
+            lastAction?: string;
+        };
+    } | null
+) => {
+    const geocodingTextInput = geography?.properties?.geocodingQueryString;
+    return {
+        // Only after confirm: candidates can carry isGeocodingImprecise before lastAction is set.
+        validation:
+            geography?.properties?.lastAction === 'findPlace' && Boolean(geography?.properties?.isGeocodingImprecise),
+        errorMessage: (t: TFunction) =>
+            t('survey:geography.geocodingStringImpreciseError', {
+                geocodingTextInput: geocodingTextInput || '',
+                interpolation: { escapeValue: true }
+            })
+    };
+};

--- a/example/demo_survey/src/survey/widgets/home.tsx
+++ b/example/demo_survey/src/survey/widgets/home.tsx
@@ -15,6 +15,8 @@ import { getHousehold } from 'evolution-common/lib/services/odSurvey/helpers';
 import waterBoundaries from '../waterBoundaries.json';
 import { canadianPostalCodeFormatter, eightDigitsAccessCodeFormatter } from 'evolution-common/lib/utils/formatters';
 import { postalCodeValidation } from 'evolution-common/lib/services/widgets/validations/validations';
+import { defaultLocationInvalidGeocodingResultTypes } from 'evolution-common/lib/services/questionnaire/sections/common/widgetsLocation';
+import { getImpreciseGeocodingValidation } from '../common/geographyValidations';
 
 export const homeIntro = {
     type: 'text',
@@ -472,7 +474,7 @@ export const homePostalCode = {
 
 export const homeGeography = {
     type: 'question',
-    inputType: 'mapPoint',
+    inputType: 'mapFindPlace',
     path: 'home.geography',
     datatype: 'geojson',
     canBeCollapsed: true,
@@ -496,6 +498,7 @@ export const homeGeography = {
         size: [80, 80]
     },
     defaultCenter: config.mapDefaultCenter,
+    invalidGeocodingResultTypes: defaultLocationInvalidGeocodingResultTypes,
     refreshGeocodingLabel: {
         fr: 'Chercher la localisation à partir de l\'adresse',
         en: 'Search location using provided address'
@@ -535,6 +538,7 @@ export const homeGeography = {
                     en: 'Location of your home is not precise enough. Please use the + zoom and drag the icon marker to confirm the precise location.'
                 }
             },
+            getImpreciseGeocodingValidation(geography),
             {
                 validation: geography && turfBooleanPointInPolygon(geography, (waterBoundaries as any).features[0]),
                 errorMessage: {

--- a/example/demo_survey/src/survey/widgets/householdMembers.tsx
+++ b/example/demo_survey/src/survey/widgets/householdMembers.tsx
@@ -27,6 +27,8 @@ import { GroupConfig } from 'evolution-common/lib/services/questionnaire/types';
 import { getFormattedDate, validateButtonAction } from 'evolution-frontend/lib/services/display/frontendHelper';
 import * as odSurveyHelper from 'evolution-common/lib/services/odSurvey/helpers';
 import { validateButtonActionWithCompleteSection } from 'evolution-frontend/lib/services/display/frontendHelper';
+import { defaultLocationInvalidGeocodingResultTypes } from 'evolution-common/lib/services/questionnaire/sections/common/widgetsLocation';
+import { getImpreciseGeocodingValidation } from '../common/geographyValidations';
 
 const personsWidgets = [
     'personNickname',
@@ -1324,7 +1326,7 @@ export const groupedPersonUsualWorkPlaceName = {
 
 export const groupedPersonUsualWorkPlaceGeography = {
     type: 'question',
-    inputType: 'mapPoint',
+    inputType: 'mapFindPlace',
     path: 'usualWorkPlace',
     datatype: 'geojson',
     canBeCollapsed: true,
@@ -1341,6 +1343,7 @@ export const groupedPersonUsualWorkPlaceGeography = {
         const homeCoordinates = surveyHelperNew.getResponse(interview, 'home.geography.geometry.coordinates', null);
         return homeCoordinates ? { lat: homeCoordinates[1], lon: homeCoordinates[0] } : config.mapDefaultCenter;
     },
+    invalidGeocodingResultTypes: defaultLocationInvalidGeocodingResultTypes,
     refreshGeocodingLabel: {
         fr: 'Chercher la localisation à partir du nom',
         en: 'Search location using the place name'
@@ -1376,6 +1379,7 @@ export const groupedPersonUsualWorkPlaceGeography = {
                     en: 'Location is not precise enough. Please use the + zoom and drag the icon marker to confirm the precise location.'
                 }
             },
+            getImpreciseGeocodingValidation(geography),
             {
                 validation: geography && turfBooleanPointInPolygon(geography, (waterBoundaries as any).features[0]),
                 errorMessage: {
@@ -1424,7 +1428,7 @@ export const groupedPersonUsualSchoolPlaceName = {
 
 export const groupedPersonUsualSchoolPlaceGeography = {
     type: 'question',
-    inputType: 'mapPoint',
+    inputType: 'mapFindPlace',
     path: 'usualSchoolPlace',
     datatype: 'geojson',
     canBeCollapsed: true,
@@ -1441,6 +1445,7 @@ export const groupedPersonUsualSchoolPlaceGeography = {
         const homeCoordinates = surveyHelperNew.getResponse(interview, 'home.geography.geometry.coordinates', null);
         return homeCoordinates ? { lat: homeCoordinates[1], lon: homeCoordinates[0] } : config.mapDefaultCenter;
     },
+    invalidGeocodingResultTypes: defaultLocationInvalidGeocodingResultTypes,
     refreshGeocodingLabel: {
         fr: 'Chercher la localisation à partir du nom',
         en: 'Search location using the place name'
@@ -1477,6 +1482,7 @@ export const groupedPersonUsualSchoolPlaceGeography = {
                     en: 'Location is not precise enough. Please use the + zoom and drag the icon marker to confirm the precise location.'
                 }
             },
+            getImpreciseGeocodingValidation(geography),
             {
                 validation: geography && turfBooleanPointInPolygon(geography, (waterBoundaries as any).features[0]),
                 errorMessage: {

--- a/example/demo_survey/src/survey/widgets/profile.tsx
+++ b/example/demo_survey/src/survey/widgets/profile.tsx
@@ -14,6 +14,8 @@ import { getHousehold, getActivePerson } from 'evolution-common/lib/services/odS
 import helper from '../helper';
 import waterBoundaries from '../waterBoundaries.json';
 import { getFormattedDate } from 'evolution-frontend/lib/services/display/frontendHelper';
+import { defaultLocationInvalidGeocodingResultTypes } from 'evolution-common/lib/services/questionnaire/sections/common/widgetsLocation';
+import { getImpreciseGeocodingValidation } from '../common/geographyValidations';
 
 export const personWorkOnTheRoad = {
     type: 'question',
@@ -371,7 +373,7 @@ export const personUsualWorkPlaceName = {
 
 export const personUsualWorkPlaceGeography = {
     type: 'question',
-    inputType: 'mapPoint',
+    inputType: 'mapFindPlace',
     path: 'household.persons.{_activePersonId}.usualWorkPlace',
     datatype: 'geojson',
     canBeCollapsed: true,
@@ -412,6 +414,7 @@ export const personUsualWorkPlaceGeography = {
         const homeCoordinates = surveyHelperNew.getResponse(interview, 'home.geography.geometry.coordinates', null);
         return homeCoordinates ? { lat: homeCoordinates[1], lon: homeCoordinates[0] } : config.mapDefaultCenter;
     },
+    invalidGeocodingResultTypes: defaultLocationInvalidGeocodingResultTypes,
     refreshGeocodingLabel: {
         fr: 'Chercher la localisation à partir du nom',
         en: 'Search location using the place name'
@@ -447,6 +450,7 @@ export const personUsualWorkPlaceGeography = {
                     en: 'Location is not precise enough. Please use the + zoom and drag the icon marker to confirm the precise location.'
                 }
             },
+            getImpreciseGeocodingValidation(geography),
             {
                 validation: geography && turfBooleanPointInPolygon(geography, (waterBoundaries as any).features[0]),
                 errorMessage: {
@@ -507,7 +511,7 @@ export const personUsualSchoolPlaceName = {
 
 export const personUsualSchoolPlaceGeography = {
     type: 'question',
-    inputType: 'mapPoint',
+    inputType: 'mapFindPlace',
     path: 'household.persons.{_activePersonId}.usualSchoolPlace',
     datatype: 'geojson',
     canBeCollapsed: true,
@@ -546,6 +550,7 @@ export const personUsualSchoolPlaceGeography = {
         const homeCoordinates = surveyHelperNew.getResponse(interview, 'home.geography.geometry.coordinates', null);
         return homeCoordinates ? { lat: homeCoordinates[1], lon: homeCoordinates[0] } : config.mapDefaultCenter;
     },
+    invalidGeocodingResultTypes: defaultLocationInvalidGeocodingResultTypes,
     refreshGeocodingLabel: {
         fr: 'Chercher la localisation à partir du nom',
         en: 'Search location using the place name'
@@ -582,6 +587,7 @@ export const personUsualSchoolPlaceGeography = {
                     en: 'Location is not precise enough. Please use the + zoom and drag the icon marker to confirm the precise location.'
                 }
             },
+            getImpreciseGeocodingValidation(geography),
             {
                 validation: geography && turfBooleanPointInPolygon(geography, (waterBoundaries as any).features[0]),
                 errorMessage: {

--- a/example/demo_survey/src/survey/widgets/segments.tsx
+++ b/example/demo_survey/src/survey/widgets/segments.tsx
@@ -15,6 +15,8 @@ import helper from '../helper';
 import subwayStations from '../subwayStations.json';
 import trainStations from '../trainStations.json';
 import busRoutes from '../busRoutes.json';
+import { defaultLocationInvalidGeocodingResultTypes } from 'evolution-common/lib/services/questionnaire/sections/common/widgetsLocation';
+import { getImpreciseGeocodingValidation } from '../common/geographyValidations';
 
 export const segmentVehicleOccupancy = {
     type: 'question',
@@ -1762,7 +1764,10 @@ export const segmentBusLines = {
 
 export const tripJunctionGeography = {
     type: 'question',
-    inputType: 'mapPoint',
+    // TODO: demo_survey segments widgets are obsolete (to be replaced by od_nationale_quebec).
+    // mapFindPlace without geocodingQueryString/refreshGeocodingLabel has no place search;
+    // keep click/drag only. Do not invent a query string here — fix in the active survey if needed.
+    inputType: 'mapFindPlace',
     path: 'junctionGeography',
     datatype: 'geojson',
     canBeCollapsed: false,
@@ -2064,7 +2069,9 @@ export const tripJunctionGeography = {
         }
         return config.mapDefaultCenter;
     },
+    invalidGeocodingResultTypes: defaultLocationInvalidGeocodingResultTypes,
     validations: function (value, customValue, interview, path, customPath) {
+        const geography: any = surveyHelperNew.getResponse(interview, path, null);
         return [
             {
                 validation: _isBlank(value),
@@ -2072,7 +2079,8 @@ export const tripJunctionGeography = {
                     fr: 'Le positionnement du lieu de transfert est requis.',
                     en: 'Transfer location is required.'
                 }
-            }
+            },
+            getImpreciseGeocodingValidation(geography)
         ];
     },
     conditional: function (interview, path) {

--- a/packages/evolution-frontend/src/components/inputs/InputMapFindPlace.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputMapFindPlace.tsx
@@ -450,7 +450,11 @@ export class InputMapFindPlace extends React.Component<
         const infoWindow = this.state.selectedPlace
             ? {
                 position: this.state.selectedPlace,
-                content: this.getInfoWindowContent(this.state.selectedPlace, this.props.widgetConfig.showPhoto)
+                content: this.getInfoWindowContent(this.state.selectedPlace, this.props.widgetConfig.showPhoto),
+                confirmLabel: this.props.widgetConfig.refreshGeocodingLabel
+                    ? this.props.t('main:ConfirmLocation')
+                    : undefined,
+                onConfirm: () => this.onConfirmPlace(undefined)
             }
             : undefined;
 

--- a/packages/evolution-frontend/src/components/inputs/__tests__/InputMapFindPlace.test.tsx
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/InputMapFindPlace.test.tsx
@@ -10,18 +10,22 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
 import { interviewAttributes } from './interviewData';
+import mockGoogleMapAdapter, { mockGeocodeMultiplePlaces } from './mockGoogleMapAdapter';
 import InputMapFindPlace from '../InputMapFindPlace';
-import { geocodeMultiplePlaces } from '../maps/google/GoogleGeocoder';
 
 // Mock react-markdown and remark-gfm as they use syntax not supported by jest
 jest.mock('react-markdown', () => 'Markdown');
 jest.mock('remark-gfm', () => 'remark-gfm');
 
-// Mock db queries
-jest.mock('../maps/google/GoogleGeocoder', () => ({
-    geocodeMultiplePlaces: jest.fn()
+// ESM-friendly mock: getter defers access until after mockGoogleMapAdapter is initialized (no require).
+jest.mock('../maps/google/GoogleMapAdapter', () => ({
+    __esModule: true,
+    get default() {
+        return mockGoogleMapAdapter;
+    }
 }));
-const mockedGeocode = geocodeMultiplePlaces as jest.MockedFunction<typeof geocodeMultiplePlaces>;
+
+const mockedGeocode = mockGeocodeMultiplePlaces;
 
 const userAttributes = {
     id: 1,
@@ -214,10 +218,12 @@ describe('Test geocoding requests', () => {
 
         // Pick the second result (place_id '2') in the selection list
         await user.selectOptions(select, placeFeature2.properties.placeData.place_id);
-        expect(screen.getByText('ConfirmLocation')).toBeInTheDocument();
+        // Bottom confirm + InfoWindow confirm are both available
+        expect(screen.getAllByText('ConfirmLocation')).toHaveLength(2);
+        expect(screen.getByTestId('mock-info-window-confirm')).toBeInTheDocument();
 
-        // Click on the confirm button and make sure the update function has been called
-        await user.click(screen.getByText('ConfirmLocation'));
+        // Click on the bottom confirm button and make sure the update function has been called
+        await user.click(document.getElementById(`${testId}_confirm`) as HTMLButtonElement);
         // The saved value must reference the SECOND place's place_id, not the first
         expect(mockOnValueChange).toHaveBeenCalledWith({
             target: {
@@ -246,8 +252,8 @@ describe('Test geocoding requests', () => {
         expect(selectionList.children.length).toEqual(2);
         expect(selectionList.children[1].textContent).toEqual('Foo extra good restaurant (123 test street)');
 
-        // Click on the confirm button and make sure the update function has been called
-        await user.click(screen.getByText('ConfirmLocation'));
+        // Click on the bottom confirm button and make sure the update function has been called
+        await user.click(document.getElementById(`${testId}_confirm`) as HTMLButtonElement);
         expect(mockOnValueChange).toHaveBeenCalledWith({
             target: {
                 value: {
@@ -270,6 +276,33 @@ describe('Test geocoding requests', () => {
         expect(screen.queryByText('ConfirmLocation')).not.toBeInTheDocument();
     });
 
+    test('InfoWindow confirm button also saves the selected place', async () => {
+        const { container } = renderWidget();
+        const user = userEvent.setup();
+
+        mockedGeocode.mockResolvedValueOnce([placeFeature1, placeFeature2]);
+        await user.click(screen.getByText('Geocode'));
+        const select = container.querySelector('select') as HTMLSelectElement;
+        await user.selectOptions(select, placeFeature1.properties.placeData.place_id);
+
+        expect(screen.getByTestId('mock-info-window-confirm')).toBeInTheDocument();
+        await user.click(screen.getByTestId('mock-info-window-confirm'));
+
+        expect(mockOnValueChange).toHaveBeenCalledWith({
+            target: {
+                value: expect.objectContaining({
+                    properties: expect.objectContaining({
+                        geocodingResultsData: expect.objectContaining({
+                            place_id: placeFeature1.properties.placeData.place_id,
+                            formatted_address: placeFeature1.properties.placeData.formatted_address
+                        })
+                    })
+                })
+            }
+        });
+        expect(screen.queryByText('ConfirmLocation')).not.toBeInTheDocument();
+    });
+
     // Re-querying after a single result clears the selection list and confirm button,
     // both when the new query yields no result and when it rejects.
     test.each([
@@ -283,7 +316,8 @@ describe('Test geocoding requests', () => {
         mockedGeocode.mockResolvedValueOnce([placeFeature1]);
         await user.click(screen.getByText('Geocode'));
         expect(container.querySelector('select')).toBeInTheDocument();
-        expect(screen.getByText('ConfirmLocation')).toBeInTheDocument();
+        // Bottom + InfoWindow confirms
+        expect(screen.getAllByText('ConfirmLocation')).toHaveLength(2);
 
         // Click the geocode button again, but get undefined results or a rejection
         const newGeocodingString = 'other string';

--- a/packages/evolution-frontend/src/components/inputs/__tests__/__snapshots__/InputMapFindPlace.test.tsx.snap
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/__snapshots__/InputMapFindPlace.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`Render InputMapPoint with various parameters Test with all parameters 1
       <button
         class="button refresh-geocode green large"
         id="test_refresh"
-        style="display: none;"
+        style="display: inline;"
         type="button"
       >
         <svg
@@ -48,13 +48,8 @@ exports[`Render InputMapPoint with various parameters Test with all parameters 1
       class="survey-question__input-map-container"
     >
       <div
-        class="loader"
-      >
-        <p>
-          Loading
-          ...
-        </p>
-      </div>
+        data-testid="mock-input-map"
+      />
     </div>
   </div>
 </div>
@@ -79,13 +74,8 @@ exports[`Render InputMapPoint with various parameters Test with minimal paramete
       class="survey-question__input-map-container"
     >
       <div
-        class="loader"
-      >
-        <p>
-          Loading
-          ...
-        </p>
-      </div>
+        data-testid="mock-input-map"
+      />
     </div>
   </div>
 </div>

--- a/packages/evolution-frontend/src/components/inputs/__tests__/mockGoogleMapAdapter.tsx
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/mockGoogleMapAdapter.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import React from 'react';
+import DOMPurify from 'dompurify';
+
+import type { MapProviderAdapter, MapWidgetProps } from '../maps/types';
+
+/** Shared geocode mock used by the adapter double and by InputMapFindPlace tests. */
+export const mockGeocodeMultiplePlaces = jest.fn();
+
+/**
+ * Test double for GoogleMapAdapter: renders InfoWindow confirm so both
+ * confirm entry points (map popup + below-map button) can be exercised.
+ */
+const MockInputMap: React.FC<MapWidgetProps> = ({ infoWindow, onMapReady }) => {
+    React.useEffect(() => {
+        onMapReady?.([0, 0, 0, 0]);
+    }, [onMapReady]);
+
+    return (
+        <div data-testid="mock-input-map">
+            {infoWindow ? (
+                <div data-testid="mock-info-window">
+                    <div
+                        dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(infoWindow.content) }}
+                    />
+                    {infoWindow.confirmLabel && infoWindow.onConfirm ? (
+                        <button
+                            type="button"
+                            data-testid="mock-info-window-confirm"
+                            onClick={infoWindow.onConfirm}
+                        >
+                            {infoWindow.confirmLabel}
+                        </button>
+                    ) : null}
+                </div>
+            ) : null}
+        </div>
+    );
+};
+
+const mockGoogleMapAdapter: MapProviderAdapter = {
+    InputMap: MockInputMap,
+    InfoMap: () => null,
+    geocodeSinglePoint: jest.fn(),
+    geocodeMultiplePlaces: mockGeocodeMultiplePlaces
+};
+
+export default mockGoogleMapAdapter;

--- a/packages/evolution-frontend/src/components/inputs/maps/google/InputMapGoogle.tsx
+++ b/packages/evolution-frontend/src/components/inputs/maps/google/InputMapGoogle.tsx
@@ -18,6 +18,7 @@ import {
 } from '@vis.gl/react-google-maps';
 import GeoJSON from 'geojson';
 import bowser from 'bowser';
+import DOMPurify from 'dompurify';
 
 import { getCurrentGoogleMapConfig, getGoogleMapId } from '../../../../config/googleMaps.config';
 import InputLoading from '../../InputLoading';
@@ -236,14 +237,38 @@ const InputMapGoogleInner: React.FunctionComponent<InputGoogleMapPointProps> = (
     React.useEffect(() => {
         if (!placesInfoWindow) return;
         placesInfoWindow.close();
-        if (props.infoWindow && map) {
-            placesInfoWindow.setContent(props.infoWindow.content);
-            placesInfoWindow.setPosition({
-                lat: props.infoWindow.position.geometry.coordinates[1],
-                lng: props.infoWindow.position.geometry.coordinates[0]
-            });
-            placesInfoWindow.open(map);
+        if (!props.infoWindow || !map) {
+            return;
         }
+
+        const container = document.createElement('div');
+        // Place name/address/photo HTML comes from geocoder data — sanitize before insert.
+        container.innerHTML = DOMPurify.sanitize(props.infoWindow.content);
+
+        let confirmButton: HTMLButtonElement | undefined;
+        const onConfirm = props.infoWindow.onConfirm;
+        if (props.infoWindow.confirmLabel && onConfirm) {
+            confirmButton = document.createElement('button');
+            confirmButton.type = 'button';
+            confirmButton.className = 'button green';
+            confirmButton.style.marginTop = '0.5rem';
+            confirmButton.textContent = props.infoWindow.confirmLabel;
+            confirmButton.addEventListener('click', onConfirm);
+            container.appendChild(confirmButton);
+        }
+
+        placesInfoWindow.setContent(container);
+        placesInfoWindow.setPosition({
+            lat: props.infoWindow.position.geometry.coordinates[1],
+            lng: props.infoWindow.position.geometry.coordinates[0]
+        });
+        placesInfoWindow.open(map);
+
+        return () => {
+            if (confirmButton && onConfirm) {
+                confirmButton.removeEventListener('click', onConfirm);
+            }
+        };
     }, [props.infoWindow, placesInfoWindow, map]);
 
     if (!isLoaded) {

--- a/packages/evolution-frontend/src/components/inputs/maps/types.ts
+++ b/packages/evolution-frontend/src/components/inputs/maps/types.ts
@@ -52,6 +52,9 @@ export type geocodeSingleFct = (
 export type InfoWindow = {
     position: GeoJSON.Feature<GeoJSON.Point>;
     content: string;
+    /** When set, InputMap renders a confirm button inside the info window. */
+    confirmLabel?: string;
+    onConfirm?: () => void;
 };
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated geography questions to use place-search maps for home, work, school, and trip locations.
  * Added confirmation controls directly within map information windows.
  * Confirming a selected place from the map now saves the selection and closes the confirmation controls.
  * Added validation to flag invalid or imprecise location results and provide clearer guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->