### PR TITLE
fix(times): treat midnight (0) as a valid time when checking presence

### DIFF
--- a/packages/evolution-common/src/services/baseObjects/Trip.ts
+++ b/packages/evolution-common/src/services/baseObjects/Trip.ts
@@ -268,10 +268,10 @@ export class Trip extends SurveyObject {
      * Setup the start and end times if they are not set
      */
     setupStartAndEndTimes(): void {
-        if (this.startTime === undefined && this.startPlace?.endTime) {
+        if (this.startTime === undefined && this.startPlace?.endTime !== undefined) {
             this.startTime = this.startPlace.endTime;
         }
-        if (this.endTime === undefined && this.endPlace?.startTime) {
+        if (this.endTime === undefined && this.endPlace?.startTime !== undefined) {
             this.endTime = this.endPlace.startTime;
         }
     }

--- a/packages/evolution-common/src/services/baseObjects/__tests__/Trip.test.ts
+++ b/packages/evolution-common/src/services/baseObjects/__tests__/Trip.test.ts
@@ -1063,6 +1063,22 @@ describe('Trip', () => {
             });
         });
 
+        describe('setupStartAndEndTimes', () => {
+            test.each([
+                ['copies midnight (0) from origin endTime and destination startTime', 0, 0],
+                ['copies non-zero times from origin and destination', 3600, 7200]
+            ])('%s', (_title, originEndTime, destinationStartTime) => {
+                const trip = new Trip({ _uuid: uuidV4() }, registry);
+                trip.origin = new VisitedPlace({ _uuid: uuidV4(), endTime: originEndTime }, registry);
+                trip.destination = new VisitedPlace({ _uuid: uuidV4(), startTime: destinationStartTime }, registry);
+
+                trip.setupStartAndEndTimes();
+
+                expect(trip.startTime).toBe(originEndTime);
+                expect(trip.endTime).toBe(destinationStartTime);
+            });
+        });
+
         describe('getBirdSpeedKph', () => {
             test('should return the bird speed in km/h', () => {
                 trip.origin = new VisitedPlace({ _place: { geography: { type: 'Feature', geometry: { type: 'Point', coordinates: [45.5, -75.5] }, properties: {} }, _isValid: true } }, registry);

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/buttonsVisitedPlace.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/buttonsVisitedPlace.test.ts
@@ -216,6 +216,45 @@ describe('buttonSaveVisitedPlace widget', () => {
                 },
                 expectedActiveVisitedPlaceId: null
             }, {
+                title: 'inserts previous home with midnight _previousArrivalTime (0)',
+                path: 'household.persons.personId1.journeys.journeyId1.visitedPlaces.otherPlace2P1',
+                activeVisitedPlaceId: 'otherPlace2P1',
+                setup: (interview: typeof interviewAttributesForTestCases) => {
+                    const journey = getJourney(interview);
+                    const visitedPlace = journey.visitedPlaces!.otherPlace2P1;
+                    visitedPlace.activity = 'workOnTheRoad';
+                    visitedPlace.activityCategory = 'work';
+                    visitedPlace.onTheRoadPreviousPlaceActivity = 'home';
+                    visitedPlace.onTheRoadNextPlaceCategory = 'wentBackHome';
+                    visitedPlace.arrivalTime = 9 * 60 * 60;
+                    visitedPlace.departureTime = 17 * 60 * 60;
+                    visitedPlace._previousArrivalTime = 0;
+                },
+                expectedInsertedPlaces: [
+                    {
+                        insertSequence: 5,
+                        newVisitedPlace: {
+                            activity: 'home',
+                            activityCategory: 'home',
+                            nextPlaceCategory: 'visitedAnotherPlace',
+                            arrivalTime: 0,
+                            departureTime: 9 * 60 * 60
+                        }
+                    },
+                    {
+                        insertSequence: 7,
+                        newVisitedPlace: {
+                            activity: 'home',
+                            activityCategory: 'home',
+                            arrivalTime: 17 * 60 * 60
+                        }
+                    }
+                ],
+                expectedFirstUpdateValuesByPath: {
+                    'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.otherPlace2P1._isNew': false
+                },
+                expectedActiveVisitedPlaceId: null
+            }, {
                 title: 'inserts two places for workOnTheRoad with workUsual departure and workUsual arrival, inlining usual places',
                 path: 'household.persons.personId1.journeys.journeyId1.visitedPlaces.otherPlace2P1',
                 activeVisitedPlaceId: 'otherPlace2P1',

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/buttonsVisitedPlace.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/buttonsVisitedPlace.ts
@@ -134,7 +134,7 @@ export class ButtonsVisitedPlaceConfigFactory implements WidgetConfigFactory {
                 activity: 'home',
                 activityCategory: 'home',
                 nextPlaceCategory: 'visitedAnotherPlace',
-                arrivalTime: currentVisitedPlace._previousArrivalTime
+                arrivalTime: !_isBlank(currentVisitedPlace._previousArrivalTime)
                     ? currentVisitedPlace._previousArrivalTime
                     : undefined,
                 departureTime: odHelpers.isLoopActivity({ visitedPlace: currentVisitedPlace })
@@ -151,7 +151,7 @@ export class ButtonsVisitedPlaceConfigFactory implements WidgetConfigFactory {
                 activity: 'workUsual' as const,
                 activityCategory: 'work' as const,
                 nextPlaceCategory: 'visitedAnotherPlace' as const,
-                arrivalTime: currentVisitedPlace._previousArrivalTime
+                arrivalTime: !_isBlank(currentVisitedPlace._previousArrivalTime)
                     ? currentVisitedPlace._previousArrivalTime
                     : undefined,
                 departureTime:

--- a/packages/evolution-frontend/src/components/admin/widgets/PersonPanel.tsx
+++ b/packages/evolution-frontend/src/components/admin/widgets/PersonPanel.tsx
@@ -95,8 +95,8 @@ export const PersonPanel = ({
         const visitedPlaceLabel = (
             <>
                 {i + 1}. {visitedPlaceDecorator.getDescription(true)}{' '}
-                {visitedPlace.startTime && visitedPlace.endTime
-                    ? '(' + Math.round((10 * (visitedPlace.endTime - visitedPlace.startTime)) / 3600) / 10 + 'h)'
+                {!_isBlank(visitedPlace.startTime) && !_isBlank(visitedPlace.endTime)
+                    ? '(' + Math.round((10 * (visitedPlace.endTime! - visitedPlace.startTime!)) / 3600) / 10 + 'h)'
                     : ''}
             </>
         );

--- a/packages/evolution-frontend/src/components/admin/widgets/__tests__/PersonPanel.test.tsx
+++ b/packages/evolution-frontend/src/components/admin/widgets/__tests__/PersonPanel.test.tsx
@@ -90,6 +90,27 @@ beforeEach(() => {
     mockGetReviewDecisionStatusForObject.mockReturnValue(undefined);
 });
 
+describe('PersonPanel visited place times', () => {
+    test('displays duration when visited place starts at midnight (0)', () => {
+        const journeyWithMidnightPlace = {
+            ...journey,
+            visitedPlaces: [{ _uuid: 'place-midnight', startTime: 0, endTime: 3600 }]
+        } as unknown as Journey;
+
+        const { getByText } = render(
+            <PersonPanel
+                person={person}
+                journey={journeyWithMidnightPlace}
+                personId={personUuid}
+                selectPlace={jest.fn()}
+                selectTrip={jest.fn()}
+            />
+        );
+
+        expect(getByText(/\(1h\)/)).toBeTruthy();
+    });
+});
+
 describe('PersonPanel rejection inheritance', () => {
     test('journey rejection propagates to trip and segment boxes', () => {
         mockGetReviewDecisionStatusForObject.mockImplementation((_map, objectType, objectUuid) => {

--- a/packages/evolution-frontend/src/components/survey/sectionTemplates/TripsAndSegmentsSection.tsx
+++ b/packages/evolution-frontend/src/components/survey/sectionTemplates/TripsAndSegmentsSection.tsx
@@ -171,7 +171,9 @@ export const SegmentsSection: React.FC<SectionProps> = (props: SectionProps) => 
                 </span>
                 <span className="survey-trip-item-element survey-trip-item-buttons">
                     <FontAwesomeIcon icon={faClock} style={{ marginRight: '0.3rem', marginLeft: '0.6rem' }} />
-                    {origin && origin.departureTime && secondsSinceMidnightToTimeStrWithSuffix(origin.departureTime)}
+                    {origin &&
+                        !_isBlank(origin.departureTime) &&
+                        secondsSinceMidnightToTimeStrWithSuffix(origin.departureTime!)}
                     <FontAwesomeIcon icon={faArrowRight} style={{ marginRight: '0.3rem', marginLeft: '0.3rem' }} />
                     {tripEndPlace &&
                         !_isBlank(tripEndPlace.arrivalTime) &&

--- a/packages/evolution-frontend/src/components/survey/sectionTemplates/VisitedPlacesSection.tsx
+++ b/packages/evolution-frontend/src/components/survey/sectionTemplates/VisitedPlacesSection.tsx
@@ -139,11 +139,11 @@ export const VisitedPlacesSection: React.FC<SectionProps> = (props: SectionProps
             });
             let departureTime = i === count - 1 ? 28 * 3600 : null;
             let arrivalTime = i === 0 ? 0 : null;
-            if (visitedPlace.departureTime) {
-                departureTime = visitedPlace.departureTime;
+            if (!_isBlank(visitedPlace.departureTime)) {
+                departureTime = visitedPlace.departureTime!;
             }
-            if (visitedPlace.arrivalTime) {
-                arrivalTime = visitedPlace.arrivalTime;
+            if (!_isBlank(visitedPlace.arrivalTime)) {
+                arrivalTime = visitedPlace.arrivalTime!;
             }
             if (visitedPlace.activity && !_isBlank(departureTime) && !_isBlank(arrivalTime)) {
                 atLeastOneCompletedVisitedPlace = true;
@@ -296,16 +296,16 @@ export const VisitedPlacesSection: React.FC<SectionProps> = (props: SectionProps
                 {
                     <span className="survey-visited-place-item-element survey-visited-place-item-buttons">
                         <FontAwesomeIcon icon={faClock} style={{ marginRight: '0.3rem', marginLeft: '0.6rem' }} />
-                        {visitedPlace.arrivalTime &&
-                            secondsSinceMidnightToTimeStrWithSuffix(visitedPlace.arrivalTime, t('main:theNextDay'))}
-                        {visitedPlace.departureTime && (
+                        {!_isBlank(visitedPlace.arrivalTime) &&
+                            secondsSinceMidnightToTimeStrWithSuffix(visitedPlace.arrivalTime!, t('main:theNextDay'))}
+                        {!_isBlank(visitedPlace.departureTime) && (
                             <FontAwesomeIcon
                                 icon={faArrowRight}
                                 style={{ marginRight: '0.3rem', marginLeft: '0.3rem' }}
                             />
                         )}
-                        {visitedPlace.departureTime &&
-                            secondsSinceMidnightToTimeStrWithSuffix(visitedPlace.departureTime, t('main:theNextDay'))}
+                        {!_isBlank(visitedPlace.departureTime) &&
+                            secondsSinceMidnightToTimeStrWithSuffix(visitedPlace.departureTime!, t('main:theNextDay'))}
                         {!selectedVisitedPlaceId /*state.editActivated*/ && props.loadingState === 0 && (
                             <button
                                 type="button"

--- a/packages/evolution-frontend/src/components/survey/sectionTemplates/__tests__/TripsAndSegmentsSection.test.tsx
+++ b/packages/evolution-frontend/src/components/survey/sectionTemplates/__tests__/TripsAndSegmentsSection.test.tsx
@@ -226,6 +226,38 @@ describe('SegmentsSection UI display', () => {
             expect(results).toHaveNoViolations();
         });
 
+        test.each([
+            {
+                title: 'origin departureTime of 0 (midnight)',
+                originDepartureTime: 0,
+                destinationArrivalTime: 7200
+            },
+            {
+                title: 'destination arrivalTime of 0 (midnight)',
+                originDepartureTime: 23 * 3600,
+                destinationArrivalTime: 0
+            }
+        ])('should display $title', ({ originDepartureTime, destinationArrivalTime }) => {
+            const { secondsSinceMidnightToTimeStrWithSuffix } = jest.requireMock(
+                '../../../../services/display/frontendHelper'
+            ) as { secondsSinceMidnightToTimeStrWithSuffix: jest.Mock };
+            secondsSinceMidnightToTimeStrWithSuffix.mockClear();
+
+            const testVisitedPlaces = _cloneDeep(visitedPlaces);
+            testVisitedPlaces.place1.departureTime = originDepartureTime;
+            testVisitedPlaces.place2.arrivalTime = destinationArrivalTime;
+            mockedGetJourneysArray.mockReturnValueOnce([{ ...journey, visitedPlaces: testVisitedPlaces }]);
+
+            render(
+                <TestContextProvider>
+                    <SegmentsSection {...props} />
+                </TestContextProvider>
+            );
+
+            expect(secondsSinceMidnightToTimeStrWithSuffix).toHaveBeenCalledWith(originDepartureTime);
+            expect(secondsSinceMidnightToTimeStrWithSuffix).toHaveBeenCalledWith(destinationArrivalTime);
+        });
+
         test('should render list of trips when loop activity in one trip, no trip selected', () => {
             const testVisitedPlaces = _cloneDeep(visitedPlaces);
             testVisitedPlaces.place2.activity = 'workOnTheRoad';

--- a/packages/evolution-frontend/src/components/survey/sectionTemplates/__tests__/VisitedPlacesSection.test.tsx
+++ b/packages/evolution-frontend/src/components/survey/sectionTemplates/__tests__/VisitedPlacesSection.test.tsx
@@ -183,6 +183,24 @@ describe('VisitedPlacesSection UI display', () => {
         expect(container).toMatchSnapshot();
     });
 
+    test('should display midnight (0) arrival and departure times', () => {
+        const props = getDefaultProps();
+        const visitedPlaces =
+            props.interview.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!;
+        visitedPlaces.workPlace1P1.arrivalTime = 0;
+        visitedPlaces.workPlace1P1.departureTime = 0;
+
+        const { container } = render(
+            <TestContextProvider>
+                <VisitedPlacesSection {...props} />
+            </TestContextProvider>
+        );
+
+        const listTimes = container.querySelectorAll('.survey-visited-place-item-buttons');
+        expect(listTimes[1].textContent?.match(/time-0/g)).toHaveLength(2);
+        expect(container.querySelectorAll('.survey-visited-places-schedule-visited-place')).toHaveLength(5);
+    });
+
     test('should throw error if no active person or journey', () => {
         const props = getDefaultProps();
         delete props.interview.response._activePersonId;


### PR DESCRIPTION
Closes #1806

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Midnight timestamps are now correctly preserved when recording trip, visited-place, and work-related travel times.
  * Trip start and end times are populated correctly when related place times are set to midnight.
  * Visited-place durations and schedule displays now show valid zero-valued times instead of treating them as missing.
  * Blank arrival times remain unavailable rather than being stored as invalid values.

* **Tests**
  * Added regression coverage for midnight and blank-time scenarios across trip and visited-place workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->