### PR TITLE
fix(validations): skip numeric check when household asset count is blank

### DIFF
--- a/packages/evolution-common/src/services/widgets/validations/__tests__/householdAssetCountValidation.test.ts
+++ b/packages/evolution-common/src/services/widgets/validations/__tests__/householdAssetCountValidation.test.ts
@@ -58,6 +58,7 @@ describe('household asset count validation', () => {
 
         test.each([
             ['', 4, 1],
+            [undefined, 4, 1],
             [-1, 4, 2],
             [1.5, 4, 0],
             [maxForSize4 + 1, 4, 3],

--- a/packages/evolution-common/src/services/widgets/validations/householdAssetCountValidation.ts
+++ b/packages/evolution-common/src/services/widgets/validations/householdAssetCountValidation.ts
@@ -82,7 +82,7 @@ const createHouseholdAssetCountValidation = (
 
         return [
             {
-                validation: isNaN(Number(value)) || !Number.isInteger(Number(value)),
+                validation: !_isBlank(value) && (isNaN(Number(value)) || !Number.isInteger(Number(value))),
                 errorMessage: (t) => t(messageKeys.invalid)
             },
             {


### PR DESCRIPTION
Number(undefined) is NaN, so the invalid-format rule fired before the required rule. Blank values now skip numeric validation and fail at index 1.

Closes #1783