### PR TITLE
feat(segments): hide implausible modes using bird-distance ranges

### DIFF
--- a/packages/evolution-common/src/services/odSurvey/__tests__/birdSpeedKmhValidRangeByModeAndDistance.test.ts
+++ b/packages/evolution-common/src/services/odSurvey/__tests__/birdSpeedKmhValidRangeByModeAndDistance.test.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import {
+    birdSpeedKmhValidRangeByModeAndDistance,
+    isBirdSpeedInRangeForModeAndDistance
+} from '../birdSpeedKmhValidRangeByModeAndDistance';
+import { modeValues, type Mode } from '../types';
+
+describe('range table covers all questionnaire modes', () => {
+    test.each(modeValues)('%s has distance-speed bands', (mode) => {
+        expect(birdSpeedKmhValidRangeByModeAndDistance[mode]).toBeDefined();
+    });
+});
+
+describe('isBirdSpeedInRangeForModeAndDistance', () => {
+    test.each(modeValues)('%s uses the first distance band', (mode: Mode) => {
+        const bands = birdSpeedKmhValidRangeByModeAndDistance[mode];
+        expect(bands).toBeDefined();
+        const [[distanceMin, distanceMax], [speedMin, speedMax]] = bands![0];
+        expect(isBirdSpeedInRangeForModeAndDistance(mode, distanceMin, speedMin)).toEqual({
+            wasFound: true,
+            inRange: true
+        });
+        expect(isBirdSpeedInRangeForModeAndDistance(mode, distanceMin, speedMin - 0.1)).toEqual({
+            wasFound: true,
+            inRange: false
+        });
+        expect(isBirdSpeedInRangeForModeAndDistance(mode, distanceMin, speedMax + 0.1)).toEqual({
+            wasFound: true,
+            inRange: false
+        });
+        if (distanceMin > 0) {
+            expect(isBirdSpeedInRangeForModeAndDistance(mode, distanceMin - 0.001, speedMin)).toEqual({
+                wasFound: false,
+                inRange: false
+            });
+        }
+        expect(distanceMax).toBeGreaterThan(distanceMin);
+    });
+});

--- a/packages/evolution-common/src/services/odSurvey/__tests__/speedAndDistanceRangesByMode.test.ts
+++ b/packages/evolution-common/src/services/odSurvey/__tests__/speedAndDistanceRangesByMode.test.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import {
+    birdDistanceMRangeByMode,
+    birdSpeedKphRangeByMode,
+    isBirdDistanceInRangeForMode,
+    isBirdSpeedInRangeForMode,
+    isModeOfferedForBirdDistance,
+    isModePreOfferedForBirdDistance,
+    modesAlwaysOfferedForBirdDistance
+} from '../speedAndDistanceRangesByMode';
+import { defaultModePreToModeMap, modeValues, type Mode } from '../types';
+
+describe('range tables cover all questionnaire modes', () => {
+    test.each(modeValues)('%s has distance and speed ranges', (mode) => {
+        expect(birdDistanceMRangeByMode[mode]).toBeDefined();
+        expect(birdSpeedKphRangeByMode[mode]).toBeDefined();
+    });
+});
+
+describe('isModeOfferedForBirdDistance', () => {
+    test.each(modeValues)('offers %s when distance is unknown', (mode) => {
+        expect(isModeOfferedForBirdDistance(mode, undefined)).toBe(true);
+    });
+
+    const modesWithMinDistance = modeValues.filter(
+        (mode) =>
+            (birdDistanceMRangeByMode[mode]?.[0] ?? 0) > 0 && !modesAlwaysOfferedForBirdDistance.includes(mode)
+    );
+    test.each(modesWithMinDistance)('hides %s just below min and offers at min', (mode) => {
+        const [min] = birdDistanceMRangeByMode[mode] as [number, number];
+        expect(isModeOfferedForBirdDistance(mode, min - 1)).toBe(false);
+        expect(isModeOfferedForBirdDistance(mode, min)).toBe(true);
+    });
+
+    test.each(modesAlwaysOfferedForBirdDistance)('always offers %s regardless of distance', (mode) => {
+        expect(isModeOfferedForBirdDistance(mode, undefined)).toBe(true);
+        expect(isModeOfferedForBirdDistance(mode, 0)).toBe(true);
+        expect(isModeOfferedForBirdDistance(mode, Number.MAX_SAFE_INTEGER)).toBe(true);
+    });
+
+    const modesWithZeroMin = modeValues.filter((mode) => birdDistanceMRangeByMode[mode]?.[0] === 0);
+    test.each(modesWithZeroMin)('offers %s regardless of distance', (mode) => {
+        expect(isModeOfferedForBirdDistance(mode, 0)).toBe(true);
+        expect(isModeOfferedForBirdDistance(mode, Number.MAX_SAFE_INTEGER)).toBe(true);
+    });
+});
+
+describe('isBirdDistanceInRangeForMode', () => {
+    test.each(modeValues)('%s respects the table min and max', (mode: Mode) => {
+        const [min, max] = birdDistanceMRangeByMode[mode] as [number, number];
+        expect(isBirdDistanceInRangeForMode(mode, min)).toBe(true);
+        if (min > 0) {
+            expect(isBirdDistanceInRangeForMode(mode, min - 1)).toBe(false);
+        }
+        if (Number.isFinite(max)) {
+            expect(isBirdDistanceInRangeForMode(mode, max)).toBe(true);
+            expect(isBirdDistanceInRangeForMode(mode, max + 1)).toBe(false);
+        } else {
+            expect(isBirdDistanceInRangeForMode(mode, min + 1e12)).toBe(true);
+        }
+    });
+});
+
+describe('isBirdSpeedInRangeForMode', () => {
+    test.each(modeValues)('%s respects the table min and max', (mode: Mode) => {
+        const [min, max] = birdSpeedKphRangeByMode[mode] as [number, number];
+        expect(isBirdSpeedInRangeForMode(mode, min)).toBe(true);
+        expect(isBirdSpeedInRangeForMode(mode, min - 0.1)).toBe(false);
+        expect(isBirdSpeedInRangeForMode(mode, max)).toBe(true);
+        expect(isBirdSpeedInRangeForMode(mode, max + 0.1)).toBe(false);
+    });
+});
+
+describe('isModePreOfferedForBirdDistance', () => {
+    const modePreEntries = Object.entries(defaultModePreToModeMap) as [string, Mode[]][];
+
+    test('hides an empty category', () => {
+        expect(isModePreOfferedForBirdDistance([], undefined)).toBe(false);
+        expect(isModePreOfferedForBirdDistance([], 0)).toBe(false);
+    });
+
+    test.each(modePreEntries)('offers %s when distance is unknown', (_modePre, modes) => {
+        expect(isModePreOfferedForBirdDistance(modes, undefined)).toBe(true);
+    });
+
+    test.each(
+        modePreEntries.map(([modePre, modes]) => {
+            const categoryMin = Math.min(
+                ...modes.map((mode) =>
+                    modesAlwaysOfferedForBirdDistance.includes(mode) ? 0 : (birdDistanceMRangeByMode[mode]?.[0] ?? 0)
+                )
+            );
+            return [modePre, categoryMin, modes] as const;
+        })
+    )('%s is hidden just below %s m and offered at min', (_modePre, categoryMin, modes) => {
+        if (categoryMin > 0) {
+            expect(isModePreOfferedForBirdDistance(modes, categoryMin - 1)).toBe(false);
+        }
+        expect(isModePreOfferedForBirdDistance(modes, categoryMin)).toBe(true);
+    });
+});

--- a/packages/evolution-common/src/services/odSurvey/birdSpeedKmhValidRangeByModeAndDistance.ts
+++ b/packages/evolution-common/src/services/odSurvey/birdSpeedKmhValidRangeByModeAndDistance.ts
@@ -1,0 +1,264 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import type { Mode } from './types';
+import type { MinMaxRange } from './speedAndDistanceRangesByMode';
+
+/**
+ * Distance band in km paired with the plausible bird-speed band in km/h.
+ * Audits only: never used to show or hide questionnaire choices.
+ * Distance lookup is half-open `[min, max)` so a boundary value (e.g. 1.0 km)
+ * uses the next band. Speed comparison is inclusive `[min, max]`.
+ */
+export type DistanceAndSpeedBand = [distanceKm: MinMaxRange, speedKph: MinMaxRange];
+
+const carLikeBands: DistanceAndSpeedBand[] = [
+    [
+        [0.0, 1.0],
+        [1.0, 90.0]
+    ],
+    [
+        [1.0, 5.0],
+        [2.0, 90.0]
+    ],
+    [
+        [5.0, 20.0],
+        [6.0, 90.0]
+    ],
+    [
+        [20.0, 50.0],
+        [10.0, 100.0]
+    ],
+    [
+        [50.0, 80.0],
+        [30.0, 100.0]
+    ],
+    [
+        [80.0, 2000.0],
+        [40.0, 110.0]
+    ]
+];
+
+const urbanTransitBands: DistanceAndSpeedBand[] = [
+    [
+        [0.0, 5.0],
+        [1.0, 50.0]
+    ],
+    [
+        [5.0, 20.0],
+        [2.0, 60.0]
+    ],
+    [
+        [20.0, 100.0],
+        [10.0, 100.0]
+    ]
+];
+
+const railTransitBands: DistanceAndSpeedBand[] = [
+    [
+        [1.0, 5.0],
+        [2.0, 50.0]
+    ],
+    [
+        [5.0, 20.0],
+        [2.0, 60.0]
+    ],
+    [
+        [20.0, 100.0],
+        [10.0, 100.0]
+    ]
+];
+
+const bicycleLikeBands: DistanceAndSpeedBand[] = [
+    [
+        [0.0, 1.0],
+        [1.0, 25.0]
+    ],
+    [
+        [1.0, 60.0],
+        [2.0, 25.0]
+    ]
+];
+
+/**
+ * Bird-speed validity bands by mode and trip distance (km).
+ * Audits only (and possible future reviewer validation): never used to show
+ * or hide questionnaire choices. Pick the distance band, then check speed.
+ */
+export const birdSpeedKmhValidRangeByModeAndDistance: Partial<Record<Mode, DistanceAndSpeedBand[]>> = {
+    carDriver: carLikeBands,
+    carDriverCarsharing: carLikeBands,
+    carPassenger: carLikeBands,
+    motorcycle: carLikeBands,
+    snowmobile: carLikeBands,
+    allTerrainVehicle: carLikeBands,
+    taxi: [
+        [
+            [0.0, 1.0],
+            [1.0, 90.0]
+        ],
+        [
+            [1.0, 5.0],
+            [2.0, 90.0]
+        ],
+        [
+            [5.0, 20.0],
+            [5.0, 90.0]
+        ],
+        [
+            [10.0, 50.0],
+            [15.0, 100.0]
+        ],
+        [
+            [50.0, 100.0],
+            [40.0, 110.0]
+        ]
+    ],
+    transitTaxi: urbanTransitBands,
+    transitOnDemand: urbanTransitBands,
+    transitBus: urbanTransitBands,
+    transitBRT: urbanTransitBands,
+    transitStreetCar: urbanTransitBands,
+    schoolBus: urbanTransitBands,
+    otherBus: urbanTransitBands,
+    transitRRT: railTransitBands,
+    transitLRT: railTransitBands,
+    transitLRRT: railTransitBands,
+    transitRegionalRail: railTransitBands,
+    transitMonorail: railTransitBands,
+    transitHSR: [
+        [
+            [20.0, 500.0],
+            [20.0, 90.0]
+        ]
+    ],
+    walk: [
+        [
+            [0.0, 1.0],
+            [0.5, 11.0]
+        ],
+        [
+            [1.0, 7.0],
+            [0.5, 10.0]
+        ]
+    ],
+    bicycle: bicycleLikeBands,
+    bicycleElectric: bicycleLikeBands,
+    bicyclePassenger: bicycleLikeBands,
+    bicycleBikesharing: bicycleLikeBands,
+    bicycleBikesharingElectric: bicycleLikeBands,
+    kickScooterElectric: bicycleLikeBands,
+    otherActiveMode: bicycleLikeBands,
+    wheelchair: [
+        [
+            [0.0, 3.0],
+            [0.5, 10.0]
+        ]
+    ],
+    mobilityScooter: [
+        [
+            [0.0, 5.0],
+            [1.0, 15.0]
+        ]
+    ],
+    paratransit: [
+        [
+            [0.0, 100.0],
+            [1.0, 60.0]
+        ]
+    ],
+    intercityBus: [
+        [
+            [20.0, 500.0],
+            [15.0, 90.0]
+        ]
+    ],
+    intercityTrain: [
+        [
+            [20.0, 500.0],
+            [20.0, 90.0]
+        ]
+    ],
+    transitFerry: [
+        [
+            [0.0, 10.0],
+            [2.0, 30.0]
+        ]
+    ],
+    ferryWithCar: [
+        [
+            [0.0, 10.0],
+            [2.0, 30.0]
+        ]
+    ],
+    privateBoat: [
+        [
+            [0.0, 10.0],
+            [2.0, 30.0]
+        ]
+    ],
+    transitGondola: [
+        [
+            [0.0, 10.0],
+            [2.0, 40.0]
+        ]
+    ],
+    transitSchoolBus: urbanTransitBands,
+    other: [
+        [
+            [0.0, 100.0],
+            [1.0, 90.0]
+        ]
+    ],
+    dontKnow: [
+        [
+            [0.0, 100.0],
+            [1.0, 120.0]
+        ]
+    ],
+    preferNotToAnswer: [
+        [
+            [0.0, 100.0],
+            [1.0, 120.0]
+        ]
+    ],
+    plane: [
+        [
+            [200.0, 20000.0],
+            [100.0, 1000.0]
+        ]
+    ]
+};
+
+/**
+ * Audits only: whether bird speed is plausible for a mode at a given distance.
+ * Not used to show or hide questionnaire choices.
+ * Distance bands are half-open `[min, max)`: 1.0 km matches `[1.0, 5.0]`,
+ * not `[0.0, 1.0]`. Speed is inclusive `>= min` and `<= max`.
+ * `wasFound` is false when the mode has no band covering `distanceKm`.
+ * @param mode questionnaire mode
+ * @param distanceKm trip bird distance in kilometres
+ * @param birdSpeedKph trip bird speed in km/h
+ */
+export const isBirdSpeedInRangeForModeAndDistance = (
+    mode: Mode,
+    distanceKm: number,
+    birdSpeedKph: number
+): { wasFound: boolean; inRange: boolean } => {
+    const bands = birdSpeedKmhValidRangeByModeAndDistance[mode];
+    if (bands === undefined) {
+        return { wasFound: false, inRange: false };
+    }
+    for (const [distanceRange, speedRange] of bands) {
+        if (distanceKm >= distanceRange[0] && distanceKm < distanceRange[1]) {
+            return {
+                wasFound: true,
+                inRange: birdSpeedKph >= speedRange[0] && birdSpeedKph <= speedRange[1]
+            };
+        }
+    }
+    return { wasFound: false, inRange: false };
+};

--- a/packages/evolution-common/src/services/odSurvey/speedAndDistanceRangesByMode.ts
+++ b/packages/evolution-common/src/services/odSurvey/speedAndDistanceRangesByMode.ts
@@ -1,0 +1,193 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import type { Mode } from './types';
+
+/**
+ * Bird-distance and bird-speed ranges by mode.
+ *
+ * Questionnaire filter (show/hide mode and modePre choices): only the
+ * **minimum** of {@link birdDistanceMRangeByMode}, via
+ * {@link isModeOfferedForBirdDistance}. Walk, bicycle, car, etc. have min 0
+ * so they stay visible on long trips.
+ *
+ * Audits re-check **min and max** of {@link birdDistanceMRangeByMode}, plus
+ * {@link birdSpeedKphRangeByMode} and the bands in
+ * `birdSpeedKmhValidRangeByModeAndDistance`. The UI filter is not a guarantee:
+ * a mode that was hidden can still appear in saved answers (tampered interview
+ * JSON, custom request). Audits flag those as reviewer warnings.
+ */
+
+/** Inclusive min and max, in the unit of the table. `Infinity` is allowed for max. */
+export type MinMaxRange = [min: number, max: number];
+
+/**
+ * Bird-speed range in km/h by mode. Audits only: never used to show or hide
+ * questionnaire choices (e.g. bicycleElectric max 30 km/h is a warning).
+ */
+export const birdSpeedKphRangeByMode: Partial<Record<Mode, MinMaxRange>> = {
+    walk: [2, 10],
+    bicycle: [4, 25],
+    bicycleElectric: [4, 30],
+    bicyclePassenger: [4, 25],
+    bicycleBikesharing: [4, 25],
+    bicycleBikesharingElectric: [4, 30],
+    kickScooterElectric: [4, 30],
+    wheelchair: [1, 10],
+    mobilityScooter: [2, 25],
+    paratransit: [10, 60],
+    carDriver: [10, 120],
+    carDriverCarsharing: [10, 120],
+    carPassenger: [10, 120],
+    motorcycle: [20, 100],
+    snowmobile: [10, 80],
+    privateBoat: [5, 40],
+    allTerrainVehicle: [10, 80],
+    transitBus: [7, 50],
+    transitBRT: [10, 60],
+    transitSchoolBus: [5, 40],
+    transitStreetCar: [7, 40],
+    transitFerry: [5, 40],
+    transitGondola: [5, 40],
+    transitMonorail: [15, 50],
+    transitRRT: [15, 50],
+    transitLRT: [15, 60],
+    transitLRRT: [30, 150],
+    transitHSR: [40, 300],
+    transitRegionalRail: [30, 150],
+    transitOnDemand: [10, 80],
+    transitTaxi: [10, 80],
+    intercityBus: [30, 110],
+    intercityTrain: [40, 200],
+    schoolBus: [5, 110],
+    otherBus: [10, 110],
+    taxi: [10, 120],
+    ferryWithCar: [5, 40],
+    plane: [100, 1200],
+    otherActiveMode: [2, 25],
+    other: [2, 100],
+    dontKnow: [2, 100],
+    preferNotToAnswer: [2, 100]
+};
+
+/**
+ * Bird-distance range in meters by mode.
+ * Questionnaire filter: only `min` hides a choice (plane below 100 km,
+ * ferry below 100 m, intercity below 5 km). Audits use **min and max**:
+ * walk stays offered beyond 3000 m, but a saved walk at 8 km (or a plane
+ * on a 2 km trip written outside the UI) is a reviewer warning.
+ */
+export const birdDistanceMRangeByMode: Partial<Record<Mode, MinMaxRange>> = {
+    walk: [0, 3000],
+    bicycle: [0, 40000],
+    bicycleElectric: [0, 50000],
+    bicyclePassenger: [0, 40000],
+    bicycleBikesharing: [0, 15000],
+    bicycleBikesharingElectric: [0, 20000],
+    kickScooterElectric: [0, 15000],
+    wheelchair: [0, 3000],
+    mobilityScooter: [0, 5000],
+    paratransit: [0, 40000],
+    carDriver: [0, 1000000],
+    carDriverCarsharing: [0, 1000000],
+    carPassenger: [0, 1000000],
+    motorcycle: [0, 1000000],
+    snowmobile: [0, 200000],
+    privateBoat: [100, 50000],
+    allTerrainVehicle: [0, 200000],
+    transitBus: [100, 100000],
+    transitBRT: [100, 100000],
+    transitSchoolBus: [200, 20000],
+    transitStreetCar: [200, 40000],
+    transitFerry: [100, 50000],
+    transitGondola: [200, 20000],
+    transitMonorail: [250, 40000],
+    transitRRT: [250, 40000],
+    transitLRT: [250, 40000],
+    transitLRRT: [250, 40000],
+    transitHSR: [250, 1000000],
+    transitRegionalRail: [500, 40000],
+    transitOnDemand: [0, 40000],
+    transitTaxi: [0, 40000],
+    intercityBus: [5000, Infinity],
+    intercityTrain: [5000, Infinity],
+    schoolBus: [200, 1000000],
+    otherBus: [500, 1000000],
+    taxi: [0, 50000],
+    ferryWithCar: [100, 500000],
+    plane: [100000, Infinity],
+    otherActiveMode: [0, 5000],
+    other: [0, Infinity],
+    dontKnow: [0, Infinity],
+    preferNotToAnswer: [0, Infinity]
+};
+
+/**
+ * Always offered in the questionnaire, regardless of bird distance.
+ * FIXME Consider exposing this on SegmentSectionConfiguration if a survey
+ * needs to override the list.
+ */
+export const modesAlwaysOfferedForBirdDistance: readonly Mode[] = ['other', 'dontKnow', 'preferNotToAnswer'];
+
+/**
+ * Questionnaire filter: whether to show this mode for the trip bird distance.
+ * Uses only `birdDistanceMRangeByMode` min. Does not use max or any speed
+ * table. Unknown distance or missing range: offer the mode.
+ * `other`, `dontKnow` and `preferNotToAnswer` are never hidden by distance.
+ * Audits still re-check min (and max) on saved answers; this function is UI only.
+ * @param mode questionnaire mode
+ * @param birdDistanceMeters trip origin-destination bird distance, if known
+ */
+export const isModeOfferedForBirdDistance = (mode: Mode, birdDistanceMeters: number | undefined): boolean => {
+    if (modesAlwaysOfferedForBirdDistance.includes(mode) || birdDistanceMeters === undefined) {
+        return true;
+    }
+    const range = birdDistanceMRangeByMode[mode];
+    if (range === undefined) {
+        return true;
+    }
+    return birdDistanceMeters >= range[0];
+};
+
+/**
+ * Questionnaire filter for a modePre category: offered if at least one of
+ * its modes passes {@link isModeOfferedForBirdDistance}. Empty category: hidden.
+ * @param modesInCategory modes that belong to the category
+ * @param birdDistanceMeters trip origin-destination bird distance, if known
+ */
+export const isModePreOfferedForBirdDistance = (
+    modesInCategory: readonly Mode[],
+    birdDistanceMeters: number | undefined
+): boolean => modesInCategory.some((mode) => isModeOfferedForBirdDistance(mode, birdDistanceMeters));
+
+/**
+ * Audits only: whether bird distance is inside `[min, max]` (both bounds).
+ * Rechecks min even when the questionnaire would have hidden the mode, because
+ * saved answers can bypass the UI. Not used to show or hide choices.
+ * @param mode questionnaire mode
+ * @param birdDistanceMeters trip bird distance in meters
+ */
+export const isBirdDistanceInRangeForMode = (mode: Mode, birdDistanceMeters: number): boolean => {
+    const range = birdDistanceMRangeByMode[mode];
+    if (range === undefined) {
+        return true;
+    }
+    return birdDistanceMeters >= range[0] && birdDistanceMeters <= range[1];
+};
+
+/**
+ * Audits only: whether bird speed is inside `birdSpeedKphRangeByMode`.
+ * Not used to show or hide questionnaire choices.
+ * @param mode questionnaire mode
+ * @param birdSpeedKph trip bird speed in km/h
+ */
+export const isBirdSpeedInRangeForMode = (mode: Mode, birdSpeedKph: number): boolean => {
+    const range = birdSpeedKphRangeByMode[mode];
+    if (range === undefined) {
+        return true;
+    }
+    return birdSpeedKph >= range[0] && birdSpeedKph <= range[1];
+};

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/helpers.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/helpers.test.ts
@@ -1098,3 +1098,43 @@ describe('getSegmentPreviousLocation and getSegmentNextLocation', () => {
     });
 
 });
+
+describe('getTripBirdDistanceMetersFromPath', () => {
+    const modePath = 'household.persons.personId1.journeys.journeyId1.trips.tripId1P1.segments.segmentId1P1T1.mode';
+
+    test('returns a positive distance when origin and destination have geography', () => {
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        setResponse(interview, 'household.persons.personId1.journeys.journeyId1.trips.tripId1P1.segments', {
+            segmentId1P1T1: { _uuid: 'segmentId1P1T1', _sequence: 1 }
+        });
+        const distance = helpers.getTripBirdDistanceMetersFromPath(interview, modePath);
+        expect(distance).toBeGreaterThan(0);
+    });
+
+    test('returns undefined when the path is not under a trip', () => {
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        expect(helpers.getTripBirdDistanceMetersFromPath(interview, 'household.size')).toBeUndefined();
+    });
+
+    test('returns undefined when origin geography is missing', () => {
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        setResponse(interview, 'household.persons.personId1.journeys.journeyId1.trips.tripId1P1.segments', {
+            segmentId1P1T1: { _uuid: 'segmentId1P1T1', _sequence: 1 }
+        });
+        setResponse(interview, 'home.geography', undefined);
+        expect(helpers.getTripBirdDistanceMetersFromPath(interview, modePath)).toBeUndefined();
+    });
+
+    test('returns undefined when destination geography is missing', () => {
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        setResponse(interview, 'household.persons.personId1.journeys.journeyId1.trips.tripId1P1.segments', {
+            segmentId1P1T1: { _uuid: 'segmentId1P1T1', _sequence: 1 }
+        });
+        setResponse(
+            interview,
+            'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.geography',
+            undefined
+        );
+        expect(helpers.getTripBirdDistanceMetersFromPath(interview, modePath)).toBeUndefined();
+    });
+});

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetSegmentMode.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetSegmentMode.test.ts
@@ -13,8 +13,9 @@ import { interviewAttributesForTestCases, widgetFactoryOptions } from '../../../
 import { setResponse, translateString } from '../../../../../utils/helpers';
 import * as surveyHelper from '../../../../odSurvey/helpers';
 import { Mode, defaultModePreToModeMap, defaultModeToModePreMap, modeValues } from '../../../../odSurvey/types';
-import { shouldShowSameAsReverseTripQuestion, getPreviousTripSingleSegment } from '../helpers';
+import { shouldShowSameAsReverseTripQuestion, getPreviousTripSingleSegment, getTripBirdDistanceMetersFromPath } from '../helpers';
 import { modeToIconMapping } from '../modeIconMapping';
+import { isModeOfferedForBirdDistance } from '../../../../odSurvey/speedAndDistanceRangesByMode';
 
 const segmentSectionConfig = {
     type: 'segments' as const,
@@ -84,8 +85,10 @@ describe('Mode choices conditionals', () => {
     // Test that modes appear when the right modePre is selected, use the
     // modePreToModeMap to get the values, but filter out the modes that have
     // specific conditionals and that will be tested separately
+    const modePath = 'household.persons.personId1.journeys.journeyId1.trips.tripId1P1.segments.segmentId1P1T1.mode';
+    const birdDistanceMeters = getTripBirdDistanceMetersFromPath(interview, modePath);
     each(
-        modeValues.filter((mode) => !['wheelchair', 'mobilityScooter', 'paratransit'].includes(mode)).flatMap((mode) => Object.keys(defaultModePreToModeMap).map((modePre) => [mode, modePre, defaultModeToModePreMap[mode].includes(modePre as any)]))
+        modeValues.filter((mode) => !['wheelchair', 'mobilityScooter', 'paratransit'].includes(mode)).flatMap((mode) => Object.keys(defaultModePreToModeMap).map((modePre) => [mode, modePre, defaultModeToModePreMap[mode].includes(modePre as any) && isModeOfferedForBirdDistance(mode, birdDistanceMeters)]))
     ).test('Test modePre conditional for mode %s with modePre %s: %s', (choiceValue, modePreValue, expected) => {
         // Find the right choice choice
         const modeChoice = choices.find((choice) => choice.value === choiceValue);
@@ -148,7 +151,7 @@ describe('Mode choices conditionals', () => {
             modeCategoryToModeMap: {
                 walking: { // Will use the fallback icon
                     modes: ['walk'] as Mode[],
-                    label: `segments:mode:Walk`
+                    label: 'segments:mode:Walk'
                 },
                 bicycle: {
                     modes: ['bicycle'] as Mode[]
@@ -164,14 +167,14 @@ describe('Mode choices conditionals', () => {
                     modes: ['dontKnow'] as Mode[]
                 }
             }
-        }
+        };
         const widgetConfig = getModeWidgetConfig(configuration, widgetFactoryOptions) as QuestionWidgetConfig & InputRadioType;
         const choices = widgetConfig.choices as RadioChoiceType[];
 
         const modePres = ['walking', 'bicycle', 'transit', 'carDriver', 'dontKnow'];
 
         each(
-            modePres.flatMap((modePre) => configuration.modesIncludeOnly!.map((mode) => [mode, modePre, (configuration.modeCategoryToModeMap as any)[modePre].modes.includes(mode as any)]))
+            modePres.flatMap((modePre) => configuration.modesIncludeOnly!.map((mode) => [mode, modePre, (configuration.modeCategoryToModeMap as any)[modePre].modes.includes(mode as any) && isModeOfferedForBirdDistance(mode, birdDistanceMeters)]))
         ).test('Test modePre conditional for mode %s with modePre %s: %s', (choiceValue, modePreValue, expected) => {
             // Find the right choice choice
             const modeChoice = choices.find((choice) => choice.value === choiceValue);
@@ -180,7 +183,55 @@ describe('Mode choices conditionals', () => {
             const modeResult = modeChoice?.conditional?.(interview, 'household.persons.personId1.journeys.journeyId1.trips.tripId1P1.segments.segmentId1P1T1.mode');
             expect(modeResult).toEqual(expected);
         });
-    })
+    });
+
+    // tripId1P1 origin is home at [-73.5932, 45.5016] (homeGeographyCoordinates).
+    // Dest [-73.5932, 45.05] ≈ 50 km (below plane min 100 km).
+    // Dest [-73.5932, 44.4] ≈ 122 km (plane offered).
+    // Dest [-73.61, 45.53] ≈ 3.4 km (below intercity min 5 km).
+    // Dest [-73.5, 45.4] ≈ 13 km (intercity offered).
+    test.each([
+        ['plane', 'other', [-73.5932, 45.05], false],
+        ['plane', 'other', [-73.5932, 44.4], true],
+        ['plane', 'other', undefined, true],
+        ['intercityBus', 'transit', [-73.61, 45.53], false],
+        ['intercityBus', 'transit', [-73.5, 45.4], true],
+        ['intercityTrain', 'transit', [-73.61, 45.53], false],
+        ['walk', 'walk', [-73.5, 45.4], true],
+        ['other', 'other', [-73.5932, 45.05], true],
+        ['dontKnow', 'dontKnow', [-73.5932, 44.4], true],
+        ['preferNotToAnswer', 'preferNotToAnswer', [-73.5932, 44.4], true]
+    ] as [Mode, string, [number, number] | undefined, boolean][])(
+        'mode %s with modePre %s and dest %p is offered: %s',
+        (mode, modePre, destinationCoordinates, expectedOffered) => {
+            const testInterview = _cloneDeep(interview);
+            const modePath =
+                'household.persons.personId1.journeys.journeyId1.trips.tripId1P1.segments.segmentId1P1T1.mode';
+            setResponse(
+                testInterview,
+                'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.geography',
+                destinationCoordinates === undefined
+                    ? undefined
+                    : {
+                        type: 'Feature',
+                        geometry: { type: 'Point', coordinates: destinationCoordinates },
+                        properties: { lastAction: 'mapClicked' }
+                    }
+            );
+            const modeChoice = choices.find((choice) => choice.value === mode);
+            expect(modeChoice).toBeDefined();
+            setResponse(
+                testInterview,
+                'household.persons.personId1.journeys.journeyId1.trips.tripId1P1.segments.segmentId1P1T1.modePre',
+                modePre
+            );
+            const modeResult = modeChoice?.conditional?.(testInterview, modePath);
+            expect(modeResult).toEqual(expectedOffered);
+            if (destinationCoordinates === undefined) {
+                expect(getTripBirdDistanceMetersFromPath(testInterview, modePath)).toBeUndefined();
+            }
+        }
+    );
 
 });
 
@@ -318,9 +369,9 @@ describe('Mode conditional', () => {
         const result = conditional!(interview, `${segmentPath}.mode`);
         expect(result).toEqual([false, mode]);
         expect(mockedShouldShowSameAsReverseTripQuestion).toHaveBeenCalledWith({ interview, path: `${segmentPath}.mode` });
-        expect(mockedGetPreviousTripSingleSegment).toHaveBeenCalledWith({ 
+        expect(mockedGetPreviousTripSingleSegment).toHaveBeenCalledWith({
             journey: interview.response.household!.persons!.personId2.journeys!.journeyId2,
-            trip: interview.response.household!.persons!.personId2.journeys!.journeyId2.trips!.tripId1P2, 
+            trip: interview.response.household!.persons!.personId2.journeys!.journeyId2.trips!.tripId1P2,
         });
     });
 

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetSegmentModePre.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/widgetSegmentModePre.test.ts
@@ -159,19 +159,19 @@ describe('getModePreWidgetConfig', () => {
                 expect.objectContaining({
                     value: 'walking',
                     label: expect.any(Function),
-                    conditional: undefined,
+                    conditional: expect.any(Function),
                     iconPath: '/dist/icons/modes/other/air_balloon.svg'
                 }),
                 expect.objectContaining({
                     value: 'bicycle',
                     label: expect.any(Function),
-                    conditional: bicycleConditional,
+                    conditional: expect.any(Function),
                     iconPath: '/dist/icons/modes/bicycle/bicycle_with_rider.svg'
                 }),
                 expect.objectContaining({
                     value: 'transit',
                     label: expect.any(Function),
-                    conditional: undefined,
+                    conditional: expect.any(Function),
                     iconPath: '/dist/icons/modes/bus/bus_city.svg'
                 }),
                 expect.objectContaining({
@@ -183,7 +183,7 @@ describe('getModePreWidgetConfig', () => {
                 expect.objectContaining({
                     value: 'dontKnow',
                     label: expect.any(Function),
-                    conditional: undefined,
+                    conditional: expect.any(Function),
                     iconPath: '/dist/icons/modes/other/question_mark.svg'
                 })
             ]),
@@ -294,6 +294,43 @@ describe('Mode choices conditionals', () => {
         expect(mockedHhMayHaveDisability).toHaveBeenLastCalledWith({ interview });
     });
 
+    // tripId1P1 origin is home at [-73.5932, 45.5016] (homeGeographyCoordinates).
+    // Dest [-73.5932, 45.502] ≈ 40 m (below transitFerry min 100 m).
+    // Dest [-73.61, 45.53] ≈ 3.4 km (ferry offered).
+    test.each([
+        ['ferry', [-73.5932, 45.502], false],
+        ['ferry', [-73.61, 45.53], true],
+        ['ferry', undefined, true],
+        ['other', [-73.5932, 45.502], true],
+        ['dontKnow', [-73.5932, 45.502], true],
+        ['preferNotToAnswer', [-73.5932, 45.502], true],
+        ['walk', [-73.5932, 45.502], true]
+    ] as [string, [number, number] | undefined, boolean][])(
+        'modePre %s with dest %p is offered: %s',
+        (modePre, destinationCoordinates, expectedOffered) => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            interview.response._activePersonId = 'personId1';
+            interview.response._activeJourneyId = 'journeyId1';
+            interview.response._activeTripId = 'tripId1P1';
+            const modePrePath =
+                'household.persons.personId1.journeys.journeyId1.trips.tripId1P1.segments.segmentId1P1T1.modePre';
+            setResponse(
+                interview,
+                'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.geography',
+                destinationCoordinates === undefined
+                    ? undefined
+                    : {
+                        type: 'Feature',
+                        geometry: { type: 'Point', coordinates: destinationCoordinates },
+                        properties: { lastAction: 'mapClicked' }
+                    }
+            );
+            const modePreChoice = choices.find((choice) => choice.value === modePre);
+            expect(modePreChoice).toBeDefined();
+            expect(modePreChoice?.conditional?.(interview, modePrePath)).toEqual(expectedOffered);
+        }
+    );
+
 });
 
 describe('Mode choices conditionals, from configurable map', () => {
@@ -333,7 +370,7 @@ describe('Mode choices conditionals, from configurable map', () => {
         expect(carDriverResult).toEqual(true);
     });
 
-    test('configured mode transit should not have a conditional', () => {
+    test('configured mode transit should still be offered when distance is valid', () => {
         // Prepare test data with active person/journey/trip
         const interview = _cloneDeep(interviewAttributesForTestCases);
         interview.response._activePersonId = 'personId2';
@@ -343,7 +380,12 @@ describe('Mode choices conditionals, from configurable map', () => {
         // Find the transit choice
         const transitChoice = choices.find((choice) => choice.value === 'transit');
         expect(transitChoice).toBeDefined();
-        expect(transitChoice?.conditional).toBeUndefined();
+        expect(transitChoice?.conditional).toEqual(expect.any(Function));
+        const transitResult = transitChoice?.conditional?.(
+            interview,
+            'household.persons.personId2.journeys.journeyId2.trips.tripId1P2.segments.segmentId1P2T1.modePre'
+        );
+        expect(transitResult).toEqual(true);
     });
 
     test('configured mode other should use provided conditional', () => {
@@ -361,6 +403,26 @@ describe('Mode choices conditionals, from configurable map', () => {
         const otherResult = otherChoice?.conditional?.(interview, 'household.persons.personId3.journeys.journeyId3.trips.tripId1P2.segments.segmentId1P3T1.modePre');
         expect(otherResult).toEqual(true);
         expect(otherConditional).toHaveBeenCalledWith(interview, 'household.persons.personId3.journeys.journeyId3.trips.tripId1P2.segments.segmentId1P3T1.modePre')
+    });
+
+    // Dest ≈ 40 m from home [-73.5932, 45.5016]; plane min is 100 km.
+    test('configured other with only plane is hidden on a short trip', () => {
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        interview.response._activePersonId = 'personId1';
+        interview.response._activeJourneyId = 'journeyId1';
+        interview.response._activeTripId = 'tripId1P1';
+        const modePrePath =
+            'household.persons.personId1.journeys.journeyId1.trips.tripId1P1.segments.segmentId1P1T1.modePre';
+        setResponse(interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.geography', {
+            type: 'Feature',
+            geometry: { type: 'Point', coordinates: [-73.5932, 45.502] },
+            properties: { lastAction: 'mapClicked' }
+        });
+        otherConditional.mockClear();
+        otherConditional.mockReturnValue(true);
+        const otherChoice = choices.find((choice) => choice.value === 'other');
+        expect(otherChoice?.conditional?.(interview, modePrePath)).toEqual(false);
+        expect(otherConditional).not.toHaveBeenCalled();
     });
 });
 

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/helpers.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/helpers.ts
@@ -27,6 +27,7 @@ import type {
     WidgetConditional
 } from '../../types';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
+import { getBirdDistanceMeters } from '../../../../utils/PhysicsUtils';
 
 /**
  * Get the mode used in the single segment of the previous trip of the current
@@ -276,15 +277,15 @@ interface SegmentSectionHelpersImplementation {
 }
 
 /**
- * Get the origin of a segment, as the origin of the trip it is part of. This
- * function can be used if we do not know of any other possible location during
- * segment entry.
+ * Get the origin geography of a trip (the GeoJSON point of the origin
+ * visited place). This can be used if we do not know of any other possible
+ * location during segment entry.
  * @param options the argument
  * @param options.trip The trip the segment is part of
  * @param options.journey The journey the trip is part of
- * @returns
+ * @returns The origin point, or null if the visited place has no geography
  */
-const getTripOrigin = ({
+const getTripOriginGeography = ({
     trip,
     journey,
     interview,
@@ -301,15 +302,15 @@ const getTripOrigin = ({
 };
 
 /**
- * Get the destination of a segment, as the destination of the trip it is part of.
- * This function can be used if we do not know of any other possible location during
- * segment entry.
+ * Get the destination geography of a trip (the GeoJSON point of the destination
+ * visited place). This can be used if we do not know of any other possible
+ * location during segment entry.
  * @param options the argument
  * @param options.trip The trip the segment is part of
  * @param options.journey The journey the trip is part of
- * @returns
+ * @returns The destination point, or null if the visited place has no geography
  */
-const getTripDestination = ({
+const getTripDestinationGeography = ({
     trip,
     journey,
     interview,
@@ -325,6 +326,26 @@ const getTripDestination = ({
     return destination !== null
         ? odHelpers.getVisitedPlaceGeography({ visitedPlace: destination, interview, person })
         : null;
+};
+
+/**
+ * Bird distance in meters between the trip origin and destination for a
+ * segment widget path. Returns undefined when origin or destination geography
+ * is missing.
+ * @param interview current interview
+ * @param path widget path under the trip (e.g. a segment mode path)
+ */
+export const getTripBirdDistanceMetersFromPath = (
+    interview: UserInterviewAttributes,
+    path: string
+): number | undefined => {
+    const tripContext = odHelpers.getTripContextFromPath({ interview, path });
+    if (tripContext === null) {
+        return undefined;
+    }
+    const origin = getTripOriginGeography({ ...tripContext, interview });
+    const destination = getTripDestinationGeography({ ...tripContext, interview });
+    return getBirdDistanceMeters(origin ?? undefined, destination ?? undefined);
 };
 
 class SegmentSectionHelpersWithFields implements SegmentSectionHelpersImplementation {
@@ -388,7 +409,7 @@ class SegmentSectionHelpersWithFields implements SegmentSectionHelpersImplementa
                 return location;
             }
         }
-        return getTripOrigin({ trip, journey, interview, person });
+        return getTripOriginGeography({ trip, journey, interview, person });
     }
 
     public getSegmentNextLocation({
@@ -416,7 +437,7 @@ class SegmentSectionHelpersWithFields implements SegmentSectionHelpersImplementa
                 return location;
             }
         }
-        return getTripDestination({ trip, journey, person, interview });
+        return getTripDestinationGeography({ trip, journey, person, interview });
     }
 
     public getCurrentSegmentOriginLocation({ segment }: { segment: Segment }): GeoJSON.Feature<GeoJSON.Point> | null {
@@ -459,7 +480,7 @@ class DefaultSegmentSectionHelpers implements SegmentSectionHelpersImplementatio
         person: Person;
         interview: UserInterviewAttributes;
     }): GeoJSON.Feature<GeoJSON.Point> | null {
-        return getTripOrigin({ trip, journey, person, interview });
+        return getTripOriginGeography({ trip, journey, person, interview });
     }
 
     public getSegmentNextLocation({
@@ -474,7 +495,7 @@ class DefaultSegmentSectionHelpers implements SegmentSectionHelpersImplementatio
         person: Person;
         interview: UserInterviewAttributes;
     }): GeoJSON.Feature<GeoJSON.Point> | null {
-        return getTripDestination({ trip, journey, person, interview });
+        return getTripDestinationGeography({ trip, journey, person, interview });
     }
 
     public getCurrentSegmentOriginLocation(): GeoJSON.Feature<GeoJSON.Point> | null {

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/widgetSegmentMode.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/widgetSegmentMode.ts
@@ -12,6 +12,7 @@ import { TFunction } from 'i18next';
 import * as odHelpers from '../../../odSurvey/helpers';
 import * as segmentHelpers from './helpers';
 import { Mode } from '../../../odSurvey/types';
+import { isModeOfferedForBirdDistance } from '../../../odSurvey/speedAndDistanceRangesByMode';
 import type { Segment } from '../../types';
 import { getModeIcon } from './modeIconMapping';
 import { WidgetFactoryOptions } from '../types';
@@ -33,6 +34,12 @@ const getModeChoices = (filteredModes: Mode[], modePreToModeMap: { [modePre: str
                 if (!modePreToModeMap[segment.modePre].includes(mode)) {
                     return false;
                 }
+            }
+            // Questionnaire filter: hide modes below their min bird distance.
+            // Distance maxima and all speed ranges are audits only.
+            const birdDistanceMeters = segmentHelpers.getTripBirdDistanceMetersFromPath(interview, path);
+            if (!isModeOfferedForBirdDistance(mode, birdDistanceMeters)) {
+                return false;
             }
             // See if there's any additional conditional for the mode
             const conditional = perModeConditionals[mode];

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/widgetSegmentModePre.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/widgetSegmentModePre.ts
@@ -15,6 +15,8 @@ import * as segmentHelpers from './helpers';
 import type { ModeCategoryConfiguration, Person } from '../../types';
 import { getModeIcon, getModePreIcon } from './modeIconMapping';
 import { WidgetFactoryOptions } from '../types';
+import { isModePreOfferedForBirdDistance } from '../../../odSurvey/speedAndDistanceRangesByMode';
+import { Mode } from '../../../odSurvey/types';
 
 const perModePreLabels: Partial<{ [modePre: string]: I18nData }> = {
     walk: (t: TFunction, interview) => {
@@ -75,16 +77,44 @@ const getModePreChoiceFromConfig = (modeCategory: string, categoryConfiguration:
     iconPath: getModeIcon(categoryConfiguration.icon ?? (modeCategory as any))
 });
 
+// FIXME Once mode and modePre share a widget factory (see FIXME on
+// getModePreChoiceFromConfig), modePre visibility can follow whether any of
+// its modes are offered. The per-mode bird-distance conditionals can then be
+// computed once and reused, instead of wrapping each modePre here (they are
+// currently recomputed on every render).
+const withBirdDistanceConditional = (
+    modePre: string,
+    previousConditional: WidgetConditional | undefined,
+    modePreToModeMap: { [modePre: string]: Mode[] }
+): WidgetConditional => {
+    const modesInCategory = modePreToModeMap[modePre] ?? [];
+    return (interview, path) => {
+        // Questionnaire filter: hide the category if no mode meets its min
+        // bird distance. Distance maxima and all speed ranges are audits only.
+        const birdDistanceMeters = segmentHelpers.getTripBirdDistanceMetersFromPath(interview, path);
+        if (!isModePreOfferedForBirdDistance(modesInCategory, birdDistanceMeters)) {
+            return false;
+        }
+        return previousConditional ? previousConditional(interview, path) : true;
+    };
+};
+
 /** TODO Get a segment config in parameter to set the sort order and choices */
 const getModePreChoices = (
     filteredModesPre: string[],
-    modeCategoryToModeMap: SegmentSectionConfiguration['modeCategoryToModeMap']
+    modeCategoryToModeMap: SegmentSectionConfiguration['modeCategoryToModeMap'],
+    modePreToModeMap: { [modePre: string]: Mode[] }
 ) => {
-    return filteredModesPre.map((modePre) =>
-        modeCategoryToModeMap?.[modePre] !== undefined
-            ? getModePreChoiceFromConfig(modePre, modeCategoryToModeMap[modePre])
-            : getDefaultModePreChoice(modePre)
-    );
+    return filteredModesPre.map((modePre) => {
+        const choice =
+            modeCategoryToModeMap?.[modePre] !== undefined
+                ? getModePreChoiceFromConfig(modePre, modeCategoryToModeMap[modePre])
+                : getDefaultModePreChoice(modePre);
+        return {
+            ...choice,
+            conditional: withBirdDistanceConditional(modePre, choice.conditional, modePreToModeMap)
+        };
+    });
 };
 
 export const getModePreWidgetConfig = (
@@ -98,7 +128,8 @@ export const getModePreWidgetConfig = (
         throw new Error('No available modes to create modePre widget configuration');
     }
     const filteredModesPre = segmentHelpers.getFilteredModesPre(sectionConfig, filteredModes);
-    const choices = getModePreChoices(filteredModesPre, sectionConfig.modeCategoryToModeMap);
+    const modePreToModeMap = segmentHelpers.getModePreToModeMap(sectionConfig);
+    const choices = getModePreChoices(filteredModesPre, sectionConfig.modeCategoryToModeMap, modePreToModeMap);
 
     return {
         type: 'question',


### PR DESCRIPTION
Hide mode and modePre choices whose minimum bird distance is not met (e.g. plane or ferry on short urban trips). other, dontKnow and preferNotToAnswer stay available. Speed bands are included for later audits.

Closes #1724