### PR TITLE
fix(survey): ignore interview updates that do not match the current id

### DIFF
--- a/packages/evolution-frontend/src/store/__tests__/configureStore.test.ts
+++ b/packages/evolution-frontend/src/store/__tests__/configureStore.test.ts
@@ -68,19 +68,27 @@ describe('configureStore', () => {
     });
 
     it('should reset state on logout', () => {
+        store.dispatch({
+            type: SurveyActionTypes.SET_INTERVIEW as const,
+            interview: testInterview,
+            interviewLoaded: true
+        });
         // Set interview, with an update interview action
+        const updatedInterview = { ...testInterview, is_completed: true };
         const action = {
             type: SurveyActionTypes.UPDATE_INTERVIEW as const,
-            interview: testInterview,
+            interview: updatedInterview,
             interviewLoaded:true,
             submitted: true,
-            errors: {field: { 'en': 'something' }}
+            errors: { field: { 'en': 'something' } }
         };
         const result =  {
-            interview: testInterview,
+            interview: updatedInterview,
             interviewLoaded:true,
             submitted: true,
-            errors: {field: { 'en': 'something' }}
+            errors: { field: { 'en': 'something' } },
+            navigation: undefined,
+            reviewDecisions: undefined
         };
         store.dispatch(action);
         const stateAfterUpdate = store.getState();

--- a/packages/evolution-frontend/src/store/survey/__tests__/reducer.test.ts
+++ b/packages/evolution-frontend/src/store/survey/__tests__/reducer.test.ts
@@ -83,26 +83,42 @@ describe('SET_INTERVIEW action', () => {
     });
 })
 
-test('Test updating an interview', () => {
-    const action = {
+describe('UPDATE_INTERVIEW action', () => {
+    const updateAction = {
         type: SurveyActionTypes.UPDATE_INTERVIEW as const,
         interview: testInterview,
         interviewLoaded: true,
         submitted: true,
-        errors: {field: { 'en': 'something' }}
+        errors: { field: { en: 'something' } }
     };
 
-    const result =  {
-        interview: testInterview,
-        interviewLoaded: true,
-        submitted: true,
-        errors: {field: { 'en': 'something' }}
-    };
+    test('updates the interview when ids match', () => {
+        const currentInterview = { ...testInterview, is_completed: true };
+        expect(
+            surveyReducer(
+                {
+                    interview: currentInterview,
+                    interviewLoaded: false
+                },
+                updateAction
+            )
+        ).toEqual({
+            interview: updateAction.interview,
+            interviewLoaded: true,
+            submitted: true,
+            errors: { field: { en: 'something' } }
+        });
+    });
 
-    expect(surveyReducer({
-        interview: testInterview,
-        interviewLoaded: false
-    }, action)).toEqual(result);
+    test.each([
+        ['no interview is set', {}],
+        ['interview id differs', { interview: { ...testInterview, id: 2 }, interviewLoaded: true }]
+    ])('ignores the update when %s', (_title, initialState) => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+        expect(surveyReducer(initialState, updateAction)).toEqual(initialState);
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        warnSpy.mockRestore();
+    });
 });
 
 describe('Navigate action', () => {

--- a/packages/evolution-frontend/src/store/survey/reducer.ts
+++ b/packages/evolution-frontend/src/store/survey/reducer.ts
@@ -22,7 +22,17 @@ const reducer: Reducer<SurveyState, SurveyAction> = (state = initialState, actio
             submitted: undefined,
             reviewDecisions: undefined
         };
-    case SurveyActionTypes.UPDATE_INTERVIEW:
+    case SurveyActionTypes.UPDATE_INTERVIEW: {
+        const currentInterviewId = state.interview?.id;
+        const updatedInterviewId = action.interview.id;
+        // Ignore stale updates from a previous interview (e.g. after switching
+        // or resetting the interview before an in-flight update returns).
+        if (currentInterviewId === undefined || currentInterviewId !== updatedInterviewId) {
+            console.warn(
+                `Ignoring interview update: current interview id is ${currentInterviewId}, updated interview id is ${updatedInterviewId}`
+            );
+            return state;
+        }
         return {
             ...state,
             interview: action.interview,
@@ -30,6 +40,7 @@ const reducer: Reducer<SurveyState, SurveyAction> = (state = initialState, actio
             errors: action.errors,
             submitted: action.submitted
         };
+    }
     case SurveyActionTypes.ADD_CONSENT:
         return {
             ...state,


### PR DESCRIPTION
Prevents a stale in-flight UPDATE_INTERVIEW from overwriting the interview after it was reset or replaced.

Closes #1781