### PR TITLE
feat(survey): persist a random order for consecutive question groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Config: `randomOrderQuestions` draws a per-interview order for consecutive widget groups at interview creation and applies it in sections and grouped objects (fixes [#1746](https://github.com/chairemobilite/evolution/issues/1746)).
 - Segments: show a specify text field when the respondent selects mode `other` (fixes [#1835](https://github.com/chairemobilite/evolution/issues/1835)).
 - Config: Support several access code formats. Set the `accessCodeFormat` config option to one of the predefined formats (e.g. `'0000-0000'` (default), `'000-000-000'`, `'ABCD-ABCD'`, `'ABC-000-000'`) to choose your survey's format (fixes [#1668](https://github.com/chairemobilite/evolution/issues/1668)).
 - Validation list: filter by several access codes at once, typed or imported from a CSV file (fixes [#1660](https://github.com/chairemobilite/evolution/issues/1660)).

--- a/packages/evolution-backend/src/services/interviews/__tests__/generateRandomOrderQuestions.test.ts
+++ b/packages/evolution-backend/src/services/interviews/__tests__/generateRandomOrderQuestions.test.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { generateRandomOrderQuestions } from '../generateRandomOrderQuestions';
+
+describe('generateRandomOrderQuestions', () => {
+    test('skips empty groups and returns a permutation of the others', () => {
+        const result = generateRandomOrderQuestions({
+            attitudes: ['q1', 'q2', 'q3'],
+            empty: [],
+            values: ['v1', 'v2']
+        });
+        expect(Object.keys(result).sort()).toEqual(['attitudes', 'values']);
+        expect([...result.attitudes].sort()).toEqual(['q1', 'q2', 'q3']);
+        expect([...result.values].sort()).toEqual(['v1', 'v2']);
+    });
+});

--- a/packages/evolution-backend/src/services/interviews/__tests__/interviews.test.ts
+++ b/packages/evolution-backend/src/services/interviews/__tests__/interviews.test.ts
@@ -8,6 +8,8 @@ import { v4 as uuidV4 } from 'uuid';
 
 import Interviews from '../interviews';
 import { InterviewAttributes } from 'evolution-common/lib/services/questionnaire/types';
+import projectConfig from 'evolution-common/lib/config/project.config';
+import { RandomOrderQuestions } from 'evolution-common/lib/services/questionnaire/randomOrderQuestions';
 import interviewsQueries from '../../../models/interviews.db.queries';
 import interviewsAccessesQueries from '../../../models/interviewsAccesses.db.queries';
 import { registerAccessCodeValidationFunction } from '../../accessCode';
@@ -214,6 +216,45 @@ describe('Create interviews', () => {
         expect(newInterview).toEqual({ uuid: expect.anything() });
         expect(mockDbGetByUuid).not.toHaveBeenCalled();
         expect(mockInterviewUpdate).not.toHaveBeenCalled();
+    });
+
+    describe('Create with randomOrderQuestions config', () => {
+
+        const configuredGroup = ['q1', 'q2', 'q3'];
+        let previousConfig: { [groupShortname: string]: string[] };
+
+        beforeEach(() => {
+            mockDbGetByUuid.mockImplementationOnce(async () => createdInterview);
+            previousConfig = projectConfig.randomOrderQuestions;
+            projectConfig.randomOrderQuestions = { attitudes: configuredGroup };
+        });
+
+        afterEach(() => {
+            projectConfig.randomOrderQuestions = previousConfig;
+        });
+
+        // The order drawn in the response of the created interview
+        const createdOrder = (): string[] =>
+            (mockDbCreate.mock.calls[0][0].response as { _randomOrderQuestions: RandomOrderQuestions })
+                ._randomOrderQuestions.attitudes;
+
+        test.each([
+            ['no order in the initial response', {}],
+            ['a blank order in the initial response', { _randomOrderQuestions: null }]
+        ])('Draws an order when there is %s', async (_title, initialResponse) => {
+            await Interviews.createInterviewForUser(participantId, initialResponse);
+            expect([...createdOrder()].sort()).toEqual(configuredGroup);
+            // The drawn order must not be overwritten by the initial response
+            expect(mockInterviewUpdate).not.toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+                valuesByPath: expect.objectContaining({ 'response._randomOrderQuestions': expect.anything() })
+            }));
+        });
+
+        test('Keeps the order set by the project', async () => {
+            const projectOrder = ['q3', 'q1', 'q2'];
+            await Interviews.createInterviewForUser(participantId, { _randomOrderQuestions: { attitudes: projectOrder } });
+            expect(createdOrder()).toEqual(projectOrder);
+        });
     });
 
     test('Create with default response', async() => {

--- a/packages/evolution-backend/src/services/interviews/generateRandomOrderQuestions.ts
+++ b/packages/evolution-backend/src/services/interviews/generateRandomOrderQuestions.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { shuffle } from 'chaire-lib-common/lib/utils/RandomUtils';
+import type { RandomOrderQuestions } from 'evolution-common/lib/services/questionnaire/randomOrderQuestions';
+
+/**
+ * Draw a stable-for-the-interview order for each configured random-order group.
+ * Called at interview creation. Empty groups are omitted.
+ *
+ * @param groups project `randomOrderQuestions` config
+ * @returns one permutation per non-empty group
+ */
+export const generateRandomOrderQuestions = (groups: RandomOrderQuestions): RandomOrderQuestions => {
+    const orders: RandomOrderQuestions = {};
+    for (const [groupShortname, widgetShortnames] of Object.entries(groups)) {
+        if (widgetShortnames.length > 0) {
+            orders[groupShortname] = shuffle(widgetShortnames);
+        }
+    }
+    return orders;
+};

--- a/packages/evolution-backend/src/services/interviews/interviews.ts
+++ b/packages/evolution-backend/src/services/interviews/interviews.ts
@@ -26,6 +26,9 @@ import {
     UserInterviewAttributes
 } from 'evolution-common/lib/services/questionnaire/types';
 import { getParadataLoggingFunction } from '../logging/paradataLogging';
+import projectConfig from 'evolution-common/lib/config/project.config';
+import { randomOrderQuestionsResponsePath } from 'evolution-common/lib/services/questionnaire/randomOrderQuestions';
+import { generateRandomOrderQuestions } from './generateRandomOrderQuestions';
 
 export type FilterType = string | string[] | ValueFilterType;
 
@@ -109,6 +112,16 @@ export default class Interviews {
         if (response._startedAt === undefined) {
             response._startedAt = moment().unix();
         }
+        // Draw the random order of the configured question groups once at
+        // creation, so the frontend applies the same order throughout the
+        // interview (sections and grouped objects). A project may have set its
+        // own order in the initial response, then it is kept as is.
+        if (_isBlank(response[randomOrderQuestionsResponsePath])) {
+            const randomOrderQuestions = generateRandomOrderQuestions(projectConfig.randomOrderQuestions ?? {});
+            if (Object.keys(randomOrderQuestions).length > 0) {
+                response[randomOrderQuestionsResponsePath] = randomOrderQuestions;
+            }
+        }
         const interview = await interviewsDbQueries.create(
             { participant_id: participantId, response, is_active: true, validations: {} },
             returning
@@ -122,9 +135,13 @@ export default class Interviews {
             throw 'Interview just created was not found!';
         }
         const valuesByPath = {};
-        Object.keys(initialResponse).forEach((key) => {
-            valuesByPath[`response.${key}`] = initialResponse[key];
-        });
+        // The random order was already saved with the created interview, don't
+        // overwrite it with a blank initial value
+        Object.keys(initialResponse)
+            .filter((key) => key !== randomOrderQuestionsResponsePath)
+            .forEach((key) => {
+                valuesByPath[`response.${key}`] = initialResponse[key];
+            });
         await updateInterview(userInterview, {
             logUpdate: getParadataLoggingFunction({ interviewId: userInterview.id, userId: creatingUserId }),
             valuesByPath,

--- a/packages/evolution-common/src/config/__tests__/project.config.test.ts
+++ b/packages/evolution-common/src/config/__tests__/project.config.test.ts
@@ -42,7 +42,8 @@ test('Expected default', () => {
         introLogoAfterStartButton: false,
         logoPaths: {},
         languageNames: { en: 'English', fr: 'Français' },
-        title: { en: 'Survey', fr: 'Enquête' }
+        title: { en: 'Survey', fr: 'Enquête' },
+        randomOrderQuestions: {}
     }));
 });
 
@@ -75,7 +76,11 @@ test('set project configuration', () => {
         introLogoAfterStartButton: true,
         logoPaths: { en: 'logo-en.png', fr: 'logo-fr.png' },
         languageNames: { en: 'English', fr: 'Français' },
-        title: { en: 'Survey title', fr: 'Titre de l\'enquête' }
+        title: { en: 'Survey title', fr: 'Titre de l\'enquête' },
+        randomOrderQuestions: {
+            attitudes: ['q1', 'q2'],
+            values: ['v1', 'v2']
+        }
     };
     setProjectConfiguration<EvolutionProjectConfiguration>(configToSet);
     const { ages: agesToSet, ...configWithoutAges } = configToSet;

--- a/packages/evolution-common/src/config/project.config.ts
+++ b/packages/evolution-common/src/config/project.config.ts
@@ -244,6 +244,32 @@ export type EvolutionProjectConfiguration = {
      */
     surveyAreaGeojsonPath?: string;
 
+    /**
+     * Groups of consecutive widgets to show in a random order that is fixed
+     * for the interview.
+     *
+     * The key is a random-order group name. It is not an Evolution `group`
+     * widget (such as `householdMembers` or `visitedPlaces`); those are a
+     * different concept. The value is the widget shortnames of that
+     * random-order group.
+     *
+     * The order is drawn once at interview creation. Those widgets must form a
+     * consecutive block in the section's widget list, or in a grouped-object
+     * widget list (no other widget in between). Their relative order in the
+     * config may differ from this array. If a list does not contain all
+     * widgets of a group as a consecutive block, the drawn order is ignored for
+     * that list.
+     *
+     * The same widget shortname may appear in more than one group, for example
+     * when that widget is reused in different sections. Groups are applied in
+     * the order of this configuration: if 2 groups share a widget in the same
+     * list, the first one is applied and the following ones are ignored, since
+     * they are not a consecutive block anymore.
+     *
+     * May later move to QuestionnaireConfiguration.
+     */
+    randomOrderQuestions: { [groupShortname: string]: string[] };
+
     // TODO Add more project configuration types
 };
 
@@ -342,7 +368,8 @@ const defaultConfig = {
     },
     reviewableSurveyObjects: ['interview', 'home', 'household', 'person'],
     auditChecksGroup: 'custom', // custom by default so older surveys works.
-    surveyBase: 'householdBased'
+    surveyBase: 'householdBased',
+    randomOrderQuestions: {}
 };
 
 // Validate and set the configuration

--- a/packages/evolution-common/src/services/questionnaire/__tests__/randomOrderQuestions.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/__tests__/randomOrderQuestions.test.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { UserInterviewAttributes } from '../types';
+import {
+    getRandomOrderedWidgets,
+    randomOrderQuestionsResponsePath,
+    RandomOrderQuestions
+} from '../randomOrderQuestions';
+
+/** Interview with only the fields used to order the widgets */
+const interviewWithOrders = (storedOrders: RandomOrderQuestions | undefined | null): UserInterviewAttributes => ({
+    id: 1,
+    uuid: 'arbitrary uuid',
+    participant_id: 1,
+    is_completed: false,
+    is_valid: true,
+    validations: {},
+    response: storedOrders === undefined ? {} : { [randomOrderQuestionsResponsePath]: storedOrders }
+});
+
+describe('getRandomOrderedWidgets', () => {
+    const storedOrders = { attitudes: ['q3', 'q1', 'q2'] };
+
+    test.each([
+        ['group in config order', ['a', 'q1', 'q2', 'q3', 'b'], ['a', 'q3', 'q1', 'q2', 'b']],
+        ['group in another order', ['a', 'q2', 'q3', 'q1', 'b'], ['a', 'q3', 'q1', 'q2', 'b']],
+        ['group is the whole list', ['q1', 'q3', 'q2'], ['q3', 'q1', 'q2']]
+    ])('applies the stored order when the %s', (_title, widgets, expected) => {
+        expect(getRandomOrderedWidgets(interviewWithOrders(storedOrders), widgets)).toEqual(expected);
+    });
+
+    test.each([
+        ['a widget of the group is missing', ['a', 'q1', 'q2', 'b'], storedOrders],
+        ['a widget is inserted in the group', ['q1', 'x', 'q2', 'q3'], storedOrders],
+        ['no widget of the group is there', ['a', 'b'], storedOrders],
+        ['no order was stored for this group', ['q1', 'q2', 'q3'], { otherGroup: ['v1', 'v2'] }],
+        ['no order was stored at all', ['q1', 'q2', 'q3'], undefined],
+        ['the stored orders are null', ['q1', 'q2', 'q3'], null]
+    ])('leaves the widgets unchanged when %s', (_title, widgets, orders) => {
+        expect(getRandomOrderedWidgets(interviewWithOrders(orders), widgets)).toEqual(widgets);
+    });
+
+    test('applies every group of the list', () => {
+        expect(
+            getRandomOrderedWidgets(interviewWithOrders({ attitudes: ['q2', 'q1'], values: ['v2', 'v1'] }), [
+                'q1',
+                'q2',
+                'mid',
+                'v1',
+                'v2'
+            ])
+        ).toEqual(['q2', 'q1', 'mid', 'v2', 'v1']);
+    });
+
+    test('applies the same stored orders to each list where the group is successive', () => {
+        const interview = interviewWithOrders({ attitudes: ['q2', 'q1'] });
+        expect(getRandomOrderedWidgets(interview, ['q1', 'q2', 'size'])).toEqual(['q2', 'q1', 'size']);
+        expect(getRandomOrderedWidgets(interview, ['age', 'q1', 'q2'])).toEqual(['age', 'q2', 'q1']);
+    });
+
+    test('applies the first group only when 2 groups share a widget in the same list', () => {
+        // Once `q1, q2` is reordered, `q2, q3` is not successive anymore
+        expect(
+            getRandomOrderedWidgets(interviewWithOrders({ first: ['q2', 'q1'], second: ['q3', 'q2'] }), [
+                'q1',
+                'q2',
+                'q3'
+            ])
+        ).toEqual(['q2', 'q1', 'q3']);
+    });
+});

--- a/packages/evolution-common/src/services/questionnaire/randomOrderQuestions.ts
+++ b/packages/evolution-common/src/services/questionnaire/randomOrderQuestions.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { isSameMultiset } from '../../utils/ArrayUtils';
+import { getResponse } from '../../utils/helpers';
+import { UserInterviewAttributes } from './types';
+
+/** Path under `interview.response` for the per-interview question order. */
+export const randomOrderQuestionsResponsePath = '_randomOrderQuestions';
+
+/**
+ * Per-interview widget order for each random-order group.
+ *
+ * Keys are random-order group names. They are not Evolution `group` widgets
+ * (such as `householdMembers` or `visitedPlaces`); those are a different
+ * concept.
+ */
+export type RandomOrderQuestions = { [randomOrderGroupShortname: string]: string[] };
+
+/**
+ * Replace the consecutive block of `widgetShortnames` that contains exactly the
+ * widgets of `orderedWidgets` with that order. If those widgets are not a
+ * consecutive block (missing widget or something inserted between), return
+ * `widgetShortnames` unchanged.
+ */
+const applyStoredOrder = (widgetShortnames: readonly string[], orderedWidgets: readonly string[]): string[] => {
+    const groupSize = orderedWidgets.length;
+    if (groupSize === 0) {
+        return [...widgetShortnames];
+    }
+    for (let startIndex = 0; startIndex <= widgetShortnames.length - groupSize; startIndex++) {
+        const block = widgetShortnames.slice(startIndex, startIndex + groupSize);
+        if (isSameMultiset(block, orderedWidgets)) {
+            return [
+                ...widgetShortnames.slice(0, startIndex),
+                ...orderedWidgets,
+                ...widgetShortnames.slice(startIndex + groupSize)
+            ];
+        }
+    }
+    return [...widgetShortnames];
+};
+
+/**
+ * Order the widgets of a section or grouped object according to the random
+ * orders drawn for this interview at its creation. Orders whose widgets are not
+ * all in this list as a consecutive block are ignored, so the same order can be
+ * stored once for widget lists that appear in many sections or in each object
+ * of a group (`householdMembers`, ...).
+ *
+ * Orders are applied in the order they were drawn, which follows the project
+ * `randomOrderQuestions` configuration: if two groups share a widget in the
+ * same list, the first one is applied and the following ones no longer form a
+ * consecutive block, so they are ignored.
+ *
+ * @param interview the interview, holding the orders drawn at its creation
+ * @param widgetShortnames widgets of the section or grouped object, in config order
+ * @returns the widgets to display, in the order for this interview
+ */
+export const getRandomOrderedWidgets = (
+    interview: UserInterviewAttributes,
+    widgetShortnames: readonly string[]
+): string[] => {
+    const storedOrders = getResponse(interview, randomOrderQuestionsResponsePath, {}) as RandomOrderQuestions;
+    let widgets = [...widgetShortnames];
+    for (const orderedWidgets of Object.values(storedOrders)) {
+        widgets = applyStoredOrder(widgets, orderedWidgets);
+    }
+    return widgets;
+};

--- a/packages/evolution-common/src/utils/ArrayUtils.ts
+++ b/packages/evolution-common/src/utils/ArrayUtils.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+/**
+ * Whether two arrays contain the same values with the same counts, regardless
+ * of order.
+ *
+ * @param left first array
+ * @param right second array
+ */
+export const isSameMultiset = (left: readonly (string | number)[], right: readonly (string | number)[]): boolean => {
+    if (left.length !== right.length) {
+        return false;
+    }
+    const remaining = new Map<string | number, number>();
+    for (const value of left) {
+        remaining.set(value, (remaining.get(value) ?? 0) + 1);
+    }
+    for (const value of right) {
+        const count = remaining.get(value);
+        if (count === undefined || count < 1) {
+            return false;
+        }
+        remaining.set(value, count - 1);
+    }
+    return true;
+};

--- a/packages/evolution-common/src/utils/__tests__/ArrayUtils.test.ts
+++ b/packages/evolution-common/src/utils/__tests__/ArrayUtils.test.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { isSameMultiset } from '../ArrayUtils';
+
+describe('isSameMultiset', () => {
+    test.each([
+        ['same order', ['a', 'b', 'a'], ['a', 'b', 'a'], true],
+        ['different order', ['a', 'b', 'a'], ['a', 'a', 'b'], true],
+        ['empty arrays', [], [], true],
+        ['different length', ['a', 'b'], ['a'], false],
+        ['different counts', ['a', 'a', 'b'], ['a', 'b', 'b'], false],
+        ['missing element', ['a', 'b'], ['a', 'c'], false],
+        ['numbers in a different order', [1, 2, 1], [1, 1, 2], true],
+        ['numbers with a missing element', [1, 2], [1, 3], false],
+        ['a number and its string', [1], ['1'], false]
+    ])('%s', (_title, left, right, expected) => {
+        expect(isSameMultiset(left, right)).toBe(expected);
+    });
+});

--- a/packages/evolution-frontend/src/components/pageParts/Section.tsx
+++ b/packages/evolution-frontend/src/components/pageParts/Section.tsx
@@ -5,7 +5,6 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import React from 'react';
-import _shuffle from 'lodash/shuffle';
 
 import config from 'chaire-lib-common/lib/config/shared/project.config';
 import { devLog } from 'evolution-common/lib/utils/helpers';
@@ -14,6 +13,7 @@ import { Widget } from '../survey/Widget';
 import LoadingPage from 'chaire-lib-frontend/lib/components/pages/LoadingPage';
 import { SectionProps, useSectionTemplate } from '../hooks/useSectionTemplate';
 import SectionProgressBar from './SectionProgressBar';
+import { getRandomOrderedWidgets } from 'evolution-common/lib/services/questionnaire/randomOrderQuestions';
 
 export const Section: React.FC<SectionProps & WithSurveyContextProps> = (
     props: SectionProps & WithSurveyContextProps
@@ -25,69 +25,27 @@ export const Section: React.FC<SectionProps & WithSurveyContextProps> = (
         window.scrollTo(0, 0);
     }, [props.shortname]);
 
-    // TODO: This should not be done here. Wrong responsability. Move elsewhere.
-    const getSortedWidgetShortnames = () => {
-        let hasRandomOrderWidgets = false;
-        let randomGroup = undefined;
-        const randomGroupsIndexes: { [key: string]: number[] } = {};
-        const randomGroupsStartIndexes: { [key: string]: number } = {};
-        const sortedShortnames: string[] = [];
-        const countWidgets = props.sectionConfig.widgets.length;
-        const unsortedWidgetShortnames: string[] = [];
-
-        // shuffle random groups indexes:
-        for (let i = 0; i < countWidgets; i++) {
-            const widgetShortname = props.sectionConfig.widgets[i];
-            const widgetConfig = props.surveyContext.widgets[widgetShortname];
-            unsortedWidgetShortnames.push(widgetShortname);
-            if (widgetConfig === undefined) {
-                continue;
-            }
-            if (widgetConfig.randomOrder === true) {
-                hasRandomOrderWidgets = true;
-                randomGroup = widgetConfig.randomGroup;
-                if (randomGroup && !randomGroupsIndexes[randomGroup]) {
-                    randomGroupsIndexes[randomGroup] = [];
-                    randomGroupsStartIndexes[randomGroup] = i;
-                } else if (randomGroup) {
-                    randomGroupsIndexes[randomGroup].push(i);
-                }
-            }
-        }
-        if (hasRandomOrderWidgets) {
-            for (const randomGroup in randomGroupsIndexes) {
-                const randomGroupIndexes = _shuffle(randomGroupsIndexes[randomGroup]);
-                for (let j = 0, count = randomGroupIndexes.length; j < count; j++) {
-                    sortedShortnames[randomGroupsStartIndexes[randomGroup] + j] =
-                        unsortedWidgetShortnames[randomGroupIndexes[j]];
-                }
-            }
-        }
-        for (let i = 0; i < countWidgets; i++) {
-            if (sortedShortnames[i] === undefined) {
-                sortedShortnames[i] = unsortedWidgetShortnames[i];
-            }
-        }
-        return sortedShortnames;
-    };
-
-    const sortedWidgetShortnames = React.useMemo(() => getSortedWidgetShortnames(), [props.sectionConfig.widgets]);
+    // The random order is drawn once at interview creation, so it only changes
+    // with the interview itself
+    const sortedWidgetShortnames = React.useMemo(
+        () => getRandomOrderedWidgets(props.interview, props.sectionConfig.widgets),
+        [props.sectionConfig.widgets, props.interview.id]
+    );
 
     if (!preloaded) {
         return <LoadingPage />;
     }
 
-    const widgetsComponentByShortname: { [key: string]: React.ReactNode } = {};
+    const sortedWidgetsComponents: React.ReactNode[] = [];
 
     devLog('%c rendering section ' + props.shortname, 'background: rgba(0,0,255,0.1);');
-    for (let i = 0, count = props.sectionConfig.widgets.length; i < count; i++) {
-        const widgetShortname = props.sectionConfig.widgets[i];
-
-        widgetsComponentByShortname[widgetShortname] = (
+    for (let i = 0, count = sortedWidgetShortnames.length; i < count; i++) {
+        const widgetShortname = sortedWidgetShortnames[i];
+        sortedWidgetsComponents.push(
             <Widget
                 key={widgetShortname}
                 currentWidgetShortname={widgetShortname}
-                nextWidgetShortname={props.sectionConfig.widgets[i + 1]}
+                nextWidgetShortname={sortedWidgetShortnames[i + 1]}
                 sectionName={props.shortname}
                 interview={props.interview}
                 errors={props.errors}
@@ -99,11 +57,6 @@ export const Section: React.FC<SectionProps & WithSurveyContextProps> = (
                 startNavigate={props.startNavigate}
             />
         );
-    }
-
-    const sortedWidgetsComponents: React.ReactNode[] = [];
-    for (let i = 0, count = sortedWidgetShortnames.length; i < count; i++) {
-        sortedWidgetsComponents.push(widgetsComponentByShortname[sortedWidgetShortnames[i]]);
     }
 
     return (

--- a/packages/evolution-frontend/src/components/survey/GroupWidgets.tsx
+++ b/packages/evolution-frontend/src/components/survey/GroupWidgets.tsx
@@ -15,6 +15,7 @@ import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
 import { devLog, parseBoolean, translateString } from 'evolution-common/lib/utils/helpers';
+import { getRandomOrderedWidgets } from 'evolution-common/lib/services/questionnaire/randomOrderQuestions';
 import { checkConditional } from '../../actions/utils/Conditional';
 import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
 import { UserRuntimeInterviewAttributes } from 'evolution-common/lib/services/questionnaire/types';
@@ -53,11 +54,17 @@ export const GroupedObject: React.FC<GroupedObjectProps> = (props) => {
     const groupedObjectId = props.objectId;
     const parentObjectIds = props.parentObjectIds;
     parentObjectIds[groupedObjectShortname] = groupedObjectId;
-    const widgetsComponents = props.widgetConfig.widgets.map((widgetShortname, idx) => (
+    // The random order is drawn once at interview creation, so it only changes
+    // with the interview itself. It is the same for every object of the group.
+    const widgetShortnames = React.useMemo(
+        () => getRandomOrderedWidgets(props.interview, props.widgetConfig.widgets),
+        [props.widgetConfig.widgets, props.interview.id]
+    );
+    const widgetsComponents = widgetShortnames.map((widgetShortname, idx) => (
         <InGroupWidget
             key={widgetShortname}
             currentWidgetShortname={widgetShortname}
-            nextWidgetShortname={props.widgetConfig.widgets[idx + 1]}
+            nextWidgetShortname={widgetShortnames[idx + 1]}
             sectionName={props.section}
             interview={props.interview}
             errors={props.errors}

--- a/packages/evolution-frontend/src/components/survey/__tests__/GroupWidgets.test.tsx
+++ b/packages/evolution-frontend/src/components/survey/__tests__/GroupWidgets.test.tsx
@@ -416,4 +416,32 @@ describe('Grouped Object', () => {
         });
     });
 
+    test('applies the random order stored in the interview to the widgets of the object', () => {
+        const interviewWithOrder = _cloneDeep(interview);
+        // Reverse the widgets of the group config, which is [widgetText, widgetQuestion]
+        interviewWithOrder.response._randomOrderQuestions = { memberQs: ['widgetQuestion', 'widgetText'] };
+        const { container } = render(
+            <TestContextProvider>
+                <GroupedObject
+                    path={`${path}.${groupedObjectIds[0]}`}
+                    widgetConfig={commonWidgetConfig}
+                    interview={interviewWithOrder}
+                    user={userAttributes}
+                    shortname={'myGroup'}
+                    section={''}
+                    startUpdateInterview={startUpdateInterviewMock}
+                    startAddGroupedObjects={startAddGroupedObjectsMock}
+                    startRemoveGroupedObjects={startRemoveGroupedObjectsMock}
+                    startNavigate={startNavigateMock}
+                    loadingState={0}
+                    parentObjectIds={{}}
+                    objectId={groupedObjectIds[0]}
+                    sequence={0}
+                />
+            </TestContextProvider>
+        );
+        const html = container.innerHTML;
+        expect(html.indexOf('Test Question Label')).toBeLessThan(html.indexOf('This is a text widget'));
+    });
+
 });


### PR DESCRIPTION
Draw the order at interview creation and apply it when the widgets form a consecutive block in the section.

Closes #1746

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable random ordering for questionnaire sections and grouped objects.
  * Interview question order is randomized when configured and preserved throughout the interview.
  * Supports multiple independent question groups with consecutive-block ordering.

* **Bug Fixes**
  * Improved handling of missing, incomplete, or invalid question orders to preserve the intended questionnaire structure.
  * Prevented empty groups from affecting displayed question order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->