### PR TITLE
InputMapFindPlace: show place photos with required attributions

### DIFF
--- a/locales/en/main.json
+++ b/locales/en/main.json
@@ -28,6 +28,7 @@
     "SelectPlaceText": "Please select the correct result on the map or in the menu below and confirm or click elsewhere on the map at the right place if the search did not return the correct location.",
     "SelectPlaceTextSingleResult": "Please confirm if the place is correctly located, or click elsewhere on the map at the right place to correct the location.",
     "SelectPlaceResultsLabel": "Search results",
+    "PhotoAttributionPrefix": "Photo:",
     "validatorLvl1": "Basic validator",
     "validatorLvl2": "Super validator",
     "ClickToSelectDate": "Click to select a date",

--- a/locales/fr/main.json
+++ b/locales/fr/main.json
@@ -28,6 +28,7 @@
     "SelectPlaceText": "Veuillez sélectionner le lieu parmi les résultats sur la carte ou dans le menu suivant et confirmez ou cliquez ailleurs sur la carte au bon endroit si les résultats ne comprennent pas le lieu exact.",
     "SelectPlaceTextSingleResult": "Veuillez confirmer si le lieu est bien placé ou cliquez ailleurs sur la carte au bon endroit pour corriger la localisation.",
     "SelectPlaceResultsLabel": "Résultats de la recherche",
+    "PhotoAttributionPrefix": "Photo :",
     "validatorLvl1": "Valideur de base",
     "validatorLvl2": "Super-valideur",
     "ClickToSelectDate": "Cliquer pour sélectionner une date",

--- a/packages/evolution-common/src/services/questionnaire/types/WidgetConfig.ts
+++ b/packages/evolution-common/src/services/questionnaire/types/WidgetConfig.ts
@@ -339,7 +339,12 @@ export type InputMapPointType = InputMapType &
  * @param height: The height of the map container in css units: example: 28rem or 550px
  * @param coordinatesPrecision: Number of decimals to keep for latitute longitude coordinates.
  * @param invalidGeocodingResultTypes: Types of geocoding results from google to set as invalid (like 'city' or 'country', which are not precise enough for the address)
- * @param showPhoto: Whether to show a photo of the selected place, when available.
+ * @param showPhoto: Per-widget only. Set to `true` to show a Google Place
+ * photo of the selected place. Unset or `false`: no photo and no Place
+ * Photos request. Default `false`. Photos are billed as the Place Photos
+ * SKU on top of search. See
+ * https://developers.google.com/maps/billing-and-pricing/sku-details
+ * TODO: Expose this as a Widgets Excel column in evolution-generator.
  * @param autoConfirmIfSingleResult: Whether to automatically confirm the selected place if there is only one result
  */
 export type InputMapFindPlaceType = InputMapType &

--- a/packages/evolution-frontend/src/components/inputs/InputMapFindPlace.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputMapFindPlace.tsx
@@ -12,11 +12,13 @@ import { faCheckCircle } from '@fortawesome/free-solid-svg-icons/faCheckCircle';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
-import projectConfig from 'chaire-lib-common/lib/config/shared/project.config';
+import projectConfig from 'evolution-common/lib/config/project.config';
 import { InputMapFindPlaceType } from 'evolution-common/lib/services/questionnaire/types';
 import * as surveyHelper from 'evolution-common/lib/utils/helpers';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { FeatureGeocodedProperties, MarkerData, defaultIconSize, PlaceGeocodedProperties } from './maps/types';
+import { fetchPlacePhotos, getPlacePhotoAttribution, getPlacePhotoUrl, PlacePhotoLike } from './maps/placePhoto';
+import { createPlaceInfoWindowElement } from './maps/placeInfoWindow';
 import InputSelect from 'chaire-lib-frontend/lib/components/input/InputSelect';
 import { CommonInputProps } from './CommonInputProps';
 import Loader from 'react-spinners/HashLoader';
@@ -76,6 +78,8 @@ export class InputMapFindPlace extends React.Component<
     private autoConfirmIfSingleResult: boolean;
     private shouldFitBoundsIdx = 0;
     private currentBounds: [number, number, number, number] | undefined = undefined;
+    /** Ignores stale Place Details photo responses after a later selection. */
+    private photoFetchGeneration = 0;
 
     constructor(props: InputMapFindPlaceProps & WithTranslation) {
         super(props);
@@ -267,6 +271,9 @@ export class InputMapFindPlace extends React.Component<
                             // Therefore, by clearing the value here, we get rid of any existing warning labels shown on the widget.
                             this.props.onValueChange({ target: { value: null } });
                         }
+                        if (isSingleResult && !this.autoConfirmIfSingleResult && !isSingleResultAndImpreciseGeocoding) {
+                            void this.refreshSelectedPlacePhotos(features[0]);
+                        }
                     }
                 );
                 if ((!this.autoConfirmIfSingleResult || !isSingleResult) && !isSingleResultAndImpreciseGeocoding) {
@@ -285,13 +292,66 @@ export class InputMapFindPlace extends React.Component<
         const placeId = e && e.target ? e.target.value : null;
         if (placeId) {
             const selectedPlace = this.state.places.find((place) => place.properties.placeData.place_id === placeId);
-            this.setState({ selectedPlace });
+            this.setState({ selectedPlace }, () => {
+                if (selectedPlace) {
+                    void this.refreshSelectedPlacePhotos(selectedPlace);
+                }
+            });
         }
     };
 
     onMarkerSelect = (feature) => {
         this.onValueChange(feature);
-        this.setState({ selectedPlace: feature });
+        this.setState({ selectedPlace: feature }, () => {
+            void this.refreshSelectedPlacePhotos(feature);
+        });
+    };
+
+    /** Widget `showPhoto === true` only. Unset or false: no photo, no billed fetch. */
+    private shouldShowPlacePhoto = (): boolean => this.props.widgetConfig.showPhoto === true;
+
+    /**
+     * Load photos for a place already chosen from textSearch results. No-op
+     * unless this widget sets `showPhoto: true`. Does not change the candidate
+     * list or ranking. If Place Details is unavailable, photos returned by
+     * textSearch (if any) stay in place.
+     */
+    private refreshSelectedPlacePhotos = async (
+        feature: GeoJSON.Feature<GeoJSON.Point, PlaceGeocodedProperties>
+    ): Promise<void> => {
+        if (!this.shouldShowPlacePhoto()) {
+            return;
+        }
+        const generation = ++this.photoFetchGeneration;
+        const photos = await fetchPlacePhotos(feature.properties.placeData.place_id);
+        if (generation !== this.photoFetchGeneration || !photos || photos.length === 0) {
+            return;
+        }
+        this.setState((state) => {
+            const selectedPlace = state.selectedPlace;
+            if (
+                selectedPlace === undefined ||
+                selectedPlace.properties.placeData.place_id !== feature.properties.placeData.place_id
+            ) {
+                return null;
+            }
+            const updatedPlace = {
+                ...selectedPlace,
+                properties: {
+                    ...selectedPlace.properties,
+                    placeData: { ...selectedPlace.properties.placeData, photos }
+                }
+            };
+            // Same object in `places` so marker icon comparison (`===`) still matches.
+            return {
+                selectedPlace: updatedPlace,
+                places: state.places.map((place) =>
+                    place.properties.placeData.place_id === updatedPlace.properties.placeData.place_id
+                        ? updatedPlace
+                        : place
+                )
+            };
+        });
     };
 
     onConfirmPlace = (e: React.MouseEvent | undefined) => {
@@ -324,24 +384,26 @@ export class InputMapFindPlace extends React.Component<
         }
     };
 
+    private getPhotoInfoWindowFields = (photo: PlacePhotoLike | undefined) => {
+        const photoAttributions = getPlacePhotoAttribution(photo);
+        return {
+            photoUrl: getPlacePhotoUrl(photo),
+            photoAttributionPrefix:
+                photoAttributions.length > 0 ? this.props.t('main:PhotoAttributionPrefix') : undefined,
+            photoAttributions: photoAttributions.length > 0 ? photoAttributions : undefined
+        };
+    };
+
     private getInfoWindowContent = (
         place: GeoJSON.Feature<GeoJSON.Point, PlaceGeocodedProperties>,
         showPhoto = false
-    ) => {
-        return `
-            <div>
-              <div>
-                ${place.properties.placeData.name}
-              </div>
-              <div class="_pale">${place.properties.placeData.formatted_address}</div>
-              ${
-    showPhoto && place.properties.placeData.photos && (place.properties.placeData.photos as any[])[0]
-        ? `<div><img src="${(
-                            place.properties.placeData.photos as any[]
-        )[0].getUrl()}" height="100" /></div>`
-        : ''
-}
-            </div>`;
+    ): string => {
+        const photo = showPhoto ? place.properties.placeData.photos?.[0] : undefined;
+        return createPlaceInfoWindowElement({
+            name: place.properties.placeData.name,
+            address: place.properties.placeData.formatted_address,
+            ...this.getPhotoInfoWindowFields(photo)
+        }).outerHTML;
     };
 
     render() {
@@ -447,10 +509,16 @@ export class InputMapFindPlace extends React.Component<
             }
         }
 
+        const showPlacePhoto = this.shouldShowPlacePhoto();
+        const selectedPlaceData = this.state.selectedPlace?.properties.placeData;
+        const selectedPhoto = showPlacePhoto ? selectedPlaceData?.photos?.[0] : undefined;
         const infoWindow = this.state.selectedPlace
             ? {
                 position: this.state.selectedPlace,
-                content: this.getInfoWindowContent(this.state.selectedPlace, this.props.widgetConfig.showPhoto),
+                content: this.getInfoWindowContent(this.state.selectedPlace, showPlacePhoto),
+                placeName: selectedPlaceData?.name,
+                placeAddress: selectedPlaceData?.formatted_address,
+                ...this.getPhotoInfoWindowFields(selectedPhoto),
                 confirmLabel: this.props.widgetConfig.refreshGeocodingLabel
                     ? this.props.t('main:ConfirmLocation')
                     : undefined,

--- a/packages/evolution-frontend/src/components/inputs/__tests__/InputMapFindPlace.test.tsx
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/InputMapFindPlace.test.tsx
@@ -5,13 +5,14 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
 import { interviewAttributes } from './interviewData';
 import mockGoogleMapAdapter, { mockGeocodeMultiplePlaces } from './mockGoogleMapAdapter';
 import InputMapFindPlace from '../InputMapFindPlace';
+import { fetchPlacePhotos } from '../maps/placePhoto';
 
 // Mock react-markdown and remark-gfm as they use syntax not supported by jest
 jest.mock('react-markdown', () => 'Markdown');
@@ -24,8 +25,13 @@ jest.mock('../maps/google/GoogleMapAdapter', () => ({
         return mockGoogleMapAdapter;
     }
 }));
+jest.mock('../maps/placePhoto', () => ({
+    ...jest.requireActual('../maps/placePhoto'),
+    fetchPlacePhotos: jest.fn().mockResolvedValue(undefined)
+}));
 
 const mockedGeocode = mockGeocodeMultiplePlaces;
+const mockedFetchPlacePhotos = fetchPlacePhotos as jest.MockedFunction<typeof fetchPlacePhotos>;
 
 const userAttributes = {
     id: 1,
@@ -382,5 +388,72 @@ describe('Test geocoding requests', () => {
         // Select list and confirm button should not be present
         expect(container.querySelector('select')).not.toBeInTheDocument();
         expect(screen.queryByText('ConfirmLocation')).not.toBeInTheDocument();
+    });
+});
+
+describe('Place photos in info window', () => {
+    const photoUrl = 'https://example.com/place.jpg';
+    const placeWithPhoto = {
+        type: 'Feature' as const,
+        geometry: { type: 'Point' as const, coordinates: [-73.2, 45.1] },
+        properties: {
+            placeData: {
+                place_id: '1',
+                formatted_address: '123 test street',
+                name: 'Foo extra good restaurant',
+                photos: [{ getUrl: () => photoUrl }]
+            }
+        }
+    };
+
+    const widgetConfig = {
+        ...baseWidgetConfig,
+        showPhoto: undefined as boolean | undefined,
+        geocodingQueryString: jest.fn().mockReturnValue('foo restaurant'),
+        refreshGeocodingLabel: {
+            fr: 'Geocode',
+            en: 'Geocode'
+        }
+    };
+
+    beforeEach(() => {
+        mockedFetchPlacePhotos.mockClear();
+        mockedFetchPlacePhotos.mockResolvedValue(undefined);
+    });
+
+    test.each([
+        ['showPhoto true', true, true],
+        ['showPhoto false', false, false],
+        ['showPhoto unset defaults to false', undefined, false]
+    ])('%s', async (_title, widgetShowPhoto, expectPhoto) => {
+        widgetConfig.showPhoto = widgetShowPhoto;
+        mockedGeocode.mockResolvedValueOnce([placeWithPhoto]);
+
+        render(
+            <InputMapFindPlace
+                id={'test'}
+                onValueChange={() => {
+                    /* nothing to do */
+                }}
+                widgetConfig={widgetConfig}
+                value={undefined}
+                inputRef={React.createRef()}
+                interview={interviewAttributes}
+                user={userAttributes}
+                path="foo.test"
+                loadingState={0}
+            />
+        );
+        await userEvent.click(screen.getByText('Geocode'));
+        await screen.findByText('Foo extra good restaurant');
+
+        const infoWindow = screen.getByTestId('mock-info-window');
+        if (expectPhoto) {
+            expect(infoWindow.querySelector(`img[src="${photoUrl}"]`)).toBeInTheDocument();
+            await waitFor(() => expect(mockedFetchPlacePhotos).toHaveBeenCalledWith('1'));
+        } else {
+            expect(infoWindow.querySelector('img')).not.toBeInTheDocument();
+            expect(mockedFetchPlacePhotos).not.toHaveBeenCalled();
+        }
     });
 });

--- a/packages/evolution-frontend/src/components/inputs/maps/__tests__/__snapshots__/placeInfoWindow.test.ts.snap
+++ b/packages/evolution-frontend/src/components/inputs/maps/__tests__/__snapshots__/placeInfoWindow.test.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`createPlaceInfoWindowElement mixed linked and plain attributions 1`] = `"<div class="map-find-place-info-window"><div class="map-find-place-info-window-text"><div>Tim Hortons</div><div class="_pale">123 Main</div></div><div class="map-find-place-info-window-body"><div class="map-find-place-info-window-photo"><img src="https://example.com/p.jpg" height="180"><div class="map-find-place-info-window-photo-attribution">Photo: <a href="https://example.com/jane" target="_blank" rel="noopener noreferrer">Jane</a>, John</div></div></div></div>"`;
+
+exports[`createPlaceInfoWindowElement photo and attribution 1`] = `"<div class="map-find-place-info-window"><div class="map-find-place-info-window-text"><div>Tim Hortons</div><div class="_pale">123 Main</div></div><div class="map-find-place-info-window-body"><div class="map-find-place-info-window-photo"><img src="https://example.com/p.jpg" height="180"><div class="map-find-place-info-window-photo-attribution">Photo: <a href="https://example.com/jane" target="_blank" rel="noopener noreferrer">Jane</a></div></div></div></div>"`;
+
+exports[`createPlaceInfoWindowElement photo without attribution 1`] = `"<div class="map-find-place-info-window"><div class="map-find-place-info-window-text"><div>Tim Hortons</div><div class="_pale">123 Main</div></div><div class="map-find-place-info-window-body"><div class="map-find-place-info-window-photo"><img src="https://example.com/p.jpg" height="180"></div></div></div>"`;
+
+exports[`createPlaceInfoWindowElement plain-text attribution fallback 1`] = `"<div class="map-find-place-info-window"><div class="map-find-place-info-window-text"><div>Tim Hortons</div><div class="_pale">123 Main</div></div><div class="map-find-place-info-window-body"><div class="map-find-place-info-window-photo"><img src="https://example.com/p.jpg" height="180"><div class="map-find-place-info-window-photo-attribution">Photo: Jane</div></div></div></div>"`;
+
+exports[`createPlaceInfoWindowElement text only 1`] = `"<div class="map-find-place-info-window"><div class="map-find-place-info-window-text"><div>Tim Hortons</div><div class="_pale">123 Main</div></div><div class="map-find-place-info-window-body"></div></div>"`;

--- a/packages/evolution-frontend/src/components/inputs/maps/__tests__/placeInfoWindow.test.ts
+++ b/packages/evolution-frontend/src/components/inputs/maps/__tests__/placeInfoWindow.test.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { createPlaceInfoWindowElement, placeInfoWindowContentFromHtml } from '../placeInfoWindow';
+
+const sampleContent = {
+    name: 'Tim Hortons',
+    address: '123 Main',
+    photoUrl: 'https://example.com/p.jpg',
+    photoAttributionPrefix: 'Photo:',
+    photoAttributions: [{ text: 'Jane', uri: 'https://example.com/jane' }]
+};
+
+describe('createPlaceInfoWindowElement', () => {
+    test.each([
+        ['photo and attribution', sampleContent],
+        ['photo without attribution', { name: 'Tim Hortons', address: '123 Main', photoUrl: 'https://example.com/p.jpg' }],
+        ['text only', { name: 'Tim Hortons', address: '123 Main' }],
+        [
+            'plain-text attribution fallback',
+            {
+                name: 'Tim Hortons',
+                address: '123 Main',
+                photoUrl: 'https://example.com/p.jpg',
+                photoAttribution: 'Photo: Jane'
+            }
+        ],
+        [
+            'mixed linked and plain attributions',
+            {
+                ...sampleContent,
+                photoAttributions: [{ text: 'Jane', uri: 'https://example.com/jane' }, { text: 'John' }]
+            }
+        ]
+    ])('%s', (_title, content) => {
+        expect(createPlaceInfoWindowElement(content).outerHTML).toMatchSnapshot();
+    });
+
+    test('keeps the text box outside the body so the confirm button can follow the photo', () => {
+        const root = createPlaceInfoWindowElement(sampleContent);
+        const text = root.querySelector('.map-find-place-info-window-text');
+        const body = root.querySelector('.map-find-place-info-window-body');
+        expect(body?.contains(text)).toBe(false);
+    });
+
+    test('renders only validated https attribution links', () => {
+        const root = createPlaceInfoWindowElement({
+            ...sampleContent,
+            photoAttributions: [
+                { text: 'Jane', uri: 'https://example.com/jane' },
+                { text: 'Evil', uri: 'javascript:alert(1)' }
+            ]
+        });
+        const links = [...root.querySelectorAll('.map-find-place-info-window-photo-attribution a')];
+        expect(links).toHaveLength(1);
+        expect(links[0].getAttribute('href')).toBe('https://example.com/jane');
+        expect(links[0].textContent).toBe('Jane');
+        expect(root.querySelector('.map-find-place-info-window-photo-attribution')?.textContent).toContain('Evil');
+    });
+});
+
+describe('placeInfoWindowContentFromHtml', () => {
+    test('recovers fields from the created element', () => {
+        expect(placeInfoWindowContentFromHtml(createPlaceInfoWindowElement(sampleContent).outerHTML)).toEqual({
+            ...sampleContent,
+            photoAttribution: undefined
+        });
+    });
+
+    test('recovers fields from flattened stale html', () => {
+        expect(
+            placeInfoWindowContentFromHtml(`<div>
+              <div>Tim Hortons</div>
+              <div>123 Main</div>
+              <div><img src="https://example.com/p.jpg" /></div>
+            </div>`)
+        ).toEqual({
+            name: 'Tim Hortons',
+            address: '123 Main',
+            photoUrl: 'https://example.com/p.jpg',
+            photoAttributionPrefix: undefined,
+            photoAttributions: undefined,
+            photoAttribution: undefined
+        });
+    });
+});

--- a/packages/evolution-frontend/src/components/inputs/maps/__tests__/placePhoto.test.ts
+++ b/packages/evolution-frontend/src/components/inputs/maps/__tests__/placePhoto.test.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { fetchPlacePhotos, getPlacePhotoAttribution, getPlacePhotoUrl } from '../placePhoto';
+
+describe('getPlacePhotoUrl', () => {
+    test.each([
+        ['getURI', { getURI: () => 'https://example.com/uri.jpg' }, 'https://example.com/uri.jpg'],
+        ['getUrl fallback', { getUrl: () => 'https://example.com/url.jpg' }, 'https://example.com/url.jpg'],
+        ['prefers getURI', { getURI: () => 'https://example.com/uri.jpg', getUrl: () => 'https://example.com/url.jpg' }, 'https://example.com/uri.jpg'],
+        ['missing photo', undefined, undefined],
+        ['no url methods', {}, undefined]
+    ])('%s', (_title, photo, expected) => {
+        expect(getPlacePhotoUrl(photo)).toBe(expected);
+    });
+});
+
+describe('getPlacePhotoAttribution', () => {
+    test.each([
+        ['single authorAttribution', { authorAttributions: [{ displayName: 'Jane' }] }, [{ text: 'Jane' }]],
+        [
+            'authorAttribution uri',
+            { authorAttributions: [{ displayName: 'Jane', uri: 'https://maps.google.com/jane' }] },
+            [{ text: 'Jane', uri: 'https://maps.google.com/jane' }]
+        ],
+        [
+            'every authorAttribution',
+            { authorAttributions: [{ displayName: 'Jane' }, { displayName: 'John' }] },
+            [{ text: 'Jane' }, { text: 'John' }]
+        ],
+        [
+            'legacy html_attributions link',
+            { html_attributions: ['<a href="https://example.com">Jane</a>'] },
+            [{ text: 'Jane', uri: 'https://example.com' }]
+        ],
+        ['every html_attribution', { html_attributions: ['Jane', 'John'] }, [{ text: 'Jane' }, { text: 'John' }]],
+        [
+            'both sources',
+            { authorAttributions: [{ displayName: 'Jane' }], html_attributions: ['John'] },
+            [{ text: 'Jane' }, { text: 'John' }]
+        ],
+        [
+            'rejects non-https author uri',
+            { authorAttributions: [{ displayName: 'Jane', uri: 'http://example.com' }] },
+            [{ text: 'Jane' }]
+        ],
+        [
+            'rejects javascript html href',
+            { html_attributions: ['<a href="javascript:alert(1)">Jane</a>'] },
+            [{ text: 'Jane' }]
+        ],
+        ['skips empty names', { authorAttributions: [{ displayName: '' }, { displayName: 'Jane' }] }, [{ text: 'Jane' }]],
+        ['no attributions', {}, []],
+        ['undefined photo', undefined, []]
+    ])('%s', (_title, photo, expected) => {
+        expect(getPlacePhotoAttribution(photo)).toEqual(expected);
+    });
+});
+
+describe('fetchPlacePhotos', () => {
+    const originalGoogle = (globalThis as { google?: unknown }).google;
+
+    afterEach(() => {
+        (globalThis as { google?: unknown }).google = originalGoogle;
+    });
+
+    test.each([
+        ['undefined place id', undefined],
+        ['empty place id', '']
+    ])('returns undefined for %s', async (_title, placeId) => {
+        expect(await fetchPlacePhotos(placeId)).toBeUndefined();
+    });
+
+    test('returns photos from Place.fetchFields', async () => {
+        const photos = [{ getURI: () => 'https://example.com/uri.jpg' }];
+        const fetchFields = jest.fn().mockResolvedValue(undefined);
+        (globalThis as { google: unknown }).google = {
+            maps: {
+                places: {
+                    Place: class {
+                        photos = photos;
+                        fetchFields = fetchFields;
+                    }
+                }
+            }
+        };
+        await expect(fetchPlacePhotos('abc')).resolves.toBe(photos);
+        expect(fetchFields).toHaveBeenCalledWith({ fields: ['photos'] });
+    });
+
+    test('returns undefined when Place Details fails', async () => {
+        (globalThis as { google: unknown }).google = {
+            maps: {
+                places: {
+                    Place: class {
+                        fetchFields = jest.fn().mockRejectedValue(new Error('unavailable'));
+                    }
+                }
+            }
+        };
+        await expect(fetchPlacePhotos('abc')).resolves.toBeUndefined();
+    });
+});

--- a/packages/evolution-frontend/src/components/inputs/maps/google/GoogleGeocoder.tsx
+++ b/packages/evolution-frontend/src/components/inputs/maps/google/GoogleGeocoder.tsx
@@ -57,6 +57,43 @@ export const geocodeSinglePoint = (
     });
 };
 
+/**
+ * Geocode a query with Google Places Text Search (legacy).
+ *
+ * Uses `PlacesService.textSearch` so MapFindPlace candidates stay those of
+ * existing surveys. `Place.searchByText` (Places API New) is a different
+ * product: Google does not guarantee the same places or the same order.
+ * Do not switch search backends without a side-by-side comparison on the
+ * queries this widget actually sends.
+ *
+ * How the two search APIs differ:
+ * - Cloud product: Places API (legacy) vs Places API (New). This flow
+ *   requires the relevant Places API products to be enabled and included
+ *   in the key's restrictions. New keys often lack the legacy API.
+ * - Ranking / area: `textSearch` takes `location` + `radius` as a soft bias
+ *   (results can fall outside). `searchByText` uses `locationBias` or
+ *   `locationRestriction`, plus optional `rankPreference` (RELEVANCE vs
+ *   DISTANCE). Same query and viewport can yield a different set and order.
+ * - Fields: `textSearch` returns a fixed `PlaceResult` (`name`,
+ *   `formatted_address`, `types`, `photos`, …). `searchByText` requires a
+ *   field mask; omitted fields are absent.
+ * - Photos: `textSearch` may include `PlacePhoto` (`getUrl`). `searchByText`
+ *   returns `Photo` (`getURI`) only if `photos` is requested. Loading the
+ *   image is a separate Place Photos SKU in both cases.
+ * - Runtime: `textSearch` needs a `Map`. `searchByText` does not.
+ *
+ * Place Details (`Place.fetchFields`) is not a search API. It loads extra
+ * fields (e.g. photos) for a `place_id` already returned by `textSearch`.
+ *
+ * @param geocodingQueryString Text query sent to Places (address, name, …).
+ * @param options.bbox Viewport used to compute the search-radius bias.
+ * @param options.map Google map instance required by `PlacesService`.
+ * @param options.language Optional language for result names/addresses.
+ * @returns Matching point features, `[]` if none, `undefined` if Google or
+ * the bbox is missing. Rejects if `map` is missing or the request fails.
+ * @see https://developers.google.com/maps/documentation/javascript/places-migration-overview
+ * @see https://developers.google.com/maps/documentation/javascript/place-search
+ */
 export const geocodeMultiplePlaces = (
     geocodingQueryString: string,
     options: { bbox?: [number, number, number, number]; map?: google.maps.Map; language?: string }

--- a/packages/evolution-frontend/src/components/inputs/maps/google/InputMapGoogle.tsx
+++ b/packages/evolution-frontend/src/components/inputs/maps/google/InputMapGoogle.tsx
@@ -18,13 +18,13 @@ import {
 } from '@vis.gl/react-google-maps';
 import GeoJSON from 'geojson';
 import bowser from 'bowser';
-import DOMPurify from 'dompurify';
 
 import { getCurrentGoogleMapConfig, getGoogleMapId } from '../../../../config/googleMaps.config';
 import InputLoading from '../../InputLoading';
 import { FeatureGeocodedProperties, MarkerData, InfoWindow as InfoWindowData } from '../types';
 import { geojson } from './GoogleMapUtils';
 import { logClientSideMessage } from '../../../../services/errorManagement/errorHandling';
+import { createPlaceInfoWindowElement, placeInfoWindowContentFromHtml } from '../placeInfoWindow';
 
 export interface InputGoogleMapPointProps {
     defaultCenter: { lat: number; lon: number };
@@ -241,9 +241,15 @@ const InputMapGoogleInner: React.FunctionComponent<InputGoogleMapPointProps> = (
             return;
         }
 
-        const container = document.createElement('div');
-        // Place name/address/photo HTML comes from geocoder data — sanitize before insert.
-        container.innerHTML = DOMPurify.sanitize(props.infoWindow.content);
+        const fromHtml = placeInfoWindowContentFromHtml(props.infoWindow.content);
+        const container = createPlaceInfoWindowElement({
+            name: props.infoWindow.placeName || fromHtml.name,
+            address: props.infoWindow.placeAddress || fromHtml.address,
+            photoUrl: props.infoWindow.photoUrl || fromHtml.photoUrl,
+            photoAttributionPrefix: props.infoWindow.photoAttributionPrefix || fromHtml.photoAttributionPrefix,
+            photoAttributions: props.infoWindow.photoAttributions ?? fromHtml.photoAttributions,
+            photoAttribution: props.infoWindow.photoAttribution || fromHtml.photoAttribution
+        });
 
         let confirmButton: HTMLButtonElement | undefined;
         const onConfirm = props.infoWindow.onConfirm;
@@ -251,10 +257,10 @@ const InputMapGoogleInner: React.FunctionComponent<InputGoogleMapPointProps> = (
             confirmButton = document.createElement('button');
             confirmButton.type = 'button';
             confirmButton.className = 'button green map-find-place-info-window-confirm';
-            confirmButton.style.marginTop = '0.5rem';
             confirmButton.textContent = props.infoWindow.confirmLabel;
             confirmButton.addEventListener('click', onConfirm);
-            container.appendChild(confirmButton);
+            const body = container.querySelector('.map-find-place-info-window-body');
+            (body ?? container).appendChild(confirmButton);
         }
 
         placesInfoWindow.setContent(container);

--- a/packages/evolution-frontend/src/components/inputs/maps/placeInfoWindow.ts
+++ b/packages/evolution-frontend/src/components/inputs/maps/placeInfoWindow.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { isHttpsAttributionUri, PLACE_PHOTO_HEIGHT, PlacePhotoAttribution } from './placePhoto';
+
+export type PlaceInfoWindowContent = {
+    name?: string;
+    address?: string;
+    photoUrl?: string;
+    photoAttributionPrefix?: string;
+    photoAttributions?: PlacePhotoAttribution[];
+    photoAttribution?: string;
+};
+
+const attributionFromAnchor = (anchor: Element): PlacePhotoAttribution | undefined => {
+    const text = anchor.textContent?.trim() ?? '';
+    if (text === '') {
+        return undefined;
+    }
+    const href = anchor.getAttribute('href');
+    return { text, ...(isHttpsAttributionUri(href) ? { uri: href } : {}) };
+};
+
+/**
+ * Recover name / address / photo / attribution from the HTML string when
+ * structured fields were not passed (e.g. stale bundle). Leaf divs are name
+ * then address. Attribution uses `.map-find-place-info-window-photo-attribution`.
+ */
+export const placeInfoWindowContentFromHtml = (html: string): PlaceInfoWindowContent => {
+    const tmp = document.createElement('div');
+    tmp.innerHTML = html;
+    const img = tmp.querySelector('img');
+    const attribution = tmp.querySelector('.map-find-place-info-window-photo-attribution');
+    const leaves = [...tmp.querySelectorAll('div')].filter((el) => el.children.length === 0);
+    const photoAttributions = [...(attribution?.querySelectorAll('a') ?? [])]
+        .map(attributionFromAnchor)
+        .filter((part): part is PlacePhotoAttribution => part !== undefined);
+    const prefixNode = attribution?.childNodes[0];
+    const photoAttributionPrefix =
+        photoAttributions.length > 0 && prefixNode?.nodeType === Node.TEXT_NODE
+            ? prefixNode.textContent?.trim() || undefined
+            : undefined;
+    return {
+        name: leaves[0]?.textContent?.trim() || undefined,
+        address: leaves[1]?.textContent?.trim() || undefined,
+        photoUrl: img?.getAttribute('src') || undefined,
+        photoAttributionPrefix,
+        photoAttributions: photoAttributions.length > 0 ? photoAttributions : undefined,
+        photoAttribution: photoAttributions.length > 0 ? undefined : attribution?.textContent?.trim() || undefined
+    };
+};
+
+const appendPhotoAttribution = (photo: HTMLElement, content: PlaceInfoWindowContent): void => {
+    const attributions = content.photoAttributions ?? [];
+    if (attributions.length === 0 && !content.photoAttribution) {
+        return;
+    }
+    const attribution = document.createElement('div');
+    attribution.className = 'map-find-place-info-window-photo-attribution';
+    if (attributions.length > 0) {
+        if (content.photoAttributionPrefix) {
+            attribution.append(document.createTextNode(`${content.photoAttributionPrefix} `));
+        }
+        attributions.forEach((part, index) => {
+            if (index > 0) {
+                attribution.append(document.createTextNode(', '));
+            }
+            if (isHttpsAttributionUri(part.uri)) {
+                const link = document.createElement('a');
+                link.setAttribute('href', new URL(part.uri).href);
+                link.setAttribute('target', '_blank');
+                link.setAttribute('rel', 'noopener noreferrer');
+                link.textContent = part.text;
+                attribution.append(link);
+            } else {
+                attribution.append(document.createTextNode(part.text));
+            }
+        });
+    } else {
+        attribution.textContent = content.photoAttribution ?? '';
+    }
+    photo.appendChild(attribution);
+};
+
+/**
+ * Build the MapFindPlace info-window DOM.
+ * Google `InfoWindow.setContent` takes an `Element` or HTML string, not a
+ * React tree, so this stays in createElement. Avoid innerHTML: sanitize
+ * unwraps nested divs and layout classes land on the wrong nodes
+ * (title-only box, confirm button above the photo).
+ * @param content name, address, optional photo and attribution
+ */
+export const createPlaceInfoWindowElement = (content: PlaceInfoWindowContent): HTMLDivElement => {
+    const root = document.createElement('div');
+    root.className = 'map-find-place-info-window';
+
+    const text = document.createElement('div');
+    text.className = 'map-find-place-info-window-text';
+    const name = document.createElement('div');
+    name.textContent = content.name ?? '';
+    const address = document.createElement('div');
+    address.className = '_pale';
+    address.textContent = content.address ?? '';
+    text.append(name, address);
+    root.appendChild(text);
+
+    const body = document.createElement('div');
+    body.className = 'map-find-place-info-window-body';
+    if (content.photoUrl) {
+        const photo = document.createElement('div');
+        photo.className = 'map-find-place-info-window-photo';
+        const img = document.createElement('img');
+        img.src = content.photoUrl;
+        img.height = PLACE_PHOTO_HEIGHT;
+        photo.appendChild(img);
+        appendPhotoAttribution(photo, content);
+        body.appendChild(photo);
+    }
+    root.appendChild(body);
+    return root;
+};

--- a/packages/evolution-frontend/src/components/inputs/maps/placePhoto.ts
+++ b/packages/evolution-frontend/src/components/inputs/maps/placePhoto.ts
@@ -1,0 +1,123 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+/** Display height of the MapFindPlace info-window photo, in pixels. */
+export const PLACE_PHOTO_HEIGHT = 180;
+
+/** Place photo from Places API New (`getURI`) or legacy PlacesService (`getUrl`). */
+export type PlacePhotoLike = {
+    getURI?: (options?: { maxHeight?: number; maxWidth?: number }) => string;
+    getUrl?: (options?: { maxHeight?: number; maxWidth?: number }) => string;
+    authorAttributions?: { displayName?: string; uri?: string | null }[];
+    html_attributions?: string[];
+};
+
+/** Author name plus optional https profile link (Places API New `uri` or legacy `<a href>`). */
+export type PlacePhotoAttribution = {
+    text: string;
+    uri?: string;
+};
+
+const attributionText = (value: string | undefined): string => (value ?? '').replace(/<[^>]+>/g, '').trim();
+
+/**
+ * True when `value` is an absolute https URL. Used before rendering attribution links.
+ * @param value candidate href from AuthorAttribution.uri or legacy html_attributions
+ */
+export const isHttpsAttributionUri = (value: string | undefined | null): value is string => {
+    if (typeof value !== 'string' || value.trim() === '') {
+        return false;
+    }
+    try {
+        return new URL(value).protocol === 'https:';
+    } catch {
+        return false;
+    }
+};
+
+const attributionFromAuthor = (attribution: {
+    displayName?: string;
+    uri?: string | null;
+}): PlacePhotoAttribution | undefined => {
+    const text = attributionText(attribution.displayName);
+    if (text === '') {
+        return undefined;
+    }
+    return { text, ...(isHttpsAttributionUri(attribution.uri) ? { uri: attribution.uri } : {}) };
+};
+
+/** Read display text and https href from a legacy `html_attributions` fragment. Does not render the HTML. */
+const attributionFromHtml = (html: string): PlacePhotoAttribution | undefined => {
+    const tmp = document.createElement('div');
+    tmp.innerHTML = html;
+    const text = (tmp.textContent ?? '').trim();
+    if (text === '') {
+        return undefined;
+    }
+    const href = tmp.querySelector('a')?.getAttribute('href');
+    return { text, ...(isHttpsAttributionUri(href) ? { uri: href } : {}) };
+};
+
+/**
+ * Image URL for a Google Place photo. The new Places library uses `getURI`;
+ * the deprecated PlacesService used `getUrl`. Calling either loads the image
+ * and is billed as the Place Photos SKU.
+ * @param photo photo object from a Place search or Place Details response
+ * @param maxHeight max image height in pixels
+ */
+export const getPlacePhotoUrl = (
+    photo: PlacePhotoLike | undefined,
+    maxHeight = PLACE_PHOTO_HEIGHT
+): string | undefined => {
+    if (photo === undefined) {
+        return undefined;
+    }
+    if (typeof photo.getURI === 'function') {
+        return photo.getURI({ maxHeight });
+    }
+    if (typeof photo.getUrl === 'function') {
+        return photo.getUrl({ maxHeight });
+    }
+    return undefined;
+};
+
+/**
+ * Every photo attribution that must be shown with the image: all
+ * `authorAttributions` (Places API New) and all legacy `html_attributions`.
+ * Keeps https profile links from `AuthorAttribution.uri` and `<a href>`.
+ * @param photo photo object from a Place search or Place Details response
+ * @returns Attributions to render, or an empty array if none
+ */
+export const getPlacePhotoAttribution = (photo: PlacePhotoLike | undefined): PlacePhotoAttribution[] => {
+    if (photo === undefined) {
+        return [];
+    }
+    return [
+        ...(photo.authorAttributions ?? []).map(attributionFromAuthor),
+        ...(photo.html_attributions ?? []).map(attributionFromHtml)
+    ].filter((attribution): attribution is PlacePhotoAttribution => attribution !== undefined);
+};
+
+/**
+ * Load photos for a place already found by PlacesService.textSearch.
+ * Uses Place Details (New) so search ranking is unchanged. Places is already
+ * loaded with the map (`libraries: ['places']`). Returns undefined if Google
+ * is unavailable or the request fails.
+ * @param placeId Google place id from the search result
+ */
+export const fetchPlacePhotos = async (placeId: string | undefined): Promise<PlacePhotoLike[] | undefined> => {
+    if (!placeId || typeof google === 'undefined') {
+        return undefined;
+    }
+    try {
+        const place = new google.maps.places.Place({ id: placeId });
+        await place.fetchFields({ fields: ['photos'] });
+        return place.photos ?? undefined;
+    } catch {
+        return undefined;
+    }
+};

--- a/packages/evolution-frontend/src/components/inputs/maps/types.ts
+++ b/packages/evolution-frontend/src/components/inputs/maps/types.ts
@@ -12,6 +12,7 @@ import type {
     UserInterviewAttributes,
     WidgetStatus
 } from 'evolution-common/lib/services/questionnaire/types';
+import type { PlacePhotoAttribution } from './placePhoto';
 
 export type FeatureGeocodedProperties = {
     lastAction?: string;
@@ -52,6 +53,13 @@ export type geocodeSingleFct = (
 export type InfoWindow = {
     position: GeoJSON.Feature<GeoJSON.Point>;
     content: string;
+    /** Structured place fields. Prefer these over parsing `content` HTML. */
+    placeName?: string;
+    placeAddress?: string;
+    photoUrl?: string;
+    photoAttributionPrefix?: string;
+    photoAttributions?: PlacePhotoAttribution[];
+    photoAttribution?: string;
     /** When set, InputMap renders a confirm button inside the info window. */
     confirmLabel?: string;
     onConfirm?: () => void;

--- a/packages/evolution-frontend/src/styles/survey/_question.scss
+++ b/packages/evolution-frontend/src/styles/survey/_question.scss
@@ -622,3 +622,52 @@ label strong,
 .react-datepicker__current-month {
     font-size: 1.6rem !important;
 }
+
+.survey-question__input-map-container {
+    .gm-style-iw-c {
+        padding: 0.5rem !important;
+    }
+
+    .gm-style-iw-ch,
+    .gm-style-iw-chr {
+        position: absolute;
+        right: 0;
+        top: 0;
+        padding: 0;
+    }
+
+    .gm-style-iw-d {
+        padding: 0 !important;
+        margin: 0 !important;
+    }
+
+    .map-find-place-info-window-text {
+        box-sizing: border-box;
+        width: 100%;
+        margin: 0;
+        padding: 0 2rem 0 0;
+    }
+
+    .map-find-place-info-window-body {
+        margin: 0;
+        padding: 0;
+    }
+
+    .map-find-place-info-window-photo img {
+        margin-top: 0.4rem;
+        display: block;
+        height: 10rem;
+    }
+
+    .map-find-place-info-window-photo-attribution {
+        font-style: italic;
+        font-size: 75%;
+        margin-top: 0.10rem;
+    }
+
+    .map-find-place-info-window-confirm {
+        display: block;
+        margin: 0.15rem auto 0 !important;
+        padding: 0.5rem 1.2rem !important;
+    }
+}

--- a/packages/evolution-generator/src/scripts/generate_widgets.py
+++ b/packages/evolution-generator/src/scripts/generate_widgets.py
@@ -296,6 +296,7 @@ def generate_widget_statement(row, gender_fields: GenderFields = None) -> Widget
         return result
 
     # Generate the widgets statement based on the input type
+    # TODO: Support mapFindPlace from Excel, including the showPhoto column.
     if input_type == "Custom":
         result["statement"] = generate_custom_widget(question_name)
     elif input_type == "BuiltIn":


### PR DESCRIPTION
Surveys can opt in via showPhoto so the selected
place info-window displays a Google Place photo and its attributions.

On mobile:
<img width="380" height="542" alt="image" src="https://github.com/user-attachments/assets/fda88211-b60f-424a-aff7-b8648b64434c" />
showPhoto disabled:
<img width="641" height="328" alt="image" src="https://github.com/user-attachments/assets/02b23def-a9fc-4150-a29c-4048f5a4eed9" />
showPhoto enabled:
<img width="548" height="323" alt="image" src="https://github.com/user-attachments/assets/fd497662-fec5-452b-8333-1087393a017f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Map location results can now display place photos with attribution when enabled.
  * Added support for secure attribution links and localized “Photo” labels in English and French.
  * Improved map info windows with clearer formatting, photo sizing, and confirmation controls.

* **Documentation**
  * Expanded guidance for map photo settings and geocoding behavior.

* **Bug Fixes**
  * Improved handling of unavailable photos, failed lookups, stale results, and unsafe attribution links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->