### PR TITLE
fix(ui-tests): click the InfoWindow confirm on mapFindPlace

### DIFF
--- a/example/demo_survey/tests/test-one-person-helpers.ts
+++ b/example/demo_survey/tests/test-one-person-helpers.ts
@@ -12,9 +12,8 @@ export function completeHomePage(context) {
     testHelpers.inputStringTest({ context, path: 'home.region', value: 'Quebec' });
     testHelpers.inputStringTest({ context, path: 'home.country', value: 'Canada' });
     testHelpers.inputStringTest({ context, path: 'home.postalCode', value: 'H1S1V7', expectedValue: 'H1S 1V7' });
-    //testHelpers.inputMapFindPlaceTest({ context, path: 'home.geography' });
     testHelpers.inputSelectTest({ context, path: 'home.dwellingType', value: 'tenantSingleDetachedHouse' });
-    testHelpers.waitForMapToBeLoaded({ context });
+    testHelpers.inputMapFindPlaceTest({ context, path: 'home.geography' });
     testHelpers.inputNextButtonTest({ context, text: 'Save and continue', nextPageUrl: '/survey/householdMembers' });
 }
 

--- a/example/demo_survey/tests/test-two-adults-no-trips.UI.spec.ts
+++ b/example/demo_survey/tests/test-two-adults-no-trips.UI.spec.ts
@@ -29,9 +29,8 @@ testHelpers.inputStringTest({ context, path: 'home.city', value: 'Montreal' });
 testHelpers.inputStringTest({ context, path: 'home.region', value: 'Quebec' });
 testHelpers.inputStringTest({ context, path: 'home.country', value: 'Canada' });
 testHelpers.inputStringTest({ context, path: 'home.postalCode', value: 'H1S1V7', expectedValue: 'H1S 1V7' });
-//testHelpers.inputMapFindPlaceTest({ context, path: 'home.geography' });
 testHelpers.inputSelectTest({ context, path: 'home.dwellingType', value: 'tenantSingleDetachedHouse' });
-testHelpers.waitForMapToBeLoaded({ context });
+testHelpers.inputMapFindPlaceTest({ context, path: 'home.geography' });
 testHelpers.inputNextButtonTest({ context, text: 'Save and continue', nextPageUrl: '/survey/householdMembers' });
 
 // Test the household page

--- a/packages/evolution-frontend/src/components/inputs/maps/google/InputMapGoogle.tsx
+++ b/packages/evolution-frontend/src/components/inputs/maps/google/InputMapGoogle.tsx
@@ -250,7 +250,7 @@ const InputMapGoogleInner: React.FunctionComponent<InputGoogleMapPointProps> = (
         if (props.infoWindow.confirmLabel && onConfirm) {
             confirmButton = document.createElement('button');
             confirmButton.type = 'button';
-            confirmButton.className = 'button green';
+            confirmButton.className = 'button green map-find-place-info-window-confirm';
             confirmButton.style.marginTop = '0.5rem';
             confirmButton.textContent = props.infoWindow.confirmLabel;
             confirmButton.addEventListener('click', onConfirm);

--- a/packages/evolution-frontend/tests/ui-testing/testHelpers.ts
+++ b/packages/evolution-frontend/tests/ui-testing/testHelpers.ts
@@ -800,13 +800,8 @@ export const inputMapFindPlaceTest: InputMapFindPlaceTest = ({ context, path }) 
         // Fetch the Google Maps API response
         const { resultsNumber } = await fetchGoogleMapsApiResponse({ context, refreshButton });
 
-        // Get the main map widget, 4 above the button
-        const inputMap = refreshButton.locator('..').locator('..').locator('..').locator('..');
-        await inputMap.scrollIntoViewIfNeeded(); // So we can see the map correctly in the screenshot when the test fails
-
-        // Check if the no result alert is visible
-        // const noResultAlertElement = inputMap.getByText('The search did not return any result');
-        // const checkIfNoResult = await noResultAlertElement.isVisible();
+        const questionContainer = context.page.locator('div.apptr__form-container').filter({ has: refreshButton });
+        await questionContainer.scrollIntoViewIfNeeded();
 
         // If no result, click again
         if (resultsNumber === 0) {
@@ -816,7 +811,7 @@ export const inputMapFindPlaceTest: InputMapFindPlaceTest = ({ context, path }) 
 
         // If there is at least one result and the select input exists, select the first option and confirm.
         // Note: This is necessary because sometimes the select input appears with only one available option.
-        const select = inputMap.locator(`id=survey-question__${newPath}_mapFindPlace`);
+        const select = context.page.locator(`id=survey-question__${newPath}_mapFindPlace`);
         if (resultsNumber >= 1 && (await select.count()) > 0) {
             // Focus on the select element to prepare for keyboard interaction
             await select.focus();
@@ -859,16 +854,19 @@ export const inputMapFindPlaceTest: InputMapFindPlaceTest = ({ context, path }) 
                 }
             }
 
-            // Confirm place selection
-            const confirmButton = inputMap.locator(`id=survey-question__${newPath}_confirm`);
+            // Confirm is in the Google InfoWindow (and still below the map). The
+            // popup covers #_confirm, so Playwright's click is intercepted.
+            // The map wrapper is aria-hidden, so getByRole cannot see the
+            // InfoWindow button either.
+            const infoWindowConfirm = context.page.locator('button.map-find-place-info-window-confirm');
+            const belowMapConfirm = context.page.locator(`[id="survey-question__${newPath}_confirm"]`);
+            const confirmButton = infoWindowConfirm.or(belowMapConfirm);
             await expect(confirmButton).toBeVisible();
             await confirmButton.click();
-            await expect(confirmButton).toBeHidden(); // Confirm button should be hidden after clicking
+            await expect(confirmButton).toBeHidden();
         }
 
-        // Make sure that the the question widget have validations implemented
-        // Check if the input has the question-valid class
-        await expect(inputMap).toHaveClass(/question-valid/);
+        await expect(questionContainer).toHaveClass(/question-valid/);
     });
 };
 
@@ -880,7 +878,9 @@ export const inputMapFindPlaceTest: InputMapFindPlaceTest = ({ context, path }) 
  */
 export const waitForMapToBeLoaded: WaitForMapLoadedTest = ({ context }) => {
     test('Wait for map to be loaded', async () => {
-        const mapContainer = context.page.locator('//div[contains(@class, \'question-type-mapPoint\')]');
+        const mapContainer = context.page.locator(
+            'div.apptr__form-container.question-type-mapFindPlace, div.apptr__form-container.question-type-mapPoint'
+        );
         await expect(mapContainer).toBeVisible();
         await mapContainer.scrollIntoViewIfNeeded();
         await expect(mapContainer).toHaveClass(/question-filled question-valid/);


### PR DESCRIPTION
The Google InfoWindow confirm covers the below-map button, so Playwright cannot click #_confirm. Also wait for mapFindPlace, not only mapPoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map-based place selection reliability across survey forms.
  * Confirmation now works consistently for both map widget layouts.
  * Map loading and form validation better support different survey configurations.

* **Tests**
  * Updated survey workflows to actively verify map place selection.
  * Expanded automated coverage for map interactions, scrolling, confirmation, and form validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->