### PR TITLE
map ui tests: only press enter if select is focused

### DIFF
--- a/packages/evolution-frontend/tests/ui-testing/testHelpers.ts
+++ b/packages/evolution-frontend/tests/ui-testing/testHelpers.ts
@@ -826,8 +826,16 @@ export const inputMapFindPlaceTest: InputMapFindPlaceTest = ({ context, path }) 
             const valueAfterKeyboard = await select.inputValue();
 
             if (valueAfterKeyboard !== initialValue) {
-                // Success: Keyboard navigation worked, confirm the selection with Enter
-                await context.page.keyboard.press('Enter');
+                // Success: Keyboard navigation changed selection and may have
+                // opened the info window. In some browser, the focus may change
+                // to go to this info window instead. If the select box is still
+                // in focus, press enter to confirm the choice, otherwise, the
+                // current selection has already been updated, so ignore.
+                const isSelectFocused = await select.evaluate((el) => el === document.activeElement);
+                if (isSelectFocused) {
+                    // Safe to confirm with Enter when the select still has focus
+                    await context.page.keyboard.press('Enter');
+                }
             } else {
                 // Fallback: Keyboard navigation failed (Mac/Safari issue), use direct option selection
                 const options = await select.locator('option').all();
@@ -860,10 +868,11 @@ export const inputMapFindPlaceTest: InputMapFindPlaceTest = ({ context, path }) 
             // InfoWindow button either.
             const infoWindowConfirm = context.page.locator('button.map-find-place-info-window-confirm');
             const belowMapConfirm = context.page.locator(`[id="survey-question__${newPath}_confirm"]`);
-            const confirmButton = infoWindowConfirm.or(belowMapConfirm);
-            await expect(confirmButton).toBeVisible();
-            await confirmButton.click();
-            await expect(confirmButton).toBeHidden();
+            await expect(infoWindowConfirm).toBeVisible();
+            await expect(belowMapConfirm).toBeVisible();
+            await infoWindowConfirm.click();
+            await expect(infoWindowConfirm).toBeHidden();
+            await expect(belowMapConfirm).toBeHidden();
         }
 
         await expect(questionContainer).toHaveClass(/question-valid/);


### PR DESCRIPTION
fixes #1821

In some browser, when the select value is changed, the info window is automatically opened and focused on. The next step pressing the "Enter" key thus did this in the info window focus. Prior to commit 485c230710869c85ffc6eb3457b10e9dce3c43bc, this caused the info window to be closed, but it did not impact the test outcome. After this commit, it actually pressed the confirm button in the window, confirming the place at the same time and resulting in hiding the confirm buttons. The tests then failed because the button was not there to be pressed.

This commit only presses "Enter" after selection change if the focus is still on the select input to confirm the change. It is not pressed if the info window is opened and has focus.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map place-selection interactions when using keyboard navigation.
  * Confirmation checks now reliably validate both the map popup and below-map buttons.
  * Ensured the map popup confirmation action is triggered and both confirmation controls are hidden afterward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->