### PR TITLE
admin frontend: set instead of update the interview when summary changes

### DIFF
--- a/packages/evolution-frontend/src/actions/SurveyAdmin.ts
+++ b/packages/evolution-frontend/src/actions/SurveyAdmin.ts
@@ -379,6 +379,11 @@ export const startFetchCorrectedInterviewAndAudits = (
                 urlParams.append('extended', 'true');
             }
             const queryString = urlParams.toString();
+            // Make sure to set the interview to `undefined` first, to override
+            // any previous interview and avoid side effects if previous state
+            // remain.
+            dispatch(setInterviewState(undefined));
+
             const response = await fetch(
                 `/api/survey/correctInterview/${interviewUuid}${queryString ? `?${queryString}` : ''}`,
                 {
@@ -394,7 +399,7 @@ export const startFetchCorrectedInterviewAndAudits = (
                     unserializeSurveyObjectsAndAudits(interview);
 
                     // Set the interview in the state first
-                    dispatch(updateInterviewState(interview));
+                    dispatch(setInterviewState(interview));
 
                     // Review decisions are fetched separately from the interview and audits;
                     // no need to await, the UI updates whenever they arrive.


### PR DESCRIPTION
fixes #1828

When the interview is first fetch for validation, with the `startFetchCorrectedInterviewAndAudits` redux action, the state should be modified with the `setInterviewState` as it is the first time the interview is fetched. Update is only when the interview was changed.

Also, set the interview to `undefined` before fetch, to make sure there is no stale interview that gets updated in the meantime and avoid possible side effects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved loading behavior when fetching corrected interview data by clearing the previous interview first.
  - Ensured the fetched corrected interview is displayed correctly after retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->