### PR TITLE
visitedPlaces: set the `_isNew` flag of new places to `true`

### DIFF
--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/buttonsVisitedPlace.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/buttonsVisitedPlace.test.ts
@@ -149,7 +149,8 @@ describe('buttonSaveVisitedPlace widget', () => {
                         insertSequence: 6,
                         newVisitedPlace: {
                             activity: 'home',
-                            activityCategory: 'home'
+                            activityCategory: 'home',
+                            _isNew: true
                         }
                     }
                 ],
@@ -169,7 +170,7 @@ describe('buttonSaveVisitedPlace widget', () => {
                 expectedInsertedPlaces: [
                     {
                         insertSequence: 3,
-                        newVisitedPlace: {}
+                        newVisitedPlace: { _isNew: true }
                     }
                 ],
                 expectedFirstUpdateValuesByPath: {
@@ -207,7 +208,8 @@ describe('buttonSaveVisitedPlace widget', () => {
                         newVisitedPlace: {
                             activity: 'home',
                             activityCategory: 'home',
-                            arrivalTime: 17 * 60 * 60
+                            arrivalTime: 17 * 60 * 60,
+                            _isNew: true
                         }
                     }
                 ],
@@ -246,7 +248,8 @@ describe('buttonSaveVisitedPlace widget', () => {
                         newVisitedPlace: {
                             activity: 'home',
                             activityCategory: 'home',
-                            arrivalTime: 17 * 60 * 60
+                            arrivalTime: 17 * 60 * 60,
+                            _isNew: true
                         }
                     }
                 ],
@@ -291,7 +294,8 @@ describe('buttonSaveVisitedPlace widget', () => {
                         newVisitedPlace: {
                             activity: 'workUsual',
                             activityCategory: 'work',
-                            arrivalTime: 17 * 60 * 60
+                            arrivalTime: 17 * 60 * 60,
+                            _isNew: true
                         }
                     }
                 ],
@@ -334,7 +338,8 @@ describe('buttonSaveVisitedPlace widget', () => {
                         newVisitedPlace: {
                             activity: 'workUsual',
                             activityCategory: 'work',
-                            arrivalTime: 17 * 60 * 60
+                            arrivalTime: 17 * 60 * 60,
+                            _isNew: true
                         }
                     }
                 ],
@@ -370,7 +375,8 @@ describe('buttonSaveVisitedPlace widget', () => {
                         newVisitedPlace: {
                             activity: 'workUsual',
                             activityCategory: 'work',
-                            arrivalTime: 17 * 60 * 60
+                            arrivalTime: 17 * 60 * 60,
+                            _isNew: true
                         }
                     }
                 ],

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/sectionVisitedPlaces.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/sectionVisitedPlaces.test.ts
@@ -297,6 +297,7 @@ describe('VisitedPlacesSectionFactory section config functionality', () => {
                 'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.placeId1': {
                     _sequence: 1,
                     _uuid: 'placeId1',
+                    _isNew: true,
                     activity: 'home',
                     activityCategory: 'home',
                     nextPlaceCategory: 'visitedAnotherPlace'
@@ -304,7 +305,8 @@ describe('VisitedPlacesSectionFactory section config functionality', () => {
                 'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.placeId1': {},
                 'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.placeId2': {
                     _sequence: 2,
-                    _uuid: 'placeId2'
+                    _uuid: 'placeId2',
+                    _isNew: true,
                 },
                 'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.placeId2': {},
                 'response._activeVisitedPlaceId': 'placeId2'
@@ -363,6 +365,7 @@ describe('VisitedPlacesSectionFactory section config functionality', () => {
                     'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.placeId1': {
                         _sequence: 1,
                         _uuid: 'placeId1',
+                        _isNew: true,
                         ...expected
                     },
                     'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.placeId1': {},

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/sectionVisitedPlaces.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/sectionVisitedPlaces.test.ts
@@ -11,10 +11,10 @@ import { interviewAttributesForTestCases, maskFunctions, setActiveSurveyObjects,
 import * as utilHelpers from '../../../../../utils/helpers';
 import * as odHelpers from '../../../../odSurvey/helpers';
 import {
-	Journey,
-	UserRuntimeInterviewAttributes,
-	VisitedPlacesSectionConfiguration,
-	WidgetConfig
+    Journey,
+    UserRuntimeInterviewAttributes,
+    VisitedPlacesSectionConfiguration,
+    WidgetConfig
 } from '../../../types';
 import { getButtonConfirmGotoNextSectionWidgetConfig } from '../buttonConfirmGotoNextSection';
 import { PersonVisitedPlacesGroupConfigFactory } from '../groupPersonVisitedPlaces';
@@ -25,113 +25,113 @@ import { SwitchPersonWidgetsFactory } from '../../common/widgetsSwitchPerson';
 import { tripDiarySectionVisibleConditional } from '../../tripDiary/tripDiaryHelpers';
 
 jest.mock('uuid', () => ({
-	v4: jest.fn().mockReturnValue('newVisitedPlaceId')
+    v4: jest.fn().mockReturnValue('newVisitedPlaceId')
 }));
 
 const mockUuidv4 = uuidv4 as jest.MockedFunction<typeof uuidv4>;
 
 const visitedPlacesSectionConfig: VisitedPlacesSectionConfiguration = {
-	type: 'visitedPlaces',
-	enabled: true,
-	tripDiaryMinTimeOfDay: 4 * 60 * 60,
-	tripDiaryMaxTimeOfDay: 28 * 60 * 60
+    type: 'visitedPlaces',
+    enabled: true,
+    tripDiaryMinTimeOfDay: 4 * 60 * 60,
+    tripDiaryMaxTimeOfDay: 28 * 60 * 60
 };
 
 beforeEach(() => {
-	jest.clearAllMocks();
+    jest.clearAllMocks();
 });
 
 describe('VisitedPlacesSectionFactory#getSectionConfig', () => {
-	test('should return the correct section config when section enabled', () => {
-		const sectionFactory = new VisitedPlacesSectionFactory(visitedPlacesSectionConfig, widgetFactoryOptions);
-		const sectionConfig = sectionFactory.getSectionConfig();
+    test('should return the correct section config when section enabled', () => {
+        const sectionFactory = new VisitedPlacesSectionFactory(visitedPlacesSectionConfig, widgetFactoryOptions);
+        const sectionConfig = sectionFactory.getSectionConfig();
 
-		expect(sectionConfig).toEqual({
-			previousSection: 'tripsIntro',
-			nextSection: 'segments',
-			isSectionVisible: tripDiarySectionVisibleConditional,
-			isSectionCompleted: expect.any(Function),
-			onSectionEntry: expect.any(Function),
-			template: 'visitedPlaces',
-			title: expect.any(Function),
-			widgets: [
-				'activePersonTitle',
-				'buttonSwitchPerson',
-				'personVisitedPlacesTitle',
-				'personVisitedPlaces',
-				'personVisitedPlacesMap',
-				'buttonVisitedPlacesConfirmNextSection'
-			]
-		});
-	});
+        expect(sectionConfig).toEqual({
+            previousSection: 'tripsIntro',
+            nextSection: 'segments',
+            isSectionVisible: tripDiarySectionVisibleConditional,
+            isSectionCompleted: expect.any(Function),
+            onSectionEntry: expect.any(Function),
+            template: 'visitedPlaces',
+            title: expect.any(Function),
+            widgets: [
+                'activePersonTitle',
+                'buttonSwitchPerson',
+                'personVisitedPlacesTitle',
+                'personVisitedPlaces',
+                'personVisitedPlacesMap',
+                'buttonVisitedPlacesConfirmNextSection'
+            ]
+        });
+    });
 
-	test('should throw when section is disabled', () => {
-		expect(
-			() =>
-				new VisitedPlacesSectionFactory(
-					{ ...visitedPlacesSectionConfig, enabled: false },
-					widgetFactoryOptions
-				)
-		).toThrow('Visited places section configuration requested but the section is not enabled');
-	});
+    test('should throw when section is disabled', () => {
+        expect(
+            () =>
+                new VisitedPlacesSectionFactory(
+                    { ...visitedPlacesSectionConfig, enabled: false },
+                    widgetFactoryOptions
+                )
+        ).toThrow('Visited places section configuration requested but the section is not enabled');
+    });
 });
 
 describe('VisitedPlacesSectionFactory#getWidgetConfigs', () => {
-	test.each([
-		'personVisitedPlacesTitle',
-		'personVisitedPlaces',
-		'personVisitedPlacesMap',
-		'buttonVisitedPlacesConfirmNextSection'
-	])('should have a widget named %s', (widgetName) => {
-		const widgetConfigs = new VisitedPlacesSectionFactory(visitedPlacesSectionConfig, widgetFactoryOptions).getWidgetConfigs();
-		expect(Object.keys(widgetConfigs)).toContain(widgetName);
-	});
+    test.each([
+        'personVisitedPlacesTitle',
+        'personVisitedPlaces',
+        'personVisitedPlacesMap',
+        'buttonVisitedPlacesConfirmNextSection'
+    ])('should have a widget named %s', (widgetName) => {
+        const widgetConfigs = new VisitedPlacesSectionFactory(visitedPlacesSectionConfig, widgetFactoryOptions).getWidgetConfigs();
+        expect(Object.keys(widgetConfigs)).toContain(widgetName);
+    });
 
-	describe('should include all widgets from person visited places group', () => {
-		const personVisitedPlacesGroupConfig = new PersonVisitedPlacesGroupConfigFactory(
-			visitedPlacesSectionConfig,
-			widgetFactoryOptions
-		).getWidgetConfigs();
-		const personVisitedPlacesWidgetNames = Object.keys(personVisitedPlacesGroupConfig);
+    describe('should include all widgets from person visited places group', () => {
+        const personVisitedPlacesGroupConfig = new PersonVisitedPlacesGroupConfigFactory(
+            visitedPlacesSectionConfig,
+            widgetFactoryOptions
+        ).getWidgetConfigs();
+        const personVisitedPlacesWidgetNames = Object.keys(personVisitedPlacesGroupConfig);
 
-		test('there should be widgets in the person visited places group', () => {
-			expect(personVisitedPlacesWidgetNames.length).toBeGreaterThan(0);
-		});
+        test('there should be widgets in the person visited places group', () => {
+            expect(personVisitedPlacesWidgetNames.length).toBeGreaterThan(0);
+        });
 
-		test.each(
-			personVisitedPlacesWidgetNames.map((widgetName) => ({
-				widgetName,
-				expected: personVisitedPlacesGroupConfig[widgetName]
-			}))
-		)('should have the person visited places group widget named $widgetName', ({ widgetName, expected }) => {
-			const widgetConfigs = new VisitedPlacesSectionFactory(
-				visitedPlacesSectionConfig,
-				widgetFactoryOptions
-			).getWidgetConfigs();
-			expect(maskFunctions(widgetConfigs[widgetName])).toEqual(maskFunctions(expected));
-		});
-	});
+        test.each(
+            personVisitedPlacesWidgetNames.map((widgetName) => ({
+                widgetName,
+                expected: personVisitedPlacesGroupConfig[widgetName]
+            }))
+        )('should have the person visited places group widget named $widgetName', ({ widgetName, expected }) => {
+            const widgetConfigs = new VisitedPlacesSectionFactory(
+                visitedPlacesSectionConfig,
+                widgetFactoryOptions
+            ).getWidgetConfigs();
+            expect(maskFunctions(widgetConfigs[widgetName])).toEqual(maskFunctions(expected));
+        });
+    });
 
-	describe('should include all widgets from switch person set', () => {
-		const switchPersonWidgetConfig = new SwitchPersonWidgetsFactory(widgetFactoryOptions).getWidgetConfigs();
-		const switchPersonWidgetNames = Object.keys(switchPersonWidgetConfig);
+    describe('should include all widgets from switch person set', () => {
+        const switchPersonWidgetConfig = new SwitchPersonWidgetsFactory(widgetFactoryOptions).getWidgetConfigs();
+        const switchPersonWidgetNames = Object.keys(switchPersonWidgetConfig);
 
-		test('there should be widgets in the switch person group', () => {
-			expect(switchPersonWidgetNames.length).toBeGreaterThan(0);
-		});
+        test('there should be widgets in the switch person group', () => {
+            expect(switchPersonWidgetNames.length).toBeGreaterThan(0);
+        });
 
-		test.each(
-			switchPersonWidgetNames.map((widgetName) => ({
-				widgetName,
-				expected: switchPersonWidgetConfig[widgetName]
-			}))
-		)('should have the switch person widget named $widgetName', ({ widgetName, expected }) => {
-			const widgetConfigs = new VisitedPlacesSectionFactory(
-				visitedPlacesSectionConfig,
-				widgetFactoryOptions
-			).getWidgetConfigs();
-			expect(maskFunctions(widgetConfigs[widgetName])).toEqual(maskFunctions(expected));
-		});
+        test.each(
+            switchPersonWidgetNames.map((widgetName) => ({
+                widgetName,
+                expected: switchPersonWidgetConfig[widgetName]
+            }))
+        )('should have the switch person widget named $widgetName', ({ widgetName, expected }) => {
+            const widgetConfigs = new VisitedPlacesSectionFactory(
+                visitedPlacesSectionConfig,
+                widgetFactoryOptions
+            ).getWidgetConfigs();
+            expect(maskFunctions(widgetConfigs[widgetName])).toEqual(maskFunctions(expected));
+        });
     });
 
     test('should attach additional label options for visited place widgets when configured', () => {
@@ -158,36 +158,36 @@ describe('VisitedPlacesSectionFactory#getWidgetConfigs', () => {
         })
     });
 
-	test('should not return extra widgets', () => {
-		const widgetConfigs = new VisitedPlacesSectionFactory(visitedPlacesSectionConfig, widgetFactoryOptions).getWidgetConfigs();
-		const switchPersonsWidgetNames = Object.keys(new SwitchPersonWidgetsFactory(widgetFactoryOptions).getWidgetConfigs());
-		const visitedPlacesGroupWidgetNames = Object.keys(
-			new PersonVisitedPlacesGroupConfigFactory(visitedPlacesSectionConfig, widgetFactoryOptions).getWidgetConfigs()
-		);
+    test('should not return extra widgets', () => {
+        const widgetConfigs = new VisitedPlacesSectionFactory(visitedPlacesSectionConfig, widgetFactoryOptions).getWidgetConfigs();
+        const switchPersonsWidgetNames = Object.keys(new SwitchPersonWidgetsFactory(widgetFactoryOptions).getWidgetConfigs());
+        const visitedPlacesGroupWidgetNames = Object.keys(
+            new PersonVisitedPlacesGroupConfigFactory(visitedPlacesSectionConfig, widgetFactoryOptions).getWidgetConfigs()
+        );
 
-		expect(Object.keys(widgetConfigs).length).toBe(3 + switchPersonsWidgetNames.length + visitedPlacesGroupWidgetNames.length);
-	});
+        expect(Object.keys(widgetConfigs).length).toBe(3 + switchPersonsWidgetNames.length + visitedPlacesGroupWidgetNames.length);
+    });
 
-	test.each([
-		{
-			widgetName: 'personVisitedPlacesTitle',
-			expected: () => getPersonVisitedPlacesTitleWidgetConfig(visitedPlacesSectionConfig, widgetFactoryOptions)
-		},
-		{
-			widgetName: 'personVisitedPlacesMap',
-			expected: () => getPersonVisitedPlacesMapConfig(widgetFactoryOptions)
-		},
-		{
-			widgetName: 'buttonVisitedPlacesConfirmNextSection',
-			expected: () => getButtonConfirmGotoNextSectionWidgetConfig(visitedPlacesSectionConfig, widgetFactoryOptions)
-		}
-	])('should return the correct widget config for $widgetName', ({ widgetName, expected }: {
-		widgetName: string;
-		expected: () => WidgetConfig;
-	}) => {
-		const widgetConfigs = new VisitedPlacesSectionFactory(visitedPlacesSectionConfig, widgetFactoryOptions).getWidgetConfigs();
-		expect(maskFunctions(widgetConfigs[widgetName])).toEqual(maskFunctions(expected()));
-	});
+    test.each([
+        {
+            widgetName: 'personVisitedPlacesTitle',
+            expected: () => getPersonVisitedPlacesTitleWidgetConfig(visitedPlacesSectionConfig, widgetFactoryOptions)
+        },
+        {
+            widgetName: 'personVisitedPlacesMap',
+            expected: () => getPersonVisitedPlacesMapConfig(widgetFactoryOptions)
+        },
+        {
+            widgetName: 'buttonVisitedPlacesConfirmNextSection',
+            expected: () => getButtonConfirmGotoNextSectionWidgetConfig(visitedPlacesSectionConfig, widgetFactoryOptions)
+        }
+    ])('should return the correct widget config for $widgetName', ({ widgetName, expected }: {
+        widgetName: string;
+        expected: () => WidgetConfig;
+    }) => {
+        const widgetConfigs = new VisitedPlacesSectionFactory(visitedPlacesSectionConfig, widgetFactoryOptions).getWidgetConfigs();
+        expect(maskFunctions(widgetConfigs[widgetName])).toEqual(maskFunctions(expected()));
+    });
 });
 
 describe('VisitedPlacesSectionFactory section config functionality', () => {
@@ -199,176 +199,176 @@ describe('VisitedPlacesSectionFactory section config functionality', () => {
         setActiveSurveyObjects(testInterview, { personId: 'personId1', journeyId: 'journeyId1' });
     });
 
-	describe('title', () => {
-		test('should return the right label for title', () => {
-			const sectionConfig = new VisitedPlacesSectionFactory(visitedPlacesSectionConfig, widgetFactoryOptions).getSectionConfig();
-			const mockedT = jest.fn();
-			utilHelpers.translateString(sectionConfig.title, { t: mockedT } as any, testInterview, 'path');
-			expect(mockedT).toHaveBeenCalledWith('visitedPlaces:VisitedPlacesTitle');
-		});
-	});
+    describe('title', () => {
+        test('should return the right label for title', () => {
+            const sectionConfig = new VisitedPlacesSectionFactory(visitedPlacesSectionConfig, widgetFactoryOptions).getSectionConfig();
+            const mockedT = jest.fn();
+            utilHelpers.translateString(sectionConfig.title, { t: mockedT } as any, testInterview, 'path');
+            expect(mockedT).toHaveBeenCalledWith('visitedPlaces:VisitedPlacesTitle');
+        });
+    });
 
-	describe('isSectionCompleted', () => {
-		const sectionConfig = new VisitedPlacesSectionFactory(visitedPlacesSectionConfig, widgetFactoryOptions).getSectionConfig();
-		const iterationContext = ['personId1'];
+    describe('isSectionCompleted', () => {
+        const sectionConfig = new VisitedPlacesSectionFactory(visitedPlacesSectionConfig, widgetFactoryOptions).getSectionConfig();
+        const iterationContext = ['personId1'];
 
-		test('should return false if person does not exist', () => {
-			const result = sectionConfig.isSectionCompleted!(testInterview, ['unexistingPerson']);
-			expect(result).toBe(false);
-		});
+        test('should return false if person does not exist', () => {
+            const result = sectionConfig.isSectionCompleted!(testInterview, ['unexistingPerson']);
+            expect(result).toBe(false);
+        });
 
-		test('should return false if no iteration context', () => {
+        test('should return false if no iteration context', () => {
             // Unset active objects
             setActiveSurveyObjects(testInterview, {});
-			const result = sectionConfig.isSectionCompleted!(testInterview, undefined);
-			expect(result).toBe(false);
-		});
+            const result = sectionConfig.isSectionCompleted!(testInterview, undefined);
+            expect(result).toBe(false);
+        });
 
-		test('should return false if there are no visited places', () => {
-			testInterview.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces = {};
+        test('should return false if there are no visited places', () => {
+            testInterview.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces = {};
 
-			const result = sectionConfig.isSectionCompleted!(testInterview, iterationContext);
-			expect(result).toBe(false);
-		});
+            const result = sectionConfig.isSectionCompleted!(testInterview, iterationContext);
+            expect(result).toBe(false);
+        });
 
-		test('should return true when there are visited places and no incomplete visited place', () => {
-			const result = sectionConfig.isSectionCompleted!(testInterview, iterationContext);
-			expect(result).toBe(true);
-		});
+        test('should return true when there are visited places and no incomplete visited place', () => {
+            const result = sectionConfig.isSectionCompleted!(testInterview, iterationContext);
+            expect(result).toBe(true);
+        });
 
-		test('should return false when there is an incomplete visited place', () => {
+        test('should return false when there is an incomplete visited place', () => {
             // Set the next place category of the last place to undefined to make it incomplete
-			testInterview.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!.otherPlace2P1.nextPlaceCategory = undefined;
+            testInterview.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!.otherPlace2P1.nextPlaceCategory = undefined;
 
-			const result = sectionConfig.isSectionCompleted!(testInterview, iterationContext);
-			expect(result).toBe(false);
-		});
-	});
+            const result = sectionConfig.isSectionCompleted!(testInterview, iterationContext);
+            expect(result).toBe(false);
+        });
+    });
 
-	describe('onSectionEntry', () => {
-		const sectionConfig = new VisitedPlacesSectionFactory(visitedPlacesSectionConfig, widgetFactoryOptions).getSectionConfig();
-		const iterationContext = ['personId1'];
+    describe('onSectionEntry', () => {
+        const sectionConfig = new VisitedPlacesSectionFactory(visitedPlacesSectionConfig, widgetFactoryOptions).getSectionConfig();
+        const iterationContext = ['personId1'];
 
-		test('should return undefined if person does not exist', () => {
+        test('should return undefined if person does not exist', () => {
             // Unset active objects
             setActiveSurveyObjects(testInterview, { });
-			const result = sectionConfig.onSectionEntry!(testInterview, ['unexistingPerson']);
-			expect(result).toBeUndefined();
-		});
+            const result = sectionConfig.onSectionEntry!(testInterview, ['unexistingPerson']);
+            expect(result).toBeUndefined();
+        });
 
-		test('should return undefined if no iteration context', () => {
+        test('should return undefined if no iteration context', () => {
             // Unset active objects
             setActiveSurveyObjects(testInterview, { });
-			const result = sectionConfig.onSectionEntry!(testInterview, undefined);
-			expect(result).toBeUndefined();
-		});
+            const result = sectionConfig.onSectionEntry!(testInterview, undefined);
+            expect(result).toBeUndefined();
+        });
 
-		test('should return undefined if person has no active journey', () => {
+        test('should return undefined if person has no active journey', () => {
             // Set journey to null
-			setActiveSurveyObjects(testInterview, { personId: 'personIdWithoutJourney', journeyId: undefined });
-			const result = sectionConfig.onSectionEntry!(testInterview, iterationContext);
-			expect(result).toBeUndefined();
-		});
+            setActiveSurveyObjects(testInterview, { personId: 'personIdWithoutJourney', journeyId: undefined });
+            const result = sectionConfig.onSectionEntry!(testInterview, iterationContext);
+            expect(result).toBeUndefined();
+        });
 
-		test('should set active visited place ID to next incomplete visited place', () => {
-			// Remove the arrival time of otherPlaceP1 to make it incomplete
-			testInterview.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!.otherPlaceP1.arrivalTime = undefined;
+        test('should set active visited place ID to next incomplete visited place', () => {
+            // Remove the arrival time of otherPlaceP1 to make it incomplete
+            testInterview.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!.otherPlaceP1.arrivalTime = undefined;
 
-			const result = sectionConfig.onSectionEntry!(testInterview, iterationContext);
-			expect(result).toEqual({ 'response._activeVisitedPlaceId': 'otherPlaceP1' });
-		});
+            const result = sectionConfig.onSectionEntry!(testInterview, iterationContext);
+            expect(result).toEqual({ 'response._activeVisitedPlaceId': 'otherPlaceP1' });
+        });
 
-		test('should set active visited place ID to undefined when all visited places are complete', () => {
-			// Journey should be complete with all required attributes by default in the test interview
-			const result = sectionConfig.onSectionEntry!(testInterview, iterationContext);
-			expect(result).toEqual({ 'response._activeVisitedPlaceId': undefined });
-		});
+        test('should set active visited place ID to undefined when all visited places are complete', () => {
+            // Journey should be complete with all required attributes by default in the test interview
+            const result = sectionConfig.onSectionEntry!(testInterview, iterationContext);
+            expect(result).toEqual({ 'response._activeVisitedPlaceId': undefined });
+        });
 
-		test('should add 2 visited places when departure place is home and select the second one', () => {
+        test('should add 2 visited places when departure place is home and select the second one', () => {
             // Reset the visited places for journey and set departure place to home
-			const testJourney = testInterview.response.household!.persons!.personId1.journeys!.journeyId1;
-			testJourney.departurePlaceIsHome = 'yes';
-			testJourney.visitedPlaces = {};
-			mockUuidv4.mockReturnValueOnce('placeId1' as any);
-			mockUuidv4.mockReturnValueOnce('placeId2' as any);
+            const testJourney = testInterview.response.household!.persons!.personId1.journeys!.journeyId1;
+            testJourney.departurePlaceIsHome = 'yes';
+            testJourney.visitedPlaces = {};
+            mockUuidv4.mockReturnValueOnce('placeId1' as any);
+            mockUuidv4.mockReturnValueOnce('placeId2' as any);
 
-			const result = sectionConfig.onSectionEntry!(testInterview, iterationContext);
-			expect(result).toEqual({
-				'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.placeId1': {
-					_sequence: 1,
-					_uuid: 'placeId1',
-					activity: 'home',
-					activityCategory: 'home',
-					nextPlaceCategory: 'visitedAnotherPlace'
-				},
-				'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.placeId1': {},
-				'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.placeId2': {
-					_sequence: 2,
-					_uuid: 'placeId2'
-				},
-				'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.placeId2': {},
-				'response._activeVisitedPlaceId': 'placeId2'
-			});
-		});
+            const result = sectionConfig.onSectionEntry!(testInterview, iterationContext);
+            expect(result).toEqual({
+                'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.placeId1': {
+                    _sequence: 1,
+                    _uuid: 'placeId1',
+                    activity: 'home',
+                    activityCategory: 'home',
+                    nextPlaceCategory: 'visitedAnotherPlace'
+                },
+                'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.placeId1': {},
+                'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.placeId2': {
+                    _sequence: 2,
+                    _uuid: 'placeId2'
+                },
+                'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.placeId2': {},
+                'response._activeVisitedPlaceId': 'placeId2'
+            });
+        });
 
-		test.each([
-			{
-				departurePlaceOther: 'otherParentHome',
-				expected: { activity: 'otherParentHome', activityCategory: 'otherParentHome' }
-			},
-			{
-				departurePlaceOther: 'restaurant',
-				expected: { activity: 'restaurant', activityCategory: 'shoppingServiceRestaurant' }
-			},
-			{
-				departurePlaceOther: 'secondaryHome',
-				expected: { activity: 'secondaryHome', activityCategory: 'leisure' }
-			},
-			{
-				departurePlaceOther: 'sleptAtFriends',
-				expected: { activity: 'visiting', activityCategory: 'leisure' }
-			},
-			{
-				departurePlaceOther: 'hotelForWork',
-				expected: { activity: 'workNotUsual', activityCategory: 'work' }
-			},
-			{
-				departurePlaceOther: 'hotelForVacation',
-				expected: { activity: 'leisureTourism', activityCategory: 'leisure' }
-			},
-			{
-				departurePlaceOther: 'studying',
-				expected: { activity: null, activityCategory: 'school' }
-			},
-			{
-				departurePlaceOther: 'workedOvernight',
-				expected: { activity: null, activityCategory: 'work' }
-			},
-			{
-				departurePlaceOther: 'unknownValue',
-				expected: { activity: null, activityCategory: null }
-			}
-		])(
-			'should map departurePlaceOther "$departurePlaceOther" to the first visited place attributes',
-			({ departurePlaceOther, expected }) => {
+        test.each([
+            {
+                departurePlaceOther: 'otherParentHome',
+                expected: { activity: 'otherParentHome', activityCategory: 'otherParentHome' }
+            },
+            {
+                departurePlaceOther: 'restaurant',
+                expected: { activity: 'restaurant', activityCategory: 'shoppingServiceRestaurant' }
+            },
+            {
+                departurePlaceOther: 'secondaryHome',
+                expected: { activity: 'secondaryHome', activityCategory: 'leisure' }
+            },
+            {
+                departurePlaceOther: 'sleptAtFriends',
+                expected: { activity: 'visiting', activityCategory: 'leisure' }
+            },
+            {
+                departurePlaceOther: 'hotelForWork',
+                expected: { activity: 'workNotUsual', activityCategory: 'work' }
+            },
+            {
+                departurePlaceOther: 'hotelForVacation',
+                expected: { activity: 'leisureTourism', activityCategory: 'leisure' }
+            },
+            {
+                departurePlaceOther: 'studying',
+                expected: { activity: null, activityCategory: 'school' }
+            },
+            {
+                departurePlaceOther: 'workedOvernight',
+                expected: { activity: null, activityCategory: 'work' }
+            },
+            {
+                departurePlaceOther: 'unknownValue',
+                expected: { activity: null, activityCategory: null }
+            }
+        ])(
+            'should map departurePlaceOther "$departurePlaceOther" to the first visited place attributes',
+            ({ departurePlaceOther, expected }) => {
                 // Reset the visited places for journey and set departure place type to other
-				const testJourney = testInterview.response.household!.persons!.personId1.journeys!.journeyId1;
-				testJourney.departurePlaceIsHome = 'no';
-				testJourney.departurePlaceOther = departurePlaceOther;
-				testJourney.visitedPlaces = {};
-				mockUuidv4.mockReturnValueOnce('placeId1' as any);
+                const testJourney = testInterview.response.household!.persons!.personId1.journeys!.journeyId1;
+                testJourney.departurePlaceIsHome = 'no';
+                testJourney.departurePlaceOther = departurePlaceOther;
+                testJourney.visitedPlaces = {};
+                mockUuidv4.mockReturnValueOnce('placeId1' as any);
 
-				const result = sectionConfig.onSectionEntry!(testInterview, iterationContext);
-				expect(result).toEqual({
-					'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.placeId1': {
-						_sequence: 1,
-						_uuid: 'placeId1',
-						...expected
-					},
-					'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.placeId1': {},
-					'response._activeVisitedPlaceId': 'placeId1'
-				});
-			}
-		);
-	});
+                const result = sectionConfig.onSectionEntry!(testInterview, iterationContext);
+                expect(result).toEqual({
+                    'response.household.persons.personId1.journeys.journeyId1.visitedPlaces.placeId1': {
+                        _sequence: 1,
+                        _uuid: 'placeId1',
+                        ...expected
+                    },
+                    'validations.household.persons.personId1.journeys.journeyId1.visitedPlaces.placeId1': {},
+                    'response._activeVisitedPlaceId': 'placeId1'
+                });
+            }
+        );
+    });
 });

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetActivityCategory.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetActivityCategory.test.ts
@@ -47,7 +47,7 @@ describe('getActivityCategoryWidgetConfig', () => {
             ]),
             label: expect.any(Function),
             validations: expect.any(Function),
-            conditional: expect.any(Function)
+            conditional: undefined
         });
     });
 });
@@ -353,35 +353,5 @@ describe('Activity category validations', () => {
         const mockedT = jest.fn();
         translateString(validation[0].errorMessage, { t: mockedT } as any, interview, 'path');
         expect(mockedT).toHaveBeenCalledWith('visitedPlaces:activityIsRequiredError');
-    });
-});
-
-describe('Activity category widget conditional', () => {
-    const widgetConfig = getActivityCategoryWidgetConfig(
-        visitedPlacesSectionConfig,
-        widgetFactoryOptions
-    ) as QuestionWidgetConfig & InputRadioType;
-    const conditional = widgetConfig.conditional;
-
-    test('should hide widget and assign home when active visited place is a new home place', () => {
-        const interview = _cloneDeep(interviewAttributesForTestCases);
-        setActiveSurveyObjects(interview, { personId: 'personId1', journeyId: 'journeyId1', visitedPlaceId: 'homePlace2P1' });
-        const activeVisitedPlace = interview.response.household!.persons!.personId1!.journeys!.journeyId1!.visitedPlaces!
-            .homePlace2P1!;
-        activeVisitedPlace._isNew = true;
-        activeVisitedPlace.activityCategory = 'home' as any;
-
-        expect(conditional!(interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.homePlace2P1.activityCategory')).toEqual([false, 'home']);
-    });
-
-    test('should show widget in regular case', () => {
-        const interview = _cloneDeep(interviewAttributesForTestCases);
-        expect(conditional!(interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.workPlace1P1.activityCategory')).toEqual([true]);
-    });
-
-    test('should show widget if context not set', () => {
-        const interview = _cloneDeep(interviewAttributesForTestCases);
-        // Use a path that won't resolve a context
-        expect(conditional!(interview, 'household.persons.personId1.journeys.journeyId1.visitedPlaces.nonExistentPlace.activityCategory')).toEqual([true]);
     });
 });

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/buttonsVisitedPlace.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/buttonsVisitedPlace.ts
@@ -343,10 +343,14 @@ export class ButtonsVisitedPlaceConfigFactory implements WidgetConfigFactory {
             if (addedGroupedObjectAfter) {
                 // The sequence would be 2+ because if a place place added before, otherwise, it is the current sequence + 1 only.
                 const nextSequence = addedGroupedObjectBefore ? visitedPlace._sequence + 2 : visitedPlace._sequence + 1;
+                // Make this place new
                 await odHelpers.insertVisitedPlace({
                     person,
                     journey,
-                    newVisitedPlace: addedGroupedObjectAfter,
+                    newVisitedPlace:
+                        addedGroupedObjectAfter !== undefined
+                            ? { _isNew: true, ...addedGroupedObjectAfter }
+                            : undefined,
                     insertSequence: nextSequence,
                     startAddGroupedObjects: callbacks.startAddGroupedObjects
                 });

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/sectionVisitedPlaces.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/sectionVisitedPlaces.ts
@@ -50,7 +50,7 @@ export class VisitedPlacesSectionFactory implements SectionConfigFactory {
     ): Record<string, unknown> | undefined => {
         // Add home as first visited place and add a second one
         if (journey.departurePlaceIsHome === 'yes') {
-            // Add 2 places: home and the next one
+            // Add 2 places: home and the next one, both set as new
             const { valuesByPath, newObjects } = addGroupedObjects(
                 interview,
                 2,
@@ -60,9 +60,12 @@ export class VisitedPlacesSectionFactory implements SectionConfigFactory {
                     {
                         activity: 'home',
                         activityCategory: 'home',
-                        nextPlaceCategory: 'visitedAnotherPlace'
+                        nextPlaceCategory: 'visitedAnotherPlace',
+                        _isNew: true
                     },
-                    {}
+                    {
+                        _isNew: true
+                    }
                 ]
             );
             // Select the second place as active place
@@ -114,7 +117,8 @@ export class VisitedPlacesSectionFactory implements SectionConfigFactory {
             [
                 {
                     activity: firstActivity,
-                    activityCategory: firstActivityCategory
+                    activityCategory: firstActivityCategory,
+                    _isNew: true
                 }
             ]
         );

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetActivityCategory.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetActivityCategory.ts
@@ -213,18 +213,7 @@ export const getActivityCategoryWidgetConfig = (
                     errorMessage: (t: TFunction) => t('visitedPlaces:activityIsRequiredError')
                 }
             ];
-        },
-        conditional: function (interview, path) {
-            const visitedPlaceContext = odHelpers.getVisitedPlaceContextFromPath({ interview, path });
-            if (!visitedPlaceContext) {
-                return [true];
-            }
-            const { visitedPlace: activeVisitedPlace } = visitedPlaceContext;
-            // Do not show for the a new place that is home
-            // FIXME This is copy pasted from od_nationale_quebec. Is this right? Do we want to hide the activity category question for a new visited place that is home? What if the user wants to change the activity category of a new visited place that is home?
-            return activeVisitedPlace._isNew === true && activeVisitedPlace.activityCategory === 'home'
-                ? [false, activeVisitedPlace.activityCategory]
-                : [true];
         }
+        // No conditional, always display
     };
 };


### PR DESCRIPTION
fixes #1626

Set the places as `_isNew = true` when they are first created when
entering the visited places section, but also when the next place is
created. This should make the `minuteStep` conditional work as expected.


Also part of this PR:

Always show the activity category widget, as this was the current effective behavior and adding the `_isNew` flag causes a bug in the visited places.

Also format a test file with 4 spaces instead of tabs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Newly created visited places are consistently identified as new.
  * Activity category fields remain visible for all visited places.
* **Bug Fixes**
  * Improved automatic insertion and initialization of visited-place records.
  * Corrected handling of home-based and departure-based place entries.
* **Tests**
  * Expanded coverage for section configuration, completion states, widget composition, translations, and place mappings.
  * Updated expectations for newly created visited places.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->