### PR TITLE
Audit: add audit log prefix to all audit logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING**: Generator inactive widgets: `active` now behaves like a real boolean (Excel `0`/`1` included), defaults to inactive when omitted, and inactive rows stay commented-out in generated widget files instead of emitting broken code (fixes [#1597](https://github.com/chairemobilite/evolution/issues/1597)).
 - **BREAKING**: Builtin widgets now only use the widget name with section as namespace as locale translation key. Any key that was overridden in the `customSurvey` namespace should be moved to the widget's namespace. (fixes [#1441](https://github.com/chairemobilite/evolution/issues/1441))
 - The Google map widgets were migrated from the deprecated `@react-google-maps/api` package to `@vis.gl/react-google-maps`, which renders vector maps and uses `AdvancedMarker` (fixes [#453](https://github.com/chairemobilite/evolution/issues/453)). This uses the new Google Map ID, for which we provide a default style, but a new `GOOGLE_MAP_ID` environment variable was added if someone wants to override the default style. See `.env.example` and the [Get a Map ID](https://developers.google.com/maps/documentation/get-map-id) docs.
+- Audit and survey-object factory console logs are prefixed with `[Audit]` via `AuditLog` so they can be filtered in server error logs (fixes [#1836](https://github.com/chairemobilite/evolution/issues/1836)).
 
 ### Deprecated
 

--- a/packages/evolution-backend/src/services/audits/AuditService.ts
+++ b/packages/evolution-backend/src/services/audits/AuditService.ts
@@ -13,6 +13,7 @@ import { ErrorsBySurveyObject } from 'evolution-common/lib/services/baseObjects/
 import { convertParamsErrorsToAudits } from './AuditUtils';
 import { AuditsByObject } from 'evolution-common/lib/services/audits/types';
 import { auditsArrayToAuditsByObject } from 'evolution-common/lib/services/audits/AuditUtils';
+import { AuditLog } from './auditLog';
 
 /**
  * Service that handles the complete audit workflow:
@@ -38,7 +39,7 @@ export class AuditService {
         interviewAttributes: InterviewAttributes,
         runExtendedAuditChecks: boolean = false
     ): Promise<SurveyObjectsWithAudits> {
-        console.log(`Starting audit workflow for interview ${interviewAttributes.uuid}`);
+        AuditLog.debug(`Starting audit workflow for interview ${interviewAttributes.uuid}`);
 
         // If the interview has no response or corrected response, return an empty survey objects with audits
         if (!interviewAttributes.response || !interviewAttributes.corrected_response) {
@@ -51,12 +52,12 @@ export class AuditService {
         }
 
         // Step 1: Create survey objects (this may produce parameter errors)
-        console.log('Step 1: Creating survey objects...');
+        AuditLog.debug('Step 1: Creating survey objects...');
         const factory = new SurveyObjectsFactory();
         const surveyObjectsWithErrors = await factory.createAllObjectsWithErrors(interviewAttributes);
 
         // Step 2: Convert parameter errors to audits (currently empty arrays in evolution-common)
-        console.log('Step 2: Converting parameter errors to audits if present...');
+        AuditLog.debug('Step 2: Converting parameter errors to audits if present...');
         // Note: This step is currently handled during object creation in evolution-common
         // but the actual conversion happens here in the backend
         const parameterAudits = this.convertCreationErrorsToAudits(surveyObjectsWithErrors.errorsByObject);
@@ -78,7 +79,7 @@ export class AuditService {
         };
 
         // Step 3: Run object audits
-        console.log('Step 3: Running object audits...');
+        AuditLog.debug('Step 3: Running object audits...');
         const objectAudits = await SurveyObjectAuditor.auditSurveyObjects(
             surveyObjectsWithAudits,
             runExtendedAuditChecks
@@ -86,7 +87,7 @@ export class AuditService {
         surveyObjectsWithAudits.audits.push(...objectAudits);
         surveyObjectsWithAudits.auditsByObject = auditsArrayToAuditsByObject(surveyObjectsWithAudits.audits);
 
-        console.log(`Auditing completed. Total audits: ${surveyObjectsWithAudits.audits.length}`);
+        AuditLog.debug(`Auditing completed. Total audits: ${surveyObjectsWithAudits.audits.length}`);
 
         return surveyObjectsWithAudits;
     }

--- a/packages/evolution-backend/src/services/audits/BatchAuditService.ts
+++ b/packages/evolution-backend/src/services/audits/BatchAuditService.ts
@@ -13,6 +13,7 @@ import { Result, createOk, createErrors } from 'evolution-common/lib/types/Resul
 import { execJob } from '../../tasks/serverWorkerPool';
 import { ValueFilterType, VALID_OPERATORS } from '../../models/interviews.db.queries';
 import { isFeature } from 'geojson-validation';
+import { AuditLog } from './auditLog';
 
 /**
  * Result for a single interview audit operation
@@ -161,7 +162,7 @@ const processInterviewAudit = async (
             status: 'success'
         };
     } catch (error) {
-        console.error(`Error processing interview ${interviewUuid}: ${error}`);
+        AuditLog.error(`Error processing interview ${interviewUuid}: ${error}`);
         return {
             uuid: interviewUuid,
             status: 'failed',
@@ -208,11 +209,11 @@ export const runBatchAuditsTask = async function (params: BatchAuditTaskParams):
     // Enforce maximum limit to prevent memory issues and long-running tasks
     if (totalCount > MAX_INTERVIEWS_PER_BATCH) {
         const errorMessage = `Batch audit request exceeds maximum limit of ${MAX_INTERVIEWS_PER_BATCH} interviews. Found ${totalCount} matching interviews. Please refine your filters.`;
-        console.error(errorMessage);
+        AuditLog.error(errorMessage);
         throw new Error(errorMessage);
     }
 
-    console.info(
+    AuditLog.info(
         `Batch audit started: totalCount=${totalCount} extended=${runExtendedAuditChecks} userId=${userId ?? 'undefined'} batchSize=${BATCH_SIZE} maxLimit=${MAX_INTERVIEWS_PER_BATCH}`
     );
 
@@ -242,7 +243,7 @@ export const runBatchAuditsTask = async function (params: BatchAuditTaskParams):
         });
 
         // Log progress
-        console.info(
+        AuditLog.info(
             `Batch audit progress: ${processed}/${totalCount} processed (${succeeded} succeeded, ${failed} failed)`
         );
     };
@@ -266,7 +267,7 @@ export const runBatchAuditsTask = async function (params: BatchAuditTaskParams):
         await processPage(pageResponse.interviews);
     }
 
-    console.info(
+    AuditLog.info(
         `Batch audit completed: totalCount=${totalCount} succeeded=${succeeded} failed=${failed} extended=${runExtendedAuditChecks}`
     );
 
@@ -338,7 +339,7 @@ export class BatchAuditService {
 
             return createOk(result as BatchAuditResult);
         } catch (error) {
-            console.error('Error running batch audits:', error);
+            AuditLog.error('Error running batch audits:', error);
             const errorObj = error instanceof Error ? error : new Error(String(error));
             return createErrors([errorObj]);
         }

--- a/packages/evolution-backend/src/services/audits/SurveyObjectAuditor.ts
+++ b/packages/evolution-backend/src/services/audits/SurveyObjectAuditor.ts
@@ -7,6 +7,7 @@
 
 import { AuditForObject, SurveyObjectsWithAudits } from 'evolution-common/lib/services/audits/types';
 import * as auditChecks from './auditChecks';
+import { AuditLog } from './auditLog';
 
 /**
  * The auditor can audit all survey objects in a single run.
@@ -40,7 +41,7 @@ export class SurveyObjectAuditor {
             );
             allAudits.push(...interviewAudits);
         } else {
-            console.warn('Interview not found or invalid, skipping survey objects audit checks');
+            AuditLog.warn('Interview not found or invalid, skipping survey objects audit checks');
             return allAudits;
         }
 

--- a/packages/evolution-backend/src/services/audits/__tests__/auditLog.test.ts
+++ b/packages/evolution-backend/src/services/audits/__tests__/auditLog.test.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { AUDIT_LOG_PREFIX, AuditLog } from '../auditLog';
+
+describe('AuditLog', () => {
+    test.each([
+        ['debug', 'debug'],
+        ['info', 'info'],
+        ['warn', 'warn'],
+        ['error', 'error']
+    ] as const)('%s prefixes a string message', (method, consoleMethod) => {
+        const spy = jest.spyOn(console, consoleMethod).mockImplementation(() => undefined);
+        AuditLog[method]('hello', 42);
+        expect(spy).toHaveBeenCalledWith(`${AUDIT_LOG_PREFIX} hello`, 42);
+        spy.mockRestore();
+    });
+
+    test('prefixes a non-string first argument', () => {
+        const spy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+        const err = new Error('boom');
+        AuditLog.error(err);
+        expect(spy).toHaveBeenCalledWith(AUDIT_LOG_PREFIX, err);
+        spy.mockRestore();
+    });
+});

--- a/packages/evolution-backend/src/services/audits/auditLog.ts
+++ b/packages/evolution-backend/src/services/audits/auditLog.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+/** Stable prefix so audit and factory console lines can be filtered in server logs. */
+export const AUDIT_LOG_PREFIX = '[Audit]';
+
+const prefixArgs = (args: unknown[]): unknown[] => {
+    if (args.length > 0 && typeof args[0] === 'string') {
+        return [`${AUDIT_LOG_PREFIX} ${args[0]}`, ...args.slice(1)];
+    }
+    return [AUDIT_LOG_PREFIX, ...args];
+};
+
+/**
+ * Console logger for the audit workflow and survey-object factories.
+ * Use this instead of `console.*` so the prefix stays in one place.
+ *
+ * TODO: replace this manual prefix with a real structured logger (winston or
+ * similar) when the backend adopts one.
+ *
+ * Levels (Node sends `debug`/`info` to stdout, `warn`/`error` to stderr):
+ * - `error`: unexpected exception or a batch/job that failed
+ * - `warn`: audit skipped because a required object is missing
+ * - `info`: batch progress (start / N of M / done)
+ * - `debug`: per-interview detail and factory outcomes (creation failed,
+ *   skipped attributes). These are interview data that become audits, not
+ *   server crashes.
+ */
+export const AuditLog = {
+    debug: (...args: unknown[]): void => {
+        console.debug(...prefixArgs(args));
+    },
+    info: (...args: unknown[]): void => {
+        console.info(...prefixArgs(args));
+    },
+    warn: (...args: unknown[]): void => {
+        console.warn(...prefixArgs(args));
+    },
+    error: (...args: unknown[]): void => {
+        console.error(...prefixArgs(args));
+    }
+};

--- a/packages/evolution-backend/src/services/interviews/interviews.ts
+++ b/packages/evolution-backend/src/services/interviews/interviews.ts
@@ -18,6 +18,7 @@ import interviewsDbQueries, {
 import interviewsAccessesDbQueries from '../../models/interviewsAccesses.db.queries';
 import { UserInterviewAccesses } from '../logging/loggingTypes';
 import { SurveyObjectsAndAuditsFactory } from '../audits/SurveyObjectsAndAuditsFactory';
+import { AuditLog } from '../audits/auditLog';
 import { AuditStatsByLevelAndObjectType } from 'evolution-common/lib/services/audits/types';
 import {
     InterviewAttributes,
@@ -188,7 +189,7 @@ export default class Interviews {
         return new Promise((resolve, reject) => {
             queryStream
                 .on('error', (error) => {
-                    console.error('queryStream failed', error);
+                    AuditLog.error('queryStream failed', error);
                     if (disableConsoleLog) {
                         console.log = oldConsoleLog;
                     }
@@ -198,7 +199,7 @@ export default class Interviews {
                     queryStream.pause();
                     const interview = row;
                     if (i % 1000 === 0 || i === 1) {
-                        console.info(`Auditing interview ${i}`);
+                        AuditLog.info(`Auditing interview ${i}`);
                     }
                     i++;
                     if (_isBlank(interview.corrected_response)) {
@@ -214,13 +215,13 @@ export default class Interviews {
                                                 res1(true);
                                             })
                                             .catch((error) => {
-                                                console.error('Error running and saving interview audits', error);
+                                                AuditLog.error('Error running and saving interview audits', error);
                                                 res1(false);
                                             });
                                     })
                             )
                             .catch((error) => {
-                                console.error('Error copying response to corrected response', error);
+                                AuditLog.error('Error copying response to corrected response', error);
                             })
                             .finally(() => {
                                 queryStream.resume();
@@ -231,7 +232,7 @@ export default class Interviews {
                             runExtendedAuditChecks
                         )
                             .catch((error) => {
-                                console.error('Error running and saving interview audits', error);
+                                AuditLog.error('Error running and saving interview audits', error);
                             })
                             .finally(() => {
                                 queryStream.resume();
@@ -239,7 +240,7 @@ export default class Interviews {
                     }
                 })
                 .on('end', () => {
-                    console.log('all interviews audited successfully.');
+                    AuditLog.info('all interviews audited successfully.');
                     if (disableConsoleLog) {
                         console.log = oldConsoleLog;
                     }

--- a/packages/evolution-backend/src/services/surveyObjects/JourneyFactory.ts
+++ b/packages/evolution-backend/src/services/surveyObjects/JourneyFactory.ts
@@ -18,6 +18,7 @@ import { SurveyObjectsWithErrors } from 'evolution-common/lib/services/baseObjec
 import { Optional } from 'evolution-common/lib/types/Optional.type';
 import projectConfig from '../../config/projectConfig';
 import { CorrectedResponse } from 'evolution-common/lib/services/questionnaire/types';
+import { AuditLog } from '../audits/auditLog';
 import { SurveyObjectsRegistry } from 'evolution-common/lib/services/baseObjects/SurveyObjectsRegistry';
 import { compareSequenceThenUuid } from 'evolution-common/lib/services/baseObjects/sequenceUtils';
 
@@ -86,9 +87,7 @@ export async function populateJourneysForPerson(
                 surveyObjectsRegistry
             );
         } else {
-            console.log(
-                `      ==== Journey ${journeyUuid} creation failed with errors count: ${journey.errors?.length || 0} ====`
-            );
+            AuditLog.debug(`Journey ${journeyUuid} creation failed with errors count: ${journey.errors?.length || 0}`);
             surveyObjectsWithErrors.errorsByObject.journeysByUuid[journeyUuid] = journey.errors;
         }
     }

--- a/packages/evolution-backend/src/services/surveyObjects/PersonFactory.ts
+++ b/packages/evolution-backend/src/services/surveyObjects/PersonFactory.ts
@@ -18,6 +18,7 @@ import projectConfig from '../../config/projectConfig';
 import { SurveyObjectsRegistry } from 'evolution-common/lib/services/baseObjects/SurveyObjectsRegistry';
 import { compareSequenceThenUuid } from 'evolution-common/lib/services/baseObjects/sequenceUtils';
 import { populateJourneysForPerson } from './JourneyFactory';
+import { AuditLog } from '../audits/auditLog';
 import { ExtendedPersonAttributes } from 'evolution-common/lib/services/baseObjects/Person';
 
 /**
@@ -41,7 +42,7 @@ export async function populatePersonsForHousehold(
 
     // If no household, return
     if (!surveyObjectsWithErrors.household) {
-        console.log('    ==== No household - skipping persons creation ====');
+        AuditLog.debug('No household - skipping persons creation');
         return;
     }
 
@@ -89,8 +90,8 @@ export async function populatePersonsForHousehold(
             // Setup work and school places after all visited places are created
             personResult.result.setupWorkAndSchoolPlaces();
         } else {
-            console.log(
-                `      ==== Person ${personUuid} creation failed with errors count: ${personResult.errors?.length || 0} ====`
+            AuditLog.debug(
+                `Person ${personUuid} creation failed with errors count: ${personResult.errors?.length || 0}`
             );
             surveyObjectsWithErrors.errorsByObject.personsByUuid[personUuid] = personResult.errors;
         }

--- a/packages/evolution-backend/src/services/surveyObjects/SegmentFactory.ts
+++ b/packages/evolution-backend/src/services/surveyObjects/SegmentFactory.ts
@@ -13,6 +13,7 @@ import projectConfig from '../../config/projectConfig';
 import { CorrectedResponse } from 'evolution-common/lib/services/questionnaire/types';
 import { SurveyObjectsRegistry } from 'evolution-common/lib/services/baseObjects/SurveyObjectsRegistry';
 import { compareSequenceThenUuid } from 'evolution-common/lib/services/baseObjects/sequenceUtils';
+import { AuditLog } from '../audits/auditLog';
 
 /**
  * Generate segments for a trip
@@ -51,9 +52,7 @@ export async function populateSegmentsForTrip(
             // Associate segment with trip
             trip.addSegment(segment.result);
         } else {
-            console.log(
-                `          ==== Segment ${segmentUuid} creation failed with errors count: ${segment.errors?.length || 0} ====`
-            );
+            AuditLog.error(`Segment ${segmentUuid} creation failed with errors count: ${segment.errors?.length || 0}`);
             surveyObjectsWithErrors.errorsByObject.segmentsByUuid[segmentUuid] = segment.errors;
         }
     }

--- a/packages/evolution-backend/src/services/surveyObjects/SurveyObjectsFactory.ts
+++ b/packages/evolution-backend/src/services/surveyObjects/SurveyObjectsFactory.ts
@@ -18,6 +18,7 @@ import { Home } from 'evolution-common/lib/services/baseObjects/Home';
 import { ExtendedHouseholdAttributes, Household } from 'evolution-common/lib/services/baseObjects/Household';
 import { SurveyObjectsRegistry } from 'evolution-common/lib/services/baseObjects/SurveyObjectsRegistry';
 import { ExtendedPlaceAttributes } from 'evolution-common/lib/services/baseObjects/Place';
+import { AuditLog } from '../audits/auditLog';
 
 /**
  * Configuration options for object creation
@@ -109,9 +110,7 @@ export class SurveyObjectsFactory {
             surveyObjectsWithErrors.interview = interviewResult.result;
         } else {
             surveyObjectsWithErrors.errorsByObject.interview = interviewResult.errors;
-            console.log(
-                `==== Interview creation failed with errors count: ${interviewResult.errors?.length || 0} ====`
-            );
+            AuditLog.debug(`Interview creation failed with errors count: ${interviewResult.errors?.length || 0}`);
         }
 
         const homeAttributes = projectConfig.surveyObjectParsers?.home
@@ -134,10 +133,10 @@ export class SurveyObjectsFactory {
                 surveyObjectsWithErrors.home = homeResult.result;
             } else {
                 surveyObjectsWithErrors.errorsByObject.home = homeResult.errors;
-                console.log(`  ==== Home creation failed with errors count: ${homeResult.errors?.length || 0} ====`);
+                AuditLog.debug(`Home creation failed with errors count: ${homeResult.errors?.length || 0}`);
             }
         } else {
-            console.log('  ==== Home creation skipped (no home attributes) ====');
+            AuditLog.debug('Home creation skipped (no home attributes)');
         }
 
         const householdAttributes = projectConfig.surveyObjectParsers?.household
@@ -162,12 +161,10 @@ export class SurveyObjectsFactory {
                 surveyObjectsWithErrors.household = householdResult.result;
             } else {
                 surveyObjectsWithErrors.errorsByObject.household = householdResult.errors;
-                console.log(
-                    `  ==== Household creation failed with errors count: ${householdResult.errors?.length || 0} ====`
-                );
+                AuditLog.debug(`Household creation failed with errors count: ${householdResult.errors?.length || 0}`);
             }
         } else {
-            console.log('  ==== Household creation skipped (no household attributes) ====');
+            AuditLog.debug('Household creation skipped (no household attributes)');
         }
 
         const home = surveyObjectsWithErrors.home;

--- a/packages/evolution-backend/src/services/surveyObjects/TripFactory.ts
+++ b/packages/evolution-backend/src/services/surveyObjects/TripFactory.ts
@@ -20,6 +20,7 @@ import {
     compareSequenceThenUuid,
     hasInvalidOrDuplicateSequences
 } from 'evolution-common/lib/services/baseObjects/sequenceUtils';
+import { AuditLog } from '../audits/auditLog';
 
 /**
  * Generate all trips for a journey
@@ -93,9 +94,7 @@ export async function populateTripsForJourney(
                 trip.result.segments = trip.result.getSegmentsWithoutWalkingInMultimode();
             }
         } else {
-            console.log(
-                `        ==== Trip ${tripUuid} creation failed with errors count: ${trip.errors?.length || 0} ====`
-            );
+            AuditLog.debug(`Trip ${tripUuid} creation failed with errors count: ${trip.errors?.length || 0}`);
             surveyObjectsWithErrors.errorsByObject.tripsByUuid[tripUuid] = trip.errors;
         }
     }

--- a/packages/evolution-backend/src/services/surveyObjects/VisitedPlaceFactory.ts
+++ b/packages/evolution-backend/src/services/surveyObjects/VisitedPlaceFactory.ts
@@ -17,6 +17,7 @@ import projectConfig from '../../config/projectConfig';
 import { CorrectedResponse } from 'evolution-common/lib/services/questionnaire/types';
 import { SurveyObjectsRegistry } from 'evolution-common/lib/services/baseObjects/SurveyObjectsRegistry';
 import { compareSequenceThenUuid } from 'evolution-common/lib/services/baseObjects/sequenceUtils';
+import { AuditLog } from '../audits/auditLog';
 
 /**
  * Create all visited places for a journey
@@ -88,8 +89,8 @@ export async function populateVisitedPlacesForJourney(
                     if (isOk(placeResult)) {
                         visitedPlace.place = placeResult.result;
                     } else {
-                        console.error(
-                            `!!! Could not create Place for visited place ${visitedPlaceUuid}:`,
+                        AuditLog.debug(
+                            `Could not create Place for visited place ${visitedPlaceUuid}:`,
                             placeResult.errors
                         );
                     }
@@ -97,8 +98,8 @@ export async function populateVisitedPlacesForJourney(
             }
             journey.addVisitedPlace(visitedPlace);
         } else {
-            console.log(
-                `        ==== VisitedPlace ${visitedPlaceUuid} creation failed with errors count: ${visitedPlaceResult.errors?.length || 0} ====`
+            AuditLog.debug(
+                `VisitedPlace ${visitedPlaceUuid} creation failed with errors count: ${visitedPlaceResult.errors?.length || 0}`
             );
             surveyObjectsWithErrors.errorsByObject.visitedPlacesByUuid[visitedPlaceUuid] = visitedPlaceResult.errors;
         }


### PR DESCRIPTION
Remove debug characters from audit logs.

Document the usage of log/info/warn/error for audit logs.

Remove _disableConsoleLog parameter for audit services, but do not update the function for now (added a TODO).

Add changes to CHANGELOG.md.

closes #1836

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Standardized audit-related console messages with a consistent `[Audit]` prefix.
  * Improved clarity for audit workflow progress, warnings, errors, and survey-object creation diagnostics.
  * Preserved existing audit processing, error handling, and result behavior.
* **Tests**
  * Added coverage verifying audit message prefixes and preservation of additional log details.
* **Documentation**
  * Updated the unreleased 0.6.0 changelog with the new audit logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->