### PR TITLE
auth: add missing translation keys for token confirmation

### DIFF
--- a/locales/en/auth.json
+++ b/locales/en/auth.json
@@ -78,8 +78,12 @@
     "errorLabel": "Error, please retry"    
   },
   "captchaRequired": "Please complete the CAPTCHA to submit your message.",
+  "ConfirmationTokenLoading": "Looking up the account linked to this confirmation code...",
   "ConfirmationTokenConfirming": "New account confirmation in progress...",
+  "ConfirmationTokenBelongsTo": "This confirmation code belongs to",
+  "ConfirmationTokenAskToConfirm": "Do you want to verify this account?",
   "ConfirmationTokenConfirmed": "The new account is now active!",
+  "ConfirmationTokenMissing": "No confirmation code was provided. Please check that you clicked on a valid confirmation link.",
   "ConfirmationTokenNotFound": "The confirmation code was not found in the database. Is the account already active?",
   "ConfirmationTokenError": "An error occurred while confirming a new user account. If login is impossible and the error persists, contact the site's administrator for more information.",
   "UnconfirmedUser": "You user account has not been confirmed. You or an administrator should receive an email with a link to confirm your account. Check your emails or contact the site's administrator."

--- a/locales/fr/auth.json
+++ b/locales/fr/auth.json
@@ -78,8 +78,12 @@
     "errorLabel": "Erreur, veuillez réessayer"    
   },
   "captchaRequired": "Veuillez confirmer que vous n'êtes pas un robot en cochant la case ci-dessous.",
+  "ConfirmationTokenLoading": "Recherche du compte lié à ce code de confirmation...",
   "ConfirmationTokenConfirming": "Confirmation du nouveau compte usager en cours...",
+  "ConfirmationTokenBelongsTo": "Ce code de confirmation correspond à",
+  "ConfirmationTokenAskToConfirm": "Voulez-vous confirmer ce compte?",
   "ConfirmationTokenConfirmed": "Le compte usager est maintenant activé!",
+  "ConfirmationTokenMissing": "Aucun code de confirmation n'a été fourni. Veuillez vérifier que vous avez cliqué sur un lien de confirmation valide.",
   "ConfirmationTokenNotFound": "Le code de confirmation n'a pas été trouvé dans la base de données. Le compte usager est peut-être déjà activé?",
   "ConfirmationTokenError": "Une erreur est survenue lors de la confirmation du compte usager. S'il est impossible de se connecter au site et que la situation persiste, contactez l'administrateur du site pour plus d'information.",
   "UnconfirmedUser": "Votre compte usager n'a pas été confirmé. Vous ou un administrateur recevrez un courriel avec un lien pour confirmer le compte. Vérifiez vos courriels ou contactez l'administrateur du site."


### PR DESCRIPTION
fixes #1841

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added English and French authentication messages for confirmation-token loading, account association, confirmation prompts, and missing-token states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->