### PR TITLE
segments: create the first mode on section entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Segments: create the first segment automatically when a trip becomes active, so its mode is asked directly instead of behind a "choose first mode" button. Added `tripHasDefinedSegments`, true when a trip has at least one segment with a non blank `mode` or `modePre`, to tell a trip the respondent started from one that only has that empty first segment (fixes [#1825](https://github.com/chairemobilite/evolution/issues/1825)).
 - Fix HTML markup showing up in templates, by using the `stripHtml` function from `frontendHelpers` (fixes [#1584](https://github.com/chairemobilite/evolution/issues/1584))
 - Fix confirm button placements in `TripsAndSegmentsSection` template to go below the map on small screens (fixes [#1837](https://github.com/chairemobilite/evolution/issues/1837))
 - InfoMap titles can be HTML (`containsHtml`), so generator tags (`<span class="_pale _oblique">`, `style="..."`) render instead of showing as text. The visited places map widget sets this flag.

--- a/example/demo_survey/src/survey/helper.ts
+++ b/example/demo_survey/src/survey/helper.ts
@@ -263,7 +263,7 @@ const tripsForPersonComplete = function (person, interview) {
     for (const tripId in trips) {
         const trip = trips[tripId];
         const segments = odSurveyHelper.getSegments({ trip });
-        if (_isBlank(trip.segments)) {
+        if (!odSurveyHelper.tripHasDefinedSegments({ trip })) {
             return false;
         }
         for (const segmentId in segments) {

--- a/packages/evolution-common/src/services/odSurvey/__tests__/helpers.test.ts
+++ b/packages/evolution-common/src/services/odSurvey/__tests__/helpers.test.ts
@@ -3140,6 +3140,14 @@ describe('selectNextIncompleteTrip', () => {
         attributes.trips!.trip2.segments = segments;
         expect(Helpers.selectNextIncompleteTrip({ journey: attributes })).toEqual(null);
     });
+
+    test('should select trip with only an empty first segment (same as add-button object)', () => {
+        const attributes = _cloneDeep(journey);
+        attributes.trips!.trip2.segments = {
+            segmentEmpty: { _uuid: 'segmentEmpty', _sequence: 1, _isNew: true }
+        };
+        expect(Helpers.selectNextIncompleteTrip({ journey: attributes })).toEqual(attributes.trips!.trip2);
+    });
 });
 
 describe('getOrigin/getDestination', () => {
@@ -3588,6 +3596,38 @@ describe('getSegments', () => {
         attributes.segments = segments;
         expect(Helpers.getSegmentsArray({ trip: attributes })).toEqual([segments.segment2, segments.segment1]);
     });
+});
+
+describe('tripHasDefinedSegments', () => {
+    const trip: Trip = { _uuid: 'arbitraryTrip', _sequence: 1 };
+
+    each([
+        ['no segments property', {}, false],
+        ['empty segments object', { segments: {} }, false],
+        ['first segment as created with the trip (no mode yet)', {
+            segments: { segment1: { _uuid: 'segment1', _sequence: 1, _isNew: true } }
+        }, false],
+        ['_isNew false but no mode (saved empty / half-edited after refresh)', {
+            segments: { segment1: { _uuid: 'segment1', _sequence: 1, _isNew: false } }
+        }, false],
+        ['blank modePre', {
+            segments: { segment1: { _uuid: 'segment1', _sequence: 1, _isNew: false, modePre: '' } }
+        }, false],
+        ['_isNew true with mode still counts as defined', {
+            segments: { segment1: { _uuid: 'segment1', _sequence: 1, _isNew: true, modePre: 'walk' } }
+        }, true],
+        ['modePre set', {
+            segments: { segment1: { _uuid: 'segment1', _sequence: 1, _isNew: false, modePre: 'walk' } }
+        }, true],
+        ['mode set', {
+            segments: { segment1: { _uuid: 'segment1', _sequence: 1, _isNew: false, mode: 'walk' as const } }
+        }, true]
+    ]).test('%s', (_title, tripAttributes, expected) => {
+        expect(Helpers.tripHasDefinedSegments({ trip: { ...trip, ...tripAttributes } })).toEqual(expected);
+    });
+});
+
+describe('getSegmentContextFromPath', () => {
 
     each([
         {

--- a/packages/evolution-common/src/services/odSurvey/helpers.ts
+++ b/packages/evolution-common/src/services/odSurvey/helpers.ts
@@ -903,7 +903,7 @@ export const selectNextIncompleteTrip = ({ journey }: { journey: Journey }): Tri
         // segment section configuration. Now we suppose there should be
         // segments and only the mode is mandatory
         const segments = getSegmentsArray({ trip });
-        if (segments.length === 0) {
+        if (!tripHasDefinedSegments({ trip })) {
             return trip;
         } else {
             // Return the trip if one of the segments does not have a mode
@@ -1780,6 +1780,20 @@ export const getSegments = ({ trip }: { trip: Trip }): { [segmentId: string]: Se
 export const getSegmentsArray = ({ trip }: { trip: Trip }): Segment[] => {
     const segments = getSegments({ trip });
     return Object.values(segments).sort((segmentA, segmentB) => segmentA._sequence - segmentB._sequence);
+};
+
+/**
+ * Whether the trip has at least one segment that the respondent has started
+ * (mode or modePre set). An auto-created first segment with no mode data is
+ * not defined: `_isNew` is not enough, because it becomes `false` after save
+ * and a half-edited segment can still be `_isNew` after a refresh.
+ *
+ * @param {Object} options - The options object.
+ * @param {Trip} options.trip The trip to inspect
+ * @returns {boolean} `true` if at least one segment has `mode` or `modePre`
+ */
+export const tripHasDefinedSegments = ({ trip }: { trip: Trip }): boolean => {
+    return getSegmentsArray({ trip }).some((segment) => !_isBlank(segment.modePre) || !_isBlank(segment.mode));
 };
 
 /**

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/buttonSaveTripSegments.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/buttonSaveTripSegments.test.ts
@@ -144,7 +144,7 @@ describe('getButtonSaveTripSegmentsConfig save callback', () => {
             activeTripId: 'tripId2P2'
         });
         // Mock function response for incomplete trip
-        const incompleteTrip = { _uuid: 'trip1', _sequence: 1 };
+        const incompleteTrip = testInterview.response.household!.persons!.personId2!.journeys!.journeyId2.trips!.tripId1P2;
         mockedSelectNextIncompleteTrip.mockReturnValueOnce(incompleteTrip);
 
         // Call the save callback
@@ -157,7 +157,7 @@ describe('getButtonSaveTripSegmentsConfig save callback', () => {
             valuesByPath: {
                 'response.household.persons.personId2.journeys.journeyId2.trips.tripId2P2.segments.segmentId1P2T2._isNew': false,
                 'response.household.persons.personId2.journeys.journeyId2.trips.tripId2P2.segments.segmentId2P2T2._isNew': false,
-                'response._activeTripId': 'trip1'
+                'response._activeTripId': 'tripId1P2'
             }
         });
     });
@@ -212,30 +212,36 @@ describe('getButtonSaveTripSegmentsConfig save callback', () => {
         });
     });
 
-    test('should just set next incomplete trip if no segments', () => {
-        // Use a path to a trip with no segments
-        const testButtonPathPrefix = 'household.persons.personId1.journeys.journeyId1.trips.tripId1P1';
-        const testButtonPath = `${testButtonPathPrefix}.buttonSaveTrip`;
-        // Set active trip ID for next incomplete trip selection
+    test('should create the first segment on the next trip when it has none', () => {
         const testInterview = _cloneDeep(interviewAttributesForTestCases);
         setActiveSurveyObjects(testInterview, {
-            personId: 'personId1',
-            journeyId: 'journeyId1',
-            activeTripId: 'tripId1P1'
+            personId: 'personId2',
+            journeyId: 'journeyId2',
+            activeTripId: 'tripId2P2'
         });
-        // Mock function response: 2 segments, active journey and incomplete trip
-        const incompleteTrip = { _uuid: 'trip1', _sequence: 1 };
-        mockedSelectNextIncompleteTrip.mockReturnValueOnce(incompleteTrip);
+        const nextTrip = testInterview.response.household!.persons!.personId2!.journeys!.journeyId2.trips!.tripId3P2;
+        mockedSelectNextIncompleteTrip.mockReturnValueOnce(nextTrip);
 
-        // Call the save callback
-        saveCallback!(updateCallbacks, testInterview, testButtonPath);
+        saveCallback!(updateCallbacks, testInterview, buttonPath);
 
-        // Test function calls
-        expect(mockedSelectNextIncompleteTrip).toHaveBeenCalledWith({ journey: testInterview.response.household!.persons!.personId1!.journeys!.journeyId1 });
-        expect(updateCallbacks.startUpdateInterview).toHaveBeenCalledWith({
-            sectionShortname: 'segments',
-            valuesByPath: { 'response._activeTripId': 'trip1' }
-        });
+        const valuesByPath = updateCallbacks.startUpdateInterview.mock.calls[0][0].valuesByPath;
+        expect(valuesByPath['response._activeTripId']).toEqual('tripId3P2');
+        const newSegmentPath = Object.keys(valuesByPath).find((path) =>
+            path.startsWith('response.household.persons.personId2.journeys.journeyId2.trips.tripId3P2.segments.')
+        );
+        expect(newSegmentPath).toBeDefined();
+        const segmentId = newSegmentPath!.split('.').pop();
+        expect(valuesByPath[newSegmentPath!]).toEqual({ _uuid: segmentId, _sequence: 1, _isNew: true });
+        expect(valuesByPath[`validations.household.persons.personId2.journeys.journeyId2.trips.tripId3P2.segments.${segmentId}`]).toEqual({});
+    });
+
+    test('should throw if the journey context is not found for the path', () => {
+        const testInterview = _cloneDeep(interviewAttributesForTestCases);
+
+        expect(() => saveCallback!(updateCallbacks, testInterview, 'invalid.path')).toThrow(
+            'buttonSaveTripSegments: saveCallback function: journey context not found for path invalid.path'
+        );
+        expect(updateCallbacks.startUpdateInterview).not.toHaveBeenCalled();
     });
 
 });

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/groupSegments.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/groupSegments.test.ts
@@ -168,11 +168,11 @@ describe('SegmentsGroupConfigFactory segments GroupConfig widget', () => {
             jest.clearAllMocks();
         });
 
-        test('should show the add button if no segments yet', () => {
+        test('should not show the add button if no segments yet', () => {
             mockedGetResponse.mockReturnValue({});
             const showAddButton = widgetConfig.showGroupedObjectAddButton;
             expect(showAddButton).toBeDefined();
-            expect((showAddButton as any)(interviewAttributesForTestCases, 'path')).toBe(true);
+            expect((showAddButton as any)(interviewAttributesForTestCases, 'path')).toBe(false);
             expect(mockedGetResponse).toHaveBeenCalledWith(interviewAttributesForTestCases, 'path', {});
         });
 

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/helpers.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/helpers.test.ts
@@ -13,6 +13,54 @@ import * as helpers from '../helpers';
 import type { Journey, Person, Segment, UserInterviewAttributes } from '../../../types';
 import { modeValues, Mode, defaultModePreToModeMap, simpleModes } from '../../../../odSurvey/types';
 
+describe('getValuesByPathForActiveTrip', () => {
+    // Trip 1 of person 1 has no segment, trip 1 of person 2 has one with a mode
+    each([
+        ['trip without segment: add the first one', 'personId1', 'journeyId1', 'tripId1P1', false, true],
+        ['trip with one segment: only select it', 'personId2', 'journeyId2', 'tripId1P2', false, false],
+        ['trip with many segments: only select it', 'personId2', 'journeyId2', 'tripId2P2', false, false],
+        ['one segment cleared by the same update: add the first one', 'personId2', 'journeyId2', 'tripId1P2', true, true],
+        // The cleared segments must not be resequenced, only the new one is expected
+        ['many segments cleared by the same update: add the first one', 'personId2', 'journeyId2', 'tripId2P2', true, true]
+    ]).test(
+        '%s',
+        (
+            _title: string,
+            personId: string,
+            journeyId: string,
+            tripId: string,
+            segmentsAreCleared: boolean,
+            expectNewSegment: boolean
+        ) => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const person = interview.response.household!.persons![personId];
+            const journey = person.journeys![journeyId];
+            const segmentsPath = `household.persons.${personId}.journeys.${journeyId}.trips.${tripId}.segments`;
+
+            const result = helpers.getValuesByPathForActiveTrip({
+                interview,
+                person,
+                journey,
+                trip: journey.trips![tripId],
+                segmentsAreCleared
+            });
+
+            if (!expectNewSegment) {
+                expect(result).toEqual({ 'response._activeTripId': tripId });
+                return;
+            }
+            // The segment uuid is generated, get it from the returned path
+            const segmentPath = Object.keys(result).find((path) => path.startsWith(`response.${segmentsPath}.`));
+            const segmentId = segmentPath!.split('.').pop();
+            expect(result).toEqual({
+                'response._activeTripId': tripId,
+                [`response.${segmentsPath}.${segmentId}`]: { _uuid: segmentId, _sequence: 1, _isNew: true },
+                [`validations.${segmentsPath}.${segmentId}`]: {}
+            });
+        }
+    );
+});
+
 describe('getPreviousTripSingleSegment', () => {
 
     test('No previous trips', () => {
@@ -26,12 +74,21 @@ describe('getPreviousTripSingleSegment', () => {
     });
 
     test('Previous trip, but no segments', () => {
-        // Prepare test data
         const interview = _cloneDeep(interviewAttributesForTestCases);
         const journey = interview.response.household!.persons!.personId1.journeys!.journeyId1;
         const trip = journey.trips!.tripId2P1;
 
-        // Test the function
+        expect(helpers.getPreviousTripSingleSegment({ journey, trip })).toBeUndefined();
+    });
+
+    test('Previous trip, only empty first segment', () => {
+        const interview = _cloneDeep(interviewAttributesForTestCases);
+        const journey = interview.response.household!.persons!.personId1.journeys!.journeyId1;
+        journey.trips!.tripId1P1.segments = {
+            segmentId1P1T1: { _uuid: 'segmentId1P1T1', _sequence: 1, _isNew: true }
+        };
+        const trip = journey.trips!.tripId2P1;
+
         expect(helpers.getPreviousTripSingleSegment({ journey, trip })).toBeUndefined();
     });
 

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/sectionSegment.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/__tests__/sectionSegment.test.ts
@@ -24,6 +24,15 @@ jest.mock('uuid', () => ({
     v4: jest.fn().mockReturnValue('newTripId')
 }));
 const mockUuidv4 = uuidv4 as jest.MockedFunction<typeof uuidv4>;
+/** Same valuesByPath as `addGroupedObjects` for the first segment (the add-mode button). */
+const expectedFirstSegmentByPath = (tripId: string, segmentId: string) => ({
+    [`response.household.persons.testPerson1.journeys.testJourney1.trips.${tripId}.segments.${segmentId}`]: {
+        _uuid: segmentId,
+        _sequence: 1,
+        _isNew: true
+    },
+    [`validations.household.persons.testPerson1.journeys.testJourney1.trips.${tripId}.segments.${segmentId}`]: {}
+});
 const segmentSectionConfig: SegmentSectionConfiguration = {
     type: 'segments' as const,
     enabled: true
@@ -238,6 +247,16 @@ describe('sectionConfig functionalities', () => {
             expect(result).toBe(false);
             expect(mockedSelectNextIncompleteTrip).toHaveBeenCalledWith({ journey: activeJourney });
         });
+
+        test('should throw if there is no active journey', () => {
+            const testInterview = _cloneDeep(interviewWithTestPerson);
+            delete testInterview.response._activeJourneyId;
+
+            expect(() => widgetConfig.isSectionCompleted!(testInterview, iterationContext)).toThrow(
+                'segments section.isSectionComplete: No active journey for person testPerson1'
+            );
+            expect(mockedSelectNextIncompleteTrip).not.toHaveBeenCalled();
+        });
     });
 
     describe('getSegmentsSectionConfig onSectionEntry', () => {
@@ -263,6 +282,15 @@ describe('sectionConfig functionalities', () => {
             expect(result).toBeUndefined();
         });
 
+        test('should throw if there is no active journey', () => {
+            const testInterview = _cloneDeep(interviewWithTestPerson);
+            delete testInterview.response._activeJourneyId;
+
+            expect(() => widgetConfig.onSectionEntry!(testInterview, iterationContext)).toThrow(
+                'segments section.onSectionEntry: No active journey for person testPerson1'
+            );
+        });
+
         test('should add trips when there are no trips', () => {
             const testInterview = _cloneDeep(interviewWithTestPerson);
             // 2 places
@@ -276,8 +304,9 @@ describe('sectionConfig functionalities', () => {
             };
             // no trips
 
-            // Should add a new trip
+            // Should add a new trip with a first segment
             mockUuidv4.mockReturnValueOnce('tripId1' as any);
+            mockUuidv4.mockReturnValueOnce('segmentId1' as any);
             const newTrip = { _uuid: 'tripId1', _sequence: 1, _originVisitedPlaceUuid: 'testPlace1', _destinationVisitedPlaceUuid: 'testPlace2' };
             mockedSelectNextIncompleteTrip.mockReturnValueOnce(null);
 
@@ -286,9 +315,10 @@ describe('sectionConfig functionalities', () => {
             expect(result).toEqual({
                 'response.household.persons.testPerson1.journeys.testJourney1.trips.tripId1': newTrip,
                 'validations.household.persons.testPerson1.journeys.testJourney1.trips.tripId1': {},
+                ...expectedFirstSegmentByPath('tripId1', 'segmentId1'),
                 'response._activeTripId': 'tripId1'
             });
-            expect(mockUuidv4).toHaveBeenCalledTimes(1);
+            expect(mockUuidv4).toHaveBeenCalledTimes(2);
         });
 
         test('should delete trips when the number of trips is greater than the number of visited places', () => {
@@ -325,6 +355,7 @@ describe('sectionConfig functionalities', () => {
                 [`validations.household.persons.${activePerson._uuid}.journeys.${activeJourney._uuid}.trips.tripId2`]: undefined,
                 [`validations.household.persons.${activePerson._uuid}.journeys.${activeJourney._uuid}.trips.tripId3`]: undefined
             });
+            expect(mockUuidv4).not.toHaveBeenCalled();
         });
 
         test('should not set an active trip if incomplete trip is to be deleted', () => {
@@ -362,6 +393,7 @@ describe('sectionConfig functionalities', () => {
                 [`validations.household.persons.${activePerson._uuid}.journeys.${activeJourney._uuid}.trips.tripId3`]: undefined,
 
             });
+            expect(mockUuidv4).not.toHaveBeenCalled();
         });
 
         test('should update trips and initialize segments when origins and destinations have changed', () => {
@@ -387,6 +419,7 @@ describe('sectionConfig functionalities', () => {
                 tripId2: trips[1]
             };
 
+            mockUuidv4.mockReturnValueOnce('segmentId1' as any);
             const result = widgetConfig.onSectionEntry!(testInterview, iterationContext);
             
             expect(result).toEqual({
@@ -396,6 +429,8 @@ describe('sectionConfig functionalities', () => {
                 'response.household.persons.testPerson1.journeys.testJourney1.trips.tripId2._originVisitedPlaceUuid': places[1]._uuid,
                 'response.household.persons.testPerson1.journeys.testJourney1.trips.tripId2._destinationVisitedPlaceUuid': places[2]._uuid,
                 'response.household.persons.testPerson1.journeys.testJourney1.trips.tripId2.segments': undefined,
+                // The first segment of the selected trip comes after its segments group is deleted
+                ...expectedFirstSegmentByPath('tripId1', 'segmentId1'),
                 'response._activeTripId': 'tripId1'
             });
         });
@@ -426,13 +461,81 @@ describe('sectionConfig functionalities', () => {
             const incompleteTrip = trips[1];
             mockedSelectNextIncompleteTrip.mockReturnValueOnce(incompleteTrip);
             const expectedJourney = _cloneDeep(testInterview.response.household!.persons!.testPerson1.journeys!.testJourney1);
+            mockUuidv4.mockReturnValueOnce('segmentId2' as any);
 
             const result = widgetConfig.onSectionEntry!(testInterview, iterationContext);
             
             expect(result).toEqual({
+                ...expectedFirstSegmentByPath('tripId2', 'segmentId2'),
                 'response._activeTripId': incompleteTrip._uuid
             });
             expect(mockedSelectNextIncompleteTrip).toHaveBeenCalledWith({ journey: expectedJourney });
+        });
+
+        test('should leave existing segments unchanged', () => {
+            const testInterview = _cloneDeep(interviewWithTestPerson);
+            const places: VisitedPlace[] = [
+                { _uuid: 'testPlace1', _sequence: 1, activity: 'home' },
+                { _uuid: 'testPlace2', _sequence: 2, activity: 'workUsual' }
+            ];
+            testInterview.response.household!.persons!.testPerson1.journeys!.testJourney1.visitedPlaces = {
+                [places[0]._uuid]: places[0],
+                [places[1]._uuid]: places[1]
+            };
+            const existingSegment = { _uuid: 'existingSegment', _sequence: 1, _isNew: false, mode: 'walk' as const, hasNextMode: false };
+            testInterview.response.household!.persons!.testPerson1.journeys!.testJourney1.trips = {
+                tripId1: {
+                    _uuid: 'tripId1',
+                    _sequence: 1,
+                    _originVisitedPlaceUuid: 'testPlace1',
+                    _destinationVisitedPlaceUuid: 'testPlace2',
+                    segments: { existingSegment }
+                }
+            };
+            mockedSelectNextIncompleteTrip.mockReturnValueOnce(
+                testInterview.response.household!.persons!.testPerson1.journeys!.testJourney1.trips!.tripId1
+            );
+
+            const result = widgetConfig.onSectionEntry!(testInterview, iterationContext);
+
+            expect(result).toEqual({
+                'response._activeTripId': 'tripId1'
+            });
+            expect(mockUuidv4).not.toHaveBeenCalled();
+        });
+
+        test('should replace existing segments when origin and destination have changed', () => {
+            const testInterview = _cloneDeep(interviewWithTestPerson);
+            const places: VisitedPlace[] = [
+                { _uuid: 'testPlace1', _sequence: 1, activity: 'home' },
+                { _uuid: 'testPlace2', _sequence: 2, activity: 'workUsual' }
+            ];
+            testInterview.response.household!.persons!.testPerson1.journeys!.testJourney1.visitedPlaces = {
+                [places[0]._uuid]: places[0],
+                [places[1]._uuid]: places[1]
+            };
+            const existingSegment = { _uuid: 'existingSegment', _sequence: 1, _isNew: false, mode: 'walk' as const, hasNextMode: false };
+            testInterview.response.household!.persons!.testPerson1.journeys!.testJourney1.trips = {
+                tripId1: {
+                    _uuid: 'tripId1',
+                    _sequence: 1,
+                    _originVisitedPlaceUuid: 'oldPlace1',
+                    _destinationVisitedPlaceUuid: 'oldPlace2',
+                    segments: { existingSegment }
+                }
+            };
+            mockUuidv4.mockReturnValueOnce('segmentId1' as any);
+            mockedSelectNextIncompleteTrip.mockReturnValueOnce(null);
+
+            const result = widgetConfig.onSectionEntry!(testInterview, iterationContext);
+
+            expect(result).toEqual({
+                'response.household.persons.testPerson1.journeys.testJourney1.trips.tripId1._originVisitedPlaceUuid': places[0]._uuid,
+                'response.household.persons.testPerson1.journeys.testJourney1.trips.tripId1._destinationVisitedPlaceUuid': places[1]._uuid,
+                'response.household.persons.testPerson1.journeys.testJourney1.trips.tripId1.segments': undefined,
+                ...expectedFirstSegmentByPath('tripId1', 'segmentId1'),
+                'response._activeTripId': 'tripId1'
+            });
         });
 
         test('should set the active trip ID to null if no incomplete trip', () => {
@@ -465,6 +568,7 @@ describe('sectionConfig functionalities', () => {
             expect(result).toEqual({
                 'response._activeTripId': null
             });
+            expect(mockUuidv4).not.toHaveBeenCalled();
             expect(mockedSelectNextIncompleteTrip).toHaveBeenCalledWith({ journey: expectedJourney });
         });
 
@@ -496,9 +600,10 @@ describe('sectionConfig functionalities', () => {
             mockedSelectNextIncompleteTrip.mockReturnValueOnce(null);
             const expectedJourney = _cloneDeep(testInterview.response.household!.persons!.testPerson1.journeys!.testJourney1);
 
-            // Should add a new trip
+            // Two new trips; only the selected one gets a first segment
             mockUuidv4.mockReturnValueOnce('tripId2' as any);
             mockUuidv4.mockReturnValueOnce('tripId3' as any);
+            mockUuidv4.mockReturnValueOnce('segmentId2' as any);
             const newTrip2 = { _uuid: 'tripId2', _sequence: 2, _originVisitedPlaceUuid: places[1]._uuid, _destinationVisitedPlaceUuid: places[2]._uuid };
             const newTrip3 = { _uuid: 'tripId3', _sequence: 3, _originVisitedPlaceUuid: places[2]._uuid, _destinationVisitedPlaceUuid: places[3]._uuid };
 
@@ -509,10 +614,11 @@ describe('sectionConfig functionalities', () => {
                 'validations.household.persons.testPerson1.journeys.testJourney1.trips.tripId2': {},
                 'response.household.persons.testPerson1.journeys.testJourney1.trips.tripId3': newTrip3,
                 'validations.household.persons.testPerson1.journeys.testJourney1.trips.tripId3': {},
+                ...expectedFirstSegmentByPath('tripId2', 'segmentId2'),
                 'response._activeTripId': 'tripId2'
             });
             expect(mockedSelectNextIncompleteTrip).toHaveBeenCalledWith({ journey: expectedJourney });
-            expect(mockUuidv4).toHaveBeenCalledTimes(2);
+            expect(mockUuidv4).toHaveBeenCalledTimes(3);
         });
     });
 

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/buttonSaveTripSegments.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/buttonSaveTripSegments.ts
@@ -10,6 +10,7 @@ import * as odHelpers from '../../../odSurvey/helpers';
 import { TFunction } from 'i18next';
 import { InterviewUpdateCallbacks, Segment, UserInterviewAttributes } from '../../types';
 import { WidgetFactoryOptions } from '../types';
+import { getValuesByPathForActiveTrip } from './helpers';
 
 export const getButtonSaveTripSegmentsConfig = (options: WidgetFactoryOptions): ButtonWidgetConfig => {
     return {
@@ -23,6 +24,12 @@ export const getButtonSaveTripSegmentsConfig = (options: WidgetFactoryOptions): 
         align: 'center',
         action: options.buttonActions.validateButtonAction,
         saveCallback: (callbacks: InterviewUpdateCallbacks, interview: UserInterviewAttributes, path: string) => {
+            const journeyContext = odHelpers.getJourneyContextFromPath({ interview, path });
+            if (journeyContext === null) {
+                throw new Error(
+                    'buttonSaveTripSegments: saveCallback function: journey context not found for path ' + path
+                );
+            }
             // Set all segments' _isNew to false and select the next trip ID as the active one
             const updateValuesbyPath = {};
             const segmentsPath = getPath(path, '../segments') as string;
@@ -34,16 +41,25 @@ export const getButtonSaveTripSegmentsConfig = (options: WidgetFactoryOptions): 
                 const segmentPath = `${segmentsPath}.${segmentUuid}`;
                 updateValuesbyPath[`response.${segmentPath}._isNew`] = false;
             }
-            const journeyContext = odHelpers.getJourneyContextFromPath({ interview, path });
             const activeJourney = odHelpers.getActiveJourney({ interview });
             // Select next active trip if journey is the active one
             const nextTrip =
-                journeyContext !== null &&
-                activeJourney !== null &&
                 journeyContext.journey._uuid === activeJourney?._uuid
                     ? odHelpers.selectNextIncompleteTrip({ journey: journeyContext.journey })
                     : null;
-            updateValuesbyPath['response._activeTripId'] = nextTrip ? nextTrip._uuid : null;
+            if (nextTrip !== null) {
+                Object.assign(
+                    updateValuesbyPath,
+                    getValuesByPathForActiveTrip({
+                        interview,
+                        person: journeyContext.person,
+                        journey: journeyContext.journey,
+                        trip: nextTrip
+                    })
+                );
+            } else {
+                updateValuesbyPath['response._activeTripId'] = null;
+            }
             callbacks.startUpdateInterview({ sectionShortname: 'segments', valuesByPath: updateValuesbyPath });
         },
         conditional: function (interview, path) {

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/groupSegments.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/groupSegments.ts
@@ -59,9 +59,10 @@ export class SegmentsGroupConfigFactory implements WidgetConfigFactory {
                 const segmentsArray = Object.values(segments).sort((segmentA, segmentB) => {
                     return segmentA['_sequence'] - segmentB['_sequence'];
                 });
-                const segmentsCount = segmentsArray.length;
-                const lastSegment = segmentsArray[segmentsCount - 1];
-                return segmentsCount === 0 || (lastSegment && lastSegment.hasNextMode === true);
+                const lastSegment = segmentsArray[segmentsArray.length - 1];
+                // First segment is created on section entry; the button is only
+                // for an additional mode after the respondent said there is one.
+                return lastSegment !== undefined && lastSegment.hasNextMode === true;
             },
             groupedObjectAddButtonLabel: (t: TFunction, interview, path) => {
                 const segments = getResponse(interview, path, {}) as { [segmentId: string]: Segment };

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/helpers.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/helpers.ts
@@ -27,7 +27,54 @@ import type {
     WidgetConditional
 } from '../../types';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
+import { addGroupedObjects } from '../../../../utils/helpers';
 import { getBirdDistanceMeters } from '../../../../utils/PhysicsUtils';
+
+/**
+ * Values to set to make a trip the active one of the segments section: the
+ * active trip ID and, when the trip has no segment yet, an empty first segment,
+ * so that its mode is asked directly instead of behind an add button.
+ *
+ * @param {Object} options - The options object.
+ * @param {UserInterviewAttributes} options.interview The interview
+ * @param {Person} options.person The person the trip belongs to
+ * @param {Journey} options.journey The journey the trip is part of
+ * @param {Trip} options.trip The trip to activate
+ * @param {boolean} [options.segmentsAreCleared] `true` when the same update
+ * deletes the trip's segments, because its origin or destination changed. The
+ * segments still on the interview are then to be considered absent.
+ * @returns Values to merge into the interview update. The returned segment
+ * paths must come after the caller's own deletions, as values are applied in
+ * insertion order.
+ */
+export const getValuesByPathForActiveTrip = ({
+    interview,
+    person,
+    journey,
+    trip,
+    segmentsAreCleared = false
+}: {
+    interview: UserInterviewAttributes;
+    person: Person;
+    journey: Journey;
+    trip: Trip;
+    segmentsAreCleared?: boolean;
+}): { [path: string]: unknown } => {
+    const valuesByPath: { [path: string]: unknown } = { 'response._activeTripId': trip._uuid };
+    if (!segmentsAreCleared && odHelpers.getSegmentsArray({ trip }).length > 0) {
+        return valuesByPath;
+    }
+    const segmentsPath = `household.persons.${person._uuid}.journeys.${journey._uuid}.trips.${trip._uuid}.segments`;
+    const { valuesByPath: addedValuesByPath, newObjects } = addGroupedObjects(interview, 1, 1, segmentsPath, [
+        { _isNew: true }
+    ]);
+    // Keep only the new segment: the other paths resequence the segments that
+    // the caller deletes in the same update.
+    const newSegmentPath = `${segmentsPath}.${newObjects[0]._uuid}`;
+    valuesByPath[`response.${newSegmentPath}`] = addedValuesByPath[`response.${newSegmentPath}`];
+    valuesByPath[`validations.${newSegmentPath}`] = addedValuesByPath[`validations.${newSegmentPath}`];
+    return valuesByPath;
+};
 
 /**
  * Get the mode used in the single segment of the previous trip of the current
@@ -52,9 +99,8 @@ export const getPreviousTripSingleSegment = ({
     const previousTrip = odHelpers.getPreviousTrip({ currentTrip: trip, journey });
     if (previousTrip) {
         const previousSegments = odHelpers.getSegmentsArray({ trip: previousTrip });
-        if (previousSegments.length === 1) {
-            const previousSegment = previousSegments[0];
-            return previousSegment;
+        if (previousSegments.length === 1 && odHelpers.tripHasDefinedSegments({ trip: previousTrip })) {
+            return previousSegments[0];
         }
     }
     return undefined;

--- a/packages/evolution-common/src/services/questionnaire/sections/segments/sectionSegments.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/segments/sectionSegments.ts
@@ -4,7 +4,6 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import _isEmpty from 'lodash/isEmpty';
 import { TFunction } from 'i18next';
 
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
@@ -12,7 +11,7 @@ import { removeGroupedObjects, addGroupedObjects } from '../../../../utils/helpe
 import * as odHelpers from '../../../odSurvey/helpers';
 import { SectionConfig, SegmentSectionConfiguration, Trip, WidgetConfig } from '../../types';
 import { applySectionAdditionalLabelOptions } from '../common/applyAdditionalLabelOptions';
-import { initializeSegmentSectionHelpers } from './helpers';
+import { getValuesByPathForActiveTrip, initializeSegmentSectionHelpers } from './helpers';
 import { SectionConfigFactory, WidgetFactoryOptions } from '../types';
 import { getPersonsTripsTitleWidgetConfig } from './widgetPersonTripsTitle';
 import { SwitchPersonWidgetsFactory } from '../common/widgetsSwitchPerson';
@@ -51,9 +50,13 @@ export class SegmentsSectionFactory implements SectionConfigFactory {
                 }
 
                 const currentJourney = odHelpers.getActiveJourney({ interview, person });
+                if (currentJourney === null) {
+                    // The section is not visible without an active journey, so this is unexpected
+                    throw new Error(`segments section.isSectionComplete: No active journey for person ${person._uuid}`);
+                }
 
                 // Section is complete if there is no next trip to complete
-                const nextTrip: Trip | null = odHelpers.selectNextIncompleteTrip({ journey: currentJourney! });
+                const nextTrip: Trip | null = odHelpers.selectNextIncompleteTrip({ journey: currentJourney });
                 return nextTrip === null;
             },
             onSectionEntry: function (interview, iterationContext) {
@@ -66,14 +69,18 @@ export class SegmentsSectionFactory implements SectionConfigFactory {
                     );
                     return undefined;
                 }
-                const responseContent = {};
-
                 const currentJourney = odHelpers.getActiveJourney({ interview, person });
+                if (currentJourney === null) {
+                    // The section is not visible without an active journey, so this is unexpected
+                    throw new Error(`segments section.onSectionEntry: No active journey for person ${person._uuid}`);
+                }
+                const responseContent = {};
+                const tripsWithClearedSegments = new Set<string>();
 
-                const tripsPath = `household.persons.${person._uuid}.journeys.${currentJourney!._uuid}.trips`;
-                const visitedPlaces = odHelpers.getVisitedPlacesArray({ journey: currentJourney! });
-                const trips = odHelpers.getTripsArray({ journey: currentJourney! });
-                let nextTripToSelect: Trip | null = odHelpers.selectNextIncompleteTrip({ journey: currentJourney! });
+                const tripsPath = `household.persons.${person._uuid}.journeys.${currentJourney._uuid}.trips`;
+                const visitedPlaces = odHelpers.getVisitedPlacesArray({ journey: currentJourney });
+                const trips = odHelpers.getTripsArray({ journey: currentJourney });
+                let nextTripToSelect: Trip | null = odHelpers.selectNextIncompleteTrip({ journey: currentJourney });
                 let foundFirstInvalidTrip = false;
 
                 // Create the missing trips objects and initialize those that may have changed
@@ -98,6 +105,7 @@ export class SegmentsSectionFactory implements SectionConfigFactory {
                             destination._uuid;
                         // also delete existing segments:
                         responseContent[`response.${tripsPath}.${trip._uuid}.segments`] = undefined;
+                        tripsWithClearedSegments.add(trip._uuid);
                         if (nextTripToSelect === null || !foundFirstInvalidTrip) {
                             // If the first invalid trip is not set, set it to this trip
                             nextTripToSelect = trip;
@@ -151,9 +159,19 @@ export class SegmentsSectionFactory implements SectionConfigFactory {
                     }
                 }
 
+                // The active trip values come last: they may recreate a segment
+                // in the segments group that was just deleted above.
                 return {
                     ...responseContent,
-                    'response._activeTripId': nextTripToSelect !== null ? nextTripToSelect._uuid : null
+                    ...(nextTripToSelect !== null
+                        ? getValuesByPathForActiveTrip({
+                            interview,
+                            person,
+                            journey: currentJourney,
+                            trip: nextTripToSelect,
+                            segmentsAreCleared: tripsWithClearedSegments.has(nextTripToSelect._uuid)
+                        })
+                        : { 'response._activeTripId': null })
                 };
             },
 

--- a/packages/evolution-frontend/src/components/survey/sectionTemplates/TripsAndSegmentsSection.tsx
+++ b/packages/evolution-frontend/src/components/survey/sectionTemplates/TripsAndSegmentsSection.tsx
@@ -18,9 +18,10 @@ import LoadingPage from 'chaire-lib-frontend/lib/components/pages/LoadingPage';
 import { getResponse } from 'evolution-common/lib/utils/helpers';
 import { SectionProps, useSectionTemplate } from '../../hooks/useSectionTemplate';
 import * as odSurveyHelper from 'evolution-common/lib/services/odSurvey/helpers';
+import { getValuesByPathForActiveTrip } from 'evolution-common/lib/services/questionnaire/sections/segments/helpers';
 import * as helpers from 'evolution-common/lib/utils/helpers';
 import { secondsSinceMidnightToTimeStrWithSuffix } from '../../../services/display/frontendHelper';
-import { VisitedPlace } from 'evolution-common/lib/services/questionnaire/types';
+import { Trip, VisitedPlace } from 'evolution-common/lib/services/questionnaire/types';
 import { getActivityMarkerIcon } from 'evolution-common/lib/services/questionnaire/sections/visitedPlaces/activityIconMapping';
 import { SurveyContext } from '../../../contexts/SurveyContext';
 
@@ -38,16 +39,6 @@ export const SegmentsSection: React.FC<SectionProps> = (props: SectionProps) => 
         }
         return iconPathsByMode;
     }, []);
-
-    const selectTrip = (tripUuid: string, e) => {
-        if (e) {
-            e.preventDefault();
-        }
-        props.startUpdateInterview({
-            sectionShortname: 'segments',
-            valuesByPath: { ['response._activeTripId']: tripUuid }
-        });
-    };
 
     if (!preloaded) {
         return <LoadingPage />;
@@ -68,6 +59,21 @@ export const SegmentsSection: React.FC<SectionProps> = (props: SectionProps) => 
         throw new Error('SegmentsSection: there are no journeys');
     }
     const currentJourney = journeys[0];
+
+    const selectTrip = (trip: Trip, e) => {
+        if (e) {
+            e.preventDefault();
+        }
+        props.startUpdateInterview({
+            sectionShortname: 'segments',
+            valuesByPath: getValuesByPathForActiveTrip({
+                interview: props.interview,
+                person,
+                journey: currentJourney,
+                trip
+            })
+        });
+    };
 
     const trips = currentJourney.trips || {};
     const tripsList: JSX.Element[] = [];
@@ -182,7 +188,7 @@ export const SegmentsSection: React.FC<SectionProps> = (props: SectionProps) => 
                         <button
                             type="button"
                             className={'survey-section__button button blue small'}
-                            onClick={(e) => selectTrip(trip._uuid!, e)}
+                            onClick={(e) => selectTrip(trip, e)}
                             style={{ marginLeft: '0.5rem' }}
                             title={t('survey:trip:editTrip')}
                         >

--- a/packages/evolution-frontend/src/components/survey/sectionTemplates/__tests__/TripsAndSegmentsSection.test.tsx
+++ b/packages/evolution-frontend/src/components/survey/sectionTemplates/__tests__/TripsAndSegmentsSection.test.tsx
@@ -403,7 +403,7 @@ describe('SegmentsSection behavior', () => {
             </TestContextProvider>
         );
         // Find the edit button
-        const editButtons = getAllByTitle("trip.editTrip");
+        const editButtons = getAllByTitle('trip.editTrip');
         expect(editButtons).toBeTruthy();
         const editButton = editButtons[0];
 
@@ -423,16 +423,21 @@ describe('SegmentsSection behavior', () => {
             </TestContextProvider>
         );
         // Find the edit button
-        const editButtons = getAllByTitle("trip.editTrip");
+        const editButtons = getAllByTitle('trip.editTrip');
         expect(editButtons).toBeTruthy();
         const editButton = editButtons[1];
 
         // Find and click (with mousedown/mouseup) on the button itself and make sure the action has been called
         fireEvent.click(editButton!);
-        expect(props.startUpdateInterview).toHaveBeenCalledWith({
-            sectionShortname: 'segments',
-            valuesByPath: { ['response._activeTripId']: 'trip2' }
-        });
+        const valuesByPath = (props.startUpdateInterview as jest.Mock).mock.calls[0][0].valuesByPath;
+        expect(valuesByPath['response._activeTripId']).toEqual('trip2');
+        const newSegmentPath = Object.keys(valuesByPath).find((path: string) =>
+            path.startsWith('response.household.persons.person1.journeys.journey1.trips.trip2.segments.')
+        );
+        expect(newSegmentPath).toBeDefined();
+        const segmentId = newSegmentPath!.split('.').pop();
+        expect(valuesByPath[newSegmentPath!]).toEqual({ _uuid: segmentId, _sequence: 1, _isNew: true });
+        expect(valuesByPath[`validations.household.persons.person1.journeys.journey1.trips.trip2.segments.${segmentId}`]).toEqual({});
     });
-    
+
 });


### PR DESCRIPTION
Ask the first mode directly instead of a "choose first mode" button, then whether there was another.

Closes #1825

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically creates the first segment when starting or selecting a trip without defined segments.
  * Preserves the new segment’s validation state and updates the active trip accordingly.
* **Bug Fixes**
  * Improved detection of trips with meaningful segment data.
  * Prevented adding segments when no valid preceding segment exists.
  * Improved handling when trip changes reset segment data.
  * Added clearer handling for missing journey context.
* **Documentation**
  * Added changelog details for automatic first-segment creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->