### PR TITLE
visitedPlaces: add person suffixes to time widgets

### DIFF
--- a/packages/evolution-common/src/services/odSurvey/types.ts
+++ b/packages/evolution-common/src/services/odSurvey/types.ts
@@ -8,6 +8,13 @@
 // Origin-Destination questionnaire context, ie with journey, trips and segments
 
 /**
+ * The distance, in meters, under which 2 places should be to be considered the
+ * same place geographically.
+ * FIXME See if this should be configurable. For now, defaults to 50 meters.
+ */
+export const sameLocationDistanceBufferMeters = 50;
+
+/**
  * Activities that do not involve a destination
  */
 export const loopActivities: Activity[] = ['workOnTheRoad', 'leisureStroll'];

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/helpers.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/helpers.test.ts
@@ -1227,4 +1227,133 @@ describe('isLastVisitedPlaceConditional', () => {
             )
         ).toEqual(expected);
     });
-})
+});
+
+describe("Visited places helpers - getSameVisitedPlacesFromOthers", () => {
+    /**
+     * Test data overview:
+     *
+     * - personId1 / journeyId1:
+     *   - homePlace1P1 (home)
+     *   - workPlace1P1 (workUsual)
+     *   - homePlace2P1 (home)
+     *   - otherPlaceP1 (shopping)
+     *   - otherPlace2P1 (shopping)
+     *
+     * - personId2 / journeyId2:
+     *   - homePlace1P2 (home)
+     *   - shoppingPlace1P2 (shopping, shortcut from person1, should be same geography as otherPlace2P1)
+     *   - otherWorkPlace1P2 (other)
+     *   - homePlace2P2 (home)
+     *
+     * - personId3 / journeyId3:
+     *   - homePlace1P3 (home)
+     *   - schoolPlace1P3 (schoolUsual)
+     *   - homePlace2P3 (home)
+     *
+     * home activity always resolves to homeGeographyCoordinates
+     * [-73.5932,45.5016] via getVisitedPlaceGeography, so all homes should be returned
+     *
+     * Otherwise, shoppingPlace1P2 should have same geography as otherPlace2P1
+     */
+    test.each([
+        {
+            title: 'should return all `home` places from other household members',
+            setupTest: (_interview: UserRuntimeInterviewAttributes) => ({
+                personId: 'personId1',
+                journeyId: 'journeyId1',
+                currentVisitedPlaceId: 'homePlace1P1'
+            }),
+            expectedVisitedPlaceIds: [
+                { personId: 'personId2', visitedPlaceId: 'homePlace1P2' },
+                { personId: 'personId2', visitedPlaceId: 'homePlace2P2' },
+                { personId: 'personId3', visitedPlaceId: 'homePlace1P3' },
+                { personId: 'personId3', visitedPlaceId: 'homePlace2P3' }
+            ]
+        },
+        {
+            title: 'should return other places used as shortcuts from other household members',
+            setupTest: (interview: UserRuntimeInterviewAttributes) => ({
+                personId: 'personId1',
+                journeyId: 'journeyId1',
+                currentVisitedPlaceId: 'otherPlace2P1'
+            }),
+            expectedVisitedPlaceIds: [
+                { personId: 'personId2', visitedPlaceId: 'shoppingPlace1P2' }
+            ]
+        },
+        {
+            title: 'should return other places used as shortcuts from other household members, reverse',
+            // Same as previous test case, but with reverse place
+            setupTest: (interview: UserRuntimeInterviewAttributes) => ({
+                personId: 'personId2',
+                journeyId: 'journeyId2',
+                currentVisitedPlaceId: 'shoppingPlace1P2'
+            }),
+            expectedVisitedPlaceIds: [
+                { personId: 'personId1', visitedPlaceId: 'otherPlace2P1' }
+            ]
+        },
+        {
+            title: 'should return other places that have slightly different geographies, but below distance threshold',
+            setupTest: (interview: UserRuntimeInterviewAttributes) => {
+                // Get base coordinates for current otherPlaceP1
+                const baseCoordinates = interview.response.household!.persons!.personId1!.journeys!.journeyId1!.visitedPlaces!.otherPlaceP1!.geography!.geometry.coordinates
+                // Change geographies for otherWorkPlace1P2 of personId2 and schoolPlace1P3 of personId3, so they are close and below threshold distance
+                // 4 decimal places is about 10 meters
+                interview.response.household!.persons!.personId2!.journeys!.journeyId2!.visitedPlaces!.otherWorkPlace1P2!.geography!.geometry.coordinates = [baseCoordinates[0] + 0.0001, baseCoordinates[1] + 0.0001];
+                interview.response.household!.persons!.personId3!.journeys!.journeyId3!.visitedPlaces!.schoolPlace1P3!.geography!.geometry.coordinates = [baseCoordinates[0] - 0.0001, baseCoordinates[1] - 0.0001];
+                return { personId: 'personId1', journeyId: 'journeyId1', currentVisitedPlaceId: 'otherPlaceP1' };
+            },
+            expectedVisitedPlaceIds: [
+                { personId: 'personId2', visitedPlaceId: 'otherWorkPlace1P2' },
+                { personId: 'personId3', visitedPlaceId: 'schoolPlace1P3' }
+            ]
+        },
+        {
+            title: 'should not return other places if they are above distance threshold',
+            setupTest: (interview: UserRuntimeInterviewAttributes) => {
+                // Get base coordinates for current otherPlaceP1
+                const baseCoordinates = interview.response.household!.persons!.personId1!.journeys!.journeyId1!.visitedPlaces!.otherPlaceP1!.geography!.geometry.coordinates
+                // Change geographies for otherWorkPlace1P2 of personId2 and schoolPlace1P3 of personId3, so they are close, but above threshold distance
+                // 3 decimals is more than 100 meters
+                interview.response.household!.persons!.personId2!.journeys!.journeyId2!.visitedPlaces!.otherWorkPlace1P2!.geography!.geometry.coordinates = [baseCoordinates[0] + 0.001, baseCoordinates[1] + 0.001];
+                interview.response.household!.persons!.personId3!.journeys!.journeyId3!.visitedPlaces!.schoolPlace1P3!.geography!.geometry.coordinates = [baseCoordinates[0] - 0.001, baseCoordinates[1] - 0.001];
+                return { personId: 'personId1', journeyId: 'journeyId1', currentVisitedPlaceId: 'otherPlaceP1' };
+            },
+            expectedVisitedPlaceIds: []
+        },
+        {
+            title: 'ignore current places without geographies',
+            setupTest: (interview: UserRuntimeInterviewAttributes) => {
+                // Remove geography from otherPlace2P1
+                delete interview.response.household!.persons!.personId1!.journeys!.journeyId1!.visitedPlaces!.otherPlace2P1!.geography;
+                return { personId: 'personId1', journeyId: 'journeyId1', currentVisitedPlaceId: 'otherPlace2P1' };
+            },
+            // No place
+            expectedVisitedPlaceIds: []
+        },
+        {
+            title: 'do not return places if there are no other members',
+            setupTest: (interview: UserRuntimeInterviewAttributes) => {
+                delete interview.response.household!.persons!.personId2;
+                delete interview.response.household!.persons!.personId3;
+                return { personId: 'personId1', journeyId: 'journeyId1', currentVisitedPlaceId: 'homePlace1P1' };
+            },
+            // No place returned
+            expectedVisitedPlaceIds: []
+        },
+    ])(
+        'getShortcutVisitedPlaces: $title',
+        ({ setupTest, expectedVisitedPlaceIds }) => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            const { personId, journeyId, currentVisitedPlaceId } = setupTest(interview);
+            const path = `household.persons.${personId}.journeys.${journeyId}.visitedPlaces.${currentVisitedPlaceId}.arrivalTime`;
+
+            const visitedPlaces = helpers.getSameVisitedPlacesFromOtherHouseholdMembers(interview, path);
+            const visitedPlaceIds = visitedPlaces.map(({ visitedPlace, person }) => ({ personId: person._uuid, visitedPlaceId: visitedPlace._uuid }));
+
+            expect(visitedPlaceIds).toEqual(expectedVisitedPlaceIds);
+        }
+    );
+});

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetsTime.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetsTime.test.ts
@@ -18,6 +18,11 @@ import { VisitedPlaceTimeWidgetFactory } from '../widgetsTime';
 import * as helpers from '../helpers';
 import { requiredValidation } from '../../../../widgets/validations/validations';
 
+// Mock the i18next so that calls to the i18n object resolve to something
+jest.mock('i18next', () => ({
+    t: jest.fn(str => `translated_${str}`)
+}));
+
 const visitedPlacesSectionConfig = {
     type: 'visitedPlaces' as const,
     enabled: true,
@@ -28,7 +33,7 @@ const visitedPlacesSectionConfig = {
 const visitedPlaceFieldPath = (visitedPlaceId: string, fieldName: string) =>
     `household.persons.personId1.journeys.journeyId1.visitedPlaces.${visitedPlaceId}.${fieldName}`;
 
-// Unset all times, so individual tests can set it again without interference
+// Unset all times for personId1, so individual tests can set it again without interference
 const unsetAllTimes = (interview: UserInterviewAttributes) => {
     const visitedPlaces = interview.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!;
     Object.values(visitedPlaces).forEach(visitedPlace => {
@@ -38,7 +43,57 @@ const unsetAllTimes = (interview: UserInterviewAttributes) => {
         visitedPlace._previousDepartureTime = undefined;
         visitedPlace._previousPreviousDepartureTime = undefined;
     });
-}
+};
+
+// All suffix time functions have similar test cases, we return them here
+const getTestCasesForSuffixTimes = (timeField: 'arrivalTime' | 'departureTime'): any[] => [
+    {
+        title: 'return empty when there are no places with same geographies',
+        visitedPlaceId: 'workPlace1P1',
+        setup: (interview: typeof interviewAttributesForTestCases) => {
+            interview.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!.otherPlace2P1.activity = 'shopping';
+        },
+        expected: {}
+    },
+    {
+        title: 'return other person\'s time when places share the same geographies',
+        visitedPlaceId: 'homePlace1P1',
+        setup: (interview: typeof interviewAttributesForTestCases) => {
+            // Add nicknames for personId2 and personId3
+            interview.response.household!.persons!.personId3.nickname = 'Manche de pelle';
+            interview.response.household!.persons!.personId2.nickname = 'p2';
+            interview.response.household!.persons!.personId2.journeys!.journeyId2.visitedPlaces!.homePlace1P2[timeField] = 7 * 3600 + 35 * 60;
+            interview.response.household!.persons!.personId2.journeys!.journeyId2.visitedPlaces!.homePlace2P2[timeField] = 9 * 3600;
+            interview.response.household!.persons!.personId3.journeys!.journeyId3.visitedPlaces!.homePlace1P3[timeField] = 7 * 3600 + 35 * 60;
+            interview.response.household!.persons!.personId3.journeys!.journeyId3.visitedPlaces!.homePlace2P3[timeField] = 15 * 3600 + 20 * 60;
+        },
+        expected: {
+            [String(7 * 3600 + 35 * 60)]: ' (Manche ...)',
+            [String(9 * 3600)]: ' (p2)',
+            [String(15 * 3600 + 20 * 60)]: ' (Manche ...)',
+        }
+    },
+    {
+        title: 'do not return suffixes if the times for other places are not set',
+        visitedPlaceId: 'homePlace1P1',
+        setup: (interview: typeof interviewAttributesForTestCases) => {
+            delete interview.response.household!.persons!.personId2.journeys!.journeyId2.visitedPlaces!.homePlace1P2[timeField];
+            delete interview.response.household!.persons!.personId2.journeys!.journeyId2.visitedPlaces!.homePlace2P2[timeField];
+            delete interview.response.household!.persons!.personId3.journeys!.journeyId3.visitedPlaces!.homePlace1P3[timeField];
+            delete interview.response.household!.persons!.personId3.journeys!.journeyId3.visitedPlaces!.homePlace2P3[timeField];
+        },
+        expected: {}
+    },
+    {
+        title: 'do not return any times person is alone',
+        visitedPlaceId: 'workPlace1P1',
+        setup: (interview: typeof interviewAttributesForTestCases) => {
+            delete interview.response.household!.persons!.personId2;
+            delete interview.response.household!.persons!.personId3;
+        },
+        expected: {}
+    }
+];
 
 describe('VisitedPlaceTimeWidgetFactory', () => {
     let factory: VisitedPlaceTimeWidgetFactory;
@@ -116,7 +171,7 @@ describe('visitedPlacePreviousPreviousDepartureTime widget', () => {
             label: expect.any(Function),
             minuteStep: 5,
             addHourSeparators: true,
-            suffixTimes:undefined,
+            suffixTimes: expect.any(Function),
             maxTimeSecondsSinceMidnight: expect.any(Function),
             minTimeSecondsSinceMidnight: expect.any(Function),
             validations: requiredValidation,
@@ -419,6 +474,25 @@ describe('visitedPlacePreviousPreviousDepartureTime widget', () => {
         });
     });
 
+    describe('suffixTimes function', () => {
+        const suffixTimesFn = widget.suffixTimes as Function;
+
+        test.each(getTestCasesForSuffixTimes('departureTime'))('should handle case: $title', ({ visitedPlaceId, setup, expected }) => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            unsetAllTimes(interview);
+            setup(interview);
+            const path = visitedPlaceFieldPath(visitedPlaceId, '_previousPreviousDepartureTime');
+            expect(suffixTimesFn(interview, path)).toEqual(expected);
+        });
+
+        test('should throw error when visited place context is not found', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            expect(() => suffixTimesFn(interview, 'invalid/nonexistent/path')).toThrow(
+                'getSameVisitedPlacesFromOthers: cannot get visited place context from path invalid/nonexistent/path'
+            );
+        });
+    });
+
 });
 
 describe('visitedPlacePreviousArrivalTime widget', () => {
@@ -440,7 +514,7 @@ describe('visitedPlacePreviousArrivalTime widget', () => {
             label: expect.any(Function),
             minuteStep: 5,
             addHourSeparators: true,
-            suffixTimes:undefined,
+            suffixTimes: expect.any(Function),
             maxTimeSecondsSinceMidnight: expect.any(Function),
             minTimeSecondsSinceMidnight: expect.any(Function),
             validations: requiredValidation,
@@ -690,6 +764,25 @@ describe('visitedPlacePreviousArrivalTime widget', () => {
         });
     });
 
+    describe('suffixTimes function', () => {
+        const suffixTimesFn = widget.suffixTimes as Function;
+
+        test.each(getTestCasesForSuffixTimes('arrivalTime'))('should handle case: $title', ({ visitedPlaceId, setup, expected }) => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            unsetAllTimes(interview);
+            setup(interview);
+            const path = visitedPlaceFieldPath(visitedPlaceId, '_previousArrivalTime');
+            expect(suffixTimesFn(interview, path)).toEqual(expected);
+        });
+
+        test('should throw error when visited place context is not found', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            expect(() => suffixTimesFn(interview, 'invalid/nonexistent/path')).toThrow(
+                'getSameVisitedPlacesFromOthers: cannot get visited place context from path invalid/nonexistent/path'
+            );
+        });
+    });
+
 });
 
 describe('visitedPlacePreviousDepartureTime widget', () => {
@@ -711,7 +804,7 @@ describe('visitedPlacePreviousDepartureTime widget', () => {
             label: expect.any(Function),
             minuteStep: expect.any(Function),
             addHourSeparators: true,
-            suffixTimes:undefined,
+            suffixTimes: expect.any(Function),
             maxTimeSecondsSinceMidnight: expect.any(Function),
             minTimeSecondsSinceMidnight: expect.any(Function),
             validations: requiredValidation,
@@ -1007,6 +1100,25 @@ describe('visitedPlacePreviousDepartureTime widget', () => {
             const interview = _cloneDeep(interviewAttributesForTestCases);
             expect(() => maxTimeFn(interview, 'invalid/nonexistent/path')).toThrow(
                 'time upper bound for field: _previousDepartureTime: visited place context not found for path invalid/nonexistent/path'
+            );
+        });
+    });
+
+    describe('suffixTimes function', () => {
+        const suffixTimesFn = widget.suffixTimes as Function;
+
+        test.each(getTestCasesForSuffixTimes('departureTime'))('should handle case: $title', ({ visitedPlaceId, setup, expected }) => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            unsetAllTimes(interview);
+            setup(interview);
+            const path = visitedPlaceFieldPath(visitedPlaceId, '_previousDepartureTime');
+            expect(suffixTimesFn(interview, path)).toEqual(expected);
+        });
+
+        test('should throw error when visited place context is not found', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            expect(() => suffixTimesFn(interview, 'invalid/nonexistent/path')).toThrow(
+                'getSameVisitedPlacesFromOthers: cannot get visited place context from path invalid/nonexistent/path'
             );
         });
     });
@@ -1418,13 +1530,39 @@ describe('visitedPlaceArrivalTime widget', () => {
     describe('suffixTimes function', () => {
         const suffixTimesFn = widget.suffixTimes as Function;
 
-        test('should return suffix for very last time', () => {
+        test.each(getTestCasesForSuffixTimes('arrivalTime'))('should handle case: $title', ({ visitedPlaceId, setup, expected }) => {
             const interview = _cloneDeep(interviewAttributesForTestCases);
             unsetAllTimes(interview);
-            const path = visitedPlaceFieldPath('workPlace1P1', 'arrivalTime');
-            expect(suffixTimesFn(interview, path)).toEqual({ [String(visitedPlacesSectionConfig.tripDiaryMaxTimeOfDay)]: expect.any(String) });
+            setup(interview);
+            const path = visitedPlaceFieldPath(visitedPlaceId, 'arrivalTime');
+            // Times should append the very last time suffix for arrival time
+            expect(suffixTimesFn(interview, path)).toEqual({
+                ...expected,
+                [String(visitedPlacesSectionConfig.tripDiaryMaxTimeOfDay)]: expect.stringContaining(` translated_visitedPlaces:orPlus`)
+            });
         });
-    })
+
+        test('should add suffix name to last time of day', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            unsetAllTimes(interview);
+            // Add nicknames for personId2 and arrivalTime of homePlace2P2 to the last time of day
+            interview.response.household!.persons!.personId2.nickname = 'p2';
+            interview.response.household!.persons!.personId2.journeys!.journeyId2.visitedPlaces!.homePlace2P2.arrivalTime = visitedPlacesSectionConfig.tripDiaryMaxTimeOfDay;
+
+            const path = visitedPlaceFieldPath('homePlace1P1', 'arrivalTime');
+            // Times should append the very last time suffix for arrival time with both 'or +' and nickname
+            expect(suffixTimesFn(interview, path)).toEqual({
+                [String(visitedPlacesSectionConfig.tripDiaryMaxTimeOfDay)]: expect.stringContaining(` translated_visitedPlaces:orPlus (p2)`)
+            });
+        });
+
+        test('should throw error when visited place context is not found', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            expect(() => suffixTimesFn(interview, 'invalid/nonexistent/path')).toThrow(
+                'getSameVisitedPlacesFromOthers: cannot get visited place context from path invalid/nonexistent/path'
+            );
+        });
+    });
 
 });
 
@@ -1446,7 +1584,7 @@ describe('visitedPlaceDepartureTime widget', () => {
             label: expect.any(Function),
             minuteStep: expect.any(Function),
             addHourSeparators: true,
-            suffixTimes:undefined,
+            suffixTimes: expect.any(Function),
             maxTimeSecondsSinceMidnight: expect.any(Function),
             minTimeSecondsSinceMidnight: expect.any(Function),
             validations: requiredValidation,
@@ -1799,5 +1937,25 @@ describe('visitedPlaceDepartureTime widget', () => {
             );
         });
     });
+
+    describe('suffixTimes function', () => {
+        const suffixTimesFn = widget.suffixTimes as Function;
+
+        test.each(getTestCasesForSuffixTimes('departureTime'))('should handle case: $title', ({ visitedPlaceId, setup, expected }) => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            unsetAllTimes(interview);
+            setup(interview);
+            const path = visitedPlaceFieldPath(visitedPlaceId, 'departureTime');
+            expect(suffixTimesFn(interview, path)).toEqual(expected);
+        });
+
+        test('should throw error when visited place context is not found', () => {
+            const interview = _cloneDeep(interviewAttributesForTestCases);
+            expect(() => suffixTimesFn(interview, 'invalid/nonexistent/path')).toThrow(
+                'getSameVisitedPlacesFromOthers: cannot get visited place context from path invalid/nonexistent/path'
+            );
+        });
+    });
     
 });
+

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/helpers.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/helpers.ts
@@ -10,7 +10,8 @@ import {
     type ActivityCategory,
     activityCategoryValues,
     activityValues,
-    activityToDisplayCategory
+    activityToDisplayCategory,
+    sameLocationDistanceBufferMeters
 } from '../../../odSurvey/types';
 import type {
     Journey,
@@ -27,6 +28,7 @@ import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { toXXhrYYminZZsec } from 'chaire-lib-common/lib/utils/DateTimeUtils';
 import { TFunction } from 'i18next';
 import config from '../../../../config/project.config';
+import { getBirdDistanceMeters } from '../../../../utils/PhysicsUtils';
 
 /**
  * Validate that the activity of the previous and next places are not in the
@@ -576,3 +578,63 @@ export const getPersonUsualSchoolPlace: ParsingFunction<{
     mayHaveUsualPlace: boolean;
     usualPlace: NamedPlace | null;
 }> = (interview, path) => visitedPlaceSectionHelpers.getPersonUsualSchoolPlace(interview, path);
+
+/**
+ * Get the visited places from other household members whose geography is within
+ * a certain buffer of the current place's geography.
+ * @param interview The interview
+ * @param path The path of the widget, containing the context of the current
+ * place
+ * @returns An array of visited places from other household members that are
+ * within a certain distance of the current place's geography.
+ */
+export const getSameVisitedPlacesFromOtherHouseholdMembers = (
+    interview,
+    path
+): { person: Person; visitedPlace: VisitedPlace }[] => {
+    const currentPlaceContext = odSurveyHelpers.getVisitedPlaceContextFromPath({ interview, path });
+    if (currentPlaceContext === null) {
+        throw new Error(`getSameVisitedPlacesFromOthers: cannot get visited place context from path ${path}`);
+    }
+    const { person, visitedPlace: currentVisitedPlace } = currentPlaceContext;
+    const currentPlaceGeography = odSurveyHelpers.getVisitedPlaceGeography({
+        visitedPlace: currentVisitedPlace,
+        interview,
+        person
+    });
+    if (currentPlaceGeography === null) {
+        return [];
+    }
+    const otherVisitedPlacesGeographies = odSurveyHelpers
+        .getPersonsArray({ interview })
+        // Get other persons
+        .filter((p) => p._uuid !== person._uuid)
+        // Get visited places and geography for other persons
+        .flatMap((otherPerson) => {
+            return odSurveyHelpers
+                .getJourneysArray({ person: otherPerson })
+                .flatMap((otherJourney) => odSurveyHelpers.getVisitedPlacesArray({ journey: otherJourney }))
+                .map((vp) => ({
+                    visitedPlace: vp,
+                    geography: odSurveyHelpers.getVisitedPlaceGeography({
+                        visitedPlace: vp,
+                        interview,
+                        person: otherPerson
+                    }),
+                    person: otherPerson
+                }));
+        })
+        // Ignore places with null geographies
+        .filter(({ geography }) => geography !== null) as {
+        visitedPlace: VisitedPlace;
+        geography: GeoJSON.Feature<GeoJSON.Point>;
+        person: Person;
+    }[];
+    // Calculate the bird distance between current and other geographies and return those within a certain distance
+    return otherVisitedPlacesGeographies
+        .filter(({ geography }) => {
+            const birdDistance = getBirdDistanceMeters(currentPlaceGeography, geography);
+            return birdDistance !== undefined && birdDistance <= sameLocationDistanceBufferMeters;
+        })
+        .map(({ visitedPlace, person }) => ({ person, visitedPlace }));
+};

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetsTime.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetsTime.ts
@@ -8,6 +8,7 @@
 import _escape from 'lodash/escape';
 import _max from 'lodash/max';
 import _min from 'lodash/min';
+import _truncate from 'lodash/truncate';
 import i18n, { type TFunction } from 'i18next';
 import type {
     InputTimeType,
@@ -19,7 +20,7 @@ import type {
 import * as odHelpers from '../../../odSurvey/helpers';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import type { WidgetConfigFactory, WidgetFactoryOptions } from '../types';
-import { formatTripDuration, isWorkOnTheRoad } from './helpers';
+import { formatTripDuration, getSameVisitedPlacesFromOtherHouseholdMembers, isWorkOnTheRoad } from './helpers';
 import { requiredValidation } from '../../../widgets/validations/validations';
 
 export type TimeWidgetOptions = Pick<
@@ -283,11 +284,32 @@ export class VisitedPlaceTimeWidgetFactory implements WidgetConfigFactory {
                 return upperBoundSecondsSinceMidnight;
             };
 
-    private getSuffixTimes = (_interview: UserInterviewAttributes, _timeField: TimeField = 'arrivalTime') => {
+    private getSuffixTimes = (
+        interview: UserInterviewAttributes,
+        path: string,
+        timeField: TimeField = 'arrivalTime'
+    ) => {
         // return an object: {[secondsSinceMidnight (string)]: suffix (string)}
         const suffixTimes = {};
 
-        // TODO Implement correctly, but specify first!
+        // Find the other visited places, from other persons, which have the
+        // same geography as this one, so we can show the other persons'
+        // nicknames next to the time.
+        const similarPlaces = getSameVisitedPlacesFromOtherHouseholdMembers(interview, path);
+        // For each similar place, if there is a time associated with the place, add a suffix for that time with the name of the person (ellipsed at 10 characters)
+        for (const { person, visitedPlace } of similarPlaces) {
+            const otherPlaceTime = visitedPlace[timeField];
+            if (typeof otherPlaceTime === 'number') {
+                // FIXME If more than one person is at that place at the same
+                // time, this only shows one of them. But truncated at 10
+                // characters, showing more makes little sense, unless
+                // participants, have very short names. See how we want to
+                // support showing more than one person.
+                const otherPersonIdentification = odHelpers.getPersonIdentificationString({ person, t: i18n.t });
+                suffixTimes[otherPlaceTime.toString()] = ` (${_truncate(otherPersonIdentification, { length: 10 })})`;
+            }
+        }
+
         return suffixTimes;
     };
 
@@ -361,7 +383,9 @@ export class VisitedPlaceTimeWidgetFactory implements WidgetConfigFactory {
         ),
         maxTimeSecondsSinceMidnight: this.getTimeSecondsUpperBoundFromNextPlacesAndTimes(
             '_previousPreviousDepartureTime'
-        )
+        ),
+        // Use departureTime for suffix as this field will be rewritten to departure anyway
+        suffixTimes: (interview, path) => this.getSuffixTimes(interview, path, 'departureTime')
     });
 
     private getPreviousArrivalTimeWidgetConfiguration = (): TimeWidgetOptions => ({
@@ -408,7 +432,9 @@ export class VisitedPlaceTimeWidgetFactory implements WidgetConfigFactory {
             });
         },
         minTimeSecondsSinceMidnight: this.getTimeSecondsLowerBoundFromPreviousPlacesAndTimes('_previousArrivalTime'),
-        maxTimeSecondsSinceMidnight: this.getTimeSecondsUpperBoundFromNextPlacesAndTimes('_previousArrivalTime')
+        maxTimeSecondsSinceMidnight: this.getTimeSecondsUpperBoundFromNextPlacesAndTimes('_previousArrivalTime'),
+        // Use arrivalTime for suffix as this field will be rewritten to arrival anyway
+        suffixTimes: (interview, path) => this.getSuffixTimes(interview, path, 'arrivalTime')
     });
 
     private getPreviousDepartureTimeWidgetConfiguration = (): TimeWidgetOptions => ({
@@ -506,7 +532,9 @@ export class VisitedPlaceTimeWidgetFactory implements WidgetConfigFactory {
             });
         },
         minTimeSecondsSinceMidnight: this.getTimeSecondsLowerBoundFromPreviousPlacesAndTimes('_previousDepartureTime'),
-        maxTimeSecondsSinceMidnight: this.getTimeSecondsUpperBoundFromNextPlacesAndTimes('_previousDepartureTime')
+        maxTimeSecondsSinceMidnight: this.getTimeSecondsUpperBoundFromNextPlacesAndTimes('_previousDepartureTime'),
+        // Use departureTime for suffix as this field will be rewritten to departure anyway
+        suffixTimes: (interview, path) => this.getSuffixTimes(interview, path, 'departureTime')
     });
 
     private getArrivalTimeWidgetConfiguration = (): TimeWidgetOptions => ({
@@ -619,10 +647,17 @@ export class VisitedPlaceTimeWidgetFactory implements WidgetConfigFactory {
         },
         minTimeSecondsSinceMidnight: this.getTimeSecondsLowerBoundFromPreviousPlacesAndTimes('arrivalTime'),
         maxTimeSecondsSinceMidnight: this.getTimeSecondsUpperBoundFromNextPlacesAndTimes('arrivalTime'),
-        suffixTimes: (interview) => {
-            const suffixTimes = this.getSuffixTimes(interview, 'arrivalTime');
+        suffixTimes: (interview, path) => {
+            const suffixTimes = this.getSuffixTimes(interview, path, 'arrivalTime');
             // Add the 'or +' at the end of the last time option
-            suffixTimes[String(this.sectionConfig.tripDiaryMaxTimeOfDay)] = ' ' + i18n.t('visitedPlaces:orPlus');
+            const lastTimeOfDay = String(this.sectionConfig.tripDiaryMaxTimeOfDay);
+            const lastTimeOfDaySuffix = ' ' + i18n.t('visitedPlaces:orPlus');
+            if (suffixTimes[lastTimeOfDay] !== undefined) {
+                // Append current suffix to the last time suffix
+                suffixTimes[lastTimeOfDay] = lastTimeOfDaySuffix + suffixTimes[lastTimeOfDay];
+            } else {
+                suffixTimes[lastTimeOfDay] = lastTimeOfDaySuffix;
+            }
 
             return suffixTimes;
         }
@@ -716,7 +751,8 @@ export class VisitedPlaceTimeWidgetFactory implements WidgetConfigFactory {
         maxTimeSecondsSinceMidnight: this.getTimeSecondsUpperBoundFromNextPlacesAndTimes(
             'departureTime',
             true /* ignoreNextLoopActivities */
-        )
+        ),
+        suffixTimes: (interview, path) => this.getSuffixTimes(interview, path, 'departureTime')
     });
 
     getWidgetConfigs = (): Record<string, InputTimeType> => {


### PR DESCRIPTION
fixes #1562

Add as suffixes for arrival/departure time widgets the name of other
household members (truncated at 10 characters max) that have visited
a place with a geography within a threshold distance of the current
visited place (presently set at 50 meters).

All variants of departureTime use the visited places' departureTime and
variants of arrivalTime use the visited places' arrivalTime, as the
variant fields are temporary and are transformed into actual visited
places when they are confirmed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added matching for visited places shared with other household members when locations are within 50 meters.
  - Arrival and departure time fields now identify matching household members alongside relevant times.
  - Names displayed with time entries are shortened when needed for readability.
  - Matching results account for linked places and support both arrival and departure details.
  - Existing “or plus” time options remain available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->