### PR TITLE
frontend: add and use a `stripHtml` function when containsHtml is `false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix HTML markup showing up in templates, by using the `stripHtml` function from `frontendHelpers` (fixes [#1584](https://github.com/chairemobilite/evolution/issues/1584))
 - Fix confirm button placements in `TripsAndSegmentsSection` template to go below the map on small screens (fixes [#1837](https://github.com/chairemobilite/evolution/issues/1837))
 - InfoMap titles can be HTML (`containsHtml`), so generator tags (`<span class="_pale _oblique">`, `style="..."`) render instead of showing as text. The visited places map widget sets this flag.
 - `joinWith` now works for widgets inside a group: the next widget status is read from the group status path instead of the top-level `widgets`, so grouped widgets are joined as expected, and the dashed separator stays continuous across joined widgets (fixes [#1621](https://github.com/chairemobilite/evolution/issues/1621)).

--- a/packages/evolution-frontend/src/components/inputs/InputCheckbox.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputCheckbox.tsx
@@ -5,7 +5,6 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import React, { JSX } from 'react';
-import DOMPurify from 'dompurify';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { shuffle } from 'chaire-lib-common/lib/utils/RandomUtils';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -16,6 +15,7 @@ import { UserInterviewAttributes } from 'evolution-common/lib/services/questionn
 import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
 import { CommonInputProps } from './CommonInputProps';
 import { sortByParameters } from './InputChoiceSorting';
+import { stripUnsafeHtml } from '../../services/display/frontendHelper';
 
 export type InputCheckboxProps = CommonInputProps & {
     value: string[];
@@ -106,7 +106,7 @@ const InputCheckboxChoice = (props: InputCheckboxChoiceProps & WithTranslation) 
                             />
                         </span>
                     )}
-                    <span dangerouslySetInnerHTML={{ __html: strLabel ? DOMPurify.sanitize(strLabel) : '' }} />
+                    <span dangerouslySetInnerHTML={{ __html: strLabel ? stripUnsafeHtml(strLabel) : '' }} />
                 </label>
             </div>
         </div>

--- a/packages/evolution-frontend/src/components/inputs/InputRadio.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputRadio.tsx
@@ -5,7 +5,6 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import React, { JSX } from 'react';
-import DOMPurify from 'dompurify';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { shuffle } from 'chaire-lib-common/lib/utils/RandomUtils';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -16,6 +15,7 @@ import { UserInterviewAttributes } from 'evolution-common/lib/services/questionn
 import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
 import { CommonInputProps } from './CommonInputProps';
 import { sortByParameters } from './InputChoiceSorting';
+import { stripUnsafeHtml } from '../../services/display/frontendHelper';
 
 export type InputRadioProps = CommonInputProps & {
     value: string | boolean;
@@ -109,7 +109,7 @@ const InputRadioChoice = (props: InputRadioChoiceProps & WithTranslation) => {
                             />
                         </span>
                     )}
-                    <span dangerouslySetInnerHTML={{ __html: strLabel ? DOMPurify.sanitize(strLabel) : '' }} />
+                    <span dangerouslySetInnerHTML={{ __html: strLabel ? stripUnsafeHtml(strLabel) : '' }} />
                 </label>
             </div>
             {props.children}

--- a/packages/evolution-frontend/src/components/inputs/__tests__/InputCheckbox.test.tsx
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/InputCheckbox.test.tsx
@@ -17,6 +17,11 @@ import i18next from 'i18next';
 jest.mock('chaire-lib-common/lib/utils/RandomUtils', () => ({
     shuffle: jest.fn()
 }));
+// Mock frontend helper to avoid undefined config error
+jest.mock('../../../services/display/frontendHelper', () => ({
+    stripUnsafeHtml: jest.fn().mockImplementation(str => str)
+}));
+
 
 const shuffleMock = shuffle as jest.MockedFunction<typeof shuffle>;
 

--- a/packages/evolution-frontend/src/components/inputs/__tests__/InputMapFindPlace.test.tsx
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/InputMapFindPlace.test.tsx
@@ -26,7 +26,8 @@ jest.mock('../maps/google/GoogleMapAdapter', () => ({
 }));
 // Mock frontend helper to avoid undefined config error
 jest.mock('../../../services/display/frontendHelper', () => ({
-    stripHtml: jest.fn().mockImplementation(str => str)
+    stripHtml: jest.fn().mockImplementation(str => str),
+    stripUnsafeHtml: jest.fn((str) => str)
 }));
 
 const mockedGeocode = mockGeocodeMultiplePlaces;

--- a/packages/evolution-frontend/src/components/inputs/__tests__/InputMapFindPlace.test.tsx
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/InputMapFindPlace.test.tsx
@@ -24,6 +24,10 @@ jest.mock('../maps/google/GoogleMapAdapter', () => ({
         return mockGoogleMapAdapter;
     }
 }));
+// Mock frontend helper to avoid undefined config error
+jest.mock('../../../services/display/frontendHelper', () => ({
+    stripHtml: jest.fn().mockImplementation(str => str)
+}));
 
 const mockedGeocode = mockGeocodeMultiplePlaces;
 

--- a/packages/evolution-frontend/src/components/inputs/__tests__/InputMapPoint.test.tsx
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/InputMapPoint.test.tsx
@@ -23,6 +23,11 @@ jest.mock('../maps/google/GoogleGeocoder', () => ({
     geocodeSinglePoint: jest.fn()
 }));
 const mockedGeocode = geocodeSinglePoint as jest.MockedFunction<typeof geocodeSinglePoint>;
+// Mock frontend helper to avoid undefined config error
+jest.mock('../../../services/display/frontendHelper', () => ({
+    stripHtml: jest.fn().mockImplementation(str => str)
+}));
+
 
 const userAttributes = {
     id: 1,

--- a/packages/evolution-frontend/src/components/inputs/__tests__/InputRadio.test.tsx
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/InputRadio.test.tsx
@@ -19,6 +19,11 @@ import i18next from 'i18next';
 jest.mock('chaire-lib-common/lib/utils/RandomUtils', () => ({
     shuffle: jest.fn()
 }));
+// Mock frontend helper to avoid undefined config error
+jest.mock('../../../services/display/frontendHelper', () => ({
+    stripUnsafeHtml: jest.fn().mockImplementation(str => str)
+}));
+
 
 const shuffleMock = shuffle as jest.MockedFunction<typeof shuffle>;
 

--- a/packages/evolution-frontend/src/components/inputs/__tests__/InputRadioNumber.test.tsx
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/InputRadioNumber.test.tsx
@@ -9,6 +9,11 @@ import InputRadioNumber from "../InputRadioNumber";
 import {UserPermissions} from "chaire-lib-common/lib/services/user/userType";
 import { render, fireEvent } from '@testing-library/react';
 
+// Mock frontend helper to avoid undefined config error
+jest.mock('../../../services/display/frontendHelper', () => ({
+    stripUnsafeHtml: jest.fn().mockImplementation(str => str)
+}));
+
 const interview = {
     id: 1,
     uuid: "",

--- a/packages/evolution-frontend/src/components/inputs/__tests__/mockGoogleMapAdapter.tsx
+++ b/packages/evolution-frontend/src/components/inputs/__tests__/mockGoogleMapAdapter.tsx
@@ -5,9 +5,9 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import React from 'react';
-import DOMPurify from 'dompurify';
 
 import type { MapProviderAdapter, MapWidgetProps } from '../maps/types';
+import { stripUnsafeHtml } from '../../../services/display/frontendHelper';
 
 /** Shared geocode mock used by the adapter double and by InputMapFindPlace tests. */
 export const mockGeocodeMultiplePlaces = jest.fn();
@@ -26,7 +26,7 @@ const MockInputMap: React.FC<MapWidgetProps> = ({ infoWindow, onMapReady }) => {
             {infoWindow ? (
                 <div data-testid="mock-info-window">
                     <div
-                        dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(infoWindow.content) }}
+                        dangerouslySetInnerHTML={{ __html: stripUnsafeHtml(infoWindow.content) }}
                     />
                     {infoWindow.confirmLabel && infoWindow.onConfirm ? (
                         <button

--- a/packages/evolution-frontend/src/components/inputs/maps/google/InputMapGoogle.tsx
+++ b/packages/evolution-frontend/src/components/inputs/maps/google/InputMapGoogle.tsx
@@ -18,13 +18,13 @@ import {
 } from '@vis.gl/react-google-maps';
 import GeoJSON from 'geojson';
 import bowser from 'bowser';
-import DOMPurify from 'dompurify';
 
 import { getCurrentGoogleMapConfig, getGoogleMapId } from '../../../../config/googleMaps.config';
 import InputLoading from '../../InputLoading';
 import { FeatureGeocodedProperties, MarkerData, InfoWindow as InfoWindowData } from '../types';
 import { geojson } from './GoogleMapUtils';
 import { logClientSideMessage } from '../../../../services/errorManagement/errorHandling';
+import { stripUnsafeHtml } from '../../../../services/display/frontendHelper';
 
 export interface InputGoogleMapPointProps {
     defaultCenter: { lat: number; lon: number };
@@ -243,7 +243,7 @@ const InputMapGoogleInner: React.FunctionComponent<InputGoogleMapPointProps> = (
 
         const container = document.createElement('div');
         // Place name/address/photo HTML comes from geocoder data — sanitize before insert.
-        container.innerHTML = DOMPurify.sanitize(props.infoWindow.content);
+        container.innerHTML = stripUnsafeHtml(props.infoWindow.content);
 
         let confirmButton: HTMLButtonElement | undefined;
         const onConfirm = props.infoWindow.onConfirm;

--- a/packages/evolution-frontend/src/components/modal/SimpleModal.tsx
+++ b/packages/evolution-frontend/src/components/modal/SimpleModal.tsx
@@ -9,6 +9,7 @@ import Modal from 'react-modal';
 import { withTranslation, WithTranslation } from 'react-i18next';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { stripHtml } from '../../services/display/frontendHelper';
 
 export interface SimpleModalProps {
     isOpen: boolean;
@@ -58,7 +59,9 @@ export const SimpleModal: React.FunctionComponent<SimpleModalProps & WithTransla
                     <div dangerouslySetInnerHTML={{ __html: props.text }} />
                 ) : (
                     <div className="help-popup">
-                        <Markdown remarkPlugins={[[remarkGfm, { singleTilde: false }]]}>{props.text}</Markdown>
+                        <Markdown remarkPlugins={[[remarkGfm, { singleTilde: false }]]}>
+                            {stripHtml(props.text)}
+                        </Markdown>
                     </div>
                 )}
                 <div className="center">

--- a/packages/evolution-frontend/src/components/modal/__tests__/SimpleModal.test.tsx
+++ b/packages/evolution-frontend/src/components/modal/__tests__/SimpleModal.test.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import SimpleModal from '../SimpleModal';
+import { stripHtml } from '../../../services/display/frontendHelper';
 
 // Mock react-markdown and remark-gfm as they use syntax not supported by jest
 jest.mock('react-markdown', () => 'Markdown');
@@ -19,6 +20,12 @@ jest.mock('react-i18next', () => ({
         return Component;
     },
 }));
+// Mock frontend helper to avoid undefined config error
+jest.mock('../../../services/display/frontendHelper', () => ({
+    stripHtml: jest.fn().mockImplementation(str => str)
+}));
+const mockStripHtml = stripHtml as jest.MockedFunction<typeof stripHtml>;
+
 
 test('Test simple modal with action on close', () =>{
     const handleClose = jest.fn();
@@ -47,6 +54,26 @@ test('Test simple modal with action on close', () =>{
     fireEvent.click(button as any);
     expect(handleClose).toHaveBeenCalledTimes(1);
     expect(action).toHaveBeenCalledTimes(1);
+});
+
+test('Test simple modal with containsHtml `false`', () =>{
+    const handleClose = jest.fn();
+    const action = jest.fn();
+    const title = 'Simple modal title';
+    const baseText = 'Text in the simple modal';
+    const text = `${baseText} <b>bold</b>`;
+    const { queryByText } = render(
+        <SimpleModal
+            isOpen={true}
+            closeModal={handleClose}
+            text={text}
+            title={title}
+            containsHtml={false}
+            action={action}
+        />
+    );
+    // Make sure the stripHtml function has been called
+    expect(mockStripHtml).toHaveBeenCalledWith(text);
 });
 
 test('Test simple modal with minimal parameters', () =>{

--- a/packages/evolution-frontend/src/components/survey/__tests__/GroupWidgets.test.tsx
+++ b/packages/evolution-frontend/src/components/survey/__tests__/GroupWidgets.test.tsx
@@ -37,6 +37,11 @@ jest.mock('react-input-range/src/js/input-range/default-class-names', () => ({
 }));
 
 jest.mock('react-input-range/lib/css/index.css', () => {});
+// Mock frontend helper to avoid undefined config error
+jest.mock('../../../services/display/frontendHelper', () => ({
+    stripHtml: jest.fn().mockImplementation(str => str)
+}));
+
 
 // Add widgets to the survey context
 const widgets = {

--- a/packages/evolution-frontend/src/components/survey/__tests__/InfoMap.test.tsx
+++ b/packages/evolution-frontend/src/components/survey/__tests__/InfoMap.test.tsx
@@ -18,6 +18,11 @@ import { WidgetStatus } from 'evolution-common/lib/services/questionnaire/types'
 // Mock react-markdown and remark-gfm as they use syntax not supported by jest
 jest.mock('react-markdown', () => 'Markdown');
 jest.mock('remark-gfm', () => 'remark-gfm');
+// Mock frontend helper to avoid undefined config error
+jest.mock('../../../services/display/frontendHelper', () => ({
+    stripUnsafeHtml: jest.fn().mockImplementation(str => str)
+}));
+
 
 const userAttributes = {
     id: 1,

--- a/packages/evolution-frontend/src/components/survey/__tests__/Question.test.tsx
+++ b/packages/evolution-frontend/src/components/survey/__tests__/Question.test.tsx
@@ -41,7 +41,8 @@ jest.mock('react-input-range/src/js/input-range/default-class-names', () => ({
 jest.mock('react-input-range/lib/css/index.css', () => {});
 // Mock frontend helper to avoid undefined config error
 jest.mock('../../../services/display/frontendHelper', () => ({
-    stripHtml: jest.fn((str) => str)
+    stripHtml: jest.fn((str) => str),
+    stripUnsafeHtml: jest.fn((str) => str)
 }));
 
 // Mock the createPortal function to allow the snapshots with Modal questions to work. With later React and React-modal versions, this won't be necessary anymore. See https://github.com/reactjs/react-modal/issues/553

--- a/packages/evolution-frontend/src/components/survey/__tests__/Question.test.tsx
+++ b/packages/evolution-frontend/src/components/survey/__tests__/Question.test.tsx
@@ -39,6 +39,10 @@ jest.mock('react-input-range/src/js/input-range/default-class-names', () => ({
 }));
 
 jest.mock('react-input-range/lib/css/index.css', () => {});
+// Mock frontend helper to avoid undefined config error
+jest.mock('../../../services/display/frontendHelper', () => ({
+    stripHtml: jest.fn((str) => str)
+}));
 
 // Mock the createPortal function to allow the snapshots with Modal questions to work. With later React and React-modal versions, this won't be necessary anymore. See https://github.com/reactjs/react-modal/issues/553
 jest.mock('react-dom', () => ({

--- a/packages/evolution-frontend/src/components/survey/sectionTemplates/VisitedPlacesSection.tsx
+++ b/packages/evolution-frontend/src/components/survey/sectionTemplates/VisitedPlacesSection.tsx
@@ -25,7 +25,7 @@ import ConfirmModal from 'chaire-lib-frontend/lib/components/modal/ConfirmModal'
 import LoadingPage from 'chaire-lib-frontend/lib/components/pages/LoadingPage';
 import { type SectionProps, useSectionTemplate } from '../../hooks/useSectionTemplate';
 import { SurveyContext } from '../../../contexts/SurveyContext';
-import { secondsSinceMidnightToTimeStrWithSuffix } from '../../../services/display/frontendHelper';
+import { secondsSinceMidnightToTimeStrWithSuffix, stripHtml } from '../../../services/display/frontendHelper';
 import type { GroupConfig, VisitedPlace } from 'evolution-common/lib/services/questionnaire/types';
 import { getResponse } from 'evolution-common/lib/utils/helpers';
 import { getActivityIcon } from 'evolution-common/lib/services/questionnaire/sections/visitedPlaces/activityIconMapping';
@@ -171,7 +171,11 @@ export const VisitedPlacesSection: React.FC<SectionProps> = (props: SectionProps
                         <img
                             src={getActivityIcon(visitedPlace.activity)}
                             style={{ height: '1.8em', padding: '0.1em' }}
-                            alt={visitedPlace.activity ? t(`visitedPlaces:activities:${visitedPlace.activity}`) : ''}
+                            alt={
+                                visitedPlace.activity
+                                    ? stripHtml(t(`visitedPlaces:activities:${visitedPlace.activity}`))
+                                    : ''
+                            }
                         />
                         <p>
                             <FontAwesomeIcon icon={faClock} style={{ marginRight: '0.3rem', marginLeft: '0.6rem' }} />
@@ -281,15 +285,15 @@ export const VisitedPlacesSection: React.FC<SectionProps> = (props: SectionProps
                             <img
                                 src={getActivityIcon(activity)}
                                 style={{ height: '3rem' }}
-                                alt={activity ? t(`visitedPlaces:activities:${activity}`) : ''}
+                                alt={activity ? stripHtml(t(`visitedPlaces:activities:${activity}`)) : ''}
                             />
                         </div>
                     )}
                 </span>
                 <span className="survey-visited-place-item-element survey-visited-place-item-description text-box-ellipsis">
                     <span className={isPlaceSelected ? '_strong' : ''}>
-                        {activity && t(`visitedPlaces:activities:${activity}`)}
-                        {actualVisitedPlace.name && <em>&nbsp;• {actualVisitedPlace.name}</em>}
+                        {activity && stripHtml(t(`visitedPlaces:activities:${activity}`))}
+                        {actualVisitedPlace.name && <em>&nbsp;• {stripHtml(actualVisitedPlace.name)}</em>}
                     </span>
                 </span>
 

--- a/packages/evolution-frontend/src/components/survey/sectionTemplates/__tests__/VisitedPlacesSection.test.tsx
+++ b/packages/evolution-frontend/src/components/survey/sectionTemplates/__tests__/VisitedPlacesSection.test.tsx
@@ -51,7 +51,8 @@ jest.mock('react-i18next', () => ({
     })
 }));
 jest.mock('../../../../services/display/frontendHelper', () => ({
-    secondsSinceMidnightToTimeStrWithSuffix: jest.fn((seconds: number) => `time-${seconds}`)
+    secondsSinceMidnightToTimeStrWithSuffix: jest.fn((seconds: number) => `time-${seconds}`),
+    stripHtml: jest.fn((str) => `stripped:${str}`)
 }));
 
 jest.mock('evolution-common/lib/services/odSurvey/helpers', () => {

--- a/packages/evolution-frontend/src/components/survey/sectionTemplates/__tests__/__snapshots__/VisitedPlacesSection.test.tsx.snap
+++ b/packages/evolution-frontend/src/components/survey/sectionTemplates/__tests__/__snapshots__/VisitedPlacesSection.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`VisitedPlacesSection UI display should render the default visited place
                 class="survey-visited-places-schedule-visited-place-icon"
               >
                 <img
-                  alt="visitedPlaces:activities:home"
+                  alt="stripped:visitedPlaces:activities:home"
                   src="/dist/icons/activities/home/home.svg"
                   style="height: 1.8em; padding: 0.1em;"
                 />
@@ -95,7 +95,7 @@ exports[`VisitedPlacesSection UI display should render the default visited place
                 class="survey-visited-places-schedule-visited-place-icon"
               >
                 <img
-                  alt="visitedPlaces:activities:workUsual"
+                  alt="stripped:visitedPlaces:activities:workUsual"
                   src="/dist/icons/activities/work/briefcase.svg"
                   style="height: 1.8em; padding: 0.1em;"
                 />
@@ -142,7 +142,7 @@ exports[`VisitedPlacesSection UI display should render the default visited place
                 class="survey-visited-places-schedule-visited-place-icon"
               >
                 <img
-                  alt="visitedPlaces:activities:home"
+                  alt="stripped:visitedPlaces:activities:home"
                   src="/dist/icons/activities/home/home.svg"
                   style="height: 1.8em; padding: 0.1em;"
                 />
@@ -189,7 +189,7 @@ exports[`VisitedPlacesSection UI display should render the default visited place
                 class="survey-visited-places-schedule-visited-place-icon"
               >
                 <img
-                  alt="visitedPlaces:activities:shopping"
+                  alt="stripped:visitedPlaces:activities:shopping"
                   src="/dist/icons/activities/shopping/shopping_cart.svg"
                   style="height: 1.8em; padding: 0.1em;"
                 />
@@ -236,7 +236,7 @@ exports[`VisitedPlacesSection UI display should render the default visited place
                 class="survey-visited-places-schedule-visited-place-icon"
               >
                 <img
-                  alt="visitedPlaces:activities:shopping"
+                  alt="stripped:visitedPlaces:activities:shopping"
                   src="/dist/icons/activities/shopping/shopping_cart.svg"
                   style="height: 1.8em; padding: 0.1em;"
                 />
@@ -289,7 +289,7 @@ exports[`VisitedPlacesSection UI display should render the default visited place
                 class="survey-visited-place-item-icon-container"
               >
                 <img
-                  alt="visitedPlaces:activities:home"
+                  alt="stripped:visitedPlaces:activities:home"
                   src="/dist/icons/activities/home/home.svg"
                   style="height: 3rem;"
                 />
@@ -301,7 +301,7 @@ exports[`VisitedPlacesSection UI display should render the default visited place
               <span
                 class=""
               >
-                visitedPlaces:activities:home
+                stripped:visitedPlaces:activities:home
               </span>
             </span>
             <span
@@ -415,7 +415,7 @@ exports[`VisitedPlacesSection UI display should render the default visited place
                 class="survey-visited-place-item-icon-container"
               >
                 <img
-                  alt="visitedPlaces:activities:workUsual"
+                  alt="stripped:visitedPlaces:activities:workUsual"
                   src="/dist/icons/activities/work/briefcase.svg"
                   style="height: 3rem;"
                 />
@@ -427,10 +427,10 @@ exports[`VisitedPlacesSection UI display should render the default visited place
               <span
                 class=""
               >
-                visitedPlaces:activities:workUsual
+                stripped:visitedPlaces:activities:workUsual
                 <em>
                    • 
-                  This is my work
+                  stripped:This is my work
                 </em>
               </span>
             </span>
@@ -546,7 +546,7 @@ exports[`VisitedPlacesSection UI display should render the default visited place
                 class="survey-visited-place-item-icon-container"
               >
                 <img
-                  alt="visitedPlaces:activities:home"
+                  alt="stripped:visitedPlaces:activities:home"
                   src="/dist/icons/activities/home/home.svg"
                   style="height: 3rem;"
                 />
@@ -558,7 +558,7 @@ exports[`VisitedPlacesSection UI display should render the default visited place
               <span
                 class=""
               >
-                visitedPlaces:activities:home
+                stripped:visitedPlaces:activities:home
               </span>
             </span>
             <span
@@ -673,7 +673,7 @@ exports[`VisitedPlacesSection UI display should render the default visited place
                 class="survey-visited-place-item-icon-container"
               >
                 <img
-                  alt="visitedPlaces:activities:shopping"
+                  alt="stripped:visitedPlaces:activities:shopping"
                   src="/dist/icons/activities/shopping/shopping_cart.svg"
                   style="height: 3rem;"
                 />
@@ -685,7 +685,7 @@ exports[`VisitedPlacesSection UI display should render the default visited place
               <span
                 class=""
               >
-                visitedPlaces:activities:shopping
+                stripped:visitedPlaces:activities:shopping
               </span>
             </span>
             <span
@@ -800,7 +800,7 @@ exports[`VisitedPlacesSection UI display should render the default visited place
                 class="survey-visited-place-item-icon-container"
               >
                 <img
-                  alt="visitedPlaces:activities:shopping"
+                  alt="stripped:visitedPlaces:activities:shopping"
                   src="/dist/icons/activities/shopping/shopping_cart.svg"
                   style="height: 3rem;"
                 />
@@ -812,10 +812,10 @@ exports[`VisitedPlacesSection UI display should render the default visited place
               <span
                 class=""
               >
-                visitedPlaces:activities:shopping
+                stripped:visitedPlaces:activities:shopping
                 <em>
                    • 
-                  This is a shopping place
+                  stripped:This is a shopping place
                 </em>
               </span>
             </span>
@@ -963,7 +963,7 @@ exports[`VisitedPlacesSection UI display should render the selected visited plac
                 class="survey-visited-places-schedule-visited-place-icon"
               >
                 <img
-                  alt="visitedPlaces:activities:home"
+                  alt="stripped:visitedPlaces:activities:home"
                   src="/dist/icons/activities/home/home.svg"
                   style="height: 1.8em; padding: 0.1em;"
                 />
@@ -1009,7 +1009,7 @@ exports[`VisitedPlacesSection UI display should render the selected visited plac
                 class="survey-visited-places-schedule-visited-place-icon"
               >
                 <img
-                  alt="visitedPlaces:activities:workUsual"
+                  alt="stripped:visitedPlaces:activities:workUsual"
                   src="/dist/icons/activities/work/briefcase.svg"
                   style="height: 1.8em; padding: 0.1em;"
                 />
@@ -1056,7 +1056,7 @@ exports[`VisitedPlacesSection UI display should render the selected visited plac
                 class="survey-visited-places-schedule-visited-place-icon"
               >
                 <img
-                  alt="visitedPlaces:activities:home"
+                  alt="stripped:visitedPlaces:activities:home"
                   src="/dist/icons/activities/home/home.svg"
                   style="height: 1.8em; padding: 0.1em;"
                 />
@@ -1103,7 +1103,7 @@ exports[`VisitedPlacesSection UI display should render the selected visited plac
                 class="survey-visited-places-schedule-visited-place-icon"
               >
                 <img
-                  alt="visitedPlaces:activities:shopping"
+                  alt="stripped:visitedPlaces:activities:shopping"
                   src="/dist/icons/activities/shopping/shopping_cart.svg"
                   style="height: 1.8em; padding: 0.1em;"
                 />
@@ -1150,7 +1150,7 @@ exports[`VisitedPlacesSection UI display should render the selected visited plac
                 class="survey-visited-places-schedule-visited-place-icon"
               >
                 <img
-                  alt="visitedPlaces:activities:shopping"
+                  alt="stripped:visitedPlaces:activities:shopping"
                   src="/dist/icons/activities/shopping/shopping_cart.svg"
                   style="height: 1.8em; padding: 0.1em;"
                 />
@@ -1203,7 +1203,7 @@ exports[`VisitedPlacesSection UI display should render the selected visited plac
                 class="survey-visited-place-item-icon-container"
               >
                 <img
-                  alt="visitedPlaces:activities:home"
+                  alt="stripped:visitedPlaces:activities:home"
                   src="/dist/icons/activities/home/home.svg"
                   style="height: 3rem;"
                 />
@@ -1215,7 +1215,7 @@ exports[`VisitedPlacesSection UI display should render the selected visited plac
               <span
                 class=""
               >
-                visitedPlaces:activities:home
+                stripped:visitedPlaces:activities:home
               </span>
             </span>
             <span
@@ -1265,7 +1265,7 @@ exports[`VisitedPlacesSection UI display should render the selected visited plac
                 class="survey-visited-place-item-icon-container"
               >
                 <img
-                  alt="visitedPlaces:activities:workUsual"
+                  alt="stripped:visitedPlaces:activities:workUsual"
                   src="/dist/icons/activities/work/briefcase.svg"
                   style="height: 3rem;"
                 />
@@ -1277,10 +1277,10 @@ exports[`VisitedPlacesSection UI display should render the selected visited plac
               <span
                 class="_strong"
               >
-                visitedPlaces:activities:workUsual
+                stripped:visitedPlaces:activities:workUsual
                 <em>
                    • 
-                  This is my work
+                  stripped:This is my work
                 </em>
               </span>
             </span>
@@ -1341,7 +1341,7 @@ exports[`VisitedPlacesSection UI display should render the selected visited plac
                 class="survey-visited-place-item-icon-container"
               >
                 <img
-                  alt="visitedPlaces:activities:home"
+                  alt="stripped:visitedPlaces:activities:home"
                   src="/dist/icons/activities/home/home.svg"
                   style="height: 3rem;"
                 />
@@ -1353,7 +1353,7 @@ exports[`VisitedPlacesSection UI display should render the selected visited plac
               <span
                 class=""
               >
-                visitedPlaces:activities:home
+                stripped:visitedPlaces:activities:home
               </span>
             </span>
             <span
@@ -1404,7 +1404,7 @@ exports[`VisitedPlacesSection UI display should render the selected visited plac
                 class="survey-visited-place-item-icon-container"
               >
                 <img
-                  alt="visitedPlaces:activities:shopping"
+                  alt="stripped:visitedPlaces:activities:shopping"
                   src="/dist/icons/activities/shopping/shopping_cart.svg"
                   style="height: 3rem;"
                 />
@@ -1416,7 +1416,7 @@ exports[`VisitedPlacesSection UI display should render the selected visited plac
               <span
                 class=""
               >
-                visitedPlaces:activities:shopping
+                stripped:visitedPlaces:activities:shopping
               </span>
             </span>
             <span
@@ -1467,7 +1467,7 @@ exports[`VisitedPlacesSection UI display should render the selected visited plac
                 class="survey-visited-place-item-icon-container"
               >
                 <img
-                  alt="visitedPlaces:activities:shopping"
+                  alt="stripped:visitedPlaces:activities:shopping"
                   src="/dist/icons/activities/shopping/shopping_cart.svg"
                   style="height: 3rem;"
                 />
@@ -1479,10 +1479,10 @@ exports[`VisitedPlacesSection UI display should render the selected visited plac
               <span
                 class=""
               >
-                visitedPlaces:activities:shopping
+                stripped:visitedPlaces:activities:shopping
                 <em>
                    • 
-                  This is a shopping place
+                  stripped:This is a shopping place
                 </em>
               </span>
             </span>

--- a/packages/evolution-frontend/src/components/survey/widgets/InputWidgetWrapper.tsx
+++ b/packages/evolution-frontend/src/components/survey/widgets/InputWidgetWrapper.tsx
@@ -10,6 +10,7 @@ import Markdown from 'react-markdown';
 import { QuestionWidgetConfig } from 'evolution-common/lib/services/questionnaire/types';
 import SurveyErrorMessage from './SurveyErrorMessage';
 import HelpPopupLink from './HelpPopupLink';
+import { stripHtml } from '../../../services/display/frontendHelper';
 
 interface InputWidgetWrapperProps {
     /** Text shown on the link and title of the modal */
@@ -42,7 +43,7 @@ const FieldsetWrapper = (props: React.PropsWithChildren<InputWidgetWrapperProps>
                             <div dangerouslySetInnerHTML={{ __html: props.label }} />
                         ) : (
                             <div className="label">
-                                <Markdown>{props.label}</Markdown>
+                                <Markdown>{stripHtml(props.label)}</Markdown>
                             </div>
                         )}
                     </div>
@@ -102,7 +103,7 @@ export const LabelOrDivWrapper = (
                         <div dangerouslySetInnerHTML={{ __html: props.label }} />
                     ) : (
                         <div className="label">
-                            <Markdown>{props.label}</Markdown>
+                            <Markdown>{stripHtml(props.label)}</Markdown>
                         </div>
                     )}
                 </LabelOrDiv>

--- a/packages/evolution-frontend/src/components/survey/widgets/SurveyErrorMessage.tsx
+++ b/packages/evolution-frontend/src/components/survey/widgets/SurveyErrorMessage.tsx
@@ -5,6 +5,7 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import React from 'react';
+import { stripHtml } from '../../../services/display/frontendHelper';
 
 interface SurveyErrorMessageProps {
     containsHtml: boolean;
@@ -22,7 +23,7 @@ export const SurveyErrorMessage = (props: SurveyErrorMessageProps) => {
                     }}
                 />
             ) : (
-                props.text
+                stripHtml(props.text)
             )}
         </p>
     );

--- a/packages/evolution-frontend/src/services/display/__tests__/frontendHelper.test.ts
+++ b/packages/evolution-frontend/src/services/display/__tests__/frontendHelper.test.ts
@@ -16,7 +16,8 @@ import {
     validateButtonAction,
     validateButtonActionWithCompleteSection,
     getVisitedPlaceDescription,
-    stripHtml
+    stripHtml,
+    stripUnsafeHtml
 } from '../frontendHelper';
 import { interviewAttributesForTestCases } from 'evolution-common/lib/tests/surveys';
 
@@ -353,4 +354,18 @@ test.each([
     { string: 'Hello <i>world</i> !', expected: 'Hello world !'}
 ])('stripHtml: should strip "$string" to "$expected"', ({ string, expected }) => {
     expect(stripHtml(string)).toEqual(expected);
+});
+
+test.each([
+    { string: '', expected: ''},
+    { string: '<strong>something', expected: '<strong>something</strong>'},
+    { string: '<strong>something</strong>', expected: '<strong>something</strong>'},
+    { string: '<strong>Important <em>text</em></strong>', expected: '<strong>Important <em>text</em></strong>'},
+    { string: '<a href="link/to/something">something</a>', expected: '<a href="link/to/something">something</a>'},
+    { string: '<a href="link/to/something"></a>', expected: '<a href="link/to/something"></a>'},
+    { string: '<a href="javascript:alert(1)">Click here</a>', expected: '<a>Click here</a>'},
+    { string: '<script>alert(1)</script>Hello', expected: 'Hello'},
+    { string: 'Hello <i>world</i> !', expected: 'Hello <i>world</i> !'}
+])('stripUnsafeHtml: should strip "$string" to "$expected"', ({ string, expected }) => {
+    expect(stripUnsafeHtml(string)).toEqual(expected);
 });

--- a/packages/evolution-frontend/src/services/display/__tests__/frontendHelper.test.ts
+++ b/packages/evolution-frontend/src/services/display/__tests__/frontendHelper.test.ts
@@ -15,7 +15,8 @@ import {
     secondsSinceMidnightToTimeStrWithSuffix,
     validateButtonAction,
     validateButtonActionWithCompleteSection,
-    getVisitedPlaceDescription
+    getVisitedPlaceDescription,
+    stripHtml
 } from '../frontendHelper';
 import { interviewAttributesForTestCases } from 'evolution-common/lib/tests/surveys';
 
@@ -338,4 +339,18 @@ describe('getVisitedPlaceDescription', () => {
         const description = getVisitedPlaceDescription(visitedPlace, true, true);
         expect(description).toEqual('survey:visitedPlace:activities:workUsual • <em>This is my work</em>');
     });
+});
+
+test.each([
+    { string: '', expected: ''},
+    { string: '<strong>something', expected: 'something'},
+    { string: '<strong>something</strong>', expected: 'something'},
+    { string: '<strong>Important <em>text</em></strong>', expected: 'Important text'},
+    { string: '<a href="link/to/something">something</a>', expected: 'something'},
+    { string: '<a href="link/to/something"></a>', expected: ''},
+    { string: '<a href="javascript:alert(1)">Click here</a>', expected: 'Click here'},
+    { string: '<script>alert(1)</script>Hello', expected: 'Hello'},
+    { string: 'Hello <i>world</i> !', expected: 'Hello world !'}
+])('stripHtml: should strip "$string" to "$expected"', ({ string, expected }) => {
+    expect(stripHtml(string)).toEqual(expected);
 });

--- a/packages/evolution-frontend/src/services/display/frontendHelper.ts
+++ b/packages/evolution-frontend/src/services/display/frontendHelper.ts
@@ -6,6 +6,7 @@
  */
 import { TFunction } from 'i18next';
 import moment from 'moment';
+import DOMPurify from 'dompurify';
 
 import i18n from '../../config/i18n.config';
 import { secondsSinceMidnightToTimeStr } from 'chaire-lib-common/lib/utils/DateTimeUtils';
@@ -203,4 +204,14 @@ export const getVisitedPlaceDescription = function (
     } else {
         return `${i18n.t(`survey:visitedPlace:activities:${visitedPlace.activity}`)}${visitedPlace.name ? ` • ${visitedPlace.name}` : ''}${times}`;
     }
+};
+
+/**
+ * Transform a string to remove all html characters
+ *
+ * @param text A string, possibly containing html characters
+ * @return a string without any html characters
+ */
+export const stripHtml = (text: string): string => {
+    return DOMPurify.sanitize(text, { ALLOWED_TAGS: [] });
 };

--- a/packages/evolution-frontend/src/services/display/frontendHelper.ts
+++ b/packages/evolution-frontend/src/services/display/frontendHelper.ts
@@ -215,3 +215,13 @@ export const getVisitedPlaceDescription = function (
 export const stripHtml = (text: string): string => {
     return DOMPurify.sanitize(text, { ALLOWED_TAGS: [] });
 };
+
+/**
+ * Transform a string to remove all unsafe html characters, like javascripts
+ *
+ * @param text A string, possibly containing unsafe html characters
+ * @return a string without unsafe html tags
+ */
+export const stripUnsafeHtml = (text: string): string => {
+    return DOMPurify.sanitize(text);
+};


### PR DESCRIPTION
fixes #1584

Add a `stripHtml` function in the `frontendHelper.ts` file, which uses `DOMPurify` to sanitize a string from all html tags in it.

This function is called whenever the `containsHtml` property is set to `false`, to remove any stray html characters the string might inadvertently contain.

Replace previous usages of `DOMPurify` directly to use the `stripHtml` helper instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected unwanted HTML characters appearing in templates, labels, messages, map content, and survey text.
  * Improved consistent handling of plain-text content while preserving intentionally formatted HTML.

* **Tests**
  * Added coverage for HTML stripping across empty, malformed, linked, and fully tagged content.
  * Updated component tests to verify the new content handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->