### PR TITLE
labels: sanitize strings at render instead of escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING**: Builtin widgets now only use the widget name with section as namespace as locale translation key. Any key that was overridden in the `customSurvey` namespace should be moved to the widget's namespace. (fixes [#1441](https://github.com/chairemobilite/evolution/issues/1441))
 - The Google map widgets were migrated from the deprecated `@react-google-maps/api` package to `@vis.gl/react-google-maps`, which renders vector maps and uses `AdvancedMarker` (fixes [#453](https://github.com/chairemobilite/evolution/issues/453)). This uses the new Google Map ID, for which we provide a default style, but a new `GOOGLE_MAP_ID` environment variable was added if someone wants to override the default style. See `.env.example` and the [Get a Map ID](https://developers.google.com/maps/documentation/get-map-id) docs.
 - Audit and survey-object factory console logs are prefixed with `[Audit]` via `AuditLog` so they can be filtered in server error logs (fixes [#1836](https://github.com/chairemobilite/evolution/issues/1836)).
+- **BREAKING**: Participant-strings are not escaped in the helpers anymore, but the strings should be sanitized at render time. Any template trusting html-safe strings should now use sanitation functions like `stripUnsafeHtml` from `frontendHelpers` (fixes [#1838](https://github.com/chairemobilite/evolution/issues/1838))
 
 ### Deprecated
 

--- a/packages/evolution-common/src/services/odSurvey/__tests__/helpers.test.ts
+++ b/packages/evolution-common/src/services/odSurvey/__tests__/helpers.test.ts
@@ -957,7 +957,7 @@ describe('getPersonIdentificationString', () => {
 
     it.each([
         [{ nickname: 'Bob', _sequence: 1, age: 30 }, 'Bob'],
-        [{ nickname: '<strong>Bob!!</strong>', _sequence: 1, age: 30 }, '&lt;strong&gt;Bob!!&lt;/strong&gt;'],
+        [{ nickname: '<strong>Bob!!</strong>', _sequence: 1, age: 30 }, '<strong>Bob!!</strong>'],
         [{ nickname: '', _sequence: 2, age: 25 }, 'Person 2, Age 25, Gender undefined'],
         [{ nickname: '  ', _sequence: 2, age: 25 }, 'Person 2, Age 25, Gender undefined'],
         [{ nickname: '  ', _sequence: 2, age: 25, gender: 'female' as const }, 'Person 2, Age 25, Gender female'],
@@ -1029,7 +1029,7 @@ describe('getHomeAddressOneLine', () => {
                 includePostalCode: true
             },
             expected:
-                '123 &lt;strong&gt;main&lt;/strong&gt; st, &lt;b&gt;montreal&lt;/b&gt;, &lt;span&gt;Quebec&lt;/span&gt;, &lt;script injectedScript/&gt;Canada, &lt;STRONG&gt;H2X 1Y4&lt;/STRONG&gt;'
+                '123 <strong>main</strong> st, <b>montreal</b>, <span>Quebec</span>, <script injectedScript/>Canada, <STRONG>H2X 1Y4</STRONG>'
         },
         {
             title: 'returns empty string when home object is missing',
@@ -1044,10 +1044,10 @@ describe('getHomeAddressOneLine', () => {
             expected: ''
         },
         {
-            title: 'returns only the address part when city is missing',
-            home: { address: '123 main st' },
+            title: 'returns only the address part when city is missing, with apostrophes',
+            home: { address: '123 rue de l\'Église' },
             options: undefined,
-            expected: '123 main st'
+            expected: '123 rue de l\'Église'
         },
         {
             title: 'returns only the city part when civic number/street is missing',
@@ -3225,15 +3225,6 @@ describe('getVisitedPlaceNames', () => {
             expected:
                 interviewAttributesForTestCases.response.household!.persons!.personId1.journeys!.journeyId1
                     .visitedPlaces!.workPlace1P1.name
-        },
-        {
-            title: 'Place with a name to escape',
-            interview: testInterviewCopy,
-            visitedPlace:
-                testInterviewCopy.response.household!.persons!.personId1.journeys!.journeyId1.visitedPlaces!
-                    .workPlace1P1,
-            expectedTVal: undefined,
-            expected: 'mocked &lt;b&gt;place&lt;/b&gt;'
         },
         {
             title: 'Place with a shortcut',

--- a/packages/evolution-common/src/services/odSurvey/helpers.ts
+++ b/packages/evolution-common/src/services/odSurvey/helpers.ts
@@ -6,7 +6,6 @@
  */
 
 import _get from 'lodash/get';
-import _escape from 'lodash/escape';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { getResponse } from '../../utils/helpers';
 import {
@@ -411,18 +410,18 @@ export const getPersonGenderContext = ({ person }: { person: Person }): string |
     person.gender ?? person.sexAssignedAtBirth ?? undefined;
 
 /**
- * Get a html-safe string that identifies a person, either by their nickname or
- * by their sequence and age.
+ * Get a string that identifies a person, either by their nickname or by their
+ * sequence and age.
  *
  * @param {Object} options - The options object.
  * @param {Person} options.person The person to identify
  * @param {TFunction} options.t The translation function
- * @returns {string} A translated and/or escaped string that identifies the
- * person, either by their nickname or by their sequence and age.
+ * @returns {string} A translated string that identifies the person, either by
+ * their nickname or by their sequence and age.
  */
 export const getPersonIdentificationString = ({ person, t }: { person: Person; t: TFunction }): string => {
     if (typeof person.nickname === 'string' && !_isBlank(person.nickname.trim())) {
-        return _escape(person.nickname);
+        return person.nickname;
     }
     return _isBlank(person.age)
         ? t('survey:personWithSequence', {
@@ -437,8 +436,7 @@ export const getPersonIdentificationString = ({ person, t }: { person: Person; t
 };
 
 /**
- * Return an html-safe address as a one line string, including all the requested
- * parts
+ * Return an address as a one line string, including all the requested parts
  *
  * @param obj The object from which to extract address parts
  * @param options Options for which parts of the address to include
@@ -479,7 +477,7 @@ const getAddressOneLine = (
     if (includePostalCode && typeof obj.postalCode === 'string' && !_isBlank(obj.postalCode.trim())) {
         addressParts.push(obj.postalCode.trim().toUpperCase());
     }
-    return _escape(addressParts.join(', '));
+    return addressParts.join(', ');
 };
 
 /**
@@ -1128,16 +1126,16 @@ export const replaceVisitedPlaceShortcuts = ({
 };
 
 /**
- * Returns the html-safe visited place name string. If no name will return
- * generic name followed by sequence
+ * Returns the visited place name string. If no name will return generic name
+ * followed by sequence
  *
  * @param {Object} options - The options object.
  * @param {TFunction} options.t The translation function
  * @param {VisitedPlace} options.visitedPlace The visited place for which to get
  * the name
  * @param {UserInterviewAttributes} options.interview The interview object
- * @returns {string} The visited place name, html-safe, or a generic name
- * followed by its sequence.
+ * @returns {string} The visited place name or a generic name followed by its
+ * sequence.
  */
 export const getVisitedPlaceName = function ({
     t,
@@ -1158,7 +1156,7 @@ export const getVisitedPlaceName = function ({
             ? getResponse(interview, visitedPlace.shortcut, null)
             : visitedPlace;
     if (actualVisitedPlace && (actualVisitedPlace as VisitedPlace).name) {
-        return _escape((actualVisitedPlace as VisitedPlace).name as string);
+        return (actualVisitedPlace as VisitedPlace).name as string;
     }
 
     return t('survey:placeWithSequenceGeneric', { sequence: visitedPlace._sequence });

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/groupPersonVisitedPlaces.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/groupPersonVisitedPlaces.test.ts
@@ -229,7 +229,7 @@ describe('PersonVisitedPlacesGroupConfigFactory personVisitedPlaces GroupConfig 
                 title: 'uses escaped name when available',
                 groupedObject: { name: '<b>Work place</b>', activity: 'shopping' },
                 sequence: 2,
-                expected: 'VisitedPlaceSequence-2 • **&lt;b&gt;Work place&lt;/b&gt;**'
+                expected: 'VisitedPlaceSequence-2 • **<b>Work place</b>**'
             },
             {
                 title: 'uses translated activity when name is missing',

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetsTime.test.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/__tests__/widgetsTime.test.ts
@@ -6,7 +6,6 @@
  */
 
 import _cloneDeep from 'lodash/cloneDeep';
-import _escape from 'lodash/escape';
 import {
     interviewAttributesForTestCases,
     setActiveSurveyObjects,
@@ -1354,7 +1353,7 @@ describe('visitedPlaceArrivalTime widget', () => {
                 ['visitedPlaces:visitedPlaceArrivalTime_shopping', 'visitedPlaces:visitedPlaceArrivalTime'], 
                 expect.objectContaining({ atPlace: 'visitedPlaces:atPlace' })
             );
-            expect(mockedT).toHaveBeenCalledWith('visitedPlaces:atPlace', { placeName: _escape(currentPlace.name) });
+            expect(mockedT).toHaveBeenCalledWith('visitedPlaces:atPlace', { placeName: currentPlace.name });
         });
 
         test('should not append duration text for loop activities', () => {

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/groupPersonVisitedPlaces.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/groupPersonVisitedPlaces.ts
@@ -4,7 +4,6 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import _escape from 'lodash/escape';
 import type { GroupConfig, VisitedPlacesSectionConfiguration, WidgetConfig } from '../../../questionnaire/types';
 import * as odHelpers from '../../../odSurvey/helpers';
 import { TFunction } from 'i18next';
@@ -110,7 +109,7 @@ export class PersonVisitedPlacesGroupConfigFactory implements WidgetConfigFactor
             name: (t: TFunction, groupedObject: unknown, sequence: number) => {
                 const groupNameStrings = [t('visitedPlaces:VisitedPlaceSequence', { count: sequence })];
                 const placeString = (groupedObject as any).name
-                    ? `**${_escape((groupedObject as any).name)}**`
+                    ? `**${(groupedObject as any).name}**`
                     : (groupedObject as any).activity
                         ? `**${t(`visitedPlaces:activities:${(groupedObject as any).activity}`)}**`
                         : undefined;

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetActivity.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetActivity.ts
@@ -6,7 +6,6 @@
  */
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import type { TFunction } from 'i18next';
-import _escape from 'lodash/escape';
 import { getResponse } from '../../../../utils/helpers';
 import type {
     I18nData,
@@ -92,7 +91,7 @@ class ActivityWidgetConfigBuilder {
             const { mayHaveUsualPlace, usualPlace } = helperFct(interview, path);
             if (mayHaveUsualPlace && usualPlace && typeof usualPlace.name === 'string') {
                 return t([`${activityLabel}_withPlace`, activityLabel], {
-                    placeName: _escape(usualPlace.name)
+                    placeName: usualPlace.name
                 });
             }
             return t(activityLabel);

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetNextPlaceCategory.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetNextPlaceCategory.ts
@@ -4,7 +4,6 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import _escape from 'lodash/escape';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import type {
     RadioChoiceType,
@@ -100,7 +99,7 @@ export const getNextPlaceCategoryWidgetConfig = (
         // use our own custom name for the place here.
         const visitedPlaceName = activeVisitedPlace?.name;
         const atPlace = !_isBlank(visitedPlaceName)
-            ? t('survey:atPlace', { placeName: _escape(visitedPlaceName) })
+            ? t('survey:atPlace', { placeName: visitedPlaceName })
             : t('survey:atThisPlace', { context: activeVisitedPlace.activity });
         return t('visitedPlaces:visitedPlaceNextPlaceCategory', {
             context: odHelpers.getPersonGenderContext({ person }),

--- a/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetsTime.ts
+++ b/packages/evolution-common/src/services/questionnaire/sections/visitedPlaces/widgetsTime.ts
@@ -5,7 +5,6 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 
-import _escape from 'lodash/escape';
 import _max from 'lodash/max';
 import _min from 'lodash/min';
 import _truncate from 'lodash/truncate';
@@ -634,7 +633,7 @@ export class VisitedPlaceTimeWidgetFactory implements WidgetConfigFactory {
                 'visitedPlaces:visitedPlaceArrivalTime'
             ];
             const place = !_isBlank(visitedPlaceName)
-                ? t('visitedPlaces:atPlace', { placeName: _escape(visitedPlaceName) })
+                ? t('visitedPlaces:atPlace', { placeName: visitedPlaceName })
                 : t('visitedPlaces:atThisPlace', { context: visitedPlace.activity });
             return (
                 t(keys, {
@@ -734,7 +733,7 @@ export class VisitedPlaceTimeWidgetFactory implements WidgetConfigFactory {
                 visitedPlace.activity === 'home'
                     ? t('visitedPlaces:theHome')
                     : !_isBlank(visitedPlaceName)
-                        ? t('visitedPlaces:place', { placeName: _escape(visitedPlaceName) })
+                        ? t('visitedPlaces:place', { placeName: visitedPlaceName })
                         : t('visitedPlaces:thisPlace', { context: visitedPlace.activity });
             const keys = [
                 `visitedPlaces:visitedPlaceDepartureTime_${visitedPlace.activity}`,

--- a/packages/evolution-frontend/src/components/inputs/InputMapFindPlace.tsx
+++ b/packages/evolution-frontend/src/components/inputs/InputMapFindPlace.tsx
@@ -26,6 +26,7 @@ import SurveyErrorMessage from '../survey/widgets/SurveyErrorMessage';
 // conditional import driven by the project config (one adapter per survey,
 // not per widget): a survey picks Google OR OSM, never both at runtime.
 import mapProviderAdapter from './maps/google/GoogleMapAdapter';
+import { stripUnsafeHtml } from '../../services/display/frontendHelper';
 
 export type InputMapFindPlaceProps = CommonInputProps & {
     value?: GeoJSON.Feature<GeoJSON.Point, FeatureGeocodedProperties>;
@@ -544,7 +545,7 @@ export class InputMapFindPlace extends React.Component<
                 )}
 
                 {afterRefreshButtonText && this.props.widgetConfig.containsHtml ? (
-                    <div dangerouslySetInnerHTML={{ __html: afterRefreshButtonText }} />
+                    <div dangerouslySetInnerHTML={{ __html: stripUnsafeHtml(afterRefreshButtonText) }} />
                 ) : (
                     <Markdown remarkPlugins={[[remarkGfm, { singleTilde: false }]]}>
                         {afterRefreshButtonText as string}

--- a/packages/evolution-frontend/src/components/modal/SimpleModal.tsx
+++ b/packages/evolution-frontend/src/components/modal/SimpleModal.tsx
@@ -6,10 +6,10 @@
  */
 import React from 'react';
 import Modal from 'react-modal';
-import { withTranslation, WithTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { stripHtml } from '../../services/display/frontendHelper';
+import { stripHtml, stripUnsafeHtml } from '../../services/display/frontendHelper';
 
 export interface SimpleModalProps {
     isOpen: boolean;
@@ -31,9 +31,8 @@ if (!process.env.IS_TESTING) {
  * @param props Component props
  * @returns The modal component
  */
-export const SimpleModal: React.FunctionComponent<SimpleModalProps & WithTranslation> = (
-    props: SimpleModalProps & WithTranslation
-) => {
+export const SimpleModal: React.FunctionComponent<SimpleModalProps> = (props: SimpleModalProps) => {
+    const { t } = useTranslation();
     const close = (ev: React.MouseEvent) => {
         if (typeof props.action === 'function') {
             props.action(ev);
@@ -56,7 +55,7 @@ export const SimpleModal: React.FunctionComponent<SimpleModalProps & WithTransla
                     </h3>
                 )}
                 {props.containsHtml ? (
-                    <div dangerouslySetInnerHTML={{ __html: props.text }} />
+                    <div dangerouslySetInnerHTML={{ __html: stripUnsafeHtml(props.text) }} />
                 ) : (
                     <div className="help-popup">
                         <Markdown remarkPlugins={[[remarkGfm, { singleTilde: false }]]}>
@@ -66,7 +65,7 @@ export const SimpleModal: React.FunctionComponent<SimpleModalProps & WithTransla
                 )}
                 <div className="center">
                     <button className="button blue" onClick={close}>
-                        {props.t('main:OK')}
+                        {t('main:OK')}
                     </button>
                 </div>
             </div>
@@ -74,4 +73,4 @@ export const SimpleModal: React.FunctionComponent<SimpleModalProps & WithTransla
     );
 };
 
-export default withTranslation()(SimpleModal);
+export default SimpleModal;

--- a/packages/evolution-frontend/src/components/modal/__tests__/SimpleModal.test.tsx
+++ b/packages/evolution-frontend/src/components/modal/__tests__/SimpleModal.test.tsx
@@ -7,24 +7,24 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import SimpleModal from '../SimpleModal';
-import { stripHtml } from '../../../services/display/frontendHelper';
+import { stripHtml, stripUnsafeHtml } from '../../../services/display/frontendHelper';
 
 // Mock react-markdown and remark-gfm as they use syntax not supported by jest
 jest.mock('react-markdown', () => 'Markdown');
 jest.mock('remark-gfm', () => 'remark-gfm');
 
 jest.mock('react-i18next', () => ({
-    // this mock makes sure any components using the translate HoC receive the t function as a prop
-    withTranslation: () => Component => {
-        Component.defaultProps = { ...Component.defaultProps, t: (key) => key };
-        return Component;
-    },
+    useTranslation: () => ({
+        t: (key: string) => key
+    })
 }));
 // Mock frontend helper to avoid undefined config error
 jest.mock('../../../services/display/frontendHelper', () => ({
-    stripHtml: jest.fn().mockImplementation(str => str)
+    stripHtml: jest.fn((str) => `stripped:(${str})`),
+    stripUnsafeHtml: jest.fn((str) => `strippedUnsafe:(${str})`)
 }));
 const mockStripHtml = stripHtml as jest.MockedFunction<typeof stripHtml>;
+const mockStripUnsafeHtml = stripUnsafeHtml as jest.MockedFunction<typeof stripUnsafeHtml>;
 
 
 test('Test simple modal with action on close', () =>{
@@ -33,7 +33,7 @@ test('Test simple modal with action on close', () =>{
     const title = 'Simple modal title';
     const baseText = 'Text in the simple modal';
     const text = `${baseText} <b>bold</b>`;
-    const { queryByText } = render(
+    const { queryByText, getByText } = render(
         <SimpleModal
             isOpen={true}
             closeModal={handleClose}
@@ -44,7 +44,15 @@ test('Test simple modal with action on close', () =>{
         />
     );
     // Html was added, so the complete text is not there, it is actually composed of many texts
-    expect(queryByText(baseText)).toBeTruthy();
+    expect(mockStripUnsafeHtml).toHaveBeenCalledWith(text);
+    // Get the inner most node, which is the bold text and validate its text and tag
+    const innerMostNode = queryByText('bold');
+    expect(innerMostNode).toBeTruthy();
+    expect(innerMostNode?.tagName).toEqual('B');
+    // Get the parent node, which should be the whole text string
+    const parentNode = innerMostNode?.parentNode;
+    expect(parentNode?.textContent).toEqual('strippedUnsafe:(Text in the simple modal bold)');
+    // Validat other strings present
     expect(queryByText(title)).toBeTruthy();
     expect(queryByText(text)).toBeFalsy();
 
@@ -79,6 +87,8 @@ test('Test simple modal with containsHtml `false`', () =>{
 test('Test simple modal with minimal parameters', () =>{
     const handleClose = jest.fn();
     const text = 'Text in the simple modal <b>bold</b>';
+    // Does not contain html by default, so should be stripped of html
+    const expectedText = 'stripped:(Text in the simple modal <b>bold</b>)'
     const title = 'Simple modal title';
     const { getByText } = render(
         <SimpleModal
@@ -88,7 +98,7 @@ test('Test simple modal with minimal parameters', () =>{
             title={title}
         />
     );
-    expect(getByText(text)).toBeTruthy();
+    expect(getByText(expectedText)).toBeTruthy();
     expect(getByText(title)).toBeTruthy();
 
     // Click on the close button

--- a/packages/evolution-frontend/src/components/survey/Text.tsx
+++ b/packages/evolution-frontend/src/components/survey/Text.tsx
@@ -15,6 +15,7 @@ import { WidgetStatus } from 'evolution-common/lib/services/questionnaire/types'
 import { TextWidgetConfig } from 'evolution-common/lib/services/questionnaire/types';
 import { UserInterviewAttributes } from 'evolution-common/lib/services/questionnaire/types';
 import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
+import { stripUnsafeHtml } from '../../services/display/frontendHelper';
 
 type TextProps = {
     widgetConfig: TextWidgetConfig;
@@ -43,7 +44,9 @@ export const Text: React.FunctionComponent<TextProps & WithTranslation> = ({
 
     return (
         <div className="survey-section__text">
-            {widgetConfig.containsHtml && <div dangerouslySetInnerHTML={{ __html: content as string }} />}
+            {widgetConfig.containsHtml && (
+                <div dangerouslySetInnerHTML={{ __html: stripUnsafeHtml(content as string) }} />
+            )}
             {!widgetConfig.containsHtml && (
                 <div
                     className={

--- a/packages/evolution-frontend/src/components/survey/__tests__/Text.test.tsx
+++ b/packages/evolution-frontend/src/components/survey/__tests__/Text.test.tsx
@@ -18,6 +18,10 @@ import { WidgetStatus } from 'evolution-common/lib/services/questionnaire/types'
 // Mock react-markdown and remark-gfm as they use syntax not supported by jest
 jest.mock('react-markdown', () => 'Markdown');
 jest.mock('remark-gfm', () => 'remark-gfm');
+// Mock frontend helper to avoid undefined config error
+jest.mock('../../../services/display/frontendHelper', () => ({
+    stripUnsafeHtml: jest.fn((str) => `strippedUnsafe:(${str})`)
+}));
 
 const userAttributes = {
     id: 1,

--- a/packages/evolution-frontend/src/components/survey/__tests__/__snapshots__/Text.test.tsx.snap
+++ b/packages/evolution-frontend/src/components/survey/__tests__/__snapshots__/Text.test.tsx.snap
@@ -8,10 +8,11 @@ exports[`Text widget: Contains html Render widget 1`] = `
     class="survey-section__text"
   >
     <div>
+      strippedUnsafe:(
       <br />
        bold text
       <br />
-      blabla
+      blabla)
     </div>
   </div>
 </div>

--- a/packages/evolution-frontend/src/components/survey/widgets/InputWidgetWrapper.tsx
+++ b/packages/evolution-frontend/src/components/survey/widgets/InputWidgetWrapper.tsx
@@ -10,7 +10,7 @@ import Markdown from 'react-markdown';
 import { QuestionWidgetConfig } from 'evolution-common/lib/services/questionnaire/types';
 import SurveyErrorMessage from './SurveyErrorMessage';
 import HelpPopupLink from './HelpPopupLink';
-import { stripHtml } from '../../../services/display/frontendHelper';
+import { stripHtml, stripUnsafeHtml } from '../../../services/display/frontendHelper';
 
 interface InputWidgetWrapperProps {
     /** Text shown on the link and title of the modal */
@@ -40,7 +40,7 @@ const FieldsetWrapper = (props: React.PropsWithChildren<InputWidgetWrapperProps>
                         }
                     >
                         {props.widgetConfig.containsHtml ? (
-                            <div dangerouslySetInnerHTML={{ __html: props.label }} />
+                            <div dangerouslySetInnerHTML={{ __html: stripUnsafeHtml(props.label) }} />
                         ) : (
                             <div className="label">
                                 <Markdown>{stripHtml(props.label)}</Markdown>
@@ -100,7 +100,7 @@ export const LabelOrDivWrapper = (
                     }
                 >
                     {props.widgetConfig.containsHtml ? (
-                        <div dangerouslySetInnerHTML={{ __html: props.label }} />
+                        <div dangerouslySetInnerHTML={{ __html: stripUnsafeHtml(props.label) }} />
                     ) : (
                         <div className="label">
                             <Markdown>{stripHtml(props.label)}</Markdown>

--- a/packages/evolution-frontend/src/components/survey/widgets/SurveyErrorMessage.tsx
+++ b/packages/evolution-frontend/src/components/survey/widgets/SurveyErrorMessage.tsx
@@ -5,7 +5,7 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import React from 'react';
-import { stripHtml } from '../../../services/display/frontendHelper';
+import { stripHtml, stripUnsafeHtml } from '../../../services/display/frontendHelper';
 
 interface SurveyErrorMessageProps {
     containsHtml: boolean;
@@ -19,7 +19,7 @@ export const SurveyErrorMessage = (props: SurveyErrorMessageProps) => {
             {props.containsHtml ? (
                 <span
                     dangerouslySetInnerHTML={{
-                        __html: props.text
+                        __html: stripUnsafeHtml(props.text)
                     }}
                 />
             ) : (


### PR DESCRIPTION
fixes #1838

The OD helper functions do not escape the participant data anymore, as
this causes places showing the data as plain text to display escaped
HTML characters.

It is the role of the renderers to correctly sanitize strings coming
from the participant, or the app in general. Where plain text is used,
escaping is handled naturally by `React`. It is where the
`dangerouslySetInnerHtml` is used to display strings from the user that
there may be problems. So in those calls, we make sure the call the
`stripUnsafeHtml` function to remove any undesired HTML markup that may
have been entered by the participants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved HTML sanitization across surveys, forms, maps, modals, labels, and error messages.
  * Unsafe markup and links are removed while approved formatting remains available where appropriate.
* **Bug Fixes**
  * Survey text, participant details, addresses, and visited-place names now display consistently without unwanted escaping.
  * Plain-text contexts no longer show HTML markup.
* **Documentation**
  * Updated the unreleased changelog with the new rendering and sanitization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->