### PR TITLE
section templates: sanitize all strings and remove html markup

### DIFF
--- a/packages/evolution-frontend/src/components/survey/sectionTemplates/TripsAndSegmentsSection.tsx
+++ b/packages/evolution-frontend/src/components/survey/sectionTemplates/TripsAndSegmentsSection.tsx
@@ -20,7 +20,7 @@ import { SectionProps, useSectionTemplate } from '../../hooks/useSectionTemplate
 import * as odSurveyHelper from 'evolution-common/lib/services/odSurvey/helpers';
 import { getValuesByPathForActiveTrip } from 'evolution-common/lib/services/questionnaire/sections/segments/helpers';
 import * as helpers from 'evolution-common/lib/utils/helpers';
-import { secondsSinceMidnightToTimeStrWithSuffix } from '../../../services/display/frontendHelper';
+import { secondsSinceMidnightToTimeStrWithSuffix, stripHtml } from '../../../services/display/frontendHelper';
 import { Trip, VisitedPlace } from 'evolution-common/lib/services/questionnaire/types';
 import { getActivityMarkerIcon } from 'evolution-common/lib/services/questionnaire/sections/visitedPlaces/activityIconMapping';
 import { SurveyContext } from '../../../contexts/SurveyContext';
@@ -156,7 +156,7 @@ export const SegmentsSection: React.FC<SectionProps> = (props: SectionProps) => 
                             <img
                                 src={iconPathsByMode[segment.mode]}
                                 style={{ height: '1.5em', marginLeft: '0.3em' }}
-                                alt={t(`segments:mode:short:${segment.mode}`)}
+                                alt={stripHtml(t(`segments:mode:short:${segment.mode}`))}
                             />
                         </React.Fragment>
                     );
@@ -211,14 +211,14 @@ export const SegmentsSection: React.FC<SectionProps> = (props: SectionProps) => 
                         <img
                             src={getActivityMarkerIcon(origin.activity)}
                             style={{ height: '4rem' }}
-                            alt={t(`visitedPlaces:activities:${origin.activity}`)}
+                            alt={stripHtml(t(`visitedPlaces:activities:${origin.activity}`))}
                         />
                         <span>
-                            {t(`visitedPlaces:activities:${origin.activity}`)}
+                            {stripHtml(t(`visitedPlaces:activities:${origin.activity}`))}
                             {actualOrigin.name && (
                                 <React.Fragment>
                                     <br />
-                                    <em>&nbsp;• {actualOrigin.name}</em>
+                                    <em>&nbsp;• {stripHtml(actualOrigin.name)}</em>
                                 </React.Fragment>
                             )}
                         </span>
@@ -230,14 +230,14 @@ export const SegmentsSection: React.FC<SectionProps> = (props: SectionProps) => 
                         <img
                             src={getActivityMarkerIcon(destination.activity)}
                             style={{ height: '4rem' }}
-                            alt={t(`visitedPlaces:activities:${destination.activity}`)}
+                            alt={stripHtml(t(`visitedPlaces:activities:${destination.activity}`))}
                         />
                         <span>
-                            {t(`visitedPlaces:activities:${destination.activity}`)}
+                            {stripHtml(t(`visitedPlaces:activities:${destination.activity}`))}
                             {actualDestination.name && (
                                 <React.Fragment>
                                     <br />
-                                    <em>&nbsp;• {actualDestination.name}</em>
+                                    <em>&nbsp;• {stripHtml(actualDestination.name)}</em>
                                 </React.Fragment>
                             )}
                         </span>
@@ -254,14 +254,14 @@ export const SegmentsSection: React.FC<SectionProps> = (props: SectionProps) => 
                                 <img
                                     src={getActivityMarkerIcon(nextDestination.activity)}
                                     style={{ height: '4rem' }}
-                                    alt={t(`visitedPlaces:activities:${nextDestination.activity}`)}
+                                    alt={stripHtml(t(`visitedPlaces:activities:${nextDestination.activity}`))}
                                 />
                                 <span>
-                                    {t(`visitedPlaces:activities:${nextDestination.activity}`)}
+                                    {stripHtml(t(`visitedPlaces:activities:${nextDestination.activity}`))}
                                     {nextDestination.name && (
                                         <React.Fragment>
                                             <br />
-                                            <em>&nbsp;• {nextDestination.name}</em>
+                                            <em>&nbsp;• {stripHtml(nextDestination.name)}</em>
                                         </React.Fragment>
                                     )}
                                 </span>

--- a/packages/evolution-frontend/src/components/survey/sectionTemplates/VisitedPlacesSection.tsx
+++ b/packages/evolution-frontend/src/components/survey/sectionTemplates/VisitedPlacesSection.tsx
@@ -25,7 +25,11 @@ import ConfirmModal from 'chaire-lib-frontend/lib/components/modal/ConfirmModal'
 import LoadingPage from 'chaire-lib-frontend/lib/components/pages/LoadingPage';
 import { type SectionProps, useSectionTemplate } from '../../hooks/useSectionTemplate';
 import { SurveyContext } from '../../../contexts/SurveyContext';
-import { secondsSinceMidnightToTimeStrWithSuffix, stripHtml } from '../../../services/display/frontendHelper';
+import {
+    secondsSinceMidnightToTimeStrWithSuffix,
+    stripHtml,
+    stripUnsafeHtml
+} from '../../../services/display/frontendHelper';
 import type { GroupConfig, VisitedPlace } from 'evolution-common/lib/services/questionnaire/types';
 import { getResponse } from 'evolution-common/lib/utils/helpers';
 import { getActivityIcon } from 'evolution-common/lib/services/questionnaire/sections/visitedPlaces/activityIconMapping';
@@ -160,7 +164,7 @@ export const VisitedPlacesSection: React.FC<SectionProps> = (props: SectionProps
                     className={`survey-visited-places-schedule-visited-place${isPersonActive && !selectedVisitedPlaceId ? ' hand-cursor-on-hover' : ''}`}
                     key={visitedPlace._uuid}
                     style={{ left: startAtPercent.toString() + '%', width: width.toString() + '%' }}
-                    title={visitedPlaceDescription}
+                    title={stripHtml(visitedPlaceDescription)}
                     onClick={
                         props.interview.allWidgetsValid && isPersonActive && !selectedVisitedPlaceId
                             ? (e) => selectVisitedPlace(visitedPlace._uuid, e)
@@ -206,13 +210,15 @@ export const VisitedPlacesSection: React.FC<SectionProps> = (props: SectionProps
                         <p className={personForSchedule._uuid === person._uuid ? 'HTML _orange' : ''}>
                             <span
                                 dangerouslySetInnerHTML={{
-                                    __html: t('visitedPlaces:dayScheduleFor', {
-                                        nickname: odHelpers.getPersonIdentificationString({
-                                            person: personForSchedule,
-                                            t
-                                        }),
-                                        count: interviewablePersons.length
-                                    })
+                                    __html: stripUnsafeHtml(
+                                        t('visitedPlaces:dayScheduleFor', {
+                                            nickname: odHelpers.getPersonIdentificationString({
+                                                person: personForSchedule,
+                                                t
+                                            }),
+                                            count: interviewablePersons.length
+                                        })
+                                    )
                                 }}
                             />
                         </p>
@@ -319,7 +325,6 @@ export const VisitedPlacesSection: React.FC<SectionProps> = (props: SectionProps
                                 title={t('visitedPlaces:editVisitedPlace')}
                             >
                                 <FontAwesomeIcon icon={faPencilAlt} className="" />
-                                {/*props.t('visitedPlaces:editVisitedPlace')*/}
                             </button>
                         )}
                         {!selectedVisitedPlaceId /*state.editActivated*/ &&

--- a/packages/evolution-frontend/src/components/survey/sectionTemplates/__tests__/TripsAndSegmentsSection.test.tsx
+++ b/packages/evolution-frontend/src/components/survey/sectionTemplates/__tests__/TripsAndSegmentsSection.test.tsx
@@ -26,7 +26,9 @@ jest.mock('../../GroupWidgets', () => ({
 }));
 // Mock frontend helper to avoid undefined config error
 jest.mock('../../../../services/display/frontendHelper', () => ({
-    secondsSinceMidnightToTimeStrWithSuffix: jest.fn().mockReturnValue('timeStr')
+    secondsSinceMidnightToTimeStrWithSuffix: jest.fn().mockReturnValue('timeStr'),
+    stripHtml: jest.fn((str) => `stripped:(${str})`),
+    stripUnsafeHtml: jest.fn((str) => `strippedUnsafe:(${str})`)
 }));
 
 // Mock the odSurveyHelper

--- a/packages/evolution-frontend/src/components/survey/sectionTemplates/__tests__/VisitedPlacesSection.test.tsx
+++ b/packages/evolution-frontend/src/components/survey/sectionTemplates/__tests__/VisitedPlacesSection.test.tsx
@@ -52,7 +52,8 @@ jest.mock('react-i18next', () => ({
 }));
 jest.mock('../../../../services/display/frontendHelper', () => ({
     secondsSinceMidnightToTimeStrWithSuffix: jest.fn((seconds: number) => `time-${seconds}`),
-    stripHtml: jest.fn((str) => `stripped:${str}`)
+    stripHtml: jest.fn((str) => `stripped:(${str})`),
+    stripUnsafeHtml: jest.fn((str) => `strippedUnsafe:(${str})`)
 }));
 
 jest.mock('evolution-common/lib/services/odSurvey/helpers', () => {

--- a/packages/evolution-frontend/src/components/survey/sectionTemplates/__tests__/__snapshots__/TripsAndSegmentsSection.test.tsx.snap
+++ b/packages/evolution-frontend/src/components/survey/sectionTemplates/__tests__/__snapshots__/TripsAndSegmentsSection.test.tsx.snap
@@ -102,16 +102,16 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
               class="survey-trip-item-element survey-trip-item-origin-description"
             >
               <img
-                alt="activities.home"
+                alt="stripped:(activities.home)"
                 src="/dist/icons/activities/home/home-marker_round.svg"
                 style="height: 4rem;"
               />
               <span>
-                activities.home
+                stripped:(activities.home)
                 <br />
                 <em>
                    • 
-                  Lieu 1
+                  stripped:(Lieu 1)
                 </em>
               </span>
             </span>
@@ -137,12 +137,12 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
               class="survey-trip-item-element survey-trip-item-destination-description"
             >
               <img
-                alt="activities.restaurant"
+                alt="stripped:(activities.restaurant)"
                 src="/dist/icons/activities/other/restaurant-marker_round.svg"
                 style="height: 4rem;"
               />
               <span>
-                activities.restaurant
+                stripped:(activities.restaurant)
               </span>
             </span>
           </li>
@@ -150,7 +150,7 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
             class="no-bullet survey-trip-item survey-trip-item-mode-icons"
           >
             <img
-              alt="mode.short.walk"
+              alt="stripped:(mode.short.walk)"
               src="/dist/images/modes_icons/walk.png"
               style="height: 1.5em; margin-left: 0.3em;"
             />
@@ -226,12 +226,12 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
               class="survey-trip-item-element survey-trip-item-origin-description"
             >
               <img
-                alt="activities.restaurant"
+                alt="stripped:(activities.restaurant)"
                 src="/dist/icons/activities/other/restaurant-marker_round.svg"
                 style="height: 4rem;"
               />
               <span>
-                activities.restaurant
+                stripped:(activities.restaurant)
               </span>
             </span>
             <span
@@ -256,12 +256,12 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
               class="survey-trip-item-element survey-trip-item-destination-description"
             >
               <img
-                alt="activities.shopping"
+                alt="stripped:(activities.shopping)"
                 src="/dist/icons/activities/shopping/shopping_cart-marker_round.svg"
                 style="height: 4rem;"
               />
               <span>
-                activities.shopping
+                stripped:(activities.shopping)
               </span>
             </span>
           </li>
@@ -389,16 +389,16 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
               class="survey-trip-item-element survey-trip-item-origin-description"
             >
               <img
-                alt="activities.home"
+                alt="stripped:(activities.home)"
                 src="/dist/icons/activities/home/home-marker_round.svg"
                 style="height: 4rem;"
               />
               <span>
-                activities.home
+                stripped:(activities.home)
                 <br />
                 <em>
                    • 
-                  Lieu 1
+                  stripped:(Lieu 1)
                 </em>
               </span>
             </span>
@@ -424,12 +424,12 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
               class="survey-trip-item-element survey-trip-item-destination-description"
             >
               <img
-                alt="activities.workOnTheRoad"
+                alt="stripped:(activities.workOnTheRoad)"
                 src="/dist/icons/activities/work/truck-marker_round.svg"
                 style="height: 4rem;"
               />
               <span>
-                activities.workOnTheRoad
+                stripped:(activities.workOnTheRoad)
               </span>
             </span>
             <span
@@ -454,12 +454,12 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
               class="survey-trip-item-element survey-trip-item-destination-description"
             >
               <img
-                alt="activities.shopping"
+                alt="stripped:(activities.shopping)"
                 src="/dist/icons/activities/shopping/shopping_cart-marker_round.svg"
                 style="height: 4rem;"
               />
               <span>
-                activities.shopping
+                stripped:(activities.shopping)
               </span>
             </span>
           </li>
@@ -467,7 +467,7 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
             class="no-bullet survey-trip-item survey-trip-item-mode-icons"
           >
             <img
-              alt="mode.short.walk"
+              alt="stripped:(mode.short.walk)"
               src="/dist/images/modes_icons/walk.png"
               style="height: 1.5em; margin-left: 0.3em;"
             />
@@ -593,16 +593,16 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
               class="survey-trip-item-element survey-trip-item-origin-description"
             >
               <img
-                alt="activities.workOnTheRoad"
+                alt="stripped:(activities.workOnTheRoad)"
                 src="/dist/icons/activities/work/truck-marker_round.svg"
                 style="height: 4rem;"
               />
               <span>
-                activities.workOnTheRoad
+                stripped:(activities.workOnTheRoad)
                 <br />
                 <em>
                    • 
-                  Lieu 1
+                  stripped:(Lieu 1)
                 </em>
               </span>
             </span>
@@ -628,12 +628,12 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
               class="survey-trip-item-element survey-trip-item-destination-description"
             >
               <img
-                alt="activities.restaurant"
+                alt="stripped:(activities.restaurant)"
                 src="/dist/icons/activities/other/restaurant-marker_round.svg"
                 style="height: 4rem;"
               />
               <span>
-                activities.restaurant
+                stripped:(activities.restaurant)
               </span>
             </span>
           </li>
@@ -641,7 +641,7 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
             class="no-bullet survey-trip-item survey-trip-item-mode-icons"
           >
             <img
-              alt="mode.short.walk"
+              alt="stripped:(mode.short.walk)"
               src="/dist/images/modes_icons/walk.png"
               style="height: 1.5em; margin-left: 0.3em;"
             />
@@ -717,12 +717,12 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
               class="survey-trip-item-element survey-trip-item-origin-description"
             >
               <img
-                alt="activities.restaurant"
+                alt="stripped:(activities.restaurant)"
                 src="/dist/icons/activities/other/restaurant-marker_round.svg"
                 style="height: 4rem;"
               />
               <span>
-                activities.restaurant
+                stripped:(activities.restaurant)
               </span>
             </span>
             <span
@@ -747,12 +747,12 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
               class="survey-trip-item-element survey-trip-item-destination-description"
             >
               <img
-                alt="activities.shopping"
+                alt="stripped:(activities.shopping)"
                 src="/dist/icons/activities/shopping/shopping_cart-marker_round.svg"
                 style="height: 4rem;"
               />
               <span>
-                activities.shopping
+                stripped:(activities.shopping)
               </span>
             </span>
           </li>
@@ -860,16 +860,16 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
               class="survey-trip-item-element survey-trip-item-origin-description"
             >
               <img
-                alt="activities.home"
+                alt="stripped:(activities.home)"
                 src="/dist/icons/activities/home/home-marker_round.svg"
                 style="height: 4rem;"
               />
               <span>
-                activities.home
+                stripped:(activities.home)
                 <br />
                 <em>
                    • 
-                  Lieu 1
+                  stripped:(Lieu 1)
                 </em>
               </span>
             </span>
@@ -895,12 +895,12 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
               class="survey-trip-item-element survey-trip-item-destination-description"
             >
               <img
-                alt="activities.restaurant"
+                alt="stripped:(activities.restaurant)"
                 src="/dist/icons/activities/other/restaurant-marker_round.svg"
                 style="height: 4rem;"
               />
               <span>
-                activities.restaurant
+                stripped:(activities.restaurant)
               </span>
             </span>
           </li>
@@ -908,7 +908,7 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
             class="no-bullet survey-trip-item survey-trip-item-mode-icons survey-trip-item-selected"
           >
             <img
-              alt="mode.short.walk"
+              alt="stripped:(mode.short.walk)"
               src="/dist/images/modes_icons/walk.png"
               style="height: 1.5em; margin-left: 0.3em;"
             />
@@ -972,12 +972,12 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
               class="survey-trip-item-element survey-trip-item-origin-description"
             >
               <img
-                alt="activities.restaurant"
+                alt="stripped:(activities.restaurant)"
                 src="/dist/icons/activities/other/restaurant-marker_round.svg"
                 style="height: 4rem;"
               />
               <span>
-                activities.restaurant
+                stripped:(activities.restaurant)
               </span>
             </span>
             <span
@@ -1002,12 +1002,12 @@ exports[`SegmentsSection UI display SegmentsSection with trips and visited place
               class="survey-trip-item-element survey-trip-item-destination-description"
             >
               <img
-                alt="activities.shopping"
+                alt="stripped:(activities.shopping)"
                 src="/dist/icons/activities/shopping/shopping_cart-marker_round.svg"
                 style="height: 4rem;"
               />
               <span>
-                activities.shopping
+                stripped:(activities.shopping)
               </span>
             </span>
           </li>

--- a/packages/evolution-frontend/src/components/survey/sectionTemplates/__tests__/__snapshots__/VisitedPlacesSection.test.tsx.snap
+++ b/packages/evolution-frontend/src/components/survey/sectionTemplates/__tests__/__snapshots__/VisitedPlacesSection.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`VisitedPlacesSection UI display should render the default visited place
             class="HTML _orange"
           >
             <span>
-              Schedule for survey:personWithSequenceAndAge
+              strippedUnsafe:(Schedule for survey:personWithSequenceAndAge)
             </span>
           </p>
           <div
@@ -43,13 +43,13 @@ exports[`VisitedPlacesSection UI display should render the default visited place
             <div
               class="survey-visited-places-schedule-visited-place hand-cursor-on-hover"
               style="left: 0%; width: 28.5714%;"
-              title="visitedPlaces:activities:home (-> 8:00)"
+              title="stripped:(visitedPlaces:activities:home (-> 8:00))"
             >
               <div
                 class="survey-visited-places-schedule-visited-place-icon"
               >
                 <img
-                  alt="stripped:visitedPlaces:activities:home"
+                  alt="stripped:(visitedPlaces:activities:home)"
                   src="/dist/icons/activities/home/home.svg"
                   style="height: 1.8em; padding: 0.1em;"
                 />
@@ -89,13 +89,13 @@ exports[`VisitedPlacesSection UI display should render the default visited place
             <div
               class="survey-visited-places-schedule-visited-place hand-cursor-on-hover"
               style="left: 29.1667%; width: 2.9762%;"
-              title="This is my work • visitedPlaces:activities:workUsual (8:10 -> 9:00)"
+              title="stripped:(This is my work • visitedPlaces:activities:workUsual (8:10 -> 9:00))"
             >
               <div
                 class="survey-visited-places-schedule-visited-place-icon"
               >
                 <img
-                  alt="stripped:visitedPlaces:activities:workUsual"
+                  alt="stripped:(visitedPlaces:activities:workUsual)"
                   src="/dist/icons/activities/work/briefcase.svg"
                   style="height: 1.8em; padding: 0.1em;"
                 />
@@ -136,13 +136,13 @@ exports[`VisitedPlacesSection UI display should render the default visited place
             <div
               class="survey-visited-places-schedule-visited-place hand-cursor-on-hover"
               style="left: 32.7381%; width: 17.2619%;"
-              title="visitedPlaces:activities:home (9:10 -> 14:00)"
+              title="stripped:(visitedPlaces:activities:home (9:10 -> 14:00))"
             >
               <div
                 class="survey-visited-places-schedule-visited-place-icon"
               >
                 <img
-                  alt="stripped:visitedPlaces:activities:home"
+                  alt="stripped:(visitedPlaces:activities:home)"
                   src="/dist/icons/activities/home/home.svg"
                   style="height: 1.8em; padding: 0.1em;"
                 />
@@ -183,13 +183,13 @@ exports[`VisitedPlacesSection UI display should render the default visited place
             <div
               class="survey-visited-places-schedule-visited-place hand-cursor-on-hover"
               style="left: 50.8929%; width: 2.6785%;"
-              title="survey:placeWithSequenceGeneric • visitedPlaces:activities:shopping (14:15 -> 15:00)"
+              title="stripped:(survey:placeWithSequenceGeneric • visitedPlaces:activities:shopping (14:15 -> 15:00))"
             >
               <div
                 class="survey-visited-places-schedule-visited-place-icon"
               >
                 <img
-                  alt="stripped:visitedPlaces:activities:shopping"
+                  alt="stripped:(visitedPlaces:activities:shopping)"
                   src="/dist/icons/activities/shopping/shopping_cart.svg"
                   style="height: 1.8em; padding: 0.1em;"
                 />
@@ -230,13 +230,13 @@ exports[`VisitedPlacesSection UI display should render the default visited place
             <div
               class="survey-visited-places-schedule-visited-place hand-cursor-on-hover"
               style="left: 54.4643%; width: 45.5357%;"
-              title="This is a shopping place • visitedPlaces:activities:shopping (15:15 ->)"
+              title="stripped:(This is a shopping place • visitedPlaces:activities:shopping (15:15 ->))"
             >
               <div
                 class="survey-visited-places-schedule-visited-place-icon"
               >
                 <img
-                  alt="stripped:visitedPlaces:activities:shopping"
+                  alt="stripped:(visitedPlaces:activities:shopping)"
                   src="/dist/icons/activities/shopping/shopping_cart.svg"
                   style="height: 1.8em; padding: 0.1em;"
                 />
@@ -289,7 +289,7 @@ exports[`VisitedPlacesSection UI display should render the default visited place
                 class="survey-visited-place-item-icon-container"
               >
                 <img
-                  alt="stripped:visitedPlaces:activities:home"
+                  alt="stripped:(visitedPlaces:activities:home)"
                   src="/dist/icons/activities/home/home.svg"
                   style="height: 3rem;"
                 />
@@ -301,7 +301,7 @@ exports[`VisitedPlacesSection UI display should render the default visited place
               <span
                 class=""
               >
-                stripped:visitedPlaces:activities:home
+                stripped:(visitedPlaces:activities:home)
               </span>
             </span>
             <span
@@ -415,7 +415,7 @@ exports[`VisitedPlacesSection UI display should render the default visited place
                 class="survey-visited-place-item-icon-container"
               >
                 <img
-                  alt="stripped:visitedPlaces:activities:workUsual"
+                  alt="stripped:(visitedPlaces:activities:workUsual)"
                   src="/dist/icons/activities/work/briefcase.svg"
                   style="height: 3rem;"
                 />
@@ -427,10 +427,10 @@ exports[`VisitedPlacesSection UI display should render the default visited place
               <span
                 class=""
               >
-                stripped:visitedPlaces:activities:workUsual
+                stripped:(visitedPlaces:activities:workUsual)
                 <em>
                    • 
-                  stripped:This is my work
+                  stripped:(This is my work)
                 </em>
               </span>
             </span>
@@ -546,7 +546,7 @@ exports[`VisitedPlacesSection UI display should render the default visited place
                 class="survey-visited-place-item-icon-container"
               >
                 <img
-                  alt="stripped:visitedPlaces:activities:home"
+                  alt="stripped:(visitedPlaces:activities:home)"
                   src="/dist/icons/activities/home/home.svg"
                   style="height: 3rem;"
                 />
@@ -558,7 +558,7 @@ exports[`VisitedPlacesSection UI display should render the default visited place
               <span
                 class=""
               >
-                stripped:visitedPlaces:activities:home
+                stripped:(visitedPlaces:activities:home)
               </span>
             </span>
             <span
@@ -673,7 +673,7 @@ exports[`VisitedPlacesSection UI display should render the default visited place
                 class="survey-visited-place-item-icon-container"
               >
                 <img
-                  alt="stripped:visitedPlaces:activities:shopping"
+                  alt="stripped:(visitedPlaces:activities:shopping)"
                   src="/dist/icons/activities/shopping/shopping_cart.svg"
                   style="height: 3rem;"
                 />
@@ -685,7 +685,7 @@ exports[`VisitedPlacesSection UI display should render the default visited place
               <span
                 class=""
               >
-                stripped:visitedPlaces:activities:shopping
+                stripped:(visitedPlaces:activities:shopping)
               </span>
             </span>
             <span
@@ -800,7 +800,7 @@ exports[`VisitedPlacesSection UI display should render the default visited place
                 class="survey-visited-place-item-icon-container"
               >
                 <img
-                  alt="stripped:visitedPlaces:activities:shopping"
+                  alt="stripped:(visitedPlaces:activities:shopping)"
                   src="/dist/icons/activities/shopping/shopping_cart.svg"
                   style="height: 3rem;"
                 />
@@ -812,10 +812,10 @@ exports[`VisitedPlacesSection UI display should render the default visited place
               <span
                 class=""
               >
-                stripped:visitedPlaces:activities:shopping
+                stripped:(visitedPlaces:activities:shopping)
                 <em>
                    • 
-                  stripped:This is a shopping place
+                  stripped:(This is a shopping place)
                 </em>
               </span>
             </span>
@@ -948,7 +948,7 @@ exports[`VisitedPlacesSection UI display should render the selected visited plac
             class="HTML _orange"
           >
             <span>
-              Schedule for survey:personWithSequenceAndAge
+              strippedUnsafe:(Schedule for survey:personWithSequenceAndAge)
             </span>
           </p>
           <div
@@ -957,13 +957,13 @@ exports[`VisitedPlacesSection UI display should render the selected visited plac
             <div
               class="survey-visited-places-schedule-visited-place"
               style="left: 0%; width: 28.5714%;"
-              title="visitedPlaces:activities:home (-> 8:00)"
+              title="stripped:(visitedPlaces:activities:home (-> 8:00))"
             >
               <div
                 class="survey-visited-places-schedule-visited-place-icon"
               >
                 <img
-                  alt="stripped:visitedPlaces:activities:home"
+                  alt="stripped:(visitedPlaces:activities:home)"
                   src="/dist/icons/activities/home/home.svg"
                   style="height: 1.8em; padding: 0.1em;"
                 />
@@ -1003,13 +1003,13 @@ exports[`VisitedPlacesSection UI display should render the selected visited plac
             <div
               class="survey-visited-places-schedule-visited-place"
               style="left: 29.1667%; width: 2.9762%;"
-              title="This is my work • visitedPlaces:activities:workUsual (8:10 -> 9:00)"
+              title="stripped:(This is my work • visitedPlaces:activities:workUsual (8:10 -> 9:00))"
             >
               <div
                 class="survey-visited-places-schedule-visited-place-icon"
               >
                 <img
-                  alt="stripped:visitedPlaces:activities:workUsual"
+                  alt="stripped:(visitedPlaces:activities:workUsual)"
                   src="/dist/icons/activities/work/briefcase.svg"
                   style="height: 1.8em; padding: 0.1em;"
                 />
@@ -1050,13 +1050,13 @@ exports[`VisitedPlacesSection UI display should render the selected visited plac
             <div
               class="survey-visited-places-schedule-visited-place"
               style="left: 32.7381%; width: 17.2619%;"
-              title="visitedPlaces:activities:home (9:10 -> 14:00)"
+              title="stripped:(visitedPlaces:activities:home (9:10 -> 14:00))"
             >
               <div
                 class="survey-visited-places-schedule-visited-place-icon"
               >
                 <img
-                  alt="stripped:visitedPlaces:activities:home"
+                  alt="stripped:(visitedPlaces:activities:home)"
                   src="/dist/icons/activities/home/home.svg"
                   style="height: 1.8em; padding: 0.1em;"
                 />
@@ -1097,13 +1097,13 @@ exports[`VisitedPlacesSection UI display should render the selected visited plac
             <div
               class="survey-visited-places-schedule-visited-place"
               style="left: 50.8929%; width: 2.6785%;"
-              title="survey:placeWithSequenceGeneric • visitedPlaces:activities:shopping (14:15 -> 15:00)"
+              title="stripped:(survey:placeWithSequenceGeneric • visitedPlaces:activities:shopping (14:15 -> 15:00))"
             >
               <div
                 class="survey-visited-places-schedule-visited-place-icon"
               >
                 <img
-                  alt="stripped:visitedPlaces:activities:shopping"
+                  alt="stripped:(visitedPlaces:activities:shopping)"
                   src="/dist/icons/activities/shopping/shopping_cart.svg"
                   style="height: 1.8em; padding: 0.1em;"
                 />
@@ -1144,13 +1144,13 @@ exports[`VisitedPlacesSection UI display should render the selected visited plac
             <div
               class="survey-visited-places-schedule-visited-place"
               style="left: 54.4643%; width: 45.5357%;"
-              title="This is a shopping place • visitedPlaces:activities:shopping (15:15 ->)"
+              title="stripped:(This is a shopping place • visitedPlaces:activities:shopping (15:15 ->))"
             >
               <div
                 class="survey-visited-places-schedule-visited-place-icon"
               >
                 <img
-                  alt="stripped:visitedPlaces:activities:shopping"
+                  alt="stripped:(visitedPlaces:activities:shopping)"
                   src="/dist/icons/activities/shopping/shopping_cart.svg"
                   style="height: 1.8em; padding: 0.1em;"
                 />
@@ -1203,7 +1203,7 @@ exports[`VisitedPlacesSection UI display should render the selected visited plac
                 class="survey-visited-place-item-icon-container"
               >
                 <img
-                  alt="stripped:visitedPlaces:activities:home"
+                  alt="stripped:(visitedPlaces:activities:home)"
                   src="/dist/icons/activities/home/home.svg"
                   style="height: 3rem;"
                 />
@@ -1215,7 +1215,7 @@ exports[`VisitedPlacesSection UI display should render the selected visited plac
               <span
                 class=""
               >
-                stripped:visitedPlaces:activities:home
+                stripped:(visitedPlaces:activities:home)
               </span>
             </span>
             <span
@@ -1265,7 +1265,7 @@ exports[`VisitedPlacesSection UI display should render the selected visited plac
                 class="survey-visited-place-item-icon-container"
               >
                 <img
-                  alt="stripped:visitedPlaces:activities:workUsual"
+                  alt="stripped:(visitedPlaces:activities:workUsual)"
                   src="/dist/icons/activities/work/briefcase.svg"
                   style="height: 3rem;"
                 />
@@ -1277,10 +1277,10 @@ exports[`VisitedPlacesSection UI display should render the selected visited plac
               <span
                 class="_strong"
               >
-                stripped:visitedPlaces:activities:workUsual
+                stripped:(visitedPlaces:activities:workUsual)
                 <em>
                    • 
-                  stripped:This is my work
+                  stripped:(This is my work)
                 </em>
               </span>
             </span>
@@ -1341,7 +1341,7 @@ exports[`VisitedPlacesSection UI display should render the selected visited plac
                 class="survey-visited-place-item-icon-container"
               >
                 <img
-                  alt="stripped:visitedPlaces:activities:home"
+                  alt="stripped:(visitedPlaces:activities:home)"
                   src="/dist/icons/activities/home/home.svg"
                   style="height: 3rem;"
                 />
@@ -1353,7 +1353,7 @@ exports[`VisitedPlacesSection UI display should render the selected visited plac
               <span
                 class=""
               >
-                stripped:visitedPlaces:activities:home
+                stripped:(visitedPlaces:activities:home)
               </span>
             </span>
             <span
@@ -1404,7 +1404,7 @@ exports[`VisitedPlacesSection UI display should render the selected visited plac
                 class="survey-visited-place-item-icon-container"
               >
                 <img
-                  alt="stripped:visitedPlaces:activities:shopping"
+                  alt="stripped:(visitedPlaces:activities:shopping)"
                   src="/dist/icons/activities/shopping/shopping_cart.svg"
                   style="height: 3rem;"
                 />
@@ -1416,7 +1416,7 @@ exports[`VisitedPlacesSection UI display should render the selected visited plac
               <span
                 class=""
               >
-                stripped:visitedPlaces:activities:shopping
+                stripped:(visitedPlaces:activities:shopping)
               </span>
             </span>
             <span
@@ -1467,7 +1467,7 @@ exports[`VisitedPlacesSection UI display should render the selected visited plac
                 class="survey-visited-place-item-icon-container"
               >
                 <img
-                  alt="stripped:visitedPlaces:activities:shopping"
+                  alt="stripped:(visitedPlaces:activities:shopping)"
                   src="/dist/icons/activities/shopping/shopping_cart.svg"
                   style="height: 3rem;"
                 />
@@ -1479,10 +1479,10 @@ exports[`VisitedPlacesSection UI display should render the selected visited plac
               <span
                 class=""
               >
-                stripped:visitedPlaces:activities:shopping
+                stripped:(visitedPlaces:activities:shopping)
                 <em>
                    • 
-                  stripped:This is a shopping place
+                  stripped:(This is a shopping place)
                 </em>
               </span>
             </span>


### PR DESCRIPTION
fixes #1848

When HTML markup could appear in strings, we use the `stripHtml` function to remove any markup. As for strings allowing html, we use the `stripUnsafeHtml` to make sure any unsafe html or javascript is removed from the strings to display

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection against unsafe or unintended HTML in survey activity labels, travel locations, schedule labels, and tooltips.
  * Ensured displayed text and image descriptions are rendered safely and consistently.
* **Tests**
  * Updated coverage and mocks for the enhanced text-sanitization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->